### PR TITLE
Escape taskStreaming tag attributes and restore scope message handlers (Fixes #3288)

### DIFF
--- a/packages/agents/src/tools/task.stream-restore.test.ts
+++ b/packages/agents/src/tools/task.stream-restore.test.ts
@@ -1,0 +1,166 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * TaskTool streaming-lifecycle tests (issue #3288).
+ *
+ * Task streaming installs a relay on `scope.onMessage` and must put the
+ * caller's handler back on every terminal path, so a scope that outlives one
+ * task does not keep relaying into a closed stream. These tests drive the real
+ * TaskTool execution path (success, subagent error, mid-run cancellation) and
+ * assert the observable state of the scope afterwards.
+ */
+
+import { describe, it, expect, vi } from 'bun:test';
+import { TaskTool } from './task.js';
+import { createTaskToolConfig } from './task-test-helpers.js';
+import type { SubagentOrchestrator } from '../core/subagentOrchestrator.js';
+import { SubagentTerminateMode } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
+
+interface RestorationScope {
+  output: {
+    emitted_vars: Record<string, string>;
+    terminate_reason: SubagentTerminateMode;
+  };
+  runInteractive: ReturnType<typeof vi.fn>;
+  runNonInteractive: ReturnType<typeof vi.fn>;
+  onMessage?: (message: string) => void;
+}
+
+/**
+ * Builds a TaskTool whose launched scope already carries `existingHandler` and
+ * whose interactive run is driven by `run` (which receives the live scope so a
+ * test can exercise the relay that streaming installed).
+ */
+function createRestorationHarness(
+  agentId: string,
+  existingHandler: (message: string) => void,
+  run: (scope: RestorationScope) => Promise<void>,
+): { scope: RestorationScope; tool: TaskTool } {
+  const scope: RestorationScope = {
+    output: {
+      emitted_vars: {},
+      terminate_reason: SubagentTerminateMode.GOAL,
+    },
+    runInteractive: vi.fn().mockImplementation(() => run(scope)),
+    runNonInteractive: vi.fn(),
+    onMessage: existingHandler,
+  };
+  const launch = vi.fn().mockResolvedValue({
+    agentId,
+    scope,
+    dispose: vi.fn().mockResolvedValue(undefined),
+    prompt: {} as unknown,
+    profile: {} as unknown,
+    config: {} as unknown,
+    runtime: {} as unknown,
+  });
+  const tool = new TaskTool(createTaskToolConfig(), {
+    orchestratorFactory: () => ({ launch }) as unknown as SubagentOrchestrator,
+    isInteractiveEnvironment: () => true,
+  });
+  return { scope, tool };
+}
+
+describe('TaskTool scope.onMessage restoration across task lifecycles', () => {
+  it('restores the pre-existing handler after a successful run', async () => {
+    const received: string[] = [];
+    const existingHandler = (message: string): void => {
+      received.push(message);
+    };
+    let relayDuringRun: ((message: string) => void) | undefined;
+    const { scope, tool } = createRestorationHarness(
+      'agent-restore-ok',
+      existingHandler,
+      async (liveScope) => {
+        relayDuringRun = liveScope.onMessage;
+        liveScope.onMessage?.('progress');
+      },
+    );
+    const appended: string[] = [];
+
+    await tool
+      .build({ subagent_name: 'helper', goal_prompt: 'Do work' })
+      .execute(new AbortController().signal, (update) => {
+        if (update.mode === 'append') {
+          appended.push(update.data);
+        }
+      });
+
+    expect(relayDuringRun).not.toBe(existingHandler);
+    expect(received).toStrictEqual(['progress']);
+    expect(appended).toStrictEqual([
+      '<subagent name="helper" id="agent-restore-ok">\n',
+      'progress',
+      '</subagent name="helper" id="agent-restore-ok">\n',
+    ]);
+    expect(scope.onMessage).toBe(existingHandler);
+  });
+
+  it('restores the pre-existing handler after the subagent throws', async () => {
+    const received: string[] = [];
+    const existingHandler = (message: string): void => {
+      received.push(message);
+    };
+    const { scope, tool } = createRestorationHarness(
+      'agent-restore-error',
+      existingHandler,
+      async () => {
+        throw new Error('crashed');
+      },
+    );
+
+    const result = await tool
+      .build({ subagent_name: 'helper', goal_prompt: 'Do work' })
+      .execute(new AbortController().signal, () => {});
+
+    expect(result.error?.message).toBe('crashed');
+    expect(scope.onMessage).toBe(existingHandler);
+  });
+
+  it('restores the pre-existing handler after the run is aborted', async () => {
+    const received: string[] = [];
+    const existingHandler = (message: string): void => {
+      received.push(message);
+    };
+    const abortController = new AbortController();
+    let signalRunStarted: (() => void) | undefined;
+    const runStarted = new Promise<void>((resolve) => {
+      signalRunStarted = resolve;
+    });
+    const { scope, tool } = createRestorationHarness(
+      'agent-restore-abort',
+      existingHandler,
+      (liveScope) =>
+        new Promise<void>((_resolve, reject) => {
+          // Proves the relay is installed before the abort lands, so this
+          // exercises the mid-run cancellation path rather than the
+          // aborted-during-launch early return.
+          expect(liveScope.onMessage).not.toBe(existingHandler);
+          abortController.signal.addEventListener(
+            'abort',
+            () => {
+              const error = new Error('run aborted');
+              error.name = 'AbortError';
+              reject(error);
+            },
+            { once: true },
+          );
+          signalRunStarted?.();
+        }),
+    );
+
+    const execution = tool
+      .build({ subagent_name: 'helper', goal_prompt: 'Do work' })
+      .execute(abortController.signal, () => {});
+    await runStarted;
+    abortController.abort();
+    const result = await execution;
+
+    expect(result.metadata?.cancelled).toBe(true);
+    expect(scope.onMessage).toBe(existingHandler);
+  });
+});

--- a/packages/agents/src/tools/taskStreaming.test.ts
+++ b/packages/agents/src/tools/taskStreaming.test.ts
@@ -1,0 +1,289 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral coverage for {@link setupTaskStreaming} (issue #3288): XML
+ * attribute escaping on the subagent wrapper tags, and restoration of a
+ * pre-existing `scope.onMessage` when the closing tag is emitted.
+ *
+ * These tests drive the real `setupTaskStreaming` with the real
+ * `startTaskHeartbeat` (an injected parameter of the signature) and collect
+ * genuine `LiveOutputUpdate` values, so reverting the production change fails
+ * them.
+ */
+
+import { describe, it, expect, afterEach } from 'bun:test';
+import {
+  setupTaskStreaming,
+  type TaskStreamingHandle,
+} from './taskStreaming.js';
+import { startTaskHeartbeat } from './taskHeartbeat.js';
+import type { SubAgentScope } from '../core/subagent.js';
+import type { LiveOutputUpdate } from '@vybestack/llxprt-code-tools';
+
+/** The part of {@link SubAgentScope} that task streaming manipulates. */
+interface TestSubAgentScope {
+  onMessage?: (message: string) => void;
+}
+
+/** Narrow bridge from the minimal test scope to the full scope type. */
+function asSubAgentScope(scope: TestSubAgentScope): SubAgentScope {
+  return scope as unknown as SubAgentScope;
+}
+
+/** A message handler that records what it received, for chaining assertions. */
+interface RecordingHandler {
+  handler: (message: string) => void;
+  received: string[];
+}
+
+function createRecordingHandler(): RecordingHandler {
+  const received: string[] = [];
+  return {
+    handler: (message: string): void => {
+      received.push(message);
+    },
+    received,
+  };
+}
+
+/**
+ * Every real heartbeat started by a test, stopped in afterEach so the 10s
+ * liveness timers do not outlive the test that armed them.
+ */
+const openStreams: TaskStreamingHandle[] = [];
+
+afterEach(() => {
+  while (openStreams.length > 0) {
+    openStreams.pop()?.heartbeat.stop();
+  }
+});
+
+interface StreamingHarness {
+  scope: TestSubAgentScope;
+  updates: LiveOutputUpdate[];
+  handle: TaskStreamingHandle;
+}
+
+/**
+ * Calls the real `setupTaskStreaming` with the real `startTaskHeartbeat` and a
+ * plain collector as `updateOutput`. Returns the scope (whose `onMessage` the
+ * tests read), the collected updates, and the streaming handle.
+ */
+function createStreamingHarness(
+  subagentName: string,
+  agentId: string,
+  options: {
+    existingHandler?: (message: string) => void;
+    updateOutput?: (update: LiveOutputUpdate) => void;
+  } = {},
+): StreamingHarness {
+  const scope: TestSubAgentScope = { onMessage: options.existingHandler };
+  const updates: LiveOutputUpdate[] = [];
+  const collect = (update: LiveOutputUpdate): void => {
+    updates.push(update);
+    options.updateOutput?.(update);
+  };
+  const handle = setupTaskStreaming(
+    subagentName,
+    agentId,
+    asSubAgentScope(scope),
+    collect,
+    startTaskHeartbeat,
+  );
+  openStreams.push(handle);
+  return { scope, updates, handle };
+}
+
+/** Extracts append payloads, skipping typed status (heartbeat) updates. */
+function appendData(updates: LiveOutputUpdate[]): string[] {
+  return updates
+    .filter((update) => update.mode === 'append')
+    .map((update) => update.data);
+}
+
+describe('setupTaskStreaming attribute escaping', () => {
+  it('escapes double quotes in the subagent name in the opening and closing tags', () => {
+    const { updates, handle } = createStreamingHarness('say "hi"', 'agent-42');
+
+    handle.emitClosingSubagentTag();
+
+    expect(appendData(updates)).toStrictEqual([
+      '<subagent name="say &quot;hi&quot;" id="agent-42">\n',
+      '</subagent name="say &quot;hi&quot;" id="agent-42">\n',
+    ]);
+  });
+
+  it('escapes ampersands and angle brackets in the subagent name', () => {
+    const { updates, handle } = createStreamingHarness('a & <b>', 'agent-42');
+
+    handle.emitClosingSubagentTag();
+
+    expect(appendData(updates)).toStrictEqual([
+      '<subagent name="a &amp; &lt;b&gt;" id="agent-42">\n',
+      '</subagent name="a &amp; &lt;b&gt;" id="agent-42">\n',
+    ]);
+  });
+
+  it('escapes apostrophes in the subagent name', () => {
+    const { updates, handle } = createStreamingHarness("it's", 'agent-42');
+
+    handle.emitClosingSubagentTag();
+
+    expect(appendData(updates)).toStrictEqual([
+      '<subagent name="it&apos;s" id="agent-42">\n',
+      '</subagent name="it&apos;s" id="agent-42">\n',
+    ]);
+  });
+
+  it('escapes an ampersand once rather than double-escaping the entities it produces', () => {
+    const { updates, handle } = createStreamingHarness(
+      '&lt;raw&gt;',
+      'agent-42',
+    );
+
+    handle.emitClosingSubagentTag();
+
+    expect(appendData(updates)[0]).toBe(
+      '<subagent name="&amp;lt;raw&amp;gt;" id="agent-42">\n',
+    );
+  });
+
+  it('escapes an agent id containing special characters', () => {
+    const { updates, handle } = createStreamingHarness('helper', 'a&b"c<d>');
+
+    handle.emitClosingSubagentTag();
+
+    expect(appendData(updates)).toStrictEqual([
+      '<subagent name="helper" id="a&amp;b&quot;c&lt;d&gt;">\n',
+      '</subagent name="helper" id="a&amp;b&quot;c&lt;d&gt;">\n',
+    ]);
+  });
+
+  it('leaves a name with no special characters byte-identical', () => {
+    const { updates, handle } = createStreamingHarness('helper', 'agent-42');
+
+    handle.emitClosingSubagentTag();
+
+    expect(appendData(updates)).toStrictEqual([
+      '<subagent name="helper" id="agent-42">\n',
+      '</subagent name="helper" id="agent-42">\n',
+    ]);
+  });
+});
+
+describe('setupTaskStreaming scope.onMessage lifecycle', () => {
+  it('restores a pre-existing handler when the closing tag is emitted', () => {
+    const existing = createRecordingHandler();
+    const { scope, handle } = createStreamingHarness('helper', 'agent-42', {
+      existingHandler: existing.handler,
+    });
+    expect(scope.onMessage).not.toBe(existing.handler);
+
+    handle.emitClosingSubagentTag();
+
+    expect(scope.onMessage).toBe(existing.handler);
+  });
+
+  it('restores undefined when the scope had no handler before streaming', () => {
+    const { scope, handle } = createStreamingHarness('helper', 'agent-42');
+    expect(scope.onMessage).toBeDefined();
+
+    handle.emitClosingSubagentTag();
+
+    expect(scope.onMessage).toBeUndefined();
+  });
+
+  it('emits the delta and chains to the pre-existing handler while streaming is open', () => {
+    const existing = createRecordingHandler();
+    const { scope, updates, handle } = createStreamingHarness(
+      'helper',
+      'agent-42',
+      { existingHandler: existing.handler },
+    );
+
+    scope.onMessage?.('first progress');
+    handle.emitClosingSubagentTag();
+
+    expect(existing.received).toStrictEqual(['first progress']);
+    expect(appendData(updates)).toStrictEqual([
+      '<subagent name="helper" id="agent-42">\n',
+      'first progress',
+      '</subagent name="helper" id="agent-42">\n',
+    ]);
+  });
+
+  it('emits nothing after the closing tag when a stale relay reference is invoked', () => {
+    const existing = createRecordingHandler();
+    const { scope, updates, handle } = createStreamingHarness(
+      'helper',
+      'agent-42',
+      { existingHandler: existing.handler },
+    );
+    const staleRelay = scope.onMessage;
+
+    handle.emitClosingSubagentTag();
+    staleRelay?.('late progress');
+
+    expect(existing.received).toStrictEqual(['late progress']);
+    expect(appendData(updates)).toStrictEqual([
+      '<subagent name="helper" id="agent-42">\n',
+      '</subagent name="helper" id="agent-42">\n',
+    ]);
+  });
+
+  it('restores the handler even when updateOutput throws while emitting the closing tag', () => {
+    const existing = createRecordingHandler();
+    const { scope, handle } = createStreamingHarness('helper', 'agent-42', {
+      existingHandler: existing.handler,
+      updateOutput: (update) => {
+        if (update.mode === 'append' && update.data.startsWith('</subagent')) {
+          throw new Error('downstream serialization failure');
+        }
+      },
+    });
+
+    expect(() => handle.emitClosingSubagentTag()).toThrow(
+      'downstream serialization failure',
+    );
+
+    expect(scope.onMessage).toBe(existing.handler);
+  });
+
+  it('leaves a handler installed while streaming was active in place at close', () => {
+    const existing = createRecordingHandler();
+    const later = createRecordingHandler();
+    const { scope, handle } = createStreamingHarness('helper', 'agent-42', {
+      existingHandler: existing.handler,
+    });
+
+    scope.onMessage = later.handler;
+    handle.emitClosingSubagentTag();
+
+    expect(scope.onMessage).toBe(later.handler);
+  });
+
+  it('does not clobber a handler installed after close when the closing tag is emitted twice', () => {
+    const existing = createRecordingHandler();
+    const later = createRecordingHandler();
+    const { scope, updates, handle } = createStreamingHarness(
+      'helper',
+      'agent-42',
+      { existingHandler: existing.handler },
+    );
+
+    handle.emitClosingSubagentTag();
+    expect(scope.onMessage).toBe(existing.handler);
+    scope.onMessage = later.handler;
+    handle.emitClosingSubagentTag();
+
+    expect(scope.onMessage).toBe(later.handler);
+    expect(appendData(updates)).toStrictEqual([
+      '<subagent name="helper" id="agent-42">\n',
+      '</subagent name="helper" id="agent-42">\n',
+    ]);
+  });
+});

--- a/packages/agents/src/tools/taskStreaming.ts
+++ b/packages/agents/src/tools/taskStreaming.ts
@@ -20,6 +20,20 @@ export interface TaskStreamingHandle {
 }
 
 /**
+ * Escapes a string for use inside a double-quoted XML attribute value. The
+ * ampersand MUST be replaced first so the entities produced for the other
+ * characters are not re-escaped.
+ */
+function escapeXmlAttributeValue(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
  * Wires the public live-output stream for a synchronous Task: emits the
  * opening `<subagent>` tag, installs the `scope.onMessage` relay (which
  * forwards normalized deltas and resets the heartbeat on real progress), and
@@ -33,6 +47,13 @@ export interface TaskStreamingHandle {
  *
  * Returns a no-op-shaped handle when no `updateOutput` observer is supplied
  * (the heartbeat start helper already short-circuits in that case).
+ *
+ * The subagent name and agent id are XML-attribute-escaped once at setup and
+ * used in both wrapper tags, and the pre-existing `scope.onMessage` is
+ * restored when the closing tag is emitted (issue #3288). Restoration runs
+ * before any emission so a throwing `updateOutput` consumer cannot leave the
+ * relay installed, and it only undoes this relay's own installation, so a
+ * handler installed by anyone else survives the close.
  */
 export function setupTaskStreaming(
   subagentName: string,
@@ -41,36 +62,53 @@ export function setupTaskStreaming(
   updateOutput: ((update: LiveOutputUpdate) => void) | undefined,
   startHeartbeat: typeof startTaskHeartbeat,
 ): TaskStreamingHandle {
+  const escapedName = escapeXmlAttributeValue(subagentName);
+  const escapedAgentId = escapeXmlAttributeValue(agentId);
   let xmlOutputOpen = false;
+  let restoreScopeHandler: (() => void) | undefined;
   const normalizer = createStreamNormalizer();
   const emitAppend = (data: string): void => {
     updateOutput?.({ mode: 'append', data });
   };
   const emitClosingSubagentTag = (): void => {
-    if (!xmlOutputOpen) {
+    const wasOpen = xmlOutputOpen;
+    xmlOutputOpen = false;
+    const restore = restoreScopeHandler;
+    restoreScopeHandler = undefined;
+    restore?.();
+    if (!wasOpen) {
       return;
     }
     const flushed = normalizer.flush();
     if (flushed !== undefined) {
       emitAppend(flushed);
     }
-    emitAppend(`</subagent name="${subagentName}" id="${agentId}">\n`);
-    xmlOutputOpen = false;
+    emitAppend(`</subagent name="${escapedName}" id="${escapedAgentId}">\n`);
   };
 
   if (updateOutput) {
-    emitAppend(`<subagent name="${subagentName}" id="${agentId}">\n`);
+    emitAppend(`<subagent name="${escapedName}" id="${escapedAgentId}">\n`);
     xmlOutputOpen = true;
 
     const existingHandler = scope.onMessage;
-    scope.onMessage = (message: string) => {
-      heartbeat.reset();
-      const delta = normalizer.push(message);
-      if (delta !== undefined) {
-        emitAppend(delta);
+    const relay = (message: string): void => {
+      if (xmlOutputOpen) {
+        heartbeat.reset();
+        const delta = normalizer.push(message);
+        if (delta !== undefined) {
+          emitAppend(delta);
+        }
       }
       existingHandler?.(message);
     };
+    restoreScopeHandler = (): void => {
+      // Only this relay's own installation is undone: a handler installed by
+      // someone else while the task ran owns the slot and must survive close.
+      if (scope.onMessage === relay) {
+        scope.onMessage = existingHandler;
+      }
+    };
+    scope.onMessage = relay;
   }
 
   // Start the heartbeat AFTER stream initialization so an exception during

--- a/project-plans/issue3288/plan.md
+++ b/project-plans/issue3288/plan.md
@@ -1,0 +1,139 @@
+# Issue #3288 — Escape taskStreaming tag attributes and restore scope message handlers
+
+## Scope
+
+Owned files:
+
+- `packages/agents/src/tools/taskStreaming.ts` (production)
+- `packages/agents/src/tools/taskStreaming.test.ts` (new, unit-level behavior)
+- `packages/agents/src/tools/task.test.ts` (TaskTool-level lifecycle evidence)
+
+Explicitly out of scope (do not touch):
+
+- `packages/agents/src/tools/taskAsyncExecution.ts` `setupAsyncStreaming` — a
+  separate function with the same shape; the issue names only `taskStreaming.ts`.
+- `packages/core/src/tools-adapters/CoreSubagentServiceAdapter.ts` — separate
+  duplicate emitter, also not named by the issue.
+- Heartbeat ordering (`task.ts` already stops the heartbeat before the closing
+  tag), per the issue's Scope section.
+- The closing-tag shape `</subagent name="..." id="...">` is not well-formed XML
+  (closing tags cannot carry attributes). Changing the wire format is NOT in
+  scope; multiple existing tests assert the current shape. We only escape the
+  interpolated values.
+
+## Accepted behavior (acceptance criteria)
+
+AC1. Attribute escaping. `subagentName` and `agentId` are escaped before being
+interpolated into the opening and closing subagent tags. Escaped characters:
+`&` -> `&amp;`, `<` -> `&lt;`, `>` -> `&gt;`, `"` -> `&quot;`, `'` -> `&apos;`.
+`&` must be replaced first so already-escaped output is not double-mangled in a
+different order.
+
+AC2. Format preserved for ordinary names. A name with no special characters
+produces byte-identical output to today (`<subagent name="helper" id="agent-42">\n`
+and `</subagent name="helper" id="agent-42">\n`). Existing tests in
+`task.test.ts`, `task.max-turns.test.ts`, `task.issues.test.ts`, and
+`task.heartbeat.test.ts` must pass unchanged.
+
+AC3. Handler restoration. When streaming closes (`emitClosingSubagentTag`),
+`scope.onMessage` is set back to whatever it was before `setupTaskStreaming`
+installed the relay, including `undefined`. Because `task.ts` calls
+`emitClosingSubagentTag()` from a `finally` block, this covers success, thrown
+error, and abort/cancellation paths. Restoration also happens when the closing
+emit itself throws (restore before emit), and repeat calls are no-ops.
+
+AC4. No output after the closing tag. If a stale reference to the installed
+relay is invoked after close, it emits nothing (no delta, no heartbeat reset).
+
+AC5. Chaining preserved. While the task is active, the relay calls the
+pre-existing `scope.onMessage` after emitting the delta. After close, a stale
+relay reference still forwards to the pre-existing handler (the same thing the
+restored `scope.onMessage` would do), it just does not emit.
+
+## Boundary inputs
+
+- name `he said "hi"` -> `he said &quot;hi&quot;`
+- name `a&b` -> `a&amp;b`
+- name `<script>` -> `&lt;script&gt;`
+- name `it's` -> `it&apos;s`
+- name with all of the above combined
+- empty name (`''`) -> unchanged, still emits `name=""`
+- ordinary name -> unchanged (AC2 regression guard)
+- `agentId` is a UUID in production, so escaping is a no-op there; it is escaped
+  anyway because the issue requires every dynamic attribute value escaped.
+
+## Implementation sketch
+
+In `taskStreaming.ts`:
+
+1. Add a module-local `escapeXmlAttributeValue(value: string): string` helper
+   (five `.replace` calls, `&` first). Not exported unless a test needs it —
+   tests assert through the emitted tags, so it stays private.
+2. Compute `escapedName` / `escapedAgentId` once at setup and use them in both
+   tag templates.
+3. Capture `existingHandler = scope.onMessage` and store a
+   `restoreScopeHandler: (() => void) | undefined` closure that reassigns it.
+4. Gate the relay body on `xmlOutputOpen`: when closed, skip
+   `heartbeat.reset()`, skip `normalizer.push`/`emitAppend`, still call
+   `existingHandler?.(message)`.
+5. In `emitClosingSubagentTag`: snapshot `xmlOutputOpen`, set it to `false`,
+   run `restoreScopeHandler?.()` and clear it (idempotent by nulling), then
+   return early if it was not open, otherwise flush and emit the closing tag.
+   Restoring before emitting means a throwing `updateOutput` cannot leak the
+   relay onto the scope.
+
+No new exports, no new abstractions, no dependency changes.
+
+## Test plan (Bun, behavioral)
+
+New file `packages/agents/src/tools/taskStreaming.test.ts` calls the real
+`setupTaskStreaming` with the real `startTaskHeartbeat` (injected dependency in
+the signature), a plain scope-shaped object, and an `updateOutput` collector
+that records the real `LiveOutputUpdate` values. Every test stops the heartbeat
+so no timer leaks. No mocking of the unit under test.
+
+1. escapes quotes in the name in both opening and closing tags
+2. escapes ampersands and angle brackets in the name in both tags
+3. escapes apostrophes in the name
+4. emits an unchanged tag for a plain name (format regression guard)
+5. escapes a dynamic agent id containing special characters
+6. restores a pre-existing `scope.onMessage` after close
+7. restores `undefined` when there was no pre-existing handler
+8. forwards messages to the pre-existing handler while active, in addition to
+   emitting the delta
+9. emits nothing when a stale relay reference is invoked after close, while
+   still forwarding to the pre-existing handler
+10. restores the handler even when `updateOutput` throws during the closing emit
+11. repeated `emitClosingSubagentTag()` calls do not re-clobber a handler
+    installed after close
+
+TaskTool-level lifecycle evidence added to `packages/agents/src/tools/task.test.ts`:
+
+12. after a successful run, `scope.onMessage` is the handler the scope had
+    before `execute()`
+13. after the subagent throws, `scope.onMessage` is restored (error path)
+14. after an abort during the run, `scope.onMessage` is restored (cancellation
+    path)
+
+## Review triage
+
+Local review round 1 (deepthinker, plus an independent OCR run that reported
+zero findings):
+
+- MEDIUM "restoration is not ownership-aware": **In-scope-Fix, applied**. The
+  restore closure now compares `scope.onMessage` to the relay it installed and
+  only restores when it still owns the slot, so a handler installed by other
+  code while the task ran survives the close. Covered by the new test "leaves a
+  handler installed while streaming was active in place at close", which fails
+  without the identity check.
+- LOW "new tests use `as unknown as` assertions": **Reject**. Every neighbouring
+  TaskTool suite (`task.test.ts`, `task.heartbeat.test.ts`,
+  `taskAsyncStreaming.test.ts`) builds its orchestrator/launch fakes the same
+  way. Constructing a full `SubagentLaunchResult` would add unrelated surface to
+  this issue and diverge from the file's established convention.
+
+## Verification
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+`npm run build`, plus the `stepfun-37` smoke run. Then `bun scripts/test-audit/scan.ts`
+to confirm no new test-audit findings on the touched files.

--- a/project-plans/issue3288/plan.md
+++ b/project-plans/issue3288/plan.md
@@ -126,6 +126,13 @@ zero findings):
   code while the task ran survives the close. Covered by the new test "leaves a
   handler installed while streaming was active in place at close", which fails
   without the identity check.
+- LOW (PR-level OCR round) "if `emitAppend(flushed)` throws, the closing tag is
+  never emitted and the stream is already marked closed": **Reject**. Not a
+  regression: before this change a throwing consumer also prevented the closing
+  tag, and it additionally left `xmlOutputOpen` true and the relay installed.
+  The throw propagates out of the `finally` in `task.ts` either way. Emitting
+  the terminator into a consumer that just threw, via a nested `finally`, is
+  speculative hardening outside this issue's acceptance criteria.
 - LOW "new tests use `as unknown as` assertions": **Reject**. Every neighbouring
   TaskTool suite (`task.test.ts`, `task.heartbeat.test.ts`,
   `taskAsyncStreaming.test.ts`) builds its orchestrator/launch fakes the same


### PR DESCRIPTION
## TLDR

`setupTaskStreaming` in `packages/agents/src/tools/taskStreaming.ts` had two defects carried over from the Bun test migration findings in #2918:

1. It interpolated the configured subagent name and the agent id straight into the streamed `<subagent name="..." id="...">` wrapper tags. A name containing a quote, ampersand, or angle bracket produced malformed streamed output.
2. It replaced `scope.onMessage` with a relay and never put the previous handler back. A scope that outlives one task kept the relay, and a late message could append text after the closing tag because the relay never checked whether the stream was still open.

Both attribute values are now XML-attribute-escaped once at setup and used in the opening and closing tags. The relay is gated on the open flag, and the previous handler is restored when the closing tag is emitted, which `task.ts` drives from a `finally` block covering the success, error, and cancellation paths.

## Dive Deeper

**Escaping.** A module-local `escapeXmlAttributeValue` replaces `&`, `<`, `>`, `"`, and `'` with entities, ampersand first so the entities it produces are not re-escaped. `agentId` is a UUID in production, so escaping it is a no-op today; it is escaped anyway because the issue asks for every dynamic attribute value to be escaped. No in-repo consumer parses these wrapper strings as XML (`liveOutput.ts` and `toolControl.ts` treat the append payload as text), and `task.ts` continues to use the original unescaped `agentId` in results and metadata, so this affects rendered wrapper text only.

**Wire format unchanged.** The closing tag still carries attributes, which is not well-formed XML but is the pre-existing format asserted by `task.test.ts`, `task.max-turns.test.ts`, `task.issues.test.ts`, and `task.heartbeat.test.ts`. Changing the format was not in scope; a name with no special characters still produces byte-identical output.

**Restoration.** `emitClosingSubagentTag` now marks the stream closed, restores the handler, and only then flushes and emits, so a throwing `updateOutput` consumer cannot leave the relay installed on the scope. The restore closure is one-shot (cleared after use) and ownership-aware: it compares `scope.onMessage` to the relay it installed and only restores when it still owns the slot, so a handler installed by other code while the task ran survives the close.

**Post-close behavior.** A stale reference to the relay emits nothing after close (no delta, no heartbeat reset) but still forwards to the handler it wrapped, which is exactly what the restored `scope.onMessage` would do, so no messages are dropped.

**Out of scope, deliberately.** `setupAsyncStreaming` in `taskAsyncExecution.ts` and the emitter in `CoreSubagentServiceAdapter.ts` have the same shape and the same two defects. Issue #3288 states it owns `taskStreaming.ts` and its tests, so they are untouched here. The heartbeat ordering finding from #2918 is also excluded because `task.ts` already calls `heartbeat.stop()` before emitting the closing tag.

## Reviewer Test Plan

```bash
git checkout issue3288
cd packages/agents
bun test src/tools/taskStreaming.test.ts src/tools/task.stream-restore.test.ts
# regression on the surrounding suites that assert the tag format
bun test src/tools/task.test.ts src/tools/task.issues.test.ts \
         src/tools/task.heartbeat.test.ts src/tools/task.max-turns.test.ts \
         src/tools/taskAsyncStreaming.test.ts
```

To confirm the tests are load-bearing, revert `packages/agents/src/tools/taskStreaming.ts` to its state on `main` and re-run: 12 of the new cases fail (all escaping cases, every restoration case, the post-close case, and the throwing-close case), while the two deliberate regression guards (plain-name output, active chaining) keep passing. Removing only the `scope.onMessage === relay` identity check fails exactly one case, "leaves a handler installed while streaming was active in place at close".

To see it end to end, configure a subagent whose name contains a quote or an ampersand and run a `task` invocation with live output; the wrapper tags now carry escaped entities instead of raw characters.

Local verification on this branch: `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`, and `bun scripts/test-audit/scan.ts` (no findings on the new files). Three unrelated `packages/agents/src/api` suites timed out in the full-suite run on a heavily loaded machine (30s and 180s timeouts) and pass in isolation: 29/29 across `mutationCoverage.tokens.behavior.test.ts`, `newSurfaceBoundary.spec.ts`, and `tasksControl.behavior.test.ts`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3288

Related to #2918 and PR #2858.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task streaming reliability when executions complete, fail, or are cancelled.
  * Preserved existing message handlers and continued forwarding messages correctly after streaming ends.
  * Escaped special characters in subagent names and IDs to prevent malformed streamed output.
  * Prevented stale streaming handlers from processing messages after a stream closes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->