### PR TITLE
State the Windows background-job lifetime contract and assert it in CI (Fixes #3321)

### DIFF
--- a/docs/tools/shell.md
+++ b/docs/tools/shell.md
@@ -48,6 +48,13 @@ On Windows, background jobs are launched via PowerShell `Start-Process`:
 - Exit-code propagation relies on caching the process handle before waiting
   (`$null = $p.Handle` → `$p.WaitForExit()` → `$p.ExitCode`).
 
+On an ordinary Windows session, a background job keeps running after the LLxprt
+process that started it exits. That is not guaranteed in every environment: when
+LLxprt runs inside a Windows job object that terminates its processes when the
+job closes, the background job is torn down along with LLxprt. This has been
+observed on GitHub Actions Windows runners. Treat survival past the LLxprt
+process as environment dependent rather than as a guarantee.
+
 To **cancel** a Windows background job, use `check_async_tasks` with
 `action: 'cancel'`, or `taskkill /T /F /PID <pid>` from a shell (the `pid` is
 available from `check_async_tasks` with `action: 'peek'`). The `/T` flag ensures

--- a/packages/core/src/services/shellJobSpawn.ts
+++ b/packages/core/src/services/shellJobSpawn.ts
@@ -215,10 +215,6 @@ function spawnWithNodeChildProcess(
   };
 }
 
-// spawn('powershell.exe', [...], { detached: true }) NEVER executes the
-// command on Windows (exits 0 with empty output). The outer process is
-// therefore spawned WITHOUT detached:true and unref()'d instead.
-
 /**
  * Escape a value for safe interpolation into a PowerShell single-quoted
  * string literal. Every embedded single quote is doubled (`'` → `''`) and the
@@ -282,11 +278,42 @@ export function buildWindowsBackgroundBootstrap(
 /**
  * Spawn a Windows background job using Start-Process semantics.
  *
- * The outer PowerShell process is spawned WITHOUT `detached: true` (which is
- * broken on Windows — see file header) with all stdio ignored, then immediately
- * unreferenced so background work cannot keep the parent event loop alive. Its
- * exit listener continues to observe completion. The inner command runs via
- * Start-Process with -EncodedCommand, writing stdout and stderr to separate logs.
+ * The outer PowerShell process is spawned WITHOUT `detached: true`, with all
+ * stdio ignored, then immediately unreferenced so background work cannot keep
+ * the parent event loop alive. Its exit listener continues to observe
+ * completion. The inner command runs via Start-Process with -EncodedCommand,
+ * writing stdout and stderr to separate logs.
+ *
+ * Why not `detached: true`: spawning `powershell.exe` (or `pwsh`) with
+ * `detached: true` was observed to exit 0 with empty output without ever
+ * running the command, so the flag is unusable here. The outer process is
+ * therefore spawned normally and `unref()`'d instead, which removes it from
+ * the parent's reference count. Note that `detached` is not a job-object
+ * breakaway on Windows: it does not request `CREATE_BREAKAWAY_FROM_JOB`, so it
+ * would not by itself change the lifetime described below.
+ *
+ * Lifetime contract, stated as observed rather than as a guarantee:
+ *
+ * - On an ordinary Windows session the background tree keeps running after the
+ *   process that spawned it exits. Windows does not kill children when a
+ *   parent exits.
+ * - Inside the GitHub Actions Windows runner the tree does NOT survive: the
+ *   outer PowerShell is gone immediately after the spawner exits and the inner
+ *   command never produces output. See the evidence recorded in
+ *   shellJobWindowsSpawn.test.ts.
+ *
+ * The leading explanation for the second case is that the runner contains the
+ * job in a Windows job object that terminates its processes when the job
+ * closes, and this child, not having broken away, is inside it. That has not
+ * been confirmed: identifying the owning job and its limit flags needs
+ * `IsProcessInJob` and `QueryInformationJobObject`, which are native Win32
+ * calls. Callers should treat survival past the spawner as environment
+ * dependent. Issue #3321.
+ *
+ * Breaking out of a containing job was considered and rejected.
+ * `CREATE_BREAKAWAY_FROM_JOB` is not exposed by `node:child_process.spawn` or
+ * `Bun.spawn` options, and it takes effect only when the containing job
+ * permits breakaway. Using it would require native Win32 calls.
  *
  * The returned `pid` is the outer PowerShell PID; `taskkill /T /F /PID <pid>`
  * reliably reaps the entire process tree.

--- a/packages/core/src/services/shellJobWindowsSpawn.test.ts
+++ b/packages/core/src/services/shellJobWindowsSpawn.test.ts
@@ -96,6 +96,51 @@ function isPidAlive(pid: number): boolean {
 }
 
 /**
+ * Run `body`, then always reap the PIDs reported by `getPids` and remove `dir`.
+ *
+ * A bare `finally` calling cleanup directly would let a cleanup throw REPLACE
+ * an in-flight assertion failure. These assertions carry an evidence string
+ * that is the only diagnosis available for a Windows-only failure, so losing it
+ * is expensive.
+ *
+ * Cleanup errors are deliberately NOT swallowed: reapAndRemoveWindowsTestDir is
+ * the fail-fast gate that catches leaked PowerShell processes and undeletable
+ * log directories. When the body and cleanup both fail, both are reported via
+ * AggregateError, matching disposeAndCleanupWindowsTest.
+ *
+ * `getPids` is a callback rather than an array because the PIDs are discovered
+ * while the body runs.
+ */
+async function withWindowsProcessCleanup(
+  dir: string,
+  getPids: () => readonly number[],
+  body: () => Promise<void>,
+): Promise<void> {
+  let bodyError: unknown;
+  try {
+    await body();
+  } catch (error) {
+    bodyError = error;
+  }
+
+  try {
+    await reapAndRemoveWindowsTestDir(dir, null, getPids());
+  } catch (cleanupError) {
+    if (bodyError !== undefined) {
+      throw new AggregateError(
+        [bodyError, cleanupError],
+        'Test body and Windows process cleanup both failed',
+      );
+    }
+    throw cleanupError;
+  }
+
+  if (bodyError !== undefined) {
+    throw bodyError;
+  }
+}
+
+/**
  * Read the tail of a redirected log for the evidence string. A missing or
  * unreadable log is rendered as `<unreadable: <error>>` rather than
  * thrown, so the evidence can still accompany whatever assertion failed.
@@ -457,50 +502,52 @@ describe.skipIf(!isWindows || availablePowerShellExes.length === 0)(
       const logPath = path.join(aliveDir, 'out.log');
       const errLogPath = path.join(aliveDir, 'err.log');
       const innerPidFilePath = path.join(aliveDir, 'inner.pid');
-      // Declared before the try so the finally can reap them even if setup throws.
+      // Declared before the body so cleanup can reap them even if setup throws.
       let outerPid = 0;
       let innerPid = 0;
-      try {
-        fs.writeFileSync(logPath, '');
-        fs.writeFileSync(errLogPath, '');
+      await withWindowsProcessCleanup(
+        aliveDir,
+        () => [outerPid, innerPid],
+        async () => {
+          fs.writeFileSync(logPath, '');
+          fs.writeFileSync(errLogPath, '');
 
-        const managedCommand = buildInnerPidMarkerCommand(
-          innerPidFilePath,
-          UNREF_SLEEP_SECONDS,
-        );
-        const spawned = spawnWindowsBackground(
-          getPowerShellExecutable(),
-          managedCommand,
-          aliveDir,
-          { ...process.env },
-          logPath,
-          errLogPath,
-        );
-        outerPid = spawned.pid ?? 0;
-        expect(
-          outerPid,
-          `spawnWindowsBackground returned no outer pid (${String(spawned.pid)})`,
-        ).toBeGreaterThan(0);
-        // Let it throw on timeout (fail fast, no swallow): a missing marker
-        // means the bootstrap never reached Start-Process. Assigned inside the try
-        // so a partial read still reaches the finally.
-        innerPid = await readInnerPidFromMarker(innerPidFilePath, 15000);
+          const managedCommand = buildInnerPidMarkerCommand(
+            innerPidFilePath,
+            UNREF_SLEEP_SECONDS,
+          );
+          const spawned = spawnWindowsBackground(
+            getPowerShellExecutable(),
+            managedCommand,
+            aliveDir,
+            { ...process.env },
+            logPath,
+            errLogPath,
+          );
+          outerPid = spawned.pid ?? 0;
+          expect(
+            outerPid,
+            `spawnWindowsBackground returned no outer pid (${String(spawned.pid)})`,
+          ).toBeGreaterThan(0);
+          // Let it throw on timeout (fail fast, no swallow): a missing marker
+          // means the bootstrap never reached Start-Process. Assigned before the
+          // assertions so a partial read still reaches cleanup.
+          innerPid = await readInnerPidFromMarker(innerPidFilePath, 15000);
 
-        // Both PIDs must be alive at the same moment. The bare booleans below
-        // say nothing about WHY a process died, and this only reproduces on
-        // Windows, so carry the evidence into the assertion message: an early exit
-        // lands in the redirected logs, making a Windows-only failure diagnosable
-        // from the CI log.
-        const evidence =
-          `outerPid=${outerPid} innerPid=${innerPid}\n` +
-          `${readLogTail('stdout log', logPath)}\n` +
-          `${readLogTail('stderr log', errLogPath)}`;
+          // Both PIDs must be alive at the same moment. The bare booleans below
+          // say nothing about WHY a process died, and this only reproduces on
+          // Windows, so carry the evidence into the assertion message: an early
+          // exit lands in the redirected logs, making a Windows-only failure
+          // diagnosable from the CI log.
+          const evidence =
+            `outerPid=${outerPid} innerPid=${innerPid}\n` +
+            `${readLogTail('stdout log', logPath)}\n` +
+            `${readLogTail('stderr log', errLogPath)}`;
 
-        expect(isPidAlive(outerPid), evidence).toBe(true);
-        expect(isPidAlive(innerPid), evidence).toBe(true);
-      } finally {
-        await reapAndRemoveWindowsTestDir(aliveDir, null, [outerPid, innerPid]);
-      }
+          expect(isPidAlive(outerPid), evidence).toBe(true);
+          expect(isPidAlive(innerPid), evidence).toBe(true);
+        },
+      );
     }, 60_000);
 
     interface UnrefFixtureRun {
@@ -515,7 +562,7 @@ describe.skipIf(!isWindows || availablePowerShellExes.length === 0)(
      * Spawn a subprocess that calls spawnWindowsBackground and exits without
      * waiting, then hand the observations to `assertRun`.
      *
-     * Both PID markers are read before `assertRun` runs, so the `finally` reaps
+     * Both PID markers are read before `assertRun` runs, so cleanup reaps
      * whichever PIDs were recovered even when an assertion fails, and removes
      * the fixture directory. Setup that throws before the fixture is spawned
      * has no process to reap, so removing the directory is sufficient there.
@@ -531,89 +578,91 @@ describe.skipIf(!isWindows || availablePowerShellExes.length === 0)(
       const innerPidFilePath = path.join(unrefDir, 'inner.pid');
       let outerPid = 0;
       let innerPid = 0;
-      try {
-        fs.writeFileSync(logPath, '');
-        fs.writeFileSync(errLogPath, '');
+      await withWindowsProcessCleanup(
+        unrefDir,
+        () => [outerPid, innerPid],
+        async () => {
+          fs.writeFileSync(logPath, '');
+          fs.writeFileSync(errLogPath, '');
 
-        const modulePath = path
-          .join(__dirname, 'shellJobSpawn.ts')
-          .replace(/\\/g, '/');
-        const powershellExe = getPowerShellExecutable();
-        const managedCommand = buildInnerPidMarkerCommand(
-          innerPidFilePath,
-          UNREF_SLEEP_SECONDS,
-        );
-        // The script does NOT manually call p.child.unref(): production code
-        // (spawnWindowsBackground) already unrefs immediately at spawn. If that
-        // production contract regresses, the spawner will hang and the
-        // status=0 assertion in the unref test will fail.
-        const script = [
-          `import { spawnWindowsBackground } from '${modulePath}';`,
-          `const p = spawnWindowsBackground(`,
-          `  ${JSON.stringify(powershellExe)},`,
-          `  ${JSON.stringify(managedCommand)},`,
-          `  ${JSON.stringify(os.tmpdir())},`,
-          `  { ...process.env },`,
-          `  ${JSON.stringify(logPath)},`,
-          `  ${JSON.stringify(errLogPath)},`,
-          `);`,
-          `require('fs').writeFileSync(${JSON.stringify(outerPidFilePath)}, String(p.pid));`,
-        ].join('\n');
+          const modulePath = path
+            .join(__dirname, 'shellJobSpawn.ts')
+            .replace(/\\/g, '/');
+          const powershellExe = getPowerShellExecutable();
+          const managedCommand = buildInnerPidMarkerCommand(
+            innerPidFilePath,
+            UNREF_SLEEP_SECONDS,
+          );
+          // The script does NOT manually call p.child.unref(): production code
+          // (spawnWindowsBackground) already unrefs immediately at spawn. If
+          // that production contract regresses, the spawner will hang and the
+          // status=0 assertion in the unref test will fail.
+          const script = [
+            `import { spawnWindowsBackground } from '${modulePath}';`,
+            `const p = spawnWindowsBackground(`,
+            `  ${JSON.stringify(powershellExe)},`,
+            `  ${JSON.stringify(managedCommand)},`,
+            `  ${JSON.stringify(os.tmpdir())},`,
+            `  { ...process.env },`,
+            `  ${JSON.stringify(logPath)},`,
+            `  ${JSON.stringify(errLogPath)},`,
+            `);`,
+            `require('fs').writeFileSync(${JSON.stringify(outerPidFilePath)}, String(p.pid));`,
+          ].join('\n');
 
-        fs.writeFileSync(scriptPath, script);
+          fs.writeFileSync(scriptPath, script);
 
-        const start = Date.now();
-        // Execute the fixture with the current Bun executable
-        // (process.execPath), not npx/tsx/Node: spawnWindowsBackground's
-        // production-unref contract is exercised by the runtime that will
-        // actually run it, which is Bun. Using npx/tsx/Node would prove
-        // nothing about production behavior.
-        const result = spawnSync(process.execPath, [scriptPath], {
-          timeout: UNREF_SPAWN_TIMEOUT_MS,
-          encoding: 'utf8',
-          shell: false,
-        });
-        const elapsed = Date.now() - start;
+          const start = Date.now();
+          // Execute the fixture with the current Bun executable
+          // (process.execPath), not npx/tsx/Node: spawnWindowsBackground's
+          // production-unref contract is exercised by the runtime that will
+          // actually run it, which is Bun. Using npx/tsx/Node would prove
+          // nothing about production behavior.
+          const result = spawnSync(process.execPath, [scriptPath], {
+            timeout: UNREF_SPAWN_TIMEOUT_MS,
+            encoding: 'utf8',
+            shell: false,
+          });
+          const elapsed = Date.now() - start;
 
-        // Capture marker PIDs BEFORE assertions so cleanup in finally always
-        // has the known PIDs even if an assertion throws.
-        try {
-          outerPid = await readInnerPidFromMarker(outerPidFilePath, 10000);
-        } catch {
-          // Marker may not exist if spawn failed before writing it.
-        }
-        try {
-          innerPid = await readInnerPidFromMarker(innerPidFilePath, 10000);
-        } catch {
-          // Inner process may not have started yet.
-        }
+          // Capture marker PIDs BEFORE assertions so cleanup always has the
+          // known PIDs even if an assertion throws.
+          try {
+            outerPid = await readInnerPidFromMarker(outerPidFilePath, 10000);
+          } catch {
+            // Marker may not exist if spawn failed before writing it.
+          }
+          try {
+            innerPid = await readInnerPidFromMarker(innerPidFilePath, 10000);
+          } catch {
+            // Inner process may not have started yet.
+          }
 
-        // The callers' assertions are bare numbers and booleans that say
-        // nothing about WHY a process died, and this only reproduces on a
-        // Windows runner, so every assertion carries this evidence string: the
-        // outer PowerShell only exits early if its inner Start-Process failed,
-        // and that failure lands in the redirected logs.
-        const evidence =
-          `outerPid=${outerPid} innerPid=${innerPid} elapsed=${elapsed}ms ` +
-          `status=${result.status}\n` +
-          `${readLogTail('stdout log', logPath)}\n` +
-          `${readLogTail('stderr log', errLogPath)}\n` +
-          `spawner stdout: ${JSON.stringify(result.stdout.slice(-500))}\n` +
-          `spawner stderr: ${JSON.stringify(result.stderr.slice(-500))}`;
+          // The callers' assertions are bare numbers and booleans that say
+          // nothing about WHY a process died, and this only reproduces on a
+          // Windows runner, so every assertion carries this evidence string:
+          // the outer PowerShell only exits early if its inner Start-Process
+          // failed, and that failure lands in the redirected logs.
+          const evidence =
+            `outerPid=${outerPid} innerPid=${innerPid} elapsed=${elapsed}ms ` +
+            `status=${result.status}\n` +
+            `${readLogTail('stdout log', logPath)}\n` +
+            `${readLogTail('stderr log', errLogPath)}\n` +
+            `spawner stdout: ${JSON.stringify(result.stdout.slice(-500))}\n` +
+            `spawner stderr: ${JSON.stringify(result.stderr.slice(-500))}`;
 
-        debugLogger.debug(
-          `[shellJobWindowsSpawn.test] unref subprocess exited in ${elapsed}ms (status ${result.status})`,
-        );
+          debugLogger.debug(
+            `[shellJobWindowsSpawn.test] unref subprocess exited in ${elapsed}ms (status ${result.status})`,
+          );
 
-        assertRun({
-          status: result.status,
-          outerPid,
-          innerPid,
-          evidence,
-        });
-      } finally {
-        await reapAndRemoveWindowsTestDir(unrefDir, null, [outerPid, innerPid]);
-      }
+          assertRun({
+            status: result.status,
+            outerPid,
+            innerPid,
+            evidence,
+          });
+        },
+      );
     }
 
     // status 0 is the deterministic regression signal: it proves the spawner

--- a/packages/core/src/services/shellJobWindowsSpawn.test.ts
+++ b/packages/core/src/services/shellJobWindowsSpawn.test.ts
@@ -56,9 +56,35 @@ const UNREF_SPAWN_TIMEOUT_MS = 25000;
 const RUN_AND_WAIT_TIMEOUT_MS = 15_000;
 
 /**
+ * Whether the current environment tears down the background process tree when
+ * the spawner exits, making the survives-the-spawner half of the contract
+ * unassertable.
+ *
+ * Observed on the nightly Windows runner:
+ *
+ *   outerPid=2936 innerPid=0 elapsed=56ms status=0
+ *   stdout log: ""  stderr log: ""  spawner stdout: ""  spawner stderr: ""
+ *
+ * The spawner exited cleanly in 56ms having produced an outer PID (the unref
+ * half working), but by assertion time that PID was gone, no inner PID marker
+ * had been observed, and neither redirected log had been written. The leading
+ * explanation is a Windows job object owned by the runner that terminates its
+ * processes when the job closes; that has not been confirmed, because
+ * identifying the owning job and its limit flags needs native Win32 calls
+ * (IsProcessInJob / QueryInformationJobObject) reachable from neither Node nor
+ * Bun.
+ *
+ * `CI` is therefore a deliberately broad proxy rather than a precise signal.
+ * It is broad on purpose: any CI environment may impose the same containment,
+ * and skipping a contract we cannot assert is preferable to a false failure.
+ * Issue #3321.
+ */
+const SPAWNER_EXIT_KILLS_TREE = process.env.CI !== undefined;
+
+/**
  * Check whether a PID is alive using signal 0 (works on both Windows and
- * POSIX). Used to verify the unref contract: the background process survives
- * the spawner's exit.
+ * POSIX). Used to verify the background tree's lifetime: that it is running
+ * while the spawner lives, and that it survives the spawner's exit.
  */
 function isPidAlive(pid: number): boolean {
   try {
@@ -66,6 +92,19 @@ function isPidAlive(pid: number): boolean {
     return true;
   } catch {
     return false;
+  }
+}
+
+/**
+ * Read the tail of a redirected log for the evidence string. A missing or
+ * unreadable log is rendered as `<unreadable: <error>>` rather than
+ * thrown, so the evidence can still accompany whatever assertion failed.
+ */
+function readLogTail(label: string, at: string): string {
+  try {
+    return `${label}: ${JSON.stringify(fs.readFileSync(at, 'utf8').slice(-500))}`;
+  } catch (error: unknown) {
+    return `${label}: <unreadable: ${String(error)}>`;
   }
 }
 
@@ -410,137 +449,202 @@ describe.skipIf(!isWindows || availablePowerShellExes.length === 0)(
       await awaitBoundedExit(spawned);
     });
 
-    // Skipped under CI, not on Windows generally.
-    //
-    // This asserts that the background tree OUTLIVES the spawner. Evidence
-    // from the nightly runner:
-    //
-    //   outerPid=2936 innerPid=0 elapsed=56ms status=0
-    //   stdout log: ""  stderr log: ""  spawner stdout: ""  spawner stderr: ""
-    //
-    // The spawner exited in 56ms having produced an outer PID, and by the time
-    // the assertion ran that PID was gone, the inner had never started, and
-    // nothing was written to either redirected log. That is the CI runner's
-    // job object tearing down the process tree when the spawner exits
-    // (JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE). spawnWindowsBackground
-    // deliberately does not pass `detached: true` (see the file header: it is
-    // broken on Windows), so the child stays inside the parent's job.
-    //
-    // A developer's Windows machine has no such job object and the tree does
-    // survive, so the contract is still exercised there. Tracked in #3321.
-    it.skipIf(process.env.CI !== undefined)(
-      'does not keep the spawner alive (production unref)',
-      async () => {
-        const unrefDir = fs.mkdtempSync(path.join(os.tmpdir(), 'win-unref-'));
-        const logPath = path.join(unrefDir, 'out.log');
-        const errLogPath = path.join(unrefDir, 'err.log');
-        const scriptPath = path.join(unrefDir, 'spawn-exit.ts');
-        const outerPidFilePath = path.join(unrefDir, 'outer.pid');
-        const innerPidFilePath = path.join(unrefDir, 'inner.pid');
-        let outerPid = 0;
-        let innerPid = 0;
+    // This asserts the tree's lifetime while this test process (the spawner) is
+    // still running, so it is unaffected by a kill-on-close job object and runs
+    // in CI (issue #3321). Only the spawner's own exit triggers that teardown.
+    it('keeps the outer and inner PowerShell alive while the spawner is running', async () => {
+      const aliveDir = fs.mkdtempSync(path.join(os.tmpdir(), 'win-alive-'));
+      const logPath = path.join(aliveDir, 'out.log');
+      const errLogPath = path.join(aliveDir, 'err.log');
+      const innerPidFilePath = path.join(aliveDir, 'inner.pid');
+      // Declared before the try so the finally can reap them even if setup throws.
+      let outerPid = 0;
+      let innerPid = 0;
+      try {
+        fs.writeFileSync(logPath, '');
+        fs.writeFileSync(errLogPath, '');
+
+        const managedCommand = buildInnerPidMarkerCommand(
+          innerPidFilePath,
+          UNREF_SLEEP_SECONDS,
+        );
+        const spawned = spawnWindowsBackground(
+          getPowerShellExecutable(),
+          managedCommand,
+          aliveDir,
+          { ...process.env },
+          logPath,
+          errLogPath,
+        );
+        outerPid = spawned.pid ?? 0;
+        expect(
+          outerPid,
+          `spawnWindowsBackground returned no outer pid (${String(spawned.pid)})`,
+        ).toBeGreaterThan(0);
+        // Let it throw on timeout (fail fast, no swallow): a missing marker
+        // means the bootstrap never reached Start-Process. Assigned inside the try
+        // so a partial read still reaches the finally.
+        innerPid = await readInnerPidFromMarker(innerPidFilePath, 15000);
+
+        // Both PIDs must be alive at the same moment. The bare booleans below
+        // say nothing about WHY a process died, and this only reproduces on
+        // Windows, so carry the evidence into the assertion message: an early exit
+        // lands in the redirected logs, making a Windows-only failure diagnosable
+        // from the CI log.
+        const evidence =
+          `outerPid=${outerPid} innerPid=${innerPid}\n` +
+          `${readLogTail('stdout log', logPath)}\n` +
+          `${readLogTail('stderr log', errLogPath)}`;
+
+        expect(isPidAlive(outerPid), evidence).toBe(true);
+        expect(isPidAlive(innerPid), evidence).toBe(true);
+      } finally {
+        await reapAndRemoveWindowsTestDir(aliveDir, null, [outerPid, innerPid]);
+      }
+    }, 60_000);
+
+    interface UnrefFixtureRun {
+      readonly status: number | null;
+      readonly outerPid: number;
+      readonly innerPid: number;
+      /** Diagnostic string for assertion messages: pids, elapsed, status, log tails. */
+      readonly evidence: string;
+    }
+
+    /**
+     * Spawn a subprocess that calls spawnWindowsBackground and exits without
+     * waiting, then hand the observations to `assertRun`.
+     *
+     * Both PID markers are read before `assertRun` runs, so the `finally` reaps
+     * whichever PIDs were recovered even when an assertion fails, and removes
+     * the fixture directory. Setup that throws before the fixture is spawned
+     * has no process to reap, so removing the directory is sufficient there.
+     */
+    async function withUnrefSpawnerFixture(
+      assertRun: (run: UnrefFixtureRun) => void,
+    ): Promise<void> {
+      const unrefDir = fs.mkdtempSync(path.join(os.tmpdir(), 'win-unref-'));
+      const logPath = path.join(unrefDir, 'out.log');
+      const errLogPath = path.join(unrefDir, 'err.log');
+      const scriptPath = path.join(unrefDir, 'spawn-exit.ts');
+      const outerPidFilePath = path.join(unrefDir, 'outer.pid');
+      const innerPidFilePath = path.join(unrefDir, 'inner.pid');
+      let outerPid = 0;
+      let innerPid = 0;
+      try {
+        fs.writeFileSync(logPath, '');
+        fs.writeFileSync(errLogPath, '');
+
+        const modulePath = path
+          .join(__dirname, 'shellJobSpawn.ts')
+          .replace(/\\/g, '/');
+        const powershellExe = getPowerShellExecutable();
+        const managedCommand = buildInnerPidMarkerCommand(
+          innerPidFilePath,
+          UNREF_SLEEP_SECONDS,
+        );
+        // The script does NOT manually call p.child.unref(): production code
+        // (spawnWindowsBackground) already unrefs immediately at spawn. If that
+        // production contract regresses, the spawner will hang and the
+        // status=0 assertion in the unref test will fail.
+        const script = [
+          `import { spawnWindowsBackground } from '${modulePath}';`,
+          `const p = spawnWindowsBackground(`,
+          `  ${JSON.stringify(powershellExe)},`,
+          `  ${JSON.stringify(managedCommand)},`,
+          `  ${JSON.stringify(os.tmpdir())},`,
+          `  { ...process.env },`,
+          `  ${JSON.stringify(logPath)},`,
+          `  ${JSON.stringify(errLogPath)},`,
+          `);`,
+          `require('fs').writeFileSync(${JSON.stringify(outerPidFilePath)}, String(p.pid));`,
+        ].join('\n');
+
+        fs.writeFileSync(scriptPath, script);
+
+        const start = Date.now();
+        // Execute the fixture with the current Bun executable
+        // (process.execPath), not npx/tsx/Node: spawnWindowsBackground's
+        // production-unref contract is exercised by the runtime that will
+        // actually run it, which is Bun. Using npx/tsx/Node would prove
+        // nothing about production behavior.
+        const result = spawnSync(process.execPath, [scriptPath], {
+          timeout: UNREF_SPAWN_TIMEOUT_MS,
+          encoding: 'utf8',
+          shell: false,
+        });
+        const elapsed = Date.now() - start;
+
+        // Capture marker PIDs BEFORE assertions so cleanup in finally always
+        // has the known PIDs even if an assertion throws.
         try {
-          fs.writeFileSync(logPath, '');
-          fs.writeFileSync(errLogPath, '');
-
-          const modulePath = path
-            .join(__dirname, 'shellJobSpawn.ts')
-            .replace(/\\/g, '/');
-          const powershellExe = getPowerShellExecutable();
-          const managedCommand = buildInnerPidMarkerCommand(
-            innerPidFilePath,
-            UNREF_SLEEP_SECONDS,
-          );
-          // The script does NOT manually call p.child.unref(): production code
-          // (spawnWindowsBackground) already unrefs immediately at spawn. If that
-          // production contract regresses, the spawner will hang and the
-          // status=0 assertion below will fail.
-          const script = [
-            `import { spawnWindowsBackground } from '${modulePath}';`,
-            `const p = spawnWindowsBackground(`,
-            `  ${JSON.stringify(powershellExe)},`,
-            `  ${JSON.stringify(managedCommand)},`,
-            `  ${JSON.stringify(os.tmpdir())},`,
-            `  { ...process.env },`,
-            `  ${JSON.stringify(logPath)},`,
-            `  ${JSON.stringify(errLogPath)},`,
-            `);`,
-            `require('fs').writeFileSync(${JSON.stringify(outerPidFilePath)}, String(p.pid));`,
-          ].join('\n');
-
-          fs.writeFileSync(scriptPath, script);
-
-          const start = Date.now();
-          // Execute the fixture with the current Bun executable
-          // (process.execPath), not npx/tsx/Node: spawnWindowsBackground's
-          // production-unref contract is exercised by the runtime that will
-          // actually run it, which is Bun. Using npx/tsx/Node would prove
-          // nothing about production behavior.
-          const result = spawnSync(process.execPath, [scriptPath], {
-            timeout: UNREF_SPAWN_TIMEOUT_MS,
-            encoding: 'utf8',
-            shell: false,
-          });
-          const elapsed = Date.now() - start;
-
-          // Capture marker PIDs BEFORE assertions so cleanup in finally always
-          // has the known PIDs even if an assertion throws.
-          try {
-            outerPid = await readInnerPidFromMarker(outerPidFilePath, 10000);
-          } catch {
-            // Marker may not exist if spawn failed before writing it.
-          }
-          try {
-            innerPid = await readInnerPidFromMarker(innerPidFilePath, 10000);
-          } catch {
-            // Inner process may not have started yet.
-          }
-
-          // status 0 is the deterministic regression signal: it proves the
-          // spawner exited on its own BEFORE the spawnSync timeout backstop.
-          // Node's spawnSync sets status to null when the timeout kills the
-          // child, so a null/non-zero status would indicate the spawner hung
-          // (the unref regression). This is race-resistant: it does not depend
-          // on wall-clock timing that varies with cold-start cost.
-          expect(result.status).toBe(0);
-
-          // Verify the unref contract directly. Both PowerShell processes must
-          // still be alive: the outer waits for the inner 30s sleep, while the
-          // inner owns the redirected logs. This proves unref detached the tree
-          // without killing it and gives teardown both PIDs for direct reaping.
-          // The bare booleans below say nothing about WHY a process died, and
-          // this only reproduces on a Windows runner, so carry the evidence into
-          // the assertion message: the outer only exits early if its inner
-          // Start-Process failed, and that failure lands in the redirected logs.
-          const readIfPresent = (label: string, at: string): string => {
-            try {
-              return `${label}: ${JSON.stringify(fs.readFileSync(at, 'utf8').slice(-500))}`;
-            } catch (error: unknown) {
-              return `${label}: <unreadable: ${String(error)}>`;
-            }
-          };
-          const evidence =
-            `outerPid=${outerPid} innerPid=${innerPid} elapsed=${elapsed}ms ` +
-            `status=${result.status}\n` +
-            `${readIfPresent('stdout log', logPath)}\n` +
-            `${readIfPresent('stderr log', errLogPath)}\n` +
-            `spawner stdout: ${JSON.stringify(result.stdout.slice(-500))}\n` +
-            `spawner stderr: ${JSON.stringify(result.stderr.slice(-500))}`;
-
-          expect(outerPid, evidence).toBeGreaterThan(0);
-          expect(isPidAlive(outerPid), evidence).toBe(true);
-          expect(innerPid, evidence).toBeGreaterThan(0);
-          expect(isPidAlive(innerPid), evidence).toBe(true);
-
-          debugLogger.debug(
-            `[shellJobWindowsSpawn.test] unref subprocess exited in ${elapsed}ms (status ${result.status})`,
-          );
-        } finally {
-          await reapAndRemoveWindowsTestDir(unrefDir, null, [
-            outerPid,
-            innerPid,
-          ]);
+          outerPid = await readInnerPidFromMarker(outerPidFilePath, 10000);
+        } catch {
+          // Marker may not exist if spawn failed before writing it.
         }
+        try {
+          innerPid = await readInnerPidFromMarker(innerPidFilePath, 10000);
+        } catch {
+          // Inner process may not have started yet.
+        }
+
+        // The callers' assertions are bare numbers and booleans that say
+        // nothing about WHY a process died, and this only reproduces on a
+        // Windows runner, so every assertion carries this evidence string: the
+        // outer PowerShell only exits early if its inner Start-Process failed,
+        // and that failure lands in the redirected logs.
+        const evidence =
+          `outerPid=${outerPid} innerPid=${innerPid} elapsed=${elapsed}ms ` +
+          `status=${result.status}\n` +
+          `${readLogTail('stdout log', logPath)}\n` +
+          `${readLogTail('stderr log', errLogPath)}\n` +
+          `spawner stdout: ${JSON.stringify(result.stdout.slice(-500))}\n` +
+          `spawner stderr: ${JSON.stringify(result.stderr.slice(-500))}`;
+
+        debugLogger.debug(
+          `[shellJobWindowsSpawn.test] unref subprocess exited in ${elapsed}ms (status ${result.status})`,
+        );
+
+        assertRun({
+          status: result.status,
+          outerPid,
+          innerPid,
+          evidence,
+        });
+      } finally {
+        await reapAndRemoveWindowsTestDir(unrefDir, null, [outerPid, innerPid]);
+      }
+    }
+
+    // status 0 is the deterministic regression signal: it proves the spawner
+    // exited on its own BEFORE the spawnSync timeout backstop. Node's spawnSync
+    // sets status to null when the timeout kills the child, so a null/non-zero
+    // status means the spawner hung, which is the unref regression. This is
+    // race-resistant: it does not depend on wall-clock timing that varies with
+    // cold-start cost, and it is unaffected by a kill-on-close job object, so
+    // it runs in CI.
+    it('does not keep the spawner alive (production unref)', async () => {
+      await withUnrefSpawnerFixture((run) => {
+        expect(run.status, run.evidence).toBe(0);
+      });
+    }, 60_000);
+
+    // The survives-the-spawner half of the contract. Both PowerShell processes
+    // must still be alive after the spawner exited: the outer waits on the
+    // inner 30s sleep, while the inner owns the redirected logs. That proves
+    // unref detached the tree from the parent's event loop without killing it.
+    // Gated by SPAWNER_EXIT_KILLS_TREE: inside the CI runner's job object the
+    // tree is torn down when the spawner exits, so the claim does not hold
+    // there (issue #3321).
+    it.skipIf(SPAWNER_EXIT_KILLS_TREE)(
+      'leaves the background tree running after the spawner exits',
+      async () => {
+        await withUnrefSpawnerFixture((run) => {
+          expect(run.outerPid, run.evidence).toBeGreaterThan(0);
+          expect(isPidAlive(run.outerPid), run.evidence).toBe(true);
+          expect(run.innerPid, run.evidence).toBeGreaterThan(0);
+          expect(isPidAlive(run.innerPid), run.evidence).toBe(true);
+        });
       },
       60_000,
     );

--- a/project-plans/issue3321/plan.md
+++ b/project-plans/issue3321/plan.md
@@ -1,0 +1,170 @@
+# Issue #3321: Windows background shell jobs are killed with the spawner under a CI job object
+
+## Problem
+
+`spawnWindowsBackground` (packages/core/src/services/shellJobSpawn.ts) launches an
+outer PowerShell that `Start-Process`es an inner PowerShell. It deliberately does
+NOT pass `detached: true` (that option makes the command never execute on
+Windows), so the outer process stays inside the spawner's job object.
+
+GitHub Actions runners wrap the job in a job object with
+`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. When the spawner exits, the runner tears
+down the whole tree. Nightly evidence:
+
+```
+outerPid=2936 innerPid=0 elapsed=56ms status=0
+stdout log: ""  stderr log: ""  spawner stdout: ""  spawner stderr: ""
+```
+
+The spawner exited in 56ms with status 0 (the unref half of the contract works),
+but by assertion time the outer PID was gone and the inner had never started.
+
+The whole `does not keep the spawner alive (production unref)` test is currently
+skipped when `process.env.CI` is set, so CI loses BOTH claims the test makes,
+including the unref claim, which is environment-independent and did pass.
+
+## Decisions (answering the issue's "Worth deciding")
+
+1. **Contract statement.** The documented contract becomes: on an ordinary
+   Windows session the background tree survives the spawner's exit; on the
+   GitHub Actions Windows runner it does not. It is stated as observed
+   behavior, not as a guarantee, and callers are told to treat survival past
+   the spawner as environment dependent. The job-object explanation is given as
+   the leading hypothesis rather than as established fact: what the nightly
+   evidence proves is that the outer PID was gone and no inner PID marker was
+   observed, and confirming job ownership and limit flags would need
+   `IsProcessInJob` / `QueryInformationJobObject`, which are native Win32 calls.
+2. **Escaping the job object.** No. `CREATE_BREAKAWAY_FROM_JOB` is not reachable
+   through `node:child_process.spawn` or `Bun.spawn` options, and it takes
+   effect only when the containing job permits breakaway. Using it would require
+   native Win32 calls. Not pursued; recorded as a rejected option in the code
+   comment. Note that `detached: true` is not a substitute: on Windows it does
+   not request job breakaway, and it is separately unusable here because the
+   spawned PowerShell exits 0 without running the command.
+3. **CI-hosted lifetime assertion.** Yes, two ways, both added:
+   - Assert the tree's lifetime *while the spawner is still alive*. That claim
+     is unaffected by a kill-on-close job object, so it runs in CI.
+   - Split the existing fixture test so its environment-independent half
+     (the spawner exits on its own) runs in CI, and only the
+     survives-past-spawner half is gated.
+
+**No runtime behavior changes.** `spawnWindowsBackground` is correct for its
+supported environment; the defect is in how the contract was stated and tested.
+
+## Acceptance criteria
+
+### AC1: The contract is stated precisely
+
+- The `spawnWindowsBackground` doc comment in
+  `packages/core/src/services/shellJobSpawn.ts` states the survival contract as
+  observed behavior with its environment caveat, distinguishes what is confirmed
+  from the unconfirmed job-object explanation, says why `detached: true` is not
+  used and that it is not a job breakaway, and says why
+  `CREATE_BREAKAWAY_FROM_JOB` was rejected.
+- `docs/tools/shell.md` → "Windows Details" states the same lifetime rule in
+  user-facing terms.
+- No production code (statements/expressions) changes.
+
+### AC2: Tree lifetime is asserted in CI without depending on spawner exit
+
+New Windows-only test in
+`packages/core/src/services/shellJobWindowsSpawn.test.ts`, NOT gated on `CI`:
+
+- Call `spawnWindowsBackground` in-process with a long-sleeping inner command
+  built by `buildInnerPidMarkerCommand`.
+- Assert the returned outer PID is positive and alive.
+- Assert the inner PID marker is written (proving the bootstrap reached
+  `Start-Process`) and that the inner PID is alive.
+- Both alive at the same time, with the spawner (the test process) still
+  running, so a kill-on-close job object cannot affect the result.
+- Reap both PIDs and remove the directory via `reapAndRemoveWindowsTestDir`
+  in a `finally`.
+
+Boundary cases: marker never appears → `readInnerPidFromMarker` throws with its
+own message (fail fast, no swallow); cleanup still runs from `finally` with
+whatever PIDs are known.
+
+### AC3: The unref claim runs in CI; only survival is gated
+
+Split the existing `does not keep the spawner alive (production unref)` test
+into two tests sharing one fixture helper:
+
+- `does not keep the spawner alive (production unref)`, runs on Windows
+  **including CI**. Asserts `result.status === 0`, which proves the spawner
+  exited on its own before the `spawnSync` timeout backstop. Node sets `status`
+  to `null` when the timeout kills the child, so a regressed unref fails here.
+- `leaves the background tree running after the spawner exits`, gated by a
+  named constant `SPAWNER_EXIT_KILLS_TREE` (currently `process.env.CI !==
+  undefined`, documented as a proxy for "inside a kill-on-close job object",
+  since querying the job object needs native Win32 calls). Asserts outer and
+  inner PIDs are positive and alive after the spawner exited.
+
+Both keep the existing `evidence` diagnostic string in assertion messages and
+both reap via `reapAndRemoveWindowsTestDir` in a `finally`.
+
+Boundary cases: fixture PID markers missing → PIDs stay 0, cleanup filters
+non-positive PIDs; fixture throws before returning → helper still cleans up its
+directory.
+
+## Implementation
+
+### Files
+
+- `packages/core/src/services/shellJobSpawn.ts`, comments only (AC1).
+- `docs/tools/shell.md`, Windows Details lifetime note (AC1).
+- `packages/core/src/services/shellJobWindowsSpawn.test.ts`, AC2 + AC3.
+
+### Test-file shape
+
+```ts
+/**
+ * Whether the current environment tears the background tree down when the
+ * spawner exits. GitHub Actions runners place the job in a job object with
+ * JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE ... (see #3321). There is no way to query
+ * job-object limits from Node/Bun without native Win32 calls, so CI is the
+ * proxy.
+ */
+const SPAWNER_EXIT_KILLS_TREE = process.env.CI !== undefined;
+
+interface UnrefFixtureRun {
+  readonly status: number | null;
+  readonly elapsedMs: number;
+  readonly outerPid: number;
+  readonly innerPid: number;
+  readonly evidence: string;
+}
+
+/**
+ * Run the spawner fixture once, hand the observations to `assertRun`, then
+ * reap both PIDs and remove the fixture directory. The directory is removed
+ * even when fixture setup throws.
+ */
+async function withUnrefSpawnerFixture(
+  assertRun: (run: UnrefFixtureRun) => void,
+): Promise<void>;
+```
+
+The fixture body is the existing test body verbatim (script generation,
+`spawnSync(process.execPath, [scriptPath], ...)`, marker reads, `evidence`
+assembly), with the assertions moved out to the callback.
+
+## Verification
+
+```bash
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```
+
+The Windows describe block is skipped on darwin/linux, so local runs prove
+compilation, lint, and non-regression only. Windows behavior is proven by CI on
+the PR (AC2 and the AC3 unref half now execute there).
+
+## Out of scope
+
+- Any change to `spawnWindowsBackground` runtime behavior.
+- Native Win32 job-object querying or breakaway.
+- Changes to POSIX spawn paths, `ShellJobManager`, or other Windows tests.


### PR DESCRIPTION
## TLDR

The nightly Windows `core` shard was failing a test that asserted a background PowerShell tree outlives the process that spawned it. That assertion does not hold on a GitHub Actions runner. The whole test had been skipped whenever `CI` was set, which also threw away the half of the test that was passing and is environment-independent.

This restates the lifetime contract as observed behavior rather than a guarantee, and gives CI back the coverage it can actually hold. **No runtime behavior changes**: only doc comments, user docs, and tests.

Reviewers should look hardest at whether the contract wording in the `spawnWindowsBackground` JSDoc is factually defensible, and at the cleanup paths in the two Windows tests.

## Dive Deeper

### What was observed

From the nightly Windows runner, with diagnostics attached to the assertions:

```
outerPid=2936 innerPid=0 elapsed=56ms status=0
stdout log: ""  stderr log: ""  spawner stdout: ""  spawner stderr: ""
```

The spawner exited cleanly in 56ms having produced an outer PID, which is the unref half of the contract working. By assertion time that PID was gone, no inner PID marker had been written, and neither redirected log had any content.

### Why the contract is environment-dependent

`spawnWindowsBackground` cannot pass `detached: true`: spawning PowerShell that way was observed to exit 0 without ever running the command. The outer process is therefore spawned normally and `unref()`'d, so it stays inside whatever Windows job object contains the spawner.

The leading explanation for the runner behavior is a job object owned by the runner that terminates its processes when the job closes. **That is stated as a hypothesis, not as fact.** Confirming which job owns the process and what limit flags it carries needs `IsProcessInJob` and `QueryInformationJobObject`, which are native Win32 calls reachable from neither Node nor Bun. The JSDoc now separates what the evidence establishes from what it does not.

Two related corrections are recorded in the same comment:

- `detached` on Windows is not a job breakaway. It does not request `CREATE_BREAKAWAY_FROM_JOB`, so it would not by itself change the lifetime even if it were usable here.
- `CREATE_BREAKAWAY_FROM_JOB` was considered and rejected. It is not exposed by `node:child_process.spawn` or `Bun.spawn` options, and it takes effect only when the containing job permits breakaway.

### Answering the issue's three open questions

1. **Should the contract be restated?** Yes. It is now stated as observed, environment-dependent behavior in both the JSDoc and `docs/tools/shell.md`, with callers told not to treat survival past the spawner as a guarantee.
2. **Is there a supported way to escape the job object?** No. See above.
3. **Could a CI-hosted Windows test assert the tree's lifetime another way?** Yes, two ways, both added below.

### Test changes

**New: `keeps the outer and inner PowerShell alive while the spawner is running`.** Asserts the outer and inner PowerShell are alive at the same moment while the spawner (the test process itself) is still running. A kill-on-close job object cannot affect that claim, so this runs in CI. It proves directly what the `runAndWait` tests only prove indirectly: the bootstrap reached `Start-Process` and both processes coexist during a long-running command.

**Split: the previously CI-skipped unref test.** It made two independent claims that are now separate tests sharing one extracted `withUnrefSpawnerFixture` helper:

- `does not keep the spawner alive (production unref)` now runs in CI. It asserts `spawnSync` status 0, which proves the spawner exited on its own before the 25s timeout backstop. Node sets status to `null` when the timeout kills the child, so if production stopped calling `child.unref()` the outer process would wait on the inner 30s sleep and this fails. This coverage was previously lost entirely in CI.
- `leaves the background tree running after the spawner exits` keeps all four original PID assertions and stays gated, now behind a named `SPAWNER_EXIT_KILLS_TREE` constant instead of an inline `process.env.CI` check.

The gate is still `process.env.CI`, deliberately. It is a broad proxy rather than a precise signal, and the comment says so: any CI environment may impose the same containment, and skipping a contract we cannot assert is better than a false failure. Narrowing it to `GITHUB_ACTIONS` was considered and rejected for that reason.

The full nightly evidence and the diagnostic `evidence` strings on every assertion are preserved.

## Reviewer Test Plan

Everything meaningful here is Windows-only, so the useful validation is CI on this PR plus a manual Windows run.

**On any platform:**

```bash
cd packages/core && bun test src/services/shellJobWindowsSpawn.test.ts
```

Expect 10 pass / 16 skip. The pure helper tests run; the whole `spawnWindowsBackground` describe block skips off Windows.

**On Windows (a developer machine, not CI):**

```bash
cd packages/core && bun test src/services/shellJobWindowsSpawn.test.ts
```

All 26 should run and pass, including `leaves the background tree running after the spawner exits`. Confirm no `powershell.exe` or `pwsh` processes are left behind afterwards and no `win-alive-*` or `win-unref-*` directories remain in `%TEMP%`.

**On Windows with `CI` set:**

```powershell
$env:CI = "1"; bun test src/services/shellJobWindowsSpawn.test.ts
```

`leaves the background tree running after the spawner exits` should skip; `does not keep the spawner alive (production unref)` and `keeps the outer and inner PowerShell alive while the spawner is running` should both run and pass.

**Regression check on the unref contract:** temporarily delete the `child.unref()` call in `spawnWindowsBackground` and re-run on Windows. `does not keep the spawner alive (production unref)` must fail, because the fixture spawner will hang on the inner 30s sleep and hit the 25s `spawnSync` backstop.

**Docs:** read the new paragraph in `docs/tools/shell.md` under "Windows Details" and confirm it does not promise more than the code does.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified locally on macOS: `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build` all pass. Windows and Linux are covered by CI on this PR, which is where the changed tests actually execute.

## Linked issues / bugs

Fixes #3321

Origin context: the last remaining `core` failure from the nightly Windows sweep in #3253.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified Windows background job behavior, including limitations in GitHub Actions and other terminating job-object environments.
  - Documented process detachment, event-loop behavior, and environment-dependent persistence after the parent process exits.

- **Tests**
  - Expanded Windows process-lifecycle coverage.
  - Improved cleanup handling for spawned process trees, including combined reporting of test and cleanup failures.
  - Accounted for environments where background process trees are terminated automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->