### PR TITLE
Propagate native exit codes through the Windows PowerShell shell path (Fixes #3320)

### DIFF
--- a/packages/core/src/services/shellExecutionService.fallback.test.ts
+++ b/packages/core/src/services/shellExecutionService.fallback.test.ts
@@ -474,12 +474,24 @@ describe('ShellExecutionService child_process fallback', () => {
 
       expect(mockCpSpawn).toHaveBeenCalledWith(
         'powershell.exe',
-        ['-NoProfile', '-Command', 'dir "foo bar"'],
+        ['-NoProfile', '-Command', expect.stringContaining('dir "foo bar"')],
         expect.objectContaining({
           shell: false,
           detached: false,
           windowsHide: true,
         }),
+      );
+
+      // Pin the full composed command through the service so the exit-code
+      // wiring is proven on non-Windows dev machines.
+      expect(mockCpSpawn).toHaveBeenCalledWith(
+        'powershell.exe',
+        [
+          '-NoProfile',
+          '-Command',
+          '$global:LASTEXITCODE = 0;\ndir "foo bar"\nif ($?) { exit 0 }\nif ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }\nexit 1',
+        ],
+        expect.anything(),
       );
     });
 
@@ -606,7 +618,7 @@ describe('ShellExecutionService child_process fallback', () => {
 
       expect(mockCpSpawn).toHaveBeenCalledWith(
         'powershell.exe',
-        ['-NoProfile', '-Command', 'echo hello'],
+        ['-NoProfile', '-Command', expect.stringContaining('echo hello')],
         expect.objectContaining({
           windowsHide: true,
         }),

--- a/packages/core/src/services/shellExecutionService.main.test.ts
+++ b/packages/core/src/services/shellExecutionService.main.test.ts
@@ -622,7 +622,7 @@ describe('ShellExecutionService', () => {
 
       expect(mockPtySpawn).toHaveBeenCalledWith(
         'powershell.exe',
-        ['-NoProfile', '-Command', 'dir "foo bar"'],
+        ['-NoProfile', '-Command', expect.stringContaining('dir "foo bar"')],
         expect.any(Object),
       );
     });

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -15,7 +15,10 @@ import type {
   ShellExecutionConfig,
   ShellOutputEvent,
 } from './shellExecutionTypes.js';
-import { ensurePromptvarsDisabled } from './shellOutputUtils.js';
+import {
+  ensurePromptvarsDisabled,
+  ensureNativeExitCodePropagated,
+} from './shellOutputUtils.js';
 import {
   SIGKILL_TIMEOUT_MS,
   isKillablePid,
@@ -93,7 +96,10 @@ export class ShellExecutionService {
     try {
       const isWindows = os.platform() === 'win32';
       const { executable, argsPrefix, shell } = getShellConfiguration();
-      const guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
+      const guardedCommand = ensureNativeExitCodePropagated(
+        ensurePromptvarsDisabled(commandToExecute, shell),
+        shell,
+      );
       const spawnArgs = [...argsPrefix, guardedCommand];
 
       const envVars = this.sanitizeEnvironment(
@@ -148,7 +154,10 @@ export class ShellExecutionService {
     const cols = shellExecutionConfig.terminalWidth ?? 80;
     const rows = shellExecutionConfig.terminalHeight ?? 30;
     const { executable, argsPrefix, shell } = getShellConfiguration();
-    const guardedCommand = ensurePromptvarsDisabled(commandToExecute, shell);
+    const guardedCommand = ensureNativeExitCodePropagated(
+      ensurePromptvarsDisabled(commandToExecute, shell),
+      shell,
+    );
     const args = [...argsPrefix, guardedCommand];
 
     const envVars = this.sanitizeEnvironment(

--- a/packages/core/src/services/shellExecutionService.windows.multibyte.test.ts
+++ b/packages/core/src/services/shellExecutionService.windows.multibyte.test.ts
@@ -101,7 +101,7 @@ describe('ShellExecutionService Windows multibyte regression tests', () => {
     // Should use powershell.exe on Windows (new shell-utils architecture)
     expect(spawn).toHaveBeenCalledWith(
       'powershell.exe',
-      ['-NoProfile', '-Command', command],
+      ['-NoProfile', '-Command', expect.stringContaining(command)],
       expect.objectContaining({
         shell: false,
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -182,7 +182,7 @@ describe('ShellExecutionService Windows multibyte regression tests', () => {
     // Should use powershell.exe with command as argument (no extra quote escaping)
     expect(spawn).toHaveBeenCalledWith(
       'powershell.exe',
-      ['-NoProfile', '-Command', command],
+      ['-NoProfile', '-Command', expect.stringContaining(command)],
       expect.objectContaining({ shell: false }),
     );
 

--- a/packages/core/src/services/shellExecutionService.windows.test.ts
+++ b/packages/core/src/services/shellExecutionService.windows.test.ts
@@ -72,7 +72,7 @@ describe('ShellExecutionService (Windows behavior)', () => {
       );
       expect(spawn).toHaveBeenCalledWith(
         expect.stringMatching(/powershell\.exe$/i),
-        ['-NoProfile', '-Command', 'echo a & echo b'],
+        ['-NoProfile', '-Command', expect.stringContaining('echo a & echo b')],
         expect.objectContaining({
           shell: false,
           windowsVerbatimArguments: false,
@@ -93,7 +93,7 @@ describe('ShellExecutionService (Windows behavior)', () => {
       );
       expect(spawn).toHaveBeenCalledWith(
         expect.stringMatching(/powershell\.exe$/i),
-        ['-NoProfile', '-Command', 'node -v'],
+        ['-NoProfile', '-Command', expect.stringContaining('node -v')],
         expect.objectContaining({
           shell: false,
           windowsVerbatimArguments: false,

--- a/packages/core/src/services/shellExitCode.bun.test.ts
+++ b/packages/core/src/services/shellExitCode.bun.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type {
+  ShellExecutionConfig,
+  ShellExecutionResult,
+} from './shellExecutionService.js';
+import { ShellExecutionService } from './shellExecutionService.js';
+import { getShellConfiguration } from '../utils/shell-utils.js';
+import { ensureNativeExitCodePropagated } from './shellOutputUtils.js';
+
+describe('ensureNativeExitCodePropagated', () => {
+  it('wraps a powershell command with the exit-code ladder on its own lines', () => {
+    expect(ensureNativeExitCodePropagated('node -v', 'powershell')).toBe(
+      '$global:LASTEXITCODE = 0;\n' +
+        'node -v\n' +
+        'if ($?) { exit 0 }\n' +
+        'if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }\n' +
+        'exit 1',
+    );
+  });
+
+  it('composes with newline separators so a trailing semicolon never forms ;;', () => {
+    expect(
+      ensureNativeExitCodePropagated('echo hi;', 'powershell'),
+    ).not.toContain(';;');
+  });
+
+  it('returns the input unchanged for bash', () => {
+    expect(ensureNativeExitCodePropagated('node -v', 'bash')).toBe('node -v');
+  });
+
+  it('returns the input unchanged for cmd', () => {
+    expect(ensureNativeExitCodePropagated('node -v', 'cmd')).toBe('node -v');
+  });
+});
+
+/**
+ * Cross-platform fixture that exits with the code given as argv[2].
+ * Written to a temp file so the command avoids shell-quoting issues.
+ */
+let fixtureDir = '';
+let fixtureScript = '';
+
+const FIXTURE_CODE = `
+process.exitCode = parseInt(process.argv[2] || '0', 10);
+process.stdout.write('LLXPRT_EXIT_FIXTURE_MARKER');
+`;
+
+// Guarded: this afterAll is file-scoped but fixtureDir is assigned in a
+// describe-scoped beforeAll, which does not run under test-name filtering.
+afterAll(() => {
+  if (fixtureDir !== '') {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+function fixtureCommand(exitCode: number): string {
+  const invocation = `"${process.execPath}" "${fixtureScript}" ${exitCode}`;
+  // A command line beginning with a quoted string parses in expression mode in
+  // PowerShell; `&` forces command mode.
+  return getShellConfiguration().shell === 'powershell'
+    ? `& ${invocation}`
+    : invocation;
+}
+
+async function executeAndCollect(
+  command: string,
+  config: ShellExecutionConfig = {},
+): Promise<ShellExecutionResult> {
+  const controller = new AbortController();
+  const handle = await ShellExecutionService.execute(
+    command,
+    '.',
+    () => {},
+    controller.signal,
+    false,
+    config,
+  );
+  return handle.result;
+}
+
+describe('native exit code propagation through ShellExecutionService', () => {
+  beforeAll(() => {
+    fixtureDir = mkdtempSync(join(tmpdir(), 'llxprt-exit-code-tests-'));
+    fixtureScript = join(fixtureDir, 'exitFixture.mjs');
+    writeFileSync(fixtureScript, FIXTURE_CODE);
+  });
+
+  it('reports a native exit code of 42', async () => {
+    const result = await executeAndCollect(fixtureCommand(42));
+    expect(result.exitCode).toBe(42);
+  });
+
+  it('reports exit code 0 for a successful command', async () => {
+    const result = await executeAndCollect(fixtureCommand(0));
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe.skipIf(process.platform !== 'win32')(
+  'PowerShell-level failures and explicit exits',
+  () => {
+    it('reports a PowerShell-level failure (Write-Error) as exit 1', async () => {
+      const result = await executeAndCollect(
+        'Write-Error LLXPRT_PS_FAIL_MARKER',
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it('lets a user command that exits 7 win over the appended suffix', async () => {
+      const result = await executeAndCollect('exit 7');
+      expect(result.exitCode).toBe(7);
+    });
+  },
+);

--- a/packages/core/src/services/shellOutputUtils.ts
+++ b/packages/core/src/services/shellOutputUtils.ts
@@ -37,6 +37,32 @@ export function ensurePromptvarsDisabled(
   return `${BASH_SHOPT_GUARD} ${command}`;
 }
 
+// PowerShell -Command does not adopt a native program's exit code (a program
+// exiting 42 surfaces as 1). The ladder mirrors hookRunner.ts's
+// buildPowerShellExitCodeWrapper (issue #3320): a bare `; exit
+// $LASTEXITCODE` would turn PowerShell-level failures (Write-Error,
+// command-not-found, where $LASTEXITCODE stays 0/$null) into exit 0.
+// `$?` preserves 0 for success, the $LASTEXITCODE branch re-raises native
+// N, and the final `exit 1` keeps PS-level failures nonzero. Newline
+// separators (not `;`) tolerate a user command ending in `;` (a `;`
+// separator would create `;;`, a parse error). The prelude avoids
+// `$null -ne 0 -> exit $null -> exit 0` when no native command ran.
+const POWERSHELL_EXIT_CODE_PRELUDE = '$global:LASTEXITCODE = 0;';
+const POWERSHELL_EXIT_CODE_SUFFIX =
+  'if ($?) { exit 0 }\n' +
+  'if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }\n' +
+  'exit 1';
+
+export function ensureNativeExitCodePropagated(
+  command: string,
+  shell: ShellType,
+): string {
+  if (shell !== 'powershell') {
+    return command;
+  }
+  return `${POWERSHELL_EXIT_CODE_PRELUDE}\n${command}\n${POWERSHELL_EXIT_CODE_SUFFIX}`;
+}
+
 /** Shared inactivity timer factory used by both CP and PTY paths. */
 export function makeInactivityTimer(
   timeoutMs: number | undefined,

--- a/project-plans/issue3320/plan.md
+++ b/project-plans/issue3320/plan.md
@@ -292,4 +292,25 @@ tmp/verify3320/*2.log.
   (config.scheduler.test.ts, engineTodoContinuation.behavior.test.ts),
   both in unrelated subsystems; both files pass when run individually
   (tmp/verify3320/rerun2.log). Same load-flake pattern as round 1.
-require user approval before inclusion.
+
+## PR outcome (PR #3330, head aba366146)
+
+- All GitHub checks pass on the PR head (ubuntu test shards incl.
+  core/agents/cli, E2E Linux sandbox:none+docker, ACP conformance,
+  SecureStore, CodeQL, lint, smokes, mergeability gate); mergeable
+  state CLEAN, zero actionable review threads.
+- CodeRabbit (CHILL profile): "No actionable comments". Pre-merge
+  checks 4/5 passed; the one failure is the Docstring Coverage warning
+  (20% < 80% threshold, computed over 5 functions touched by the diff).
+  Disposition: Reject — satisfying the threshold would require TSDoc on
+  test functions, which contradicts the repo's test style and the
+  "comments sparingly, why not what" convention; the new exported
+  helper carries a rationale comment instead, mirroring the sibling
+  functions in shellOutputUtils.ts. Warning is non-blocking.
+- PR OpenCodeReview workflow (ocr v1.8.4, full range): exit 0, no
+  findings on all 7 completed eligible files.
+- Windows proof: the acceptance-critical test (native exit 42 → 42)
+  runs on the Windows nightly core shard, which is scheduled, not PR
+  CI; the PR-level proof is the exact composed-command assertion plus
+  the cross-platform behavioral suite. The nightly run will exercise
+  the skipIf(!isWindows) suites (Write-Error → 1, user exit 7 → 7).

--- a/project-plans/issue3320/plan.md
+++ b/project-plans/issue3320/plan.md
@@ -1,0 +1,295 @@
+# Plan: Propagate native exit codes through the Windows PowerShell shell path (Issue #3320)
+
+Plan ID: PLAN-20260825-ISSUE3320
+Generated: 2026-08-25
+Issue: #3320
+Status: In progress
+
+## Problem statement
+
+On Windows, `ShellExecutionService` composes
+`powershell.exe -NoProfile -Command <cmd>` (from `getShellConfiguration()` in
+`packages/core/src/utils/shell-utils.ts`). Windows PowerShell's `-Command`
+does not adopt the exit status of the last native executable: a program that
+exits 42 makes `powershell.exe` exit 1. Every consumer of the shell tool's
+exit code on Windows (the model's view of a failed command, retry logic that
+keys off exact codes) sees 1 instead of the real status. bash (non-Windows)
+propagates natively; the codebase already works around this PowerShell quirk
+in one subsystem (`packages/core/src/hooks/hookRunner.ts`,
+`buildPowerShellExitCodeWrapper`) but not in the general shell path.
+
+Evidence (issue): nightly Windows `core` shard fixture exiting 42 reported
+`Expected: 42 / Received: 1`. `shellBoundedAcquisition.bun.test.ts` had to
+add a fixture-level `propagateExit()` helper (`; exit $LASTEXITCODE` at the
+call site) to keep its own test meaningful — proof the product path loses the
+code.
+
+## Accepted behavior (acceptance criteria)
+
+- AC1: On the PowerShell shell configuration, a command whose underlying
+  native program exits with code N (N ≠ 0) is reported with `exitCode === N`
+  by `ShellExecutionService` (both the child_process fallback and the PTY
+  path).
+- AC2: Successful commands still report `exitCode === 0` (native exit 0 and
+  successful PowerShell statements).
+- AC3: PowerShell-level failures (e.g. `Write-Error`, command-not-found)
+  still report a nonzero code (1). A naive `; exit $LASTEXITCODE` suffix
+  would turn these into 0 because `$LASTEXITCODE` stays 0/$null when no
+  native command ran — this regression is explicitly rejected.
+- AC4: A user command that itself ends in `exit N` still yields N (the
+  shell exits before the appended suffix runs).
+- AC5: Signal/termination cases are unchanged (exitCode null + signal,
+  `aborted` flag; handled upstream in `createCpResultPromise` /
+  `createPtyResultPromise`, untouched by this change — verified by the
+  existing abort/signal tests continuing to pass).
+- AC6: bash and cmd behaviour is unchanged: `getShellConfiguration()`
+  output is byte-identical; the bash composition (`shopt` guard + command)
+  is byte-identical; nothing changes for non-PowerShell shell types.
+- AC7: The behavior is covered by a test that fails against the current
+  Windows behaviour (a real-subprocess test asserting exit code 42, which
+  fails on the Windows CI runner today and passes after the fix; on
+  macOS/Linux it is a regression guard since bash already propagates).
+
+Boundary cases in scope:
+
+- A command ending with `;` or a newline must not produce a parse error
+  from the appended suffix (use newline as the statement separator between
+  the user command and the suffix; a bare `;` separator would create `;;`).
+- Multiline user commands keep working (PowerShell already accepts
+  newlines in `-Command`; this is permitted today when the parser is
+  available).
+- Empty command string: composed result still exits 0 (assignment prelude
+  succeeds).
+
+## Preflight findings (verified in code)
+
+1. Composition sites — exactly two, both in
+   `packages/core/src/services/shellExecutionService.ts`:
+   - `childProcessFallback` (~L95): `const guardedCommand =
+     ensurePromptvarsDisabled(commandToExecute, shell);` then
+     `[...argsPrefix, guardedCommand]` into `cpSpawn`.
+   - `executeWithPty` (~L150): same composition into `ptyInfo.module.spawn`.
+   `ensurePromptvarsDisabled` (`packages/core/src/services/shellOutputUtils.ts`)
+   prepends a `shopt` guard for bash only and is a no-op for PowerShell —
+   the natural sibling location for the new helper.
+2. `getShellConfiguration()` on Windows ALWAYS returns shell `powershell`
+   (either ComSpec pointing at powershell.exe/pwsh.exe, or the
+   `powershell.exe` default); `cmd` never wins, so the wrapper is
+   PowerShell-only by construction.
+3. `hookRunner.ts` semantics to mirror (lines 67-80): pre-initialize
+   `$global:LASTEXITCODE = 0`; after the user script, `if ($?) { exit 0 }`;
+   `if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }`; `exit 1`. This
+   ordering matters: `$?` is False after a native command exits nonzero
+   (both PS 5.1 and 7.x), so native-N lands in the `$LASTEXITCODE` branch,
+   while PS-level failures (no native involved) fall through to `exit 1`.
+   The pre-initialization avoids `$null -ne 0 → exit $null → 0` for
+   PS-level failures.
+4. Tests asserting the exact composed spawn args through the service
+   (must be updated when the command string changes):
+   - `packages/core/src/services/shellExecutionService.fallback.test.ts`
+     L477 (`dir "foo bar"`), L609 (`echo hello`) — win32-stubbed, run on
+     every platform.
+   - `packages/core/src/services/shellExecutionService.main.test.ts` L625
+     (`dir "foo bar"`, PTY path, `../utils/runtime.js` mocked) — runs on
+     every platform.
+   - `packages/core/src/services/shellExecutionService.windows.test.ts`
+     L75, L96 — `skipIf(!isWindows)`, Windows CI only.
+   - `packages/core/src/services/shellExecutionService.windows.multibyte.test.ts`
+     L104, L185 — win32-stubbed, every platform.
+   - NOT affected (spawn PowerShell directly, not through the service):
+     `shellProcessKill.test.ts`, `shellExecutionService.terminatePty.test.ts`,
+     `shellJobWindowsSpawn.test.ts`, `shellJobManager.test.ts` (job manager
+     is not modified).
+5. Real-subprocess cross-platform test pattern exists in
+   `shellBoundedAcquisition.bun.test.ts`: temp-dir `.mjs` fixture run via
+   `process.execPath`, with the `&` call operator prefix needed for
+   PowerShell expression-mode quirks. `.bun.test.ts` files run under the
+   normal suite (`packages/core` `test` = `bun run-bun-tests.ts`).
+
+## Implementation design
+
+### Production change (2 files)
+
+1. `packages/core/src/services/shellOutputUtils.ts` — add
+   `ensureNativeExitCodePropagated(command: string, shell: ShellType): string`
+   next to `ensurePromptvarsDisabled`:
+
+   ```ts
+   const POWERSHELL_EXIT_CODE_PRELUDE = '$global:LASTEXITCODE = 0;';
+   const POWERSHELL_EXIT_CODE_SUFFIX =
+     'if ($?) { exit 0 }\n' +
+     'if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }\n' +
+     'exit 1';
+
+   export function ensureNativeExitCodePropagated(
+     command: string,
+     shell: ShellType,
+   ): string {
+     if (shell !== 'powershell') {
+       return command;
+     }
+     return `${POWERSHELL_EXIT_CODE_PRELUDE}\n${command}\n${POWERSHELL_EXIT_CODE_SUFFIX}`;
+   }
+   ```
+
+   Newline separators tolerate a trailing `;` in the user command. Comment
+   references hookRunner's wrapper and issue #3320 (why the ladder, not a
+   bare `; exit $LASTEXITCODE`).
+
+2. `packages/core/src/services/shellExecutionService.ts` — at both
+   composition sites:
+
+   ```ts
+   const guardedCommand = ensureNativeExitCodePropagated(
+     ensurePromptvarsDisabled(commandToExecute, shell),
+     shell,
+   );
+   ```
+
+   (The two helpers are mutually exclusive by shell type: shopt guard is
+   bash-only, propagation is powershell-only.)
+
+### Tests
+
+1. NEW `packages/core/src/services/shellExitCode.bun.test.ts`
+   (copyright 2026, real subprocesses, model after
+   `shellBoundedAcquisition.bun.test.ts`):
+   - Unit describe for `ensureNativeExitCodePropagated` (pure
+     transformation, literals on the input side):
+     - powershell: exact composed string for a representative command
+       (prelude, command on its own line, exit ladder).
+     - powershell: command ending in `;` still composes without `;;`.
+     - bash: identity. cmd: identity.
+   - Behavioral describe (child_process fallback, real subprocesses,
+     cross-platform):
+     - fixture script exiting 42 → `result.exitCode === 42` (AC1/AC7;
+       fails on Windows today).
+     - fixture script exiting 0 → `result.exitCode === 0` (AC2).
+   - Windows-only describe (`describe.skipIf(process.platform !== 'win32')`):
+     - `Write-Error` command → `exitCode === 1` (AC3; fails if the fix
+       regresses PS-level failures to 0).
+     - `exit 7` command → `exitCode === 7` (AC4).
+   - Fixture: temp-dir `.mjs` with `process.exitCode = N`; invoke via
+     quoted `process.execPath` with `& ` prefix when
+     `getShellConfiguration().shell === 'powershell'` (documented
+     PowerShell expression-mode quirk).
+2. Updated spawn-arg assertions (keep those tests focused on what they
+   actually test — shell/executable/spawn options — by matching the command
+   arg with `expect.stringContaining(<original command>)`):
+   - `shellExecutionService.fallback.test.ts` (2 sites) + add ONE new
+     exact-args assertion pinning the full composed command
+     (prelude + command + ladder) through the service on win32 stub, so
+     the wiring is proven on non-Windows dev machines.
+   - `shellExecutionService.main.test.ts` (1 site, PTY path — proves the
+     PTY composition site).
+   - `shellExecutionService.windows.test.ts` (2 sites).
+   - `shellExecutionService.windows.multibyte.test.ts` (2 sites).
+
+### Out of scope (rejected/deferred)
+
+- `shellJobManager` background-job Windows path (Start-Process semantics,
+  separate subsystem) — potential follow-up issue, not this PR.
+- `hookRunner` (already correct; do NOT unify its wrapper with the new
+  helper — different context, different constraints).
+- Removing the now-redundant `propagateExit` fixture helper in
+  `shellBoundedAcquisition.bun.test.ts` (owned by #3253's test; harmless
+  and self-contained; touching it couples this PR to another effort).
+- Zed terminal manager, shellProcessor, prompt processors (interactive
+  shell selection, not `-Command` execution with exit codes).
+- Any change to `getShellConfiguration()` itself.
+
+## Test-first ordering
+
+1. Write the unit tests for `ensureNativeExitCodePropagated` + the
+   behavioral test file → RED (helper missing; on Windows CI the 42-test
+   is the true red, on macOS the unit tests are red first).
+2. Implement the helper + wire both composition sites → GREEN locally.
+3. Update the six existing assertions (they pin the old composed string
+   and go red the moment the helper lands — update together with it).
+
+## Verification
+
+Full cycle per the issue workflow (run by the implementer, the reviewer,
+and after any remediation):
+
+```bash
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```
+
+Windows-specific proof: the cross-platform behavioral tests + the
+Windows-only describe run on the Windows CI shard of the PR (AC7); locally
+on macOS we prove composition wiring via the win32-stubbed tests.
+
+## Review triage policy
+
+Findings classified as Blocker-Fix / In-scope-Fix / Reject / Defer.
+Scope additions (job manager, hookRunner unification, fixture cleanup)
+## Review triage policy
+
+Findings classified as Blocker-Fix / In-scope-Fix / Reject / Defer.
+Scope additions (job manager, hookRunner unification, fixture cleanup)
+require user approval before inclusion.
+
+## Review outcomes
+
+### deepthinker review (round 1, 2026-08-25)
+
+Verdict: PASS, findings NONE. Independently re-ran the six targeted test
+files (all green), lint (0), typecheck (0), `git diff --check` (clean),
+and the test-audit scanner (no findings on the new test or changed
+lines). Scope assessment: working tree stays strictly within plan.md.
+
+### OCR round 1 (local, workspace scope, ocr v1.10.0, run 20260825T170523Z-5e315e95)
+
+Status complete, 7/7 files reviewed, 3 findings:
+
+1. MEDIUM (test): Windows-only tests never run on Linux CI; suggested
+   pwsh cross-platform detection. **Reject.** The repo's Windows CI
+   shard (where #3253 observed the original bug) executes these
+   `skipIf(!isWindows)` suites — the established pattern in sibling
+   test files. pwsh 7 propagates native exit codes natively, so the
+   42→42 test would pass without the fix on pwsh and could never
+   detect the Windows PowerShell 5.1 regression it exists to catch;
+   the suggestion would also add out-of-scope test infrastructure.
+2. LOW (maintainability): exact-string assertion in
+   `shellExecutionService.fallback.test.ts` duplicates the ladder
+   format. **Reject.** The single exact pin through the real service
+   path is deliberate (proves composition order and separators at the
+   wiring site; all sibling assertions were relaxed to
+   `stringContaining`). Exporting the constants and composing the
+   expectation from them would make the assertion circular.
+3. LOW (bug): file-scoped `afterAll` could call `rmSync('')` when the
+   describe-scoped `beforeAll` never ran (test-name filtering or
+   beforeAll throw), masking results. **In-scope-Fix (applied):**
+   guarded cleanup on `fixtureDir !== ''` in
+   `shellExitCode.bun.test.ts`.
+
+Verification cycle re-run after the fix (round 2): targeted test file
+green, format 0; full suite/lint/typecheck/build re-run — results in
+tmp/verify3320/*2.log.
+
+### Environmental notes (both verification rounds)
+
+- First typecheck failed on `packages/core/src/telemetry/sdk.test.ts`
+  (`getTelemetryLogApiBodiesEnabled` missing): stale local
+  `packages/telemetry/dist` built before main HEAD e84a100a9 added the
+  property; green after `npm run build` refreshed dist. Not related to
+  this change.
+- First full-suite run had 6 timeout-signature failures in unrelated
+  subsystems (grep tool internals, direct-web-fetch transport, agents
+  cli-turn-parity/scheduler-factory/session); the suite ran concurrently
+  with build+typecheck. Every one of the 6 files passed when re-run
+  individually on the idle machine (tmp/verify3320/rerun.log).
+- Smoke test fails with provider 400 "you have no active step plan
+  subscription" (account state on the stepfun provider); startup itself
+  boots cleanly to the API call. Unrelated to this diff.
+- Round 2 full-suite run: 2 timeout-signature failures
+  (config.scheduler.test.ts, engineTodoContinuation.behavior.test.ts),
+  both in unrelated subsystems; both files pass when run individually
+  (tmp/verify3320/rerun2.log). Same load-flake pattern as round 1.
+require user approval before inclusion.


### PR DESCRIPTION
## TLDR

On Windows, `ShellExecutionService` runs commands via `powershell.exe -NoProfile -Command <cmd>`, and Windows PowerShell's `-Command` does **not** adopt a native executable's exit status: a program exiting 42 made the shell report 1. Every consumer of the shell tool's exit code on Windows (the model's view of a failed command, retry logic that keys off exact codes) saw 1 instead of the real status. The codebase already solves this in `hookRunner.ts` (`buildPowerShellExitCodeWrapper`); this PR applies the same ladder to the general shell execution path. `bash`/`cmd` composition is untouched (identity).

## Dive Deeper

**The fix** (`packages/core/src/services/shellOutputUtils.ts`): new `ensureNativeExitCodePropagated(command, shell)`, PowerShell-only, composing:

```powershell
$global:LASTEXITCODE = 0;
<user command>
if ($?) { exit 0 }
if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
exit 1
```

Why a three-branch ladder instead of the naive `; exit $LASTEXITCODE` suggested in the issue:

- A bare `exit $LASTEXITCODE` suffix would turn PowerShell-level failures (`Write-Error`, command-not-found — where `$LASTEXITCODE` stays 0/`$null`) into **exit 0**, regressing "nonzero means failed". The `$?` branch preserves 0 for success, the `$LASTEXITCODE` branch re-raises native N, and the final `exit 1` keeps PS-level failures nonzero — the same proven ordering as `hookRunner.ts`.
- The `$global:LASTEXITCODE = 0` prelude avoids `$null -ne 0 → exit $null → exit 0` when no native command ever ran (mirrors hookRunner's initialization).
- Newline separators (not `;`) tolerate a user command ending in `;` — a `;` separator would create `;;`, a parse error that would break every such command.
- A user command that itself ends in `exit N` still yields N: the shell exits before the suffix runs.
- Parse errors, signal/termination, and abort handling are untouched (the suffix is just more `-Command` text; kills are handled upstream in `createCpResultPromise`/`createPtyResultPromise`).

**Wiring** (`packages/core/src/services/shellExecutionService.ts`): both composition sites — `childProcessFallback` and `executeWithPty` — now compose `ensureNativeExitCodePropagated(ensurePromptvarsDisabled(cmd, shell), shell)`. `getShellConfiguration()` itself is unchanged.

**Tests** (`packages/core/src/services/shellExitCode.bun.test.ts`, new):
- Unit: exact composed string; trailing-`;` produces no `;;`; bash/cmd identity.
- Behavioral (real subprocesses, cross-platform): native exit 42 → `exitCode === 42` (this is the test that fails on Windows today), native exit 0 → 0.
- Windows-only (`skipIf !win32`): `Write-Error` → 1 (guards the PS-level-failure regression), user `exit 7` wins over the suffix.
- Four existing spawn-contract suites that pinned the exact old command string were relaxed to `stringContaining(<cmd>)`, plus **one** new exact-args assertion through the service on the win32 stub so the wiring is provable on non-Windows dev machines.

**Reviews**: deepthinker review passed with zero findings (independently re-ran targeted tests, lint, typecheck, `git diff --check`, test-audit scan). Local OCR (v1.10.0, workspace scope, complete, 7/7 files) raised 3 findings: one accepted and fixed (guarded `afterAll` cleanup in the new test), two rejected with rationale recorded in `project-plans/issue3320/plan.md` (pwsh cross-platform test infra would test the wrong PowerShell — pwsh 7 propagates natively so it can never catch the 5.1 regression; the single exact composed-command assertion is deliberate, importing the constants would make it circular).

**Out of scope** (deliberately, per the issue's "needs care" note): `shellJobManager` Windows background jobs, unifying `hookRunner`'s wrapper, and removing `propagateExit` from the #3253 fixture. Full triage and acceptance criteria: `project-plans/issue3320/plan.md`.

## Reviewer Test Plan

- `bun test packages/core/src/services/shellExitCode.bun.test.ts` — unit + behavioral coverage.
- `bun test packages/core/src/services/shellExecutionService.fallback.test.ts` — contains the exact composed-command pin through the service.
- On Windows (or the Windows CI shard, which is where it matters): the 42-test is the acceptance proof — red on `main`, green with this change.
- Quick manual sanity on any platform: `echo hi` → 0 through the shell tool; on Windows additionally `Write-Error x` → 1 and a program exiting N → N.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅ (test/lint/typecheck/format/build; 2 load flakes re-verified green individually) | ❓ (CI) | ❓ (CI) |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Environmental notes (both local verification rounds, details in the plan): first typecheck failure traced to a stale local `packages/telemetry/dist` predating main HEAD e84a100a9 (green after rebuild — unrelated); smoke test blocked by provider 400 "no active step plan subscription" (account state, boot healthy).

## Linked issues / bugs

Fixes #3320
Related to #3253 (the nightly Windows failures that surfaced this; its test now makes propagation explicit at the fixture level while this PR fixes the product path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PowerShell command execution so native process exit codes are consistently reported.
  - PowerShell failures now return appropriate error codes, while explicit user exit codes remain preserved.
  - Bash and Command Prompt behavior remains unchanged.

- **Tests**
  - Added coverage for successful commands, native failures, PowerShell errors, and explicit exit codes across supported execution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->