### PR TITLE
Restore session approvals and cancellation progress (Fixes #3299)

### DIFF
--- a/packages/agents/src/core/coreToolScheduler.issue3299.test.ts
+++ b/packages/agents/src/core/coreToolScheduler.issue3299.test.ts
@@ -1,0 +1,632 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Regression suite for issue #3299.
+ *
+ * AC2: a policy-bus tool that initially requires confirmation is confirmed on
+ * its first call. The call's onConfirm receives ProceedAlways and publishes
+ * UPDATE_POLICY through a real CoreMessageBusAdapter; the real
+ * createPolicyUpdater subscriber (the same wiring the foreground startup
+ * installs; that subscription itself is proven by the CLI bootstrap test)
+ * converts it into an ALLOW rule on the real PolicyEngine, so a later
+ * matching call on the same scheduler succeeds without awaiting_approval.
+ * An unrelated tool stays gated and ProceedOnce stays call-local.
+ *
+ * AC4-AC6: cancelling the last awaiting call in a mixed batch re-drives
+ * the scheduler gate so approved `scheduled` siblings execute, gating holds
+ * while a sibling still awaits, and each completed batch fires exactly once.
+ */
+
+import { describe, it, expect, afterEach } from 'bun:test';
+import type { ToolCall, CompletedToolCall } from './coreToolScheduler.js';
+import { CoreToolScheduler } from './coreToolScheduler.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { ApprovalMode } from '@vybestack/llxprt-code-core/config/configTypes.js';
+import { PolicyDecision } from '@vybestack/llxprt-code-core';
+import {
+  MessageBus,
+  PolicyEngine,
+  createPolicyUpdater,
+} from '@vybestack/llxprt-code-core';
+import { CoreMessageBusAdapter } from '@vybestack/llxprt-code-core/tools-adapters/CoreMessageBusAdapter.js';
+import {
+  MessageBusType,
+  type ToolConfirmationRequest,
+  type ToolConfirmationResponse,
+} from '@vybestack/llxprt-code-core/confirmation-bus/types.js';
+import type { ToolRegistry } from '@vybestack/llxprt-code-tools';
+import type { ToolCallConfirmationDetails } from '@vybestack/llxprt-code-tools';
+import { ToolConfirmationOutcome } from '@vybestack/llxprt-code-tools/types/tool-confirmation-types.js';
+import { MockTool } from '@vybestack/llxprt-code-core/test-utils/mock-tool.js';
+import { waitFor } from '@vybestack/llxprt-code-test-utils';
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+const schedulersToDispose: CoreToolScheduler[] = [];
+
+afterEach(() => {
+  for (const scheduler of schedulersToDispose) {
+    scheduler.dispose();
+  }
+  schedulersToDispose.length = 0;
+});
+
+/**
+ * Policy-gated tool: the engine is the only source of truth. While it says
+ * ASK_USER the tool asks; the user's ProceedAlways routes through the real
+ * adapter so the live createPolicyUpdater subscriber makes the engine ALLOW.
+ */
+function makeGatedTool(
+  command: string,
+  engine: PolicyEngine,
+  adapter: CoreMessageBusAdapter,
+  recordExecution: (toolName: string) => void,
+): MockTool {
+  return new MockTool({
+    name: command,
+    shouldConfirmExecute: async (
+      params: { command?: unknown },
+      _signal: AbortSignal,
+    ): Promise<ToolCallConfirmationDetails | false> => {
+      if (
+        engine.evaluate(command, {
+          command: String(params.command ?? command),
+        }) === PolicyDecision.ALLOW
+      ) {
+        return false;
+      }
+      return {
+        type: 'exec',
+        title: `Confirm ${command}`,
+        command: String(params.command ?? command),
+        rootCommand: command,
+        rootCommands: [command],
+        onConfirm: async (outcome: ToolConfirmationOutcome) => {
+          if (outcome === ToolConfirmationOutcome.ProceedAlways) {
+            const policyUpdate: {
+              toolName: string;
+              commandPrefix: string[];
+            } = {
+              toolName: command,
+              commandPrefix: [command],
+            };
+            await adapter.publishPolicyUpdate(outcome, policyUpdate);
+          }
+        },
+      };
+    },
+    execute: async () => {
+      recordExecution(command);
+      return {
+        llmContent: `${command} ran`,
+        returnDisplay: `${command} ran`,
+      };
+    },
+  });
+}
+
+interface Harness {
+  scheduler: CoreToolScheduler;
+  engine: PolicyEngine;
+  bus: MessageBus;
+  updates: ToolCall[][];
+  completions: CompletedToolCall[][];
+  executionsByTool: Readonly<Map<string, number>>;
+}
+
+function makeHarness(commands: string[]): Harness {
+  const engine = new PolicyEngine({});
+  const bus = new MessageBus(engine);
+  const adapter = new CoreMessageBusAdapter(bus);
+  createPolicyUpdater(engine, bus);
+  const executionsByTool = new Map<string, number>();
+  const tools = commands.map((command) =>
+    makeGatedTool(command, engine, adapter, (toolName) => {
+      executionsByTool.set(toolName, (executionsByTool.get(toolName) ?? 0) + 1);
+    }),
+  );
+  const registry = makeRegistry(tools);
+  const updates: ToolCall[][] = [];
+  const completions: CompletedToolCall[][] = [];
+  const scheduler = new CoreToolScheduler({
+    config: makeConfig(engine, registry, bus),
+    messageBus: bus,
+    toolRegistry: registry,
+    onAllToolCallsComplete: async (calls: CompletedToolCall[]) => {
+      completions.push(calls);
+    },
+    onToolCallsUpdate: (calls: ToolCall[]) => {
+      updates.push(calls);
+    },
+    getPreferredEditor: () => 'vscode',
+    onEditorClose: () => {},
+  });
+  schedulersToDispose.push(scheduler);
+  return { scheduler, engine, bus, updates, completions, executionsByTool };
+}
+
+/**
+ * Builds one fresh ToolRegistry and one fresh set of tool instances per
+ * scheduler harness. The SAME registry instance is passed to both Config and the
+ * scheduler so the scheduler executes the exact tools the policy decision applies to.
+ */
+function makeRegistry(tools: MockTool[]): ToolRegistry {
+  const byName = new Map(tools.map((tool) => [tool.name, tool]));
+  return {
+    getTool: (name: string) => byName.get(name),
+    getFunctionDeclarations: () => [],
+    tools: new Map(),
+    discovery: {},
+    registerTool: () => {},
+    getToolByName: (name: string) => byName.get(name),
+    getToolByDisplayName: (name: string) => byName.get(name),
+    getTools: () => [],
+    discoverTools: async () => {},
+    getAllTools: () => tools,
+    getToolsByServer: () => [],
+  } as unknown as ToolRegistry;
+}
+
+function makeConfig(
+  engine: PolicyEngine,
+  registry: ToolRegistry,
+  bus: MessageBus,
+): Config {
+  return {
+    getSessionId: () => 'test-session-id',
+    getUsageStatisticsEnabled: () => true,
+    getDebugMode: () => false,
+    isInteractive: () => true,
+    getApprovalMode: () => ApprovalMode.DEFAULT,
+    getEphemeralSettings: () => ({}),
+    getAllowedTools: () => [],
+    getContentGeneratorConfig: () => ({ model: 'test-model' }),
+    getToolRegistry: () => registry,
+    getMessageBus: () => bus,
+    getEnableHooks: () => false,
+    getPolicyEngine: () => engine,
+    getModel: () => 'gemini-2.5-pro',
+  } as unknown as Config;
+}
+
+async function waitForStatus<Status extends ToolCall['status']>(
+  updates: ToolCall[][],
+  callId: string,
+  status: Status,
+): Promise<Extract<ToolCall, { status: Status }>> {
+  let call: ToolCall | undefined;
+  await waitFor(() => {
+    call = latestOf(updates, callId);
+    if (call === undefined) {
+      throw new Error(`No emitted snapshot found for ${callId}`);
+    }
+    if (!hasStatus(call, status)) {
+      throw new Error(
+        `Call ${callId} latest status ${call.status} is not ${status}`,
+      );
+    }
+  });
+  if (call === undefined || !hasStatus(call, status)) {
+    throw new Error(`No ${status} snapshot found for ${callId}`);
+  }
+  return call;
+}
+
+function hasStatus<Status extends ToolCall['status']>(
+  call: ToolCall,
+  status: Status,
+): call is Extract<ToolCall, { status: Status }> {
+  return call.status === status;
+}
+
+/**
+ * Returns the state of `callId` in the LATEST emitted snapshot that
+ * contains it. Unlike a scan that matches any historical snapshot, a
+ * `scheduled` state observed before execution cannot satisfy a post-execution
+ * check.
+ */
+function latestOf(updates: ToolCall[][], callId: string): ToolCall | undefined {
+  for (let index = updates.length - 1; index >= 0; index -= 1) {
+    const call = updates[index].find(
+      (candidate) => candidate.request.callId === callId,
+    );
+    if (call !== undefined) {
+      return call;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Asserts the call is currently in `scheduled` (the latest emitted snapshot)
+ * and has never reached `executing`, `success`, or `error` in any snapshot.
+ */
+function expectWaitingScheduled(updates: ToolCall[][], callId: string): void {
+  const latest = latestOf(updates, callId);
+  if (latest === undefined) {
+    throw new Error(`No emitted snapshot found for ${callId}`);
+  }
+  expect(latest.status).toBe('scheduled');
+  expect(
+    updates.some((snapshot) =>
+      snapshot.some(
+        (call) =>
+          call.request.callId === callId &&
+          (call.status === 'executing' ||
+            call.status === 'success' ||
+            call.status === 'error'),
+      ),
+    ),
+  ).toBe(false);
+}
+
+const terminalStatuses: ReadonlyArray<ToolCall['status']> = [
+  'success',
+  'error',
+  'cancelled',
+];
+
+async function confirmCall(
+  call: ToolCall,
+  outcome: ToolConfirmationOutcome,
+): Promise<void> {
+  if (call.status !== 'awaiting_approval') {
+    throw new Error(`expected awaiting_approval call, got ${call.status}`);
+  }
+  const details = call.confirmationDetails;
+  if (!('onConfirm' in details)) {
+    throw new Error('confirmationDetails carries no onConfirm callback');
+  }
+  await details.onConfirm(outcome);
+}
+
+// ── AC2: "allow for this session" applies to a later matching call ──
+
+describe('issue #3299: ProceedAlways applies to a later matching call (AC2)', () => {
+  it('confirms the first policy-bus call, then a later matching call succeeds without confirmation while an unrelated tool stays gated', async () => {
+    const { scheduler, engine, updates, completions, executionsByTool } =
+      makeHarness(['approvalTool', 'otherTool']);
+
+    await scheduler.schedule(
+      [requestFor('first', 'approvalTool')],
+      new AbortController().signal,
+    );
+    const firstCall = await waitForStatus(
+      updates,
+      'first',
+      'awaiting_approval',
+    );
+    await confirmCall(firstCall, ToolConfirmationOutcome.ProceedAlways);
+    await waitForStatus(updates, 'first', 'success');
+    await waitFor(() => {
+      expect(completions).toHaveLength(1);
+    });
+
+    expect(engine.evaluate('approvalTool', { command: 'approvalTool' })).toBe(
+      PolicyDecision.ALLOW,
+    );
+
+    await scheduler.schedule(
+      [requestFor('later', 'approvalTool')],
+      new AbortController().signal,
+    );
+    await waitForStatus(updates, 'later', 'success');
+    await waitFor(() => {
+      expect(completions).toHaveLength(2);
+    });
+    const laterBatch = completions[1];
+    expect(
+      laterBatch.find((call) => call.request.callId === 'later')?.status,
+    ).toBe('success');
+    expect(laterBatch).toHaveLength(1);
+    expect(laterBatch[0]?.status).toBe('success');
+
+    await scheduler.schedule(
+      [requestFor('other', 'otherTool')],
+      new AbortController().signal,
+    );
+    const otherCall = await waitForStatus(
+      updates,
+      'other',
+      'awaiting_approval',
+    );
+    await confirmCall(otherCall, ToolConfirmationOutcome.ProceedAlways);
+    await waitForStatus(updates, 'other', 'success');
+    await waitFor(() => {
+      expect(completions).toHaveLength(3);
+    });
+    expect(executionsByTool.get('approvalTool')).toBe(2);
+    expect(executionsByTool.get('otherTool')).toBe(1);
+  });
+
+  it('ProceedOnce stays call-local: a later matching call is confirmed again', async () => {
+    const { scheduler, updates, completions, executionsByTool } = makeHarness([
+      'onceTool',
+    ]);
+
+    await scheduler.schedule(
+      [requestFor('first', 'onceTool')],
+      new AbortController().signal,
+    );
+    const firstCall = await waitForStatus(
+      updates,
+      'first',
+      'awaiting_approval',
+    );
+    await confirmCall(firstCall, ToolConfirmationOutcome.ProceedOnce);
+    await waitForStatus(updates, 'first', 'success');
+
+    await scheduler.schedule(
+      [requestFor('later', 'onceTool')],
+      new AbortController().signal,
+    );
+    const laterCall = await waitForStatus(
+      updates,
+      'later',
+      'awaiting_approval',
+    );
+    await confirmCall(laterCall, ToolConfirmationOutcome.ProceedOnce);
+    await waitForStatus(updates, 'later', 'success');
+    await waitFor(() => {
+      expect(completions).toHaveLength(2);
+    });
+    expect(executionsByTool.get('onceTool')).toBe(2);
+  });
+});
+
+// ── AC4: cancelling the last awaiting call releases approved siblings ──
+
+describe('issue #3299: cancelling the last awaiting call releases approved siblings (AC4)', () => {
+  it('a ProceedOnce-approved sibling executes once the last awaiting sibling is cancelled', async () => {
+    const { scheduler, updates, completions, executionsByTool } = makeHarness([
+      'sharedTool',
+    ]);
+
+    await scheduler.schedule(
+      [requestFor('call-a', 'sharedTool'), requestFor('call-b', 'sharedTool')],
+      new AbortController().signal,
+    );
+    const awaitingA = await waitForStatus(
+      updates,
+      'call-a',
+      'awaiting_approval',
+    );
+    await waitForStatus(updates, 'call-b', 'awaiting_approval');
+
+    await confirmCall(awaitingA, ToolConfirmationOutcome.ProceedOnce);
+    await waitForStatus(updates, 'call-a', 'scheduled');
+    await waitFor(() => {
+      expect(executionsByTool.get('sharedTool')).toBe(undefined);
+    });
+
+    const awaitingB = await waitForStatus(
+      updates,
+      'call-b',
+      'awaiting_approval',
+    );
+    await confirmCall(awaitingB, ToolConfirmationOutcome.Cancel);
+    await waitForStatus(updates, 'call-b', 'cancelled');
+    await waitForStatus(updates, 'call-a', 'success');
+
+    await waitFor(() => {
+      expect(completions).toHaveLength(1);
+    });
+    const completedCalls = completions[0];
+    expect(completedCalls).toHaveLength(2);
+    for (const call of completedCalls) {
+      expect(terminalStatuses).toContain(call.status);
+    }
+    expect(executionsByTool.get('sharedTool')).toBe(1);
+  });
+
+  it('a response for serialized confirmation details cancels the final waiter and releases a scheduled sibling', async () => {
+    const { scheduler, bus, updates, completions, executionsByTool } =
+      makeHarness(['approvedTool', 'serializedTool']);
+    let serializedCorrelationId: string | undefined;
+    bus.subscribe<ToolConfirmationRequest>(
+      MessageBusType.TOOL_CONFIRMATION_REQUEST,
+      (request) => {
+        if (request.toolCall.name === 'serializedTool') {
+          serializedCorrelationId = request.correlationId;
+        }
+      },
+    );
+
+    await scheduler.schedule(
+      [
+        requestFor('approved', 'approvedTool'),
+        requestFor('serialized', 'serializedTool'),
+      ],
+      new AbortController().signal,
+    );
+    const approved = await waitForStatus(
+      updates,
+      'approved',
+      'awaiting_approval',
+    );
+    const serialized = await waitForStatus(
+      updates,
+      'serialized',
+      'awaiting_approval',
+    );
+    // The MessageBus branch accepts details that crossed a serialization
+    // boundary and no longer carry the in-process callback.
+    if (!Reflect.deleteProperty(serialized.confirmationDetails, 'onConfirm')) {
+      throw new Error('could not serialize confirmation details');
+    }
+    await confirmCall(approved, ToolConfirmationOutcome.ProceedOnce);
+    await waitForStatus(updates, 'approved', 'scheduled');
+    expect(executionsByTool.get('approvedTool')).toBeUndefined();
+
+    await waitFor(() => {
+      expect(serializedCorrelationId).toBeDefined();
+    });
+    if (serializedCorrelationId === undefined) {
+      throw new Error('serialized confirmation request was not published');
+    }
+    bus.publish({
+      type: MessageBusType.TOOL_CONFIRMATION_RESPONSE,
+      correlationId: serializedCorrelationId,
+      outcome: ToolConfirmationOutcome.Cancel,
+    } satisfies ToolConfirmationResponse);
+
+    await waitForStatus(updates, 'serialized', 'cancelled');
+    await waitForStatus(updates, 'approved', 'success');
+    await waitFor(() => {
+      expect(completions).toHaveLength(1);
+    });
+    expect(completions[0]).toHaveLength(2);
+    expect(executionsByTool.get('approvedTool')).toBe(1);
+    expect(executionsByTool.get('serializedTool')).toBeUndefined();
+  });
+});
+
+// ── AC5: gating is preserved while any sibling still awaits ───────────
+
+describe('issue #3299: gating is preserved while a sibling still awaits (AC5)', () => {
+  it('a ProceedOnce-approved sibling stays scheduled until the last awaiting call is cancelled', async () => {
+    const { scheduler, updates, completions, executionsByTool } = makeHarness([
+      'sharedTool',
+    ]);
+
+    await scheduler.schedule(
+      [
+        requestFor('call-a', 'sharedTool'),
+        requestFor('call-b', 'sharedTool'),
+        requestFor('call-c', 'sharedTool'),
+      ],
+      new AbortController().signal,
+    );
+    const awaitingA = await waitForStatus(
+      updates,
+      'call-a',
+      'awaiting_approval',
+    );
+    await waitForStatus(updates, 'call-b', 'awaiting_approval');
+    await waitForStatus(updates, 'call-c', 'awaiting_approval');
+
+    await confirmCall(awaitingA, ToolConfirmationOutcome.ProceedOnce);
+    await waitForStatus(updates, 'call-a', 'scheduled');
+    await waitForStatus(updates, 'call-b', 'awaiting_approval');
+    await waitForStatus(updates, 'call-c', 'awaiting_approval');
+    expectWaitingScheduled(updates, 'call-a');
+    await waitFor(() => {
+      expect(executionsByTool.get('sharedTool')).toBe(undefined);
+    });
+
+    const awaitingB = await waitForStatus(
+      updates,
+      'call-b',
+      'awaiting_approval',
+    );
+    await confirmCall(awaitingB, ToolConfirmationOutcome.Cancel);
+    await waitForStatus(updates, 'call-b', 'cancelled');
+    await waitForStatus(updates, 'call-c', 'awaiting_approval');
+    expectWaitingScheduled(updates, 'call-a');
+    expect(completions).toHaveLength(0);
+
+    const awaitingC = await waitForStatus(
+      updates,
+      'call-c',
+      'awaiting_approval',
+    );
+    await confirmCall(awaitingC, ToolConfirmationOutcome.Cancel);
+    await waitForStatus(updates, 'call-a', 'success');
+    await waitForStatus(updates, 'call-c', 'cancelled');
+    await waitFor(() => {
+      expect(completions).toHaveLength(1);
+    });
+    const completedCalls = completions[0];
+    expect(completedCalls).toHaveLength(3);
+    for (const call of completedCalls) {
+      expect(terminalStatuses).toContain(call.status);
+    }
+    expect(executionsByTool.get('sharedTool')).toBe(1);
+  });
+});
+
+// ── AC6: ProceedAlways cascade completes after incompatible cancel ───
+
+describe('issue #3299: ProceedAlways cascade completes after incompatible sibling is cancelled (AC6)', () => {
+  it('two compatible siblings scheduled by the ProceedAlways cascade execute once the incompatible awaiting call is cancelled', async () => {
+    const { scheduler, updates, completions, executionsByTool } = makeHarness([
+      'sharedTool',
+      'blockedTool',
+    ]);
+
+    await scheduler.schedule(
+      [
+        requestFor('shared-a', 'sharedTool'),
+        requestFor('shared-b', 'sharedTool'),
+        requestFor('blocked', 'blockedTool'),
+      ],
+      new AbortController().signal,
+    );
+    const awaitingSharedA = await waitForStatus(
+      updates,
+      'shared-a',
+      'awaiting_approval',
+    );
+    await waitForStatus(updates, 'shared-b', 'awaiting_approval');
+    await waitForStatus(updates, 'blocked', 'awaiting_approval');
+
+    await confirmCall(awaitingSharedA, ToolConfirmationOutcome.ProceedAlways);
+    await waitForStatus(updates, 'shared-a', 'scheduled');
+    await waitForStatus(updates, 'shared-b', 'scheduled');
+    expectWaitingScheduled(updates, 'shared-a');
+    expectWaitingScheduled(updates, 'shared-b');
+    await waitFor(() => {
+      expect(executionsByTool.get('sharedTool')).toBe(undefined);
+    });
+    expect(executionsByTool.get('blockedTool')).toBe(undefined);
+
+    const awaitingBlocked = await waitForStatus(
+      updates,
+      'blocked',
+      'awaiting_approval',
+    );
+    await confirmCall(awaitingBlocked, ToolConfirmationOutcome.Cancel);
+    await waitForStatus(updates, 'shared-a', 'success');
+    await waitForStatus(updates, 'shared-b', 'success');
+    await waitForStatus(updates, 'blocked', 'cancelled');
+
+    await waitFor(() => {
+      expect(completions).toHaveLength(1);
+    });
+    const completedCalls = completions[0];
+    expect(completedCalls).toHaveLength(3);
+    expect(
+      completedCalls.filter((call) => call.status === 'success'),
+    ).toHaveLength(2);
+    expect(
+      completedCalls.filter((call) => call.status === 'cancelled'),
+    ).toHaveLength(1);
+    for (const call of completedCalls) {
+      expect(terminalStatuses).toContain(call.status);
+    }
+    expect(executionsByTool.get('sharedTool')).toBe(2);
+  });
+});
+
+function requestFor(
+  callId: string,
+  name: string,
+): {
+  callId: string;
+  name: string;
+  args: { command: string };
+  isClientInitiated: boolean;
+  prompt_id: string;
+} {
+  return {
+    callId,
+    name,
+    args: { command: name },
+    isClientInitiated: false,
+    prompt_id: 'issue3299',
+  };
+}

--- a/packages/agents/src/scheduler/confirmation-coordinator.ts
+++ b/packages/agents/src/scheduler/confirmation-coordinator.ts
@@ -470,7 +470,7 @@ export class ConfirmationCoordinator {
       this.pendingConfirmations.delete(response.correlationId);
       this.pendingOriginalConfirmHandlers.delete(response.correlationId);
       this.statusMutator.setOutcome(callId, ToolConfirmationOutcome.Cancel);
-      void this.handleCancellation(callId);
+      void this.handleCancellation(callId, signal);
       return;
     }
 
@@ -545,7 +545,7 @@ export class ConfirmationCoordinator {
     this.statusMutator.setOutcome(callId, outcome);
 
     if (outcome === ToolConfirmationOutcome.Cancel || signal.aborted) {
-      await this.handleCancellation(callId);
+      await this.handleCancellation(callId, signal);
     } else if (
       outcome === ToolConfirmationOutcome.ModifyWithEditor &&
       waitingToolCall
@@ -571,8 +571,12 @@ export class ConfirmationCoordinator {
 
   // ── Sub-handlers ──────────────────────────────────────────────────────────
 
-  private async handleCancellation(callId: string): Promise<void> {
+  private async handleCancellation(
+    callId: string,
+    signal: AbortSignal,
+  ): Promise<void> {
     this.statusMutator.setCancelled(callId, 'User did not allow tool call');
+    await this.schedulerAccessor.attemptExecution(signal);
   }
 
   private async handleApproval(

--- a/packages/cli/src/cliAgentBootstrap.test.ts
+++ b/packages/cli/src/cliAgentBootstrap.test.ts
@@ -217,6 +217,11 @@ describe('createForegroundAgent @plan:PLAN-20270110-ISSUE2378.P01 @requirement:R
   });
 
   it('applies session policy updates from the Agent-owned bus to the Config policy engine', async () => {
+    bus.publish({
+      type: MessageBusType.UPDATE_POLICY,
+      toolName: 'activate_skill',
+      persist: false,
+    });
     expect(engine.evaluate('activate_skill', { name: 'pr-creator' })).toBe(
       PolicyDecision.ASK_USER,
     );

--- a/packages/cli/src/cliAgentBootstrap.test.ts
+++ b/packages/cli/src/cliAgentBootstrap.test.ts
@@ -20,7 +20,13 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'bun:test';
+import {
+  MessageBus,
+  PolicyDecision,
+  PolicyEngine,
+} from '@vybestack/llxprt-code-core';
 import type { Config } from '@vybestack/llxprt-code-core';
+import { MessageBusType } from '@vybestack/llxprt-code-core/confirmation-bus/types.js';
 import type { Agent } from '@vybestack/llxprt-code-agents';
 
 const { fromConfigMock } = {
@@ -43,6 +49,7 @@ interface FakeAgent {
   getConfig: () => Config;
   getProvider: () => string | undefined;
   getModel: () => string;
+  getMessageBus: () => MessageBus;
 }
 
 function makeConfig(
@@ -51,10 +58,12 @@ function makeConfig(
     model?: string;
     ephemerals?: Record<string, unknown>;
   } = {},
-): Config {
+): Fixture {
   const ephemerals = { ...(overrides.ephemerals ?? {}) };
-  return {
-    getPolicyEngine: () => null,
+  const engine = new PolicyEngine({});
+  const bus = new MessageBus(engine);
+  const config = {
+    getPolicyEngine: () => engine,
     getDebugMode: () => false,
     getProvider: () => overrides.provider,
     getModel: () => overrides.model ?? 'gemini-2.5-pro',
@@ -63,23 +72,41 @@ function makeConfig(
       ephemerals[key] = value;
     },
   } as unknown as Config;
+  return { config, engine, bus };
+}
+
+interface Fixture {
+  config: Config;
+  engine: PolicyEngine;
+  bus: MessageBus;
+}
+
+function makeFakeAgent(config: Config, bus: MessageBus): FakeAgent {
+  return {
+    dispose: vi.fn().mockResolvedValue(undefined),
+    getConfig: () => config,
+    getProvider: () => 'gemini',
+    getModel: () => 'gemini-2.5-pro',
+    getMessageBus: () => bus,
+  };
 }
 
 describe('createForegroundAgent @plan:PLAN-20270110-ISSUE2378.P01 @requirement:REQ-2378-001', () => {
   let config: Config;
+  let engine: PolicyEngine;
+  let bus: MessageBus;
   let fakeAgent: FakeAgent;
+
+  function useFixture(overrides: Parameters<typeof makeConfig>[0] = {}): void {
+    ({ config, engine, bus } = makeConfig(overrides));
+    fakeAgent = makeFakeAgent(config, bus);
+    fromConfigMock.mockResolvedValue(fakeAgent as unknown as Agent);
+  }
 
   beforeEach(() => {
     __resetCleanupStateForTesting();
     fromConfigMock.mockReset();
-    config = makeConfig();
-    fakeAgent = {
-      dispose: vi.fn().mockResolvedValue(undefined),
-      getConfig: () => config,
-      getProvider: () => 'gemini',
-      getModel: () => 'gemini-2.5-pro',
-    };
-    fromConfigMock.mockResolvedValue(fakeAgent as unknown as Agent);
+    useFixture();
   });
 
   afterEach(() => {
@@ -162,7 +189,7 @@ describe('createForegroundAgent @plan:PLAN-20270110-ISSUE2378.P01 @requirement:R
   });
 
   it('declares the configured provider and model in the activation intent', async () => {
-    config = makeConfig({ provider: 'glm', model: 'glm-4' });
+    useFixture({ provider: 'glm', model: 'glm-4' });
     await createForegroundAgent({ config });
 
     const options = fromConfigMock.mock.calls[0][0] as {
@@ -176,7 +203,7 @@ describe('createForegroundAgent @plan:PLAN-20270110-ISSUE2378.P01 @requirement:R
   });
 
   it('omits the model from the intent when the config model is the placeholder', async () => {
-    config = makeConfig({ provider: 'glm', model: 'placeholder-model' });
+    useFixture({ provider: 'glm', model: 'placeholder-model' });
     await createForegroundAgent({ config });
 
     const options = fromConfigMock.mock.calls[0][0] as {
@@ -187,5 +214,24 @@ describe('createForegroundAgent @plan:PLAN-20270110-ISSUE2378.P01 @requirement:R
       authMode: 'auto',
     });
     expect(options.activation).not.toHaveProperty('model');
+  });
+
+  it('applies session policy updates from the Agent-owned bus to the Config policy engine', async () => {
+    expect(engine.evaluate('activate_skill', { name: 'pr-creator' })).toBe(
+      PolicyDecision.ASK_USER,
+    );
+
+    await createForegroundAgent({ config });
+
+    bus.publish({
+      type: MessageBusType.UPDATE_POLICY,
+      toolName: 'activate_skill',
+      persist: false,
+    });
+
+    expect(engine.evaluate('activate_skill', { name: 'pr-creator' })).toBe(
+      PolicyDecision.ALLOW,
+    );
+    expect(engine.evaluate('ast_edit', {})).toBe(PolicyDecision.ASK_USER);
   });
 });

--- a/packages/cli/src/cliAgentBootstrap.ts
+++ b/packages/cli/src/cliAgentBootstrap.ts
@@ -13,6 +13,7 @@ import {
 } from '@vybestack/llxprt-code-agents';
 
 import { registerCleanup } from './utils/cleanup.js';
+import { createPolicyUpdater } from './config/policy.js';
 import {
   hasProfileAuthEphemerals,
   snapshotProfileAuthEphemerals,
@@ -73,6 +74,11 @@ export async function createForegroundAgent({
     activation: activationPreflightIntent ?? activation,
     activationPreflightToken,
   });
+
+  // Wire the session policy engine to UPDATE_POLICY bus messages ("Allow for
+  // this session/for all future sessions") against the exact Config engine
+  // and Agent bus the scheduler uses.
+  createPolicyUpdater(config.getPolicyEngine(), agent.getMessageBus());
 
   registerCleanup(async () => {
     await agent.dispose();

--- a/project-plans/issue3299/plan.md
+++ b/project-plans/issue3299/plan.md
@@ -127,6 +127,17 @@ The two implementation-review rounds and two local OCR rounds produced the follo
 | A post-review read-only inspection found that a scheduled-state helper accepted a caller-provided zero and asserted it unchanged. | **In-scope-Fix** | Removed the parameter and tautological assertion. The tests continue to assert emitted scheduler state and the real per-tool execution counters before and after cancellation. |
 | Bun can leak a mocked `node:fs/promises` module between core policy test files in one process. | **Defer** | The failure reproduces on the base commit and the policy suite passes with process isolation. Changing Bun test isolation is outside AC1 through AC6. |
 
+### PR finding triage
+
+| Finding | Classification | Resolution |
+| --- | --- | --- |
+| CodeRabbit requested an `UPDATE_POLICY` publication before foreground bootstrap as a negative control. | **In-scope-Fix** | The bootstrap test now publishes before startup and observes `ASK_USER`, then publishes after startup and observes `ALLOW` for the matching tool. |
+| CodeRabbit's aggregate docstring-coverage check requested comments on touched test helpers and the short cancellation handler. | **Reject** | The repository favors sparse comments that explain non-obvious intent. Adding docstrings to direct test fixtures and a private three-line handler would not strengthen AC1 through AC6. |
+| LLxprt PR Review reported that `project-plans/issue3299/plan.md` was missing from the change. | **Reject** | The file is present in commit `6466ca638` and in the PR's five-file diff. |
+| The CI OCR comment reported 0/4 changed-file coverage while also reporting no findings. | **Reject** | The review artifact and detached exact-range OCR manifest both show all four eligible code files completed. No code change follows from the inconsistent coverage summary. |
+
+The CI PR OCR and one detached exact-range PR OCR completed with no code findings. These are the two permitted PR OCR rounds; no further PR OCR round is permitted.
+
 ## Local verification record
 
 - Final focused behavior command: `bun test packages/agents/src/core/coreToolScheduler.issue3299.test.ts packages/cli/src/cliAgentBootstrap.test.ts` passed 15 tests with 69 assertions.

--- a/project-plans/issue3299/plan.md
+++ b/project-plans/issue3299/plan.md
@@ -1,0 +1,138 @@
+# Issue #3299: Restore policy updates and complete mixed approval batches
+
+## Scope
+
+This issue fixes two approval-flow failures and no adjacent behavior:
+
+1. The foreground CLI must subscribe its session policy engine to `UPDATE_POLICY` messages on the Agent-owned session bus.
+2. Cancelling an awaiting call must re-evaluate a mixed batch so approved siblings are not left in `scheduled` forever.
+
+The existing policy rule format, persistence format, confirmation UI, shell-tool allowlist, and batch execution policy remain unchanged.
+
+## Accepted behavior
+
+### AC1: Foreground CLI policy updates use the live session objects
+
+**Given** the foreground CLI has created an Agent from a Config with a policy engine,
+**when** the Agent is returned from `createForegroundAgent`,
+**then** `createPolicyUpdater` is attached to that Config policy engine and the exact MessageBus exposed by `agent.getMessageBus()`.
+
+Behavioral proof:
+
+- Before startup wiring, an `UPDATE_POLICY` message for a tool does not change the engine's decision.
+- After foreground Agent creation, publishing that message changes the matching tool decision to `ALLOW`.
+- An unrelated tool remains governed by its prior decision.
+
+Boundary: do not construct a second MessageBus or policy engine. Missing required runtime objects are startup contract violations and must not be swallowed.
+
+### AC2: “Allow for this session” affects a later matching call
+
+**Given** a policy-bus tool initially requires confirmation,
+**when** its first call is approved with `ProceedAlways` and publishes a non-persistent policy update,
+**then** a later matching call in the same session executes without another confirmation request.
+
+Boundaries:
+
+- `ProceedOnce` remains limited to the current call.
+- The dynamic rule remains scoped by the existing `toolName`, `argsPattern`, and `commandPrefix` semantics.
+- The change does not replace or modify the shell tool's instance allowlist.
+
+### AC3: “Allow for all future sessions” reaches existing persistence
+
+**Given** a policy-bus tool publishes `UPDATE_POLICY` with `persist: true`,
+**when** the foreground subscriber receives it,
+**then** the dynamic rule applies immediately and the existing `persistPolicyToToml` path writes the rule for later sessions.
+
+Proof is compositional: the new startup integration test proves the live subscriber is installed; existing core persistence tests prove a persistent update received by that subscriber writes the TOML rule. No persistence format or file-handling change is in scope.
+
+### AC4: Cancelling the last awaiting call releases approved siblings
+
+**Given** one or more calls in a batch are `scheduled` after approval and one call remains `awaiting_approval`,
+**when** the remaining awaiting call is cancelled,
+**then** the cancelled call reaches `cancelled`, every scheduled sibling executes, and `onAllToolCallsComplete` receives a batch in which every call has exactly one terminal status (`success`, `error`, or `cancelled`).
+
+### AC5: Cancelling before the last decision does not start the batch early
+
+**Given** a batch contains a scheduled call and at least two awaiting calls,
+**when** one awaiting call is cancelled but another still awaits a decision,
+**then** the scheduled call remains gated. Once the final awaiting call is cancelled, the scheduled call executes and the batch completes.
+
+This preserves the existing all-decisions-before-execution behavior.
+
+### AC6: Compatible ProceedAlways cascades still complete after an incompatible sibling is cancelled
+
+**Given** `ProceedAlways` schedules compatible pending siblings while an incompatible call remains awaiting approval,
+**when** the incompatible call is cancelled,
+**then** all scheduled compatible calls execute, the incompatible call remains cancelled, and the batch completion callback fires with terminal states for all calls.
+
+## Test-first implementation
+
+1. Add a failing foreground-bootstrap test using a real policy engine and MessageBus. Publish `UPDATE_POLICY` through the Agent-exposed bus and observe policy decisions.
+2. Add a failing sequential scheduler test for a policy-bus tool: first call uses `ProceedAlways`; the later matching call does not prompt.
+3. Add failing scheduler tests for AC4 through AC6 using the real `CoreToolScheduler` state machine.
+4. Wire `createPolicyUpdater` in `createForegroundAgent` after successful Agent construction, using `config.getPolicyEngine()` and `agent.getMessageBus()`.
+5. After cancellation changes the call to `cancelled`, invoke the scheduler's existing execution attempt with that call's signal. The existing scheduler gate decides whether awaiting calls remain.
+
+## Out of scope
+
+- Confirmation-dialog UI changes.
+- New policy rule types, priorities, persistence files, or settings.
+- Changes to shell command allowlisting.
+- Refactoring Agent, MessageBus, policy-engine, or scheduler ownership.
+- New public abstractions, dependencies, workflows, quality-tool configuration, or agent memory.
+- Cancellation semantics outside an awaiting approval response.
+
+## Finding triage
+
+Every review finding will be classified as:
+
+- **Blocker-Fix**: breaks an accepted behavior, safety requirement, build, or required gate.
+- **In-scope-Fix**: defect in code or tests changed for AC1 through AC6.
+- **Reject**: factually incorrect, already covered, or would weaken a requirement.
+- **Defer**: valid work outside AC1 through AC6. Record it without implementing it in this PR.
+
+Review suggestions do not expand scope. Adding a subsystem, public abstraction, dependency, workflow, agent-memory change, quality-tool change, or unrelated refactor requires user approval.
+
+## Completion gates
+
+- Focused tests for AC1, AC2, AC4, AC5, and AC6 pass. AC3 is covered by the startup integration plus existing core persistence behavior tests.
+- Changed tests introduce no new test-audit findings.
+- Run the complete `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, and `npm run build` cycle on the candidate head.
+- Run the `stepfun-37` smoke test and record any external provider failure without treating it as a code pass.
+- Complete implementation review and no more than two local OCR rounds; classify every finding and resolve all Blocker-Fix and In-scope-Fix findings.
+- Require passing PR CI, classified CodeRabbit findings, a conflict-free PR, and ancestry based on the intended `main` head before declaring completion.
+
+## Review triage record
+
+The two implementation-review rounds and two local OCR rounds produced the following findings. No further local review round is permitted for this issue.
+
+| Finding | Classification | Resolution |
+| --- | --- | --- |
+| The initial tests did not exercise a later matching scheduler call after `ProceedAlways`. | **In-scope-Fix** | Added a real `CoreToolScheduler`, policy engine, MessageBus, and adapter test that confirms the first call and observes the later call execute without another confirmation. |
+| `ProceedOnce` and unrelated-tool boundaries were not explicit. | **In-scope-Fix** | Added behavioral assertions that a later matching `ProceedOnce` call prompts again and an unrelated tool remains awaiting approval. |
+| The bootstrap call lacked mutation-sensitive behavioral coverage. | **Blocker-Fix** | Added a real engine/bus test. Removing the updater call changes the expected decision from `ALLOW` to `ASK_USER` and fails the test. |
+| A proposed single test would need to traverse the CLI package and the agents scheduler package. | **Reject** | The production boundary is covered compositionally: the bootstrap test proves subscription on the exact live objects, and the agents test proves subsequent scheduler behavior. A cross-layer test harness or public abstraction would duplicate package internals without adding a new accepted behavior. |
+| Status polling could accept missing or historical snapshots. | **Blocker-Fix** | Polling now throws until the latest emitted snapshot for the call has the requested status, and its generic return type narrows to that state. |
+| AC5 and AC6 survived an unconditional scheduler-gate mutation. | **Blocker-Fix** | Replaced historical-state checks with latest-state and execution-side-effect assertions. The gate mutation now fails AC4 through AC6. |
+| Completion and execution callback cardinality were under-specified. | **In-scope-Fix** | Tests assert one batch completion, terminal states for every call, and exactly one execution per eligible tool. |
+| Scheduler instances were not disposed. | **In-scope-Fix** | Added shared `afterEach` disposal for every test harness scheduler. |
+| Tests built duplicate registries or tool instances. | **In-scope-Fix** | Each harness now creates one registry and one tool set shared by Config and scheduler. |
+| Bootstrap fixtures could pair a replacement Config with a stale fake-Agent bus. | **In-scope-Fix** | Added a fixture installer that replaces Config, engine, bus, and fake Agent together. |
+| New tests used avoidable type assertions and an execute-function reassignment. | **In-scope-Fix** | Removed the reassignment and private-field assertions. Remaining `Config` and `ToolRegistry` assertions are fixture boundaries for large repository interfaces and follow adjacent test patterns. |
+| Cancellation through a bus response whose details no longer contain `onConfirm` lacked behavioral coverage. | **In-scope-Fix** | Added a real scheduler test that removes the callback after routing, sends the real bus response, and observes cancellation, sibling execution, and batch completion. |
+| A mock-only malformed-details coordinator test asserted calls rather than behavior. | **In-scope-Fix** | Removed it after the test-audit scanner flagged `MOCK_ONLY_ORACLE`; the real scheduler scenario replaces it. |
+| A rejection test duplicated existing startup-failure behavior and did not prove updater behavior. | **In-scope-Fix** | Kept the existing startup rejection test and removed the redundant test. |
+| Changed tests had lint/typecheck failures and a production comment misspelled `UPDATE_POLICY`. | **Blocker-Fix** | Corrected the code and tests; focused lint and repository typecheck pass. |
+| The issue test contained excessive narration. | **In-scope-Fix** | Retained comments that explain the real integration setup, serialization boundary, latest-state checks, or fixture boundaries. |
+| A post-review read-only inspection found that a scheduled-state helper accepted a caller-provided zero and asserted it unchanged. | **In-scope-Fix** | Removed the parameter and tautological assertion. The tests continue to assert emitted scheduler state and the real per-tool execution counters before and after cancellation. |
+| Bun can leak a mocked `node:fs/promises` module between core policy test files in one process. | **Defer** | The failure reproduces on the base commit and the policy suite passes with process isolation. Changing Bun test isolation is outside AC1 through AC6. |
+
+## Local verification record
+
+- Final focused behavior command: `bun test packages/agents/src/core/coreToolScheduler.issue3299.test.ts packages/cli/src/cliAgentBootstrap.test.ts` passed 15 tests with 69 assertions.
+- Full `npm run lint`, `npm run typecheck`, `npm run format`, and `npm run build` passed on the candidate. Formatting changed only the issue-specific scheduler test, after which the focused 15-test command, `npm run lint:changed`, and `git diff --check` passed again.
+- The final changed-test audit reports no finding for `coreToolScheduler.issue3299.test.ts`. Its only match in `cliAgentBootstrap.test.ts` is the pre-existing cleanup-registration test's `MOCK_ONLY_ORACLE`; the new policy-update test introduces no audit finding.
+- A complete default-concurrency `npm run test` passed every non-agents workspace and 376 of 377 agents files. The only failure was the first test in `agent.approvalMode.behavior.test.ts`, which reached its existing 180-second timeout; the file passed rapidly when run alone with the agents test preload and working directory.
+- A serialized agents retry reproduced unrelated 180-second first-test timeouts in `agent.approvalMode.behavior.test.ts` and `hookAdmin.behavior.test.ts`. The retry was stopped after it could no longer produce a passing root command and began repeating the same loaded-machine failure pattern. No changed scheduler or CLI bootstrap test failed in any full or focused run.
+- The required `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"` smoke reached the StepFun provider but returned HTTP 400, `you have no active step plan subscription`. This is an external account blocker, not a passing smoke result.
+- Two implementation-review rounds and two local OCR rounds are complete. The table above records every finding and disposition; no further local review round is permitted.


### PR DESCRIPTION
## TLDR

This PR restores the missing foreground subscriber for policy updates and re-drives scheduler execution after an awaiting tool call is cancelled.

`ProceedAlways` now affects later matching policy-bus calls in the same session. `ProceedAlwaysAndSave` reaches the existing persistence subscriber. In mixed batches, cancelling the final waiting sibling releases approved calls instead of leaving them scheduled indefinitely.

## Dive Deeper

Foreground Agent construction now calls `createPolicyUpdater` with `config.getPolicyEngine()` and the exact MessageBus returned by `agent.getMessageBus()`. It does not create replacement runtime objects or change policy formats, priorities, or persistence behavior.

`ConfirmationCoordinator` now passes the call's existing `AbortSignal` into cancellation handling. After marking the call cancelled, it invokes the scheduler's existing execution attempt. The scheduler's current all-decisions gate continues to prevent premature execution while any sibling still awaits approval.

Behavioral coverage uses real `PolicyEngine`, `MessageBus`, `CoreMessageBusAdapter`, and `CoreToolScheduler` instances. It covers:

- foreground startup wiring on the Agent-owned bus;
- a later matching call after `ProceedAlways`;
- `ProceedOnce` remaining call-local and unrelated tools remaining gated;
- release of scheduled siblings after the final cancellation;
- continued gating while another decision is pending;
- compatible `ProceedAlways` cascades with an incompatible cancelled sibling;
- cancellation through serialized confirmation details that no longer contain `onConfirm`.

The accepted criteria, scope boundaries, review triage, and local evidence are recorded in `project-plans/issue3299/plan.md`.

## Reviewer Test Plan

1. Run `bun test packages/agents/src/core/coreToolScheduler.issue3299.test.ts packages/cli/src/cliAgentBootstrap.test.ts`.
2. Run `npm run lint`, `npm run typecheck`, and `npm run build`.
3. In an interactive CLI session, approve an `activate_skill` call with **Allow for this session**, then issue the same call again and confirm that it does not prompt.
4. Exercise a mixed batch with one approved call and one awaiting call; cancel the final waiter and confirm that the approved call runs and the batch completes.

## Testing Matrix

|          | 🍏 | 🪟 | 🐧 |
| -------- | --- | --- | --- |
| npm run  | ⚠️ | ❓ | ❓ |
| npx      | ❓ | ❓ | ❓ |
| Docker   | ❓ | ❓ | ❓ |
| Podman   | ❓ | - | - |
| Seatbelt | ❓ | - | - |

macOS results:

- Focused issue tests: 15 passed, 0 failed, 69 assertions.
- Full `npm run lint`, `npm run typecheck`, `npm run format`, and `npm run build`: passed.
- Changed-test audit: no new finding in either changed test; the one reported CLI finding belongs to a pre-existing cleanup test.
- Complete default-concurrency `npm run test`: every non-agents workspace passed; agents passed 376 of 377 files. The first test in `agent.approvalMode.behavior.test.ts` hit its existing 180-second timeout, then passed rapidly in isolation with the agents test preload. A serialized retry reproduced unrelated first-test timeout behavior in that file and `hookAdmin.behavior.test.ts`. No changed scheduler or bootstrap test failed.
- Required `stepfun-37` smoke: reached the provider but was externally blocked by HTTP 400, `you have no active step plan subscription`. This is not reported as a passing smoke result.

## Linked issues / bugs

Fixes #3299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Policy changes made during an agent session now take effect consistently for subsequent matching actions while preserving unrelated policies.
  * “Allow once” approvals remain limited to the current action.
  * Improved cancellation handling so approved actions continue appropriately when other pending approvals are cancelled.
  * Confirmation responses now resume execution reliably, with completion reported only once.

* **Tests**
  * Added coverage for policy updates, cancellation scenarios, mixed approval batches, and serialized confirmations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->