### PR TITLE
fix(core): keep session recording alive after no-op or failed compression (Fixes #3263)

### DIFF
--- a/packages/core/src/recording/RecordingIntegration.core.test.ts
+++ b/packages/core/src/recording/RecordingIntegration.core.test.ts
@@ -316,6 +316,103 @@ describe('RecordingIntegration @plan:PLAN-20260211-SESSIONRECORDING.P13', () => 
       );
     });
 
+    it('records content after an argless endCompression without compressionEnded', async () => {
+      integration.subscribeToHistory(historyService);
+      historyService.add(textContent('before'));
+      historyService.startCompression();
+
+      historyService.endCompression();
+
+      historyService.add(textContent('after'));
+
+      const events = await flushAndRead(integration, recordingService);
+      const contentTexts = events
+        .filter((event) => event.type === 'content')
+        .map((event) => {
+          const payload = event.payload as { content: IContent };
+          return (payload.content.blocks[0] as { type: 'text'; text: string })
+            .text;
+        });
+      expect(contentTexts).toStrictEqual(['before', 'after']);
+      expect(
+        events.filter((event) => event.type === 'compressed'),
+      ).toHaveLength(0);
+    });
+
+    it('records content after a failed-shaped endCompression without compressionEnded', async () => {
+      integration.subscribeToHistory(historyService);
+      historyService.add(textContent('before'));
+      historyService.startCompression();
+
+      historyService.endCompression(undefined, 5);
+
+      historyService.add(textContent('after'));
+
+      const events = await flushAndRead(integration, recordingService);
+      const contentTexts = events
+        .filter((event) => event.type === 'content')
+        .map((event) => {
+          const payload = event.payload as { content: IContent };
+          return (payload.content.blocks[0] as { type: 'text'; text: string })
+            .text;
+        });
+      expect(contentTexts).toStrictEqual(['before', 'after']);
+      expect(
+        events.filter((event) => event.type === 'compressed'),
+      ).toHaveLength(0);
+    });
+
+    it('records content after sequential noop compression cycles', async () => {
+      integration.subscribeToHistory(historyService);
+      historyService.startCompression();
+      historyService.endCompression();
+      historyService.add(textContent('after-first-noop'));
+
+      historyService.startCompression();
+      historyService.endCompression();
+      historyService.add(textContent('after-second-noop'));
+
+      const events = await flushAndRead(integration, recordingService);
+      const contentTexts = events
+        .filter((event) => event.type === 'content')
+        .map((event) => {
+          const payload = event.payload as { content: IContent };
+          return (payload.content.blocks[0] as { type: 'text'; text: string })
+            .text;
+        });
+      expect(contentTexts).toStrictEqual([
+        'after-first-noop',
+        'after-second-noop',
+      ]);
+      expect(
+        events.filter((event) => event.type === 'compressed'),
+      ).toHaveLength(0);
+    });
+
+    it('records applied compression with an argless-queued add still suppressed', async () => {
+      integration.subscribeToHistory(historyService);
+      historyService.add(textContent('before'));
+      historyService.startCompression();
+      historyService.add(textContent('during'));
+
+      historyService.endCompression(textContent('summary', 'ai'), 3);
+
+      historyService.add(textContent('after'));
+
+      const events = await flushAndRead(integration, recordingService);
+      const contentTexts = events
+        .filter((event) => event.type === 'content')
+        .map((event) => {
+          const payload = event.payload as { content: IContent };
+          return (payload.content.blocks[0] as { type: 'text'; text: string })
+            .text;
+        });
+      expect(contentTexts).toStrictEqual(['before', 'after']);
+      expect(
+        events.filter((event) => event.type === 'compressed'),
+      ).toHaveLength(1);
+    });
+
     it('emits one compressed event per compression cycle', async () => {
       integration.subscribeToHistory(historyService);
       emitter.emit('contentAdded', textContent('baseline-materialize'));

--- a/packages/core/src/recording/RecordingIntegration.ts
+++ b/packages/core/src/recording/RecordingIntegration.ts
@@ -60,6 +60,13 @@ export class RecordingIntegration {
       this.compressionInProgress = true;
     };
 
+    const onCompressionLockReleased = () => {
+      if (this.disposed) {
+        return;
+      }
+      this.compressionInProgress = false;
+    };
+
     const onCompressionEnded = (summary: IContent, itemsCompressed: number) => {
       if (this.disposed) {
         return;
@@ -70,11 +77,13 @@ export class RecordingIntegration {
 
     historyService.on('contentAdded', onContentAdded);
     historyService.on('compressionStarted', onCompressionStarted);
+    historyService.on('compressionLockReleased', onCompressionLockReleased);
     historyService.on('compressionEnded', onCompressionEnded);
 
     this.historySubscription = () => {
       historyService.off('contentAdded', onContentAdded);
       historyService.off('compressionStarted', onCompressionStarted);
+      historyService.off('compressionLockReleased', onCompressionLockReleased);
       historyService.off('compressionEnded', onCompressionEnded);
     };
   }

--- a/packages/core/src/services/history/HistoryService.ts
+++ b/packages/core/src/services/history/HistoryService.ts
@@ -1138,8 +1138,8 @@ export class HistoryService
   /**
    * Mark compression as complete
    * This will flush all queued operations.
-   * When summary and itemsCompressed are provided, emits a compressionEnded
-   * event so the recording service can log the compression.
+   * Always emits a compressionLockReleased event so recording can stop suppressing
+   * content, while compressionEnded stays conditional on summary + itemsCompressed.
    */
   endCompression(summary?: IContent, itemsCompressed?: number): void {
     this.logger.debug('Compression complete - unlocking history', {
@@ -1160,6 +1160,11 @@ export class HistoryService
     this.logger.debug('Flushed pending operations', {
       count: operations.length,
     });
+
+    // Emitted after the queue drain so flushed rebuild content stays inside the
+    // recording suppression window; fires unconditionally so a summary-less
+    // end (no-op/failed compression) cannot wedge recording. (Issue #3263)
+    this.emit('compressionLockReleased');
 
     if (summary && itemsCompressed !== undefined) {
       this.emit('compressionEnded', summary, itemsCompressed);

--- a/packages/core/src/services/history/compression-locking.test.ts
+++ b/packages/core/src/services/history/compression-locking.test.ts
@@ -245,4 +245,76 @@ describe('Compression locking', () => {
 
     expect(compressionMessages.length).toBe(3);
   });
+
+  describe('compressionLockReleased event', () => {
+    let observed: string[];
+
+    beforeEach(() => {
+      observed = [];
+      historyService.on('contentAdded', () => {
+        observed.push('contentAdded');
+      });
+      historyService.on('compressionLockReleased', () => {
+        observed.push('compressionLockReleased');
+      });
+      historyService.on('compressionEnded', () => {
+        observed.push('compressionEnded');
+      });
+    });
+
+    it('releases the lock on an argless endCompression without compressionEnded', () => {
+      historyService.startCompression();
+
+      historyService.endCompression();
+
+      expect(observed).toContain('compressionLockReleased');
+      expect(observed).not.toContain('compressionEnded');
+    });
+
+    it('releases the lock on a failed-shaped endCompression without compressionEnded', () => {
+      historyService.startCompression();
+
+      historyService.endCompression(undefined, 3);
+
+      expect(observed).toContain('compressionLockReleased');
+      expect(observed).not.toContain('compressionEnded');
+    });
+
+    it('releases the lock and emits compressionEnded when a summary is provided', () => {
+      historyService.startCompression();
+
+      historyService.endCompression(
+        { speaker: 'human', blocks: [{ type: 'text', text: 'summary' }] },
+        3,
+      );
+
+      expect(observed).toContain('compressionLockReleased');
+      expect(observed).toContain('compressionEnded');
+    });
+
+    it('flushes queued contentAdded before compressionLockReleased then compressionEnded', () => {
+      historyService.startCompression();
+      historyService.add({
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'queued during compression' }],
+      });
+
+      historyService.endCompression(
+        { speaker: 'human', blocks: [{ type: 'text', text: 'summary' }] },
+        3,
+      );
+
+      expect(observed).toStrictEqual([
+        'contentAdded',
+        'compressionLockReleased',
+        'compressionEnded',
+      ]);
+    });
+
+    it('emits compressionLockReleased without a preceding startCompression', () => {
+      historyService.endCompression();
+
+      expect(observed).toContain('compressionLockReleased');
+    });
+  });
 });

--- a/packages/core/src/services/history/historyEventTypes.ts
+++ b/packages/core/src/services/history/historyEventTypes.ts
@@ -27,6 +27,7 @@ export interface HistoryServiceEventEmitter {
   ): this;
   on(event: 'contentAdded', listener: (content: IContent) => void): this;
   on(event: 'compressionStarted', listener: () => void): this;
+  on(event: 'compressionLockReleased', listener: () => void): this;
   on(
     event: 'compressionEnded',
     listener: (summary: IContent, itemsCompressed: number) => void,
@@ -34,6 +35,7 @@ export interface HistoryServiceEventEmitter {
   emit(event: 'tokensUpdated', eventData: TokensUpdatedEvent): boolean;
   emit(event: 'contentAdded', content: IContent): boolean;
   emit(event: 'compressionStarted'): boolean;
+  emit(event: 'compressionLockReleased'): boolean;
   emit(
     event: 'compressionEnded',
     summary: IContent,
@@ -45,6 +47,7 @@ export interface HistoryServiceEventEmitter {
   ): this;
   off(event: 'contentAdded', listener: (content: IContent) => void): this;
   off(event: 'compressionStarted', listener: () => void): this;
+  off(event: 'compressionLockReleased', listener: () => void): this;
   off(
     event: 'compressionEnded',
     listener: (summary: IContent, itemsCompressed: number) => void,

--- a/project-plans/issue3263/plan.md
+++ b/project-plans/issue3263/plan.md
@@ -1,0 +1,175 @@
+# Plan: Session recording stops permanently after a no-op or failed compression
+
+Issue: #3263
+Branch: `issue3263`
+
+## Problem (verified at HEAD)
+
+`RecordingIntegration` suppresses `contentAdded` while its private
+`compressionInProgress` flag is `true`, and clears that flag only in its
+`compressionEnded` handler. `HistoryService.endCompression()` emits
+`compressionEnded` only when given both a summary and an `itemsCompressed`
+count. `CompressionHandler.performCompression` ends compression in three
+shapes:
+
+- `applied` → `endCompression(summary, preCompressionCount)` → emits
+  `compressionEnded` → flag cleared. OK.
+- `noop` → `endCompression()` → no event → flag stuck `true` forever.
+- `failed` → `endCompression(undefined, preCompressionCount)` → no event →
+  flag stuck `true` forever.
+
+Once stuck, every subsequent `content` record for the rest of the session is
+silently dropped; the session file stops growing and resume loses everything
+after the failed compression.
+
+Probe at HEAD (real `HistoryService` + `RecordingIntegration` +
+`SessionRecordingService`, `tmp/issue3263-probe/probe.ts`):
+
+- noop shape (`startCompression(); endCompression()`): content=1, expected 2.
+- failed shape (`endCompression(undefined, 5)`): content=1, expected 2.
+- applied shape (`endCompression(summary, 5)`): content=2, compressed=1 (correct).
+
+## Fix direction (from the issue)
+
+Clear the suppression flag on a signal that ALWAYS fires when the compression
+lock is released, rather than on the summary-bearing `compressionEnded` event.
+Emitting `compressionEnded` unconditionally is explicitly rejected: the
+`compressed` record must stay suppressed on a no-op (#2602), and `compressionEnded`
+carries the summary payload semantics.
+
+## Accepted behavior (acceptance criteria)
+
+### AC-1: HistoryService emits a lock-release signal on every endCompression
+
+`endCompression()` — in every argument shape (no args, summary-less, full
+summary) — emits a new `compressionLockReleased` event, after the pending
+operations queue is drained. `compressionEnded` remains conditional on
+summary + itemsCompressed exactly as today.
+
+### AC-2: Recording survives a no-op-shaped compression end (issue reproduction)
+
+Real `HistoryService` + `RecordingIntegration` + `SessionRecordingService`:
+`add(before)`, `startCompression()`, `endCompression()`, `add(after)` → the
+recording file contains exactly 2 `content` records (`before` and `after`) and
+0 `compressed` records.
+
+### AC-3: Recording survives a failed-shaped compression end
+
+Same as AC-2 but `endCompression(undefined, 5)` → 2 `content` records, 0
+`compressed` records. Repeated no-op cycles in sequence also keep recording
+(each cycle's post-compression content is recorded).
+
+### AC-4: Applied compression behavior is unchanged
+
+Going through the real `endCompression(summary, count)` with content queued
+during the compression window: the flushed rebuild/queued content is still
+suppressed (no duplicate content records), exactly one `compressed` record is
+written, and post-compression content is recorded. This pins the emission
+order: pending-queue drain first (still inside the suppression window), then
+`compressionLockReleased`, then the conditional `compressionEnded`.
+
+### AC-5: Subscription hygiene unchanged
+
+`compressionLockReleased` listener is registered in `subscribeToHistory` and
+removed in `unsubscribeFromHistory` (no listener leak, flag reset on
+unsubscribe). Existing semantics of `unsubscribeFromHistory`, `dispose`, and
+`onHistoryServiceReplaced` are unchanged. `onCompressionEnded` still clears
+the flag itself so direct `compressionEnded` emissions (as existing tests do)
+behave identically.
+
+## Boundary cases
+
+- `endCompression()` without a preceding `startCompression()` (unbalanced):
+  `compressionLockReleased` still fires; harmless when flag was already false.
+- Content queued during compression and flushed by a no-op-shaped
+  `endCompression()`: stays suppressed this cycle (consistent with the applied
+  path, where flushed rebuild content is suppressed); the NEXT content after
+  the release is recorded (AC-2/AC-3).
+- Multiple sequential no-op cycles: flag cleared on every release.
+
+## Out of scope (explicitly)
+
+- Whether external content queued during the compression window should be
+  recorded (adjacent to #3132 duplicate-content territory; loss window is the
+  compression duration only, not permanent).
+- Any CompressionHandler changes; its three `endCompression` call shapes stay.
+- ReplayEngine / resume behavior changes (correct recording fixes resume input
+  data going forward).
+- Emitting `compressionEnded` unconditionally or changing its payload types.
+
+## Files
+
+- `packages/core/src/services/history/HistoryService.ts` — emit
+  `compressionLockReleased` in `endCompression()` after the queue drain.
+- `packages/core/src/services/history/historyEventTypes.ts` — add
+  `on`/`emit`/`off` overloads for `compressionLockReleased`.
+- `packages/core/src/recording/RecordingIntegration.ts` — subscribe a handler
+  that clears `compressionInProgress`; unsubscribe it symmetrically.
+- Tests:
+  - `packages/core/src/services/history/compression-locking.test.ts` —
+    lock-release signal always fires, ordering relative to queue drain and
+    `compressionEnded`, `compressionEnded` still conditional.
+  - `packages/core/src/recording/RecordingIntegration.core.test.ts` — AC-2,
+    AC-3, AC-4 behavioral tests through the real HistoryService API.
+
+## Test plan (TDD; bun tests, real components, no mocks)
+
+1. HistoryService level (compression-locking.test.ts):
+   - argless `endCompression()` emits `compressionLockReleased`, not
+     `compressionEnded`.
+   - failed-shape `endCompression(undefined, n)` same.
+   - summary-shape emits both.
+   - ordering: queued `add` flushed first, then `compressionLockReleased`,
+     then `compressionEnded` (record observed event order via public emitter).
+   - unbalanced `endCompression()` still emits the signal.
+2. RecordingIntegration level (core test, through real service API):
+   - AC-2 noop shape: 2 content, 0 compressed.
+   - AC-3 failed shape: 2 content, 0 compressed; sequential noop cycles.
+   - AC-4 applied shape through real endCompression: [before, after] content
+     texts, 1 compressed, queued-during content suppressed.
+
+## Verification
+
+Full cycle per the issue workflow: `npm run test`, `npm run lint`,
+`npm run typecheck`, `npm run format`, `npm run build`, and the stepfun-37
+smoke test; then OCR (max 2 rounds), PR, CI watch, CodeRabbit triage.
+
+## Review triage
+
+Findings classified as Blocker-Fix / In-scope-Fix / Reject / Defer; reviewer
+suggestions do not authorize scope expansion.
+
+## Implementation notes
+
+Changed files:
+
+- `packages/core/src/services/history/historyEventTypes.ts` — added
+  `on`/`emit`/`off` overloads for the new `compressionLockReleased` event
+  (`() => void` listener), mirroring `compressionStarted`.
+- `packages/core/src/services/history/HistoryService.ts` — `endCompression()`
+  now emits `compressionLockReleased` after the pending-queue drain and before
+  the conditional `compressionEnded`; doc comment updated.
+- `packages/core/src/recording/RecordingIntegration.ts` — new
+  `onCompressionLockReleased` handler clears `compressionInProgress`;
+  registered/unregistered symmetrically in `subscribeToHistory`. The existing
+  flag-clear in `onCompressionEnded` is kept so direct `compressionEnded`
+  emissions behave as before.
+- `packages/core/src/services/history/compression-locking.test.ts` — new
+  `compressionLockReleased event` describe: argless/failed/summary shapes,
+  flush→lockReleased→ended ordering, unbalanced endCompression.
+- `packages/core/src/recording/RecordingIntegration.core.test.ts` — new tests
+  in `Compression-aware filtering`: noop shape (AC-2), failed shape + repeated
+  noop cycles (AC-3), applied shape through the real API with a queued add
+  suppressed (AC-4).
+
+RED evidence: with the three production files reverted (git stash of
+production only), 8 of the 9 new tests fail:
+
+- 5 in `compression-locking.test.ts` (lock-release event absent).
+- 3 in `RecordingIntegration.core.test.ts` (post-noop/failed content lost).
+- The applied-shape ordering guard passes on main by design — it pins
+  unchanged behavior (AC-4).
+
+Reproduction probe (`tmp/issue3263-probe/probe.ts`, real components): before
+the fix noop/failed shapes recorded content=1 (expected 2); after the fix all
+three shapes record content=2, with `compressed=1` only for the applied shape.


### PR DESCRIPTION
## TLDR

Session recording stopped permanently after a no-op or failed compression. `RecordingIntegration` suppressed `contentAdded` while `compressionInProgress` was `true` and cleared that flag only in its `compressionEnded` handler, but `HistoryService.endCompression()` emits `compressionEnded` only when given both a summary and an `itemsCompressed` count. `CompressionHandler` ends a no-op compression with `endCompression()` (no args) and a failed one with an `undefined` summary, so nothing was emitted and the flag stayed `true` for the rest of the session — every subsequent content record was silently dropped, the session file stopped growing, and a later resume lost everything after that compression.

Fixes #3263.

## Dive Deeper

The fix follows the direction the issue prescribes: clear the suppression flag on a signal that always fires when the compression lock is released, rather than on the summary-bearing `compressionEnded` event.

- `HistoryService.endCompression()` now emits a new `compressionLockReleased` event **after** the pending-operations drain and **before** the conditional `compressionEnded` emit, in every argument shape (no args, summary-less, full summary). Typed overloads were added to `HistoryServiceEventEmitter` (`historyEventTypes.ts`) mirroring `compressionStarted`.
- `RecordingIntegration.subscribeToHistory()` listens for `compressionLockReleased` and clears `compressionInProgress`; the listener is removed symmetrically in the subscription teardown.

Why the ordering matters:

- Emitting **after the drain** keeps flushed (queued-during-compression / rebuild) content inside the suppression window, so applied-compression behavior is byte-for-byte unchanged and no duplicate content records appear.
- `compressionEnded` remains conditional on `summary && itemsCompressed !== undefined`, so a no-op or failed compression still writes **no** `compressed` record — preserving the guarantee #2602 introduced deliberately.
- Emitting `compressionEnded` unconditionally would have been the wrong fix for exactly that reason; a dedicated lock-release signal carries the "suppression window closed" meaning without dragging the summary payload semantics along.
- The existing flag-clear inside `onCompressionEnded` is kept, so direct `compressionEnded` emissions (as in the pre-existing tests) behave identically.

`CompressionHandler` is untouched: its three `endCompression` call shapes (applied / noop / failed) are all covered by the unconditional release signal.

Reproduction (from the issue, verified at HEAD before the fix with a probe against real `HistoryService` + `RecordingIntegration` + `SessionRecordingService`): `add(before)`, `startCompression()`, `endCompression()`, `add(after)` recorded 1 content record instead of 2. After the fix all three shapes record both content records, with a `compressed` record only for the applied shape.

## Reviewer Test Plan

```bash
bun test packages/core/src/services/history/compression-locking.test.ts packages/core/src/recording/RecordingIntegration.core.test.ts
```

New coverage:

- `compression-locking.test.ts` → `compressionLockReleased event`: argless and summary-less `endCompression` emit the release signal and not `compressionEnded`; summary-shape emits both; observed ordering is flushed `contentAdded` → `compressionLockReleased` → `compressionEnded`; unbalanced `endCompression()` (no start) still emits.
- `RecordingIntegration.core.test.ts` → `Compression-aware filtering` (driven through the real HistoryService API): content after an argless end (noop shape) and after `endCompression(undefined, 5)` (failed shape) is recorded with 0 `compressed` records; sequential no-op cycles keep recording; applied compression through real `endCompression(summary, count)` suppresses the flushed during-compression add, writes exactly one `compressed` record, and records post-compression content.

TDD evidence: with the three production files reverted, 8 of the 9 new tests fail (the applied-shape ordering guard passes on main by design — it pins unchanged behavior).

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | -   | -   | -   |
| Seatbelt | ❓  | -   | -   |

On 🍏 (macOS, Bun): full `npm run test` (all workspaces, 0 failures), `npm run lint`, `npm run typecheck`, `npm run format`, and `npm run build` all pass on the candidate head. The `stepfun-37` smoke command was run twice and failed only with `API Error: 400 you have no active step plan subscription`; the identical error reproduces on unmodified `main`, so it is an environment/provider-account issue, not a regression.

## Linked issues / bugs

Fixes #3263

Related context: #2602 (no-op compression semantics preserved), #3132 (found this issue while working on duplicate content records; that scope is not touched here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recording behavior after compression completes, including no-op and unsuccessful compression attempts.
  * Ensured queued content is handled correctly while recording suppression is active.
  * Prevented suppressed content from being recorded and limited compressed-event notifications to applied compression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->