### PR TITLE
Eliminate per-execution shell retention and bound secondary accumulators

### DIFF
--- a/packages/agents/src/core/coreToolScheduler.seenCallIds.test.ts
+++ b/packages/agents/src/core/coreToolScheduler.seenCallIds.test.ts
@@ -1,0 +1,232 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ * @plan PLAN-20260825-SHELLMEM.P02
+ * @requirement REQ-3329-05
+ */
+
+import { describe, expect, it, vi } from 'bun:test';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { ApprovalMode } from '@vybestack/llxprt-code-core/config/configTypes.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
+import { CoreMessageBusAdapter } from '@vybestack/llxprt-code-core/tools-adapters/CoreMessageBusAdapter.js';
+import { PolicyEngine } from '@vybestack/llxprt-code-core/policy/policy-engine.js';
+import {
+  PolicyDecision,
+  type PolicyEngineConfig,
+} from '@vybestack/llxprt-code-core/policy/types.js';
+import { ToolRegistry } from '@vybestack/llxprt-code-tools/tools/tool-registry.js';
+import {
+  BaseDeclarativeTool,
+  BaseToolInvocation,
+  Kind,
+  type ToolInvocation,
+  type ToolResult,
+} from '@vybestack/llxprt-code-tools/tools/tools.js';
+import type { IToolMessageBus } from '@vybestack/llxprt-code-tools';
+import { CoreToolScheduler } from './coreToolScheduler.js';
+
+interface CountingParams {
+  readonly value: number;
+}
+
+/** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-05 */
+class CountingInvocation extends BaseToolInvocation<
+  CountingParams,
+  ToolResult
+> {
+  constructor(
+    params: CountingParams,
+    messageBus: IToolMessageBus | undefined,
+    private readonly recordExecution: () => void,
+  ) {
+    super(params, messageBus, 'counting_tool', 'Counting Tool');
+  }
+
+  getDescription(): string {
+    return `Count ${this.params.value}`;
+  }
+
+  async execute(): Promise<ToolResult> {
+    this.recordExecution();
+    return {
+      llmContent: `counted ${this.params.value}`,
+      returnDisplay: `counted ${this.params.value}`,
+    };
+  }
+}
+
+/** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-05 */
+class CountingTool extends BaseDeclarativeTool<CountingParams, ToolResult> {
+  private executionCount = 0;
+
+  constructor(messageBus: IToolMessageBus) {
+    super(
+      'counting_tool',
+      'Counting Tool',
+      'Counts scheduler executions',
+      Kind.Other,
+      {
+        type: 'object',
+        properties: { value: { type: 'number' } },
+        required: ['value'],
+      },
+      false,
+      false,
+      messageBus,
+    );
+  }
+
+  get executions(): number {
+    return this.executionCount;
+  }
+
+  protected createInvocation(
+    params: CountingParams,
+    messageBus?: IToolMessageBus,
+  ): ToolInvocation<CountingParams, ToolResult> {
+    return new CountingInvocation(params, messageBus, () => {
+      this.executionCount += 1;
+    });
+  }
+}
+
+interface SchedulerHarness {
+  readonly scheduler: CoreToolScheduler;
+  readonly tool: CountingTool;
+}
+
+/** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-05 */
+function createHarness(): SchedulerHarness {
+  const policyConfig: PolicyEngineConfig = {
+    rules: [
+      {
+        decision: PolicyDecision.ALLOW,
+        priority: 1,
+        modes: [ApprovalMode.YOLO],
+        source: 'scheduler-cap-test',
+      },
+    ],
+    defaultDecision: PolicyDecision.ASK_USER,
+  };
+  const policyEngine = new PolicyEngine(policyConfig);
+  policyEngine.setApprovalMode(ApprovalMode.YOLO);
+  const messageBus = new MessageBus(policyEngine, false);
+  const messageBusAdapter = new CoreMessageBusAdapter(messageBus);
+  const toolRegistry = new ToolRegistry(
+    {
+      getEphemeralSettings: () => ({}),
+      getCoreTools: () => [],
+      getExcludeTools: () => [],
+    },
+    messageBusAdapter,
+  );
+  const tool = new CountingTool(messageBusAdapter);
+  toolRegistry.registerTool(tool);
+
+  const config = {
+    getSessionId: () => 'seen-call-id-cap-test',
+    getUsageStatisticsEnabled: () => false,
+    getDebugMode: () => false,
+    isInteractive: () => false,
+    getApprovalMode: () => ApprovalMode.YOLO,
+    getEphemeralSettings: () => ({
+      'tool-output-max-tokens': 50_000,
+      'tool-output-max-items': 50,
+    }),
+    getAllowedTools: () => [],
+    getContentGeneratorConfig: () => ({ model: 'test-model' }),
+    getToolRegistry: () => toolRegistry,
+    getMessageBus: () => messageBus,
+    getEnableHooks: () => false,
+    getHookSystem: () => null,
+    getPolicyEngine: () => policyEngine,
+    getModel: () => 'test-model',
+  } as unknown as Config;
+
+  return {
+    tool,
+    scheduler: new CoreToolScheduler({
+      config,
+      messageBus,
+      toolRegistry,
+      getPreferredEditor: () => undefined,
+      onEditorClose: vi.fn(),
+      toolContextInteractiveMode: false,
+    }),
+  };
+}
+
+/** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-05 */
+function request(callId: string, value: number) {
+  return {
+    callId,
+    name: 'counting_tool',
+    args: { value },
+    isClientInitiated: false,
+    prompt_id: 'seen-call-id-cap-test',
+  };
+}
+
+/** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-05 */
+describe('CoreToolScheduler recent call ID deduplication', () => {
+  /** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-05 */
+  it('drops a duplicate call ID within one batch', async () => {
+    const { scheduler, tool } = createHarness();
+
+    await scheduler.schedule(
+      [request('duplicate', 1), request('duplicate', 2)],
+      new AbortController().signal,
+    );
+
+    expect(tool.executions).toBe(1);
+    scheduler.dispose();
+  });
+
+  /** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-05 */
+  it('allows a call ID to run again after it leaves the 1024-ID window', async () => {
+    const { scheduler, tool } = createHarness();
+    const initialBatch = Array.from({ length: 1_025 }, (_, index) =>
+      request(`call-${index}`, index),
+    );
+
+    await scheduler.schedule(initialBatch, new AbortController().signal);
+
+    // The oldest retained ID (call-1) is still inside the window and must
+    // remain suppressed; only call-0 fell out.
+    await scheduler.schedule(
+      request('call-1', 2_001),
+      new AbortController().signal,
+    );
+    expect(tool.executions).toBe(1_025);
+
+    await scheduler.schedule(
+      request('call-0', 2_000),
+      new AbortController().signal,
+    );
+
+    expect(tool.executions).toBe(1_026);
+    scheduler.dispose();
+  });
+
+  /** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-05 */
+  it('drops an in-batch duplicate even when the window evicts its first copy', async () => {
+    const { scheduler, tool } = createHarness();
+    // call-A, then 1024 distinct IDs (evicting call-A from the 1024-entry
+    // window mid-batch), then call-A again: both copies sit in ONE batch,
+    // so the duplicate must still be dropped.
+    const batch = [
+      request('call-A', 0),
+      ...Array.from({ length: 1_024 }, (_, index) =>
+        request(`fill-${index}`, index + 1),
+      ),
+      request('call-A', 2_000),
+    ];
+
+    await scheduler.schedule(batch, new AbortController().signal);
+
+    expect(tool.executions).toBe(1_025);
+    scheduler.dispose();
+  });
+});

--- a/packages/agents/src/core/coreToolScheduler.ts
+++ b/packages/agents/src/core/coreToolScheduler.ts
@@ -67,6 +67,7 @@ interface QueuedRequest {
 }
 
 const toolSchedulerLogger = new DebugLogger('llxprt:core:tool-scheduler');
+const MAX_SEEN_CALL_IDS = 1024;
 
 export type {
   ValidatingToolCall,
@@ -104,6 +105,7 @@ export interface CoreToolSchedulerOptions {
   toolContextInteractiveMode?: boolean;
 }
 
+/** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-05 */
 export class CoreToolScheduler implements ToolSchedulerContract {
   private toolCalls: ToolCall[] = [];
   private outputUpdateHandler?: OutputUpdateHandler;
@@ -370,12 +372,17 @@ export class CoreToolScheduler implements ToolSchedulerContract {
 
     const freshRequests: ToolCallRequestInfo[] = [];
     const duplicates: ToolCallRequestInfo[] = [];
+    // Batch-local view: the session window may evict early IDs mid-batch
+    // (cap 1024), which would otherwise re-admit a duplicate appearing
+    // again later in the same batch. Dedup against both sets.
+    const batchCallIds = new Set<string>();
     for (const r of requestsToProcess) {
-      if (this.seenCallIds.has(r.callId)) {
+      if (batchCallIds.has(r.callId) || this.seenCallIds.has(r.callId)) {
         duplicates.push(r);
       } else {
         freshRequests.push(r);
-        this.seenCallIds.add(r.callId);
+        batchCallIds.add(r.callId);
+        this.rememberCallId(r.callId);
       }
     }
     if (duplicates.length > 0) {
@@ -385,6 +392,21 @@ export class CoreToolScheduler implements ToolSchedulerContract {
     }
     return freshRequests;
   }
+
+  /** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-05 */
+  private rememberCallId(callId: string): void {
+    this.seenCallIds.add(callId);
+    if (this.seenCallIds.size <= MAX_SEEN_CALL_IDS) {
+      return;
+    }
+    // The size check above guarantees at least one entry, so this loop
+    // body runs exactly once to evict the oldest-inserted ID.
+    for (const oldest of this.seenCallIds) {
+      this.seenCallIds.delete(oldest);
+      break;
+    }
+  }
+
   private isHookRestrictedRequest(req: ToolCallRequestInfo): boolean {
     const allowedTools = req.hookRestrictedAllowedTools;
     if (allowedTools === undefined) {

--- a/packages/core/src/services/shellCpExecution.ts
+++ b/packages/core/src/services/shellCpExecution.ts
@@ -25,7 +25,20 @@ import {
 import { resolveShellRetentionBudget } from './shellAcquisitionConfig.js';
 import { MAX_SNIFF_SIZE } from './shellOutputUtils.js';
 
-/** Create the child_process result promise with all event handlers. */
+/**
+ * Upper bound on how long finalization waits for stdio streams to close
+ * after the child exits. Normally 'close' follows 'exit' within a tick;
+ * the bound only matters when a grandchild inherits the pipe fds.
+ */
+const CP_OUTPUT_DRAIN_GRACE_MS = 500;
+
+/**
+ * Create the child_process result promise with all event handlers.
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-01
+ * @requirement REQ-3329-02
+ * @requirement REQ-3329-03
+ */
 export function createCpResultPromise(
   child: ChildProcess,
   isWindows: boolean,
@@ -35,18 +48,22 @@ export function createCpResultPromise(
   outputRetentionMaxBytes: number | undefined,
 ): Promise<ShellExecutionResult> {
   const exitedGuard = createExitGuard();
-  const { reset: resetInactivityTimer, controller: inactivityAbortController } =
-    makeInactivityTimer(inactivityTimeoutMs, exitedGuard);
+  const {
+    reset: resetInactivityTimer,
+    cancel: cancelInactivityTimer,
+    controller: inactivityAbortController,
+  } = makeInactivityTimer(inactivityTimeoutMs, exitedGuard);
 
   const budget = resolveShellRetentionBudget(outputRetentionMaxBytes);
 
   const state: CpExecState = {
-    child,
     isWindows,
     abortSignal,
     onOutputEvent,
     inactivityAbortController,
     resetInactivityTimer,
+    cancelInactivityTimer,
+    inactivityAbortHandler: null,
     exitedGuard,
     stdoutDecoder: null,
     stderrDecoder: null,
@@ -58,20 +75,23 @@ export function createCpResultPromise(
     sniffBuffer: Buffer.alloc(MAX_SNIFF_SIZE),
     hasResolved: false,
     cleanedUp: false,
+    drainGraceTimeout: null,
   };
 
   return new Promise<ShellExecutionResult>((resolve) => {
-    setupCpInactivityHandler(state, inactivityTimeoutMs, resetInactivityTimer);
-    const abortHandler = setupCpAbortHandler(state);
-
-    const handleExit = (code: number | null, signal: NodeJS.Signals | null) => {
-      if (state.hasResolved) {
-        return;
-      }
-      state.hasResolved = true;
-      const { finalBuffer } = cleanupCpResources(state, abortHandler);
-      resolve(buildCpExitResult(state, code, signal, finalBuffer));
-    };
+    setupCpInactivityHandler(
+      state,
+      child,
+      inactivityTimeoutMs,
+      resetInactivityTimer,
+    );
+    const abortHandler = setupCpAbortHandler(state, child);
+    const handleExit = createCpExitFinalizer(
+      state,
+      child,
+      abortHandler,
+      resolve,
+    );
 
     child.stdout?.on('data', (data: Buffer) =>
       handleCpOutput(state, data, 'stdout'),
@@ -85,44 +105,167 @@ export function createCpResultPromise(
     });
 
     abortSignal.addEventListener('abort', abortHandler, { once: true });
-    registerCpExitHandlers(state, handleExit);
+    registerCpExitHandlers(child, handleExit);
   });
 }
+/**
+ * Test doubles may be bare EventEmitters without Readable flags; treat
+ * objects lacking both flags as settled (they cannot deliver more data).
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-01
+ */
+function isCpStreamSettled(
+  stream: NonNullable<ChildProcess['stdout']>,
+): boolean {
+  const flags = stream as {
+    destroyed?: boolean;
+    readableEnded?: boolean;
+  };
+  if (flags.destroyed === undefined && flags.readableEnded === undefined) {
+    return true;
+  }
+  return flags.destroyed === true || flags.readableEnded === true;
+}
 
+/**
+ * Build the exit/error finalizer for a child_process execution.
+ *
+ * Node and Bun can emit 'exit' before the final 'data' chunks arrive on the
+ * stdio pipes; finalizing at 'exit' drops that output (Issue #3329 test
+ * path). Instead, when Readable stdio streams are still open, defer
+ * finalization until every stream has settled ('end' or 'close'; Bun does
+ * not always emit 'close' for child stdio). The grace timer bounds the wait
+ * so a grandchild holding the pipe fds cannot delay resolution
+ * indefinitely. Objects that do not implement the Readable settle contract
+ * cannot deliver further data and count as settled, keeping 'exit' the
+ * prompt finalization trigger for them.
+ *
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-01
+ * @requirement REQ-3329-03
+ */
+function createCpExitFinalizer(
+  state: CpExecState,
+  child: ChildProcess,
+  abortHandler: () => void,
+  resolve: (value: ShellExecutionResult) => void,
+): (code: number | null, signal: NodeJS.Signals | null) => void {
+  const streamSettledListeners = new Map<
+    NonNullable<ChildProcess['stdout']>,
+    () => void
+  >();
+
+  const finalize = (
+    code: number | null,
+    signal: NodeJS.Signals | null,
+  ): void => {
+    if (state.hasResolved) {
+      return;
+    }
+    state.hasResolved = true;
+    for (const [stream, listener] of streamSettledListeners) {
+      stream.removeListener('close', listener);
+      stream.removeListener('end', listener);
+    }
+    streamSettledListeners.clear();
+    const { finalBuffer } = cleanupCpResources(state, child, abortHandler);
+    const result = buildCpExitResult(state, child, code, signal, finalBuffer);
+    state.rawCollector = null;
+    state.sniffBuffer = null;
+    resolve(result);
+  };
+
+  return (code: number | null, signal: NodeJS.Signals | null): void => {
+    if (state.hasResolved) {
+      return;
+    }
+    const openStreams = [child.stdout, child.stderr].filter(
+      (stream): stream is NonNullable<ChildProcess['stdout']> =>
+        stream !== null && !isCpStreamSettled(stream),
+    );
+    if (openStreams.length === 0) {
+      finalize(code, signal);
+      return;
+    }
+    if (state.drainGraceTimeout !== null) {
+      return;
+    }
+    state.drainGraceTimeout = setTimeout(
+      () => finalize(code, signal),
+      CP_OUTPUT_DRAIN_GRACE_MS,
+    );
+    for (const stream of openStreams) {
+      const onSettled = (): void => {
+        // Remove both registrations: whichever of 'end'/'close' fires, the
+        // other may never arrive (Bun does not always emit 'close'), and a
+        // lingering once-listener would retain the finalizer closure.
+        stream.removeListener('close', onSettled);
+        stream.removeListener('end', onSettled);
+        streamSettledListeners.delete(stream);
+        if (state.hasResolved) {
+          return;
+        }
+        const stillOpen = [child.stdout, child.stderr].some(
+          (candidate) => candidate !== null && !isCpStreamSettled(candidate),
+        );
+        if (!stillOpen) {
+          finalize(code, signal);
+        }
+      };
+      streamSettledListeners.set(stream, onSettled);
+      stream.once('close', onSettled);
+      stream.once('end', onSettled);
+    }
+  };
+}
+
+/**
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-02
+ */
 function setupCpInactivityHandler(
   state: CpExecState,
+  child: ChildProcess,
   inactivityTimeoutMs: number | undefined,
   resetInactivityTimer: () => void,
 ): void {
   if (inactivityTimeoutMs === undefined || inactivityTimeoutMs <= 0) {
     return;
   }
+  const inactivityAbortHandler = () => {
+    void cpKillOnAbort(state, child);
+  };
+  state.inactivityAbortHandler = inactivityAbortHandler;
   state.inactivityAbortController.signal.addEventListener(
     'abort',
-    () => {
-      void cpKillOnAbort(state);
-    },
+    inactivityAbortHandler,
     { once: true },
   );
   resetInactivityTimer();
 }
 
-function setupCpAbortHandler(state: CpExecState): () => void {
+function setupCpAbortHandler(
+  state: CpExecState,
+  child: ChildProcess,
+): () => void {
   return () => {
-    void cpKillOnAbort(state);
+    void cpKillOnAbort(state, child);
   };
 }
 
 /** Kill the child process group on abort or inactivity timeout. */
-async function cpKillOnAbort(state: CpExecState): Promise<void> {
+async function cpKillOnAbort(
+  state: CpExecState,
+  child: ChildProcess,
+): Promise<void> {
   // Guard the pid before it can reach process.kill(-pid): pid 0 would signal
   // the caller's own process group. isKillablePid also rejects negative and
   // non-finite pids, which the previous `!== 0` check let through.
-  if (isKillablePid(state.child.pid) && !state.exitedGuard.isExited()) {
+  if (isKillablePid(child.pid) && !state.exitedGuard.isExited()) {
     await killProcessWithEscalation(
-      state.child.pid,
+      child.pid,
       state.isWindows,
-      () => state.child.kill('SIGKILL'),
+      () => child.kill('SIGKILL'),
       state.exitedGuard,
     );
   }

--- a/packages/core/src/services/shellCpHelpers.ts
+++ b/packages/core/src/services/shellCpHelpers.ts
@@ -19,14 +19,20 @@ import { stripAnsiIfPresent, MAX_SNIFF_SIZE } from './shellOutputUtils.js';
 import { BoundedCombinedCollector } from '@vybestack/llxprt-code-tools/acquisition.js';
 import type { ByteBudget } from '@vybestack/llxprt-code-tools/acquisition.js';
 
-/** State bag shared across child_process helper closures. */
+/**
+ * State bag shared across child_process helper closures.
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-02
+ * @requirement REQ-3329-03
+ */
 export interface CpExecState {
-  child: ChildProcess;
   isWindows: boolean;
   abortSignal: AbortSignal;
   onOutputEvent: (event: ShellOutputEvent) => void;
   inactivityAbortController: AbortController;
   resetInactivityTimer: () => void;
+  cancelInactivityTimer: () => void;
+  inactivityAbortHandler: (() => void) | null;
   exitedGuard: ExitGuard;
   stdoutDecoder: TextDecoder | null;
   stderrDecoder: TextDecoder | null;
@@ -35,9 +41,14 @@ export interface CpExecState {
   error: Error | null;
   isStreamingRawContent: boolean;
   sniffedBytes: number;
-  sniffBuffer: Buffer;
+  sniffBuffer: Buffer | null;
   hasResolved: boolean;
   cleanedUp: boolean;
+  /**
+   * Bounded grace timer armed when the child 'exit' event arrives while
+   * stdio streams are still delivering data (see createCpResultPromise).
+   */
+  drainGraceTimeout: NodeJS.Timeout | null;
 }
 
 /** Create decoders and the bounded collector from the detected encoding. */
@@ -65,6 +76,14 @@ export function ensureDecoders(
   return state.rawCollector;
 }
 
+/** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-03 */
+function requireSniffBuffer(state: CpExecState): Buffer {
+  if (state.sniffBuffer === null) {
+    throw new Error('CP sniff buffer accessed after execution teardown');
+  }
+  return state.sniffBuffer;
+}
+
 /**
  * Sniff initial output for binary content detection.
  *
@@ -80,11 +99,12 @@ function checkBinarySniff(state: CpExecState, data: Buffer): void {
   if (remaining <= 0) {
     return;
   }
+  const sniffBuffer = requireSniffBuffer(state);
   const writeLen = Math.min(data.length, remaining);
-  data.copy(state.sniffBuffer, state.sniffedBytes, 0, writeLen);
+  data.copy(sniffBuffer, state.sniffedBytes, 0, writeLen);
   state.sniffedBytes += writeLen;
 
-  if (isBinary(state.sniffBuffer.subarray(0, state.sniffedBytes))) {
+  if (isBinary(sniffBuffer.subarray(0, state.sniffedBytes))) {
     state.isStreamingRawContent = false;
     state.onOutputEvent({ type: 'binary_detected' });
   }
@@ -127,21 +147,39 @@ function emitFinalDecodedChunk(
   }
 }
 
-/** Clean up child_process listeners and materialize bounded raw output. */
+/**
+ * Clean up child_process listeners and materialize bounded raw output.
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-01
+ * @requirement REQ-3329-02
+ */
 export function cleanupCpResources(
   state: CpExecState,
+  child: ChildProcess,
   abortHandler: () => void,
 ): { finalBuffer: Buffer } {
   state.exitedGuard.markExited();
+  state.cancelInactivityTimer();
+  if (state.drainGraceTimeout !== null) {
+    clearTimeout(state.drainGraceTimeout);
+    state.drainGraceTimeout = null;
+  }
+  if (state.inactivityAbortHandler !== null) {
+    state.inactivityAbortController.signal.removeEventListener(
+      'abort',
+      state.inactivityAbortHandler,
+    );
+    state.inactivityAbortHandler = null;
+  }
   state.abortSignal.removeEventListener('abort', abortHandler);
 
   if (!state.cleanedUp) {
     state.cleanedUp = true;
-    state.child.stdout?.removeAllListeners('data');
-    state.child.stderr?.removeAllListeners('data');
-    state.child.removeAllListeners('error');
-    state.child.removeAllListeners('exit');
-    state.child.removeAllListeners('close');
+    child.stdout?.removeAllListeners('data');
+    child.stderr?.removeAllListeners('data');
+    child.removeAllListeners('error');
+    child.removeAllListeners('exit');
+    child.removeAllListeners('close');
   }
 
   emitFinalDecodedChunk(state, state.stdoutDecoder);
@@ -162,9 +200,14 @@ function combineOutputSections(first: string, second: string): string {
   return first + (first.endsWith('\n') ? '' : '\n') + second;
 }
 
-/** Build the ShellExecutionResult for a child_process exit. */
+/**
+ * Build the ShellExecutionResult for a child_process exit.
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-03
+ */
 export function buildCpExitResult(
   state: CpExecState,
+  child: ChildProcess,
   code: number | null,
   signal: NodeJS.Signals | null,
   finalBuffer: Buffer,
@@ -202,34 +245,38 @@ export function buildCpExitResult(
     error: state.error,
     aborted: state.abortSignal.aborted,
     inactivityTimedOut: state.inactivityAbortController.signal.aborted,
-    pid: state.child.pid,
+    pid: child.pid,
     executionMethod: 'child_process',
   };
 }
 
-/** Register exit/close event handlers on the child process. */
+/**
+ * Register exit/close event handlers on the child process.
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-03
+ */
 export function registerCpExitHandlers(
-  state: CpExecState,
+  child: ChildProcess,
   handleExit: (code: number | null, signal: NodeJS.Signals | null) => void,
 ): void {
-  const childOnce = state.child.once as
+  const childOnce = child.once as
     | ((
         event: 'exit' | 'close',
         listener: (code: number | null, signal: NodeJS.Signals | null) => void,
-      ) => typeof state.child)
+      ) => ChildProcess)
     | undefined;
   if (childOnce !== undefined) {
-    childOnce.call(state.child, 'exit', (code, signal) => {
+    childOnce.call(child, 'exit', (code, signal) => {
       handleExit(code, signal);
     });
-    childOnce.call(state.child, 'close', (code, signal) => {
+    childOnce.call(child, 'close', (code, signal) => {
       handleExit(code, signal);
     });
   } else {
-    state.child.on('exit', (code, signal) => {
+    child.on('exit', (code, signal) => {
       handleExit(code, signal);
     });
-    state.child.on('close', (code, signal) => {
+    child.on('close', (code, signal) => {
       handleExit(code, signal);
     });
   }

--- a/packages/core/src/services/shellCpTeardown.paths.test.ts
+++ b/packages/core/src/services/shellCpTeardown.paths.test.ts
@@ -1,0 +1,213 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import EventEmitter from 'node:events';
+import { describe, expect, it } from 'bun:test';
+import type { ChildProcess } from 'node:child_process';
+import { createCpResultPromise } from './shellCpExecution.js';
+
+/**
+ * Deterministic teardown coverage for the child_process drain path of
+ * issue #3329: finalization deferred past 'exit' must not leave stream
+ * listeners attached when a stream settles via 'end' without 'close' (the
+ * Bun behavior the drain design cites) or when the bounded grace timeout
+ * fires, and the caller abort listener must be detached on completion.
+ *
+ * Streams are manual EventEmitters with explicit destroyed/readableEnded
+ * flags so the settle contract is exercised precisely; the finalizer under
+ * test is the production createCpExitFinalizer.
+ *
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-03
+ */
+
+interface ManualStream extends EventEmitter {
+  destroyed: boolean;
+  readableEnded: boolean;
+}
+
+interface FakeChild extends EventEmitter {
+  pid: number;
+  stdout: ManualStream;
+  stderr: ManualStream;
+  kill: () => boolean;
+}
+
+const INACTIVITY_TIMEOUT_MS = 60_000;
+
+/** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-03 */
+function buildManualStream(): ManualStream {
+  const stream = new EventEmitter() as ManualStream;
+  stream.destroyed = false;
+  stream.readableEnded = false;
+  return stream;
+}
+
+/** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-03 */
+function buildFakeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.pid = 4242;
+  child.stdout = buildManualStream();
+  child.stderr = buildManualStream();
+  child.kill = () => true;
+  return child;
+}
+
+/** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-03 */
+async function tick(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+/**
+ * AbortSignal is an EventTarget without listenerCount, so track the
+ * function listeners production registers/detaches by intercepting the
+ * registration APIs.
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-02
+ */
+function trackSignalListeners(controller: AbortController): () => number {
+  const signal = controller.signal;
+  const originalAdd = signal.addEventListener.bind(signal);
+  const originalRemove = signal.removeEventListener.bind(signal);
+  const registered = new Map<EventListener, EventListener>();
+  signal.addEventListener = ((
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: AddEventListenerOptions | boolean,
+  ) => {
+    if (typeof listener === 'function') {
+      const once = typeof options === 'object' && options.once === true;
+      const effective = once
+        ? (...args: Parameters<EventListener>) => {
+            registered.delete(listener);
+            return listener(...args);
+          }
+        : listener;
+      registered.set(listener, effective);
+      return originalAdd(type, effective, options);
+    }
+    return originalAdd(type, listener, options);
+  }) as AbortSignal['addEventListener'];
+  signal.removeEventListener = ((
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+  ) => {
+    if (typeof listener === 'function') {
+      const effective = registered.get(listener) ?? listener;
+      registered.delete(listener);
+      return originalRemove(type, effective);
+    }
+    return originalRemove(type, listener);
+  }) as AbortSignal['removeEventListener'];
+  return () => registered.size;
+}
+
+function waitFor<T>(promise: Promise<T>, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`Timed out waiting for ${label}`));
+    }, 3_000);
+    void promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timeout);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      },
+    );
+  });
+}
+
+describe('child_process drain teardown paths (issue #3329)', () => {
+  /**
+   * @plan PLAN-20260825-SHELLMEM.P01
+   * @requirement REQ-3329-03
+   */
+  it('detaches both drain listeners when a stream settles via end without close', async () => {
+    const child = buildFakeChild();
+    const promise = createCpResultPromise(
+      child as unknown as ChildProcess,
+      false,
+      () => undefined,
+      new AbortController().signal,
+      INACTIVITY_TIMEOUT_MS,
+      undefined,
+    );
+    child.stdout.emit('data', Buffer.from('hi\n'));
+    child.emit('exit', 0, null);
+    await tick();
+
+    // Settle both streams via 'end' only; 'close' never arrives.
+    for (const stream of [child.stdout, child.stderr]) {
+      stream.readableEnded = true;
+      stream.emit('end');
+    }
+
+    const result = await waitFor(promise, 'end-only settlement');
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('hi');
+    for (const stream of [child.stdout, child.stderr]) {
+      expect(stream.listenerCount('close')).toBe(0);
+      expect(stream.listenerCount('end')).toBe(0);
+    }
+  });
+
+  /**
+   * @plan PLAN-20260825-SHELLMEM.P01
+   * @requirement REQ-3329-03
+   */
+  it('finalizes via the bounded grace timeout and detaches drain listeners', async () => {
+    const child = buildFakeChild();
+    const promise = createCpResultPromise(
+      child as unknown as ChildProcess,
+      false,
+      () => undefined,
+      new AbortController().signal,
+      INACTIVITY_TIMEOUT_MS,
+      undefined,
+    );
+    child.stdout.emit('data', Buffer.from('hi\n'));
+    child.emit('exit', 0, null);
+    await tick();
+
+    // Streams never settle; the 500ms grace timer must finalize.
+    const result = await waitFor(promise, 'grace timeout finalization');
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain('hi');
+    for (const stream of [child.stdout, child.stderr]) {
+      expect(stream.listenerCount('close')).toBe(0);
+      expect(stream.listenerCount('end')).toBe(0);
+    }
+  });
+
+  /**
+   * @plan PLAN-20260825-SHELLMEM.P01
+   * @requirement REQ-3329-02
+   */
+  it('removes the caller abort listener on completion', async () => {
+    const child = buildFakeChild();
+    const caller = new AbortController();
+    const listenerCount = trackSignalListeners(caller);
+    const promise = createCpResultPromise(
+      child as unknown as ChildProcess,
+      false,
+      () => undefined,
+      caller.signal,
+      INACTIVITY_TIMEOUT_MS,
+      undefined,
+    );
+    child.emit('exit', 0, null);
+    await tick();
+    for (const stream of [child.stdout, child.stderr]) {
+      stream.readableEnded = true;
+      stream.emit('end');
+    }
+    await waitFor(promise, 'caller listener completion');
+    expect(listenerCount()).toBe(0);
+  });
+});

--- a/packages/core/src/services/shellExecutionService.memory.test.ts
+++ b/packages/core/src/services/shellExecutionService.memory.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import EventEmitter from 'node:events';
+import { PassThrough } from 'node:stream';
+import { describe, expect, it } from 'bun:test';
+import type { ChildProcess } from 'node:child_process';
+import { createCpResultPromise } from './shellCpExecution.js';
+
+/**
+ * Heap-retention regression coverage for the child_process execution path of
+ * issue #3329: once an execution completes while its inactivity deadline is
+ * still in the future, the per-execution state (inactivity AbortController,
+ * abort listener closure, child references, raw collector) must be
+ * collectable, and output written just before exit must survive
+ * finalization.
+ *
+ * The child is a fake (EventEmitter + PassThrough streams) driven directly
+ * through the production createCpResultPromise, because bun's test runner
+ * intermittently drops every event for real detached child_process spawns
+ * (verified with a minimal spawn-only repro on Bun 1.3.14; independent of
+ * this code). The PTY counterpart lives in shellPtyMemory.bun.test.ts.
+ *
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-02
+ * @requirement REQ-3329-03
+ */
+
+const EXECUTION_COUNT = 40;
+const RETAINED_CLASS_THRESHOLD = 8;
+const INACTIVITY_TIMEOUT_MS = 60_000;
+
+interface FakeChild extends EventEmitter {
+  pid: number;
+  stdout: PassThrough;
+  stderr: PassThrough;
+  kill: () => boolean;
+}
+
+function buildFakeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.pid = 4242;
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.kill = () => true;
+  return child;
+}
+
+function waitFor<T>(promise: Promise<T>, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`Timed out waiting for ${label}`));
+    }, 10_000);
+    void promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timeout);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      },
+    );
+  });
+}
+
+/**
+ * Drives one execution through the exact race that lost output before the
+ * drain fix: the final stdout chunk is written, then 'exit' fires in the
+ * same tick, before the queued 'data' event is delivered.
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-02
+ * @requirement REQ-3329-03
+ */
+async function executeFakeChild(
+  signal: AbortSignal,
+): Promise<{ output: string; exitCode: number | null }> {
+  const child = buildFakeChild();
+  const promise = createCpResultPromise(
+    child as unknown as ChildProcess,
+    false,
+    () => undefined,
+    signal,
+    INACTIVITY_TIMEOUT_MS,
+    undefined,
+  );
+  child.stdout.write('hi\n');
+  child.emit('exit', 0, null);
+  await new Promise((resolve) => setImmediate(resolve));
+  child.stdout.end();
+  child.stderr.end();
+  const result = await waitFor(promise, 'fake child result');
+  return { output: result.output, exitCode: result.exitCode };
+}
+
+/** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-02 */
+function collectGarbage(): void {
+  Bun.gc(true);
+  Bun.gc(true);
+}
+
+/** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-02 */
+function countHeapClass(name: string): number {
+  const snapshot = Bun.generateHeapSnapshot();
+  // Validate the snapshot layout via a class every JavaScript heap has; a
+  // Bun format change must fail loudly instead of silently counting zero.
+  if (
+    snapshot.nodes.length % 4 !== 0 ||
+    snapshot.nodeClassNames.indexOf('Object') < 0
+  ) {
+    throw new Error(
+      'Unexpected heap snapshot encoding; class counts would be unreliable',
+    );
+  }
+  const classIndex = snapshot.nodeClassNames.indexOf(name);
+  if (classIndex < 0) {
+    return 0;
+  }
+
+  let count = 0;
+  for (let position = 2; position < snapshot.nodes.length; position += 4) {
+    if (snapshot.nodes[position] === classIndex) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+describe('ShellExecutionService completed child_process execution memory (issue #3329)', () => {
+  /**
+   * @plan PLAN-20260825-SHELLMEM.P01
+   * @requirement REQ-3329-02
+   * @requirement REQ-3329-03
+   */
+  it('releases child-process execution state while the inactivity deadline remains in the future', async () => {
+    collectGarbage();
+    const abortControllerBaseline = countHeapClass('AbortController');
+    const uint8ArrayBaseline = countHeapClass('Uint8Array');
+
+    const sharedSignal = new AbortController().signal;
+    for (let index = 0; index < EXECUTION_COUNT; index += 1) {
+      const { output, exitCode } = await executeFakeChild(sharedSignal);
+      expect(output).toContain('hi');
+      expect(exitCode).toBe(0);
+    }
+
+    collectGarbage();
+    expect(
+      countHeapClass('AbortController') - abortControllerBaseline,
+    ).toBeLessThanOrEqual(RETAINED_CLASS_THRESHOLD);
+    expect(
+      countHeapClass('Uint8Array') - uint8ArrayBaseline,
+    ).toBeLessThanOrEqual(RETAINED_CLASS_THRESHOLD);
+  }, 60_000);
+});

--- a/packages/core/src/services/shellOutputUtils.inactivityTimer.test.ts
+++ b/packages/core/src/services/shellOutputUtils.inactivityTimer.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-01
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { createExitGuard } from './shellExitGuard.js';
+import { makeInactivityTimer } from './shellOutputUtils.js';
+
+// Margins chosen to stay reliable under CI load: the wait window is at
+// least four times the timeout so a delayed timer callback still lands
+// inside it.
+const TIMEOUT_MS = 100;
+const WAIT_MS = 400;
+const PARTIAL_WAIT_MS = 40;
+
+/** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-01 */
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-01 */
+describe('makeInactivityTimer', () => {
+  /** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-01 */
+  it('aborts its controller when an armed timer expires', async () => {
+    const timer = makeInactivityTimer(TIMEOUT_MS, createExitGuard());
+
+    timer.reset();
+    await wait(WAIT_MS);
+
+    expect(timer.controller.signal.aborted).toBe(true);
+  });
+
+  /** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-01 */
+  it('resets a partially elapsed timer back to the full window', async () => {
+    const timer = makeInactivityTimer(TIMEOUT_MS, createExitGuard());
+
+    timer.reset();
+    await wait(PARTIAL_WAIT_MS);
+    timer.reset();
+    // Only PARTIAL_WAIT_MS has passed since the second reset; the timer
+    // must still be armed (not aborted) until a full window elapses.
+    await wait(PARTIAL_WAIT_MS);
+    expect(timer.controller.signal.aborted).toBe(false);
+
+    await wait(TIMEOUT_MS);
+    expect(timer.controller.signal.aborted).toBe(true);
+  });
+
+  /** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-01 */
+  it('does not abort after an armed timer is cancelled', async () => {
+    const timer = makeInactivityTimer(TIMEOUT_MS, createExitGuard());
+
+    timer.reset();
+    timer.cancel();
+    await wait(WAIT_MS);
+
+    expect(timer.controller.signal.aborted).toBe(false);
+  });
+
+  /** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-01 */
+  it('can be cancelled before it is armed', async () => {
+    const timer = makeInactivityTimer(TIMEOUT_MS, createExitGuard());
+
+    timer.cancel();
+    await wait(WAIT_MS);
+
+    expect(timer.controller.signal.aborted).toBe(false);
+  });
+
+  /** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-01 */
+  it('does not rearm after cancellation', async () => {
+    const timer = makeInactivityTimer(TIMEOUT_MS, createExitGuard());
+
+    timer.cancel();
+    timer.reset();
+    await wait(WAIT_MS);
+
+    expect(timer.controller.signal.aborted).toBe(false);
+  });
+
+  /** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-01 */
+  it('does not abort after the execution is marked exited', async () => {
+    const exitedGuard = createExitGuard();
+    const timer = makeInactivityTimer(TIMEOUT_MS, exitedGuard);
+
+    timer.reset();
+    exitedGuard.markExited();
+    await wait(WAIT_MS);
+
+    expect(timer.controller.signal.aborted).toBe(false);
+  });
+});

--- a/packages/core/src/services/shellOutputUtils.ts
+++ b/packages/core/src/services/shellOutputUtils.ts
@@ -63,30 +63,52 @@ export function ensureNativeExitCodePropagated(
   return `${POWERSHELL_EXIT_CODE_PRELUDE}\n${command}\n${POWERSHELL_EXIT_CODE_SUFFIX}`;
 }
 
-/** Shared inactivity timer factory used by both CP and PTY paths. */
+/**
+ * Shared inactivity timer factory used by both CP and PTY paths.
+ * Cancellation is terminal: reset() is a no-op after cancel().
+ *
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-01
+ */
 export function makeInactivityTimer(
   timeoutMs: number | undefined,
   exitedGuard: { isExited(): boolean },
 ): {
   reset: () => void;
+  cancel: () => void;
   controller: AbortController;
 } {
   const controller = new AbortController();
   let timeout: NodeJS.Timeout | null = null;
+  let cancelled = false;
 
   const reset = () => {
-    if (timeoutMs === undefined || timeoutMs <= 0 || exitedGuard.isExited()) {
+    if (
+      cancelled ||
+      timeoutMs === undefined ||
+      timeoutMs <= 0 ||
+      exitedGuard.isExited()
+    ) {
       return;
     }
     if (timeout !== null) {
       clearTimeout(timeout);
     }
     timeout = setTimeout(() => {
+      timeout = null;
       if (!exitedGuard.isExited()) {
         controller.abort('inactivity_timeout');
       }
     }, timeoutMs);
   };
 
-  return { reset, controller };
+  const cancel = () => {
+    cancelled = true;
+    if (timeout !== null) {
+      clearTimeout(timeout);
+      timeout = null;
+    }
+  };
+
+  return { reset, cancel, controller };
 }

--- a/packages/core/src/services/shellPtyExecution.bun.test.ts
+++ b/packages/core/src/services/shellPtyExecution.bun.test.ts
@@ -28,6 +28,18 @@ interface FakePtyHarness {
   resumeCount(): number;
 }
 
+/**
+ * Null-guarded collector access: a harness refactor that skips collector
+ * initialization must fail with a clear assertion, not a TypeError from a
+ * non-null assertion.
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-04
+ */
+function requireCollector(state: PtyExecState): BoundedCombinedCollector {
+  expect(state.rawCollector).not.toBeNull();
+  return state.rawCollector as BoundedCombinedCollector;
+}
+
 function createFakePtyState(supportsBackpressure: boolean): FakePtyHarness {
   let dataListener: ((data: string) => void) | undefined;
   let pauses = 0;
@@ -177,7 +189,7 @@ describe('PTY bounded processing queue', () => {
 
     expect(overflows).toHaveLength(1);
     expect(harness.state.queueOverflowed).toBe(true);
-    expect(harness.state.rawCollector.observedByteCount).toBe(
+    expect(requireCollector(harness.state).observedByteCount).toBe(
       PTY_QUEUE_HARD_LIMIT_ITEMS + 1,
     );
     await harness.state.processingChain;
@@ -203,11 +215,11 @@ describe('PTY bounded processing queue', () => {
 
     expect(overflows).toHaveLength(1);
     expect(harness.state.queueOverflowed).toBe(true);
-    expect(harness.state.rawCollector.observedByteCount).toBe(
+    expect(requireCollector(harness.state).observedByteCount).toBe(
       Buffer.byteLength(output),
     );
     expect(
-      harness.state.rawCollector.getResult().tailText.endsWith(tailMarker),
+      requireCollector(harness.state).getResult().tailText.endsWith(tailMarker),
     ).toBe(true);
     await harness.state.processingChain;
     expect(harness.state.pendingQueueItems).toBe(0);

--- a/packages/core/src/services/shellPtyExecution.ts
+++ b/packages/core/src/services/shellPtyExecution.ts
@@ -17,6 +17,7 @@ import {
   maybeEmitRenderedOutput,
 } from './shellPtyHelpers.js';
 import type {
+  BoundedCombinedCollector,
   ByteBudget,
   CombinedAcquisitionResult,
   TruncationMetadata,
@@ -98,18 +99,31 @@ function buildPtyTruncationMetadata(
   return acquisition.metadata.truncated ? acquisition.metadata : undefined;
 }
 
-/** Build a ShellExecutionResult for the PTY path. */
+/** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-03 */
+function requireRawCollector(state: PtyExecState): BoundedCombinedCollector {
+  if (state.rawCollector === null) {
+    throw new Error('PTY raw collector accessed after execution teardown');
+  }
+  return state.rawCollector;
+}
+
+/**
+ * Build a ShellExecutionResult for the PTY path.
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-03
+ */
 export function buildPtyResult(
   state: PtyExecState,
   exitCode: number,
   signal: number | null,
   aborted: boolean,
 ): ShellExecutionResult {
-  const acquisition = state.rawCollector.getResult();
+  const rawCollector = requireRawCollector(state);
+  const acquisition = rawCollector.getResult();
   const terminalOutput = getFullBufferText(state.headlessTerminal);
 
   return {
-    rawOutput: state.rawCollector.getBoundedRawBuffer(),
+    rawOutput: rawCollector.getBoundedRawBuffer(),
     output: buildPtyTextOutput(state, acquisition, terminalOutput),
     outputTruncation: buildPtyTruncationMetadata(state, acquisition),
     exitCode,
@@ -286,8 +300,9 @@ function appendPtyOutput(
   state: PtyExecState,
   data: string | Buffer,
 ): { text: string; byteLength: number } {
+  const rawCollector = requireRawCollector(state);
   if (Buffer.isBuffer(data)) {
-    state.rawCollector.append(data, 'stdout');
+    rawCollector.append(data, 'stdout');
     return { text: data.toString('utf8'), byteLength: data.length };
   }
 
@@ -307,7 +322,7 @@ function appendPtyOutput(
       end -= 1;
     }
     const encoded = Buffer.from(data.slice(offset, end), 'utf8');
-    state.rawCollector.append(encoded, 'stdout');
+    rawCollector.append(encoded, 'stdout');
     observedBytes += encoded.length;
     offset = end;
   }
@@ -318,11 +333,12 @@ function inspectPtyBinaryPrefix(state: PtyExecState, budget: ByteBudget): void {
   if (!state.isStreamingRawContent || state.sniffedBytes >= MAX_SNIFF_SIZE) {
     return;
   }
-  const sniffBuffer = state.rawCollector.getHeadBytes(
+  const rawCollector = requireRawCollector(state);
+  const sniffBuffer = rawCollector.getHeadBytes(
     Math.min(MAX_SNIFF_SIZE, budget.bytes),
   );
   state.sniffedBytes = Math.min(
-    state.rawCollector.observedByteCount,
+    rawCollector.observedByteCount,
     MAX_SNIFF_SIZE,
     budget.bytes,
   );
@@ -367,7 +383,7 @@ function processPtyChunk(
       if (!state.isStreamingRawContent) {
         state.onOutputEvent({
           type: 'binary_progress',
-          bytesReceived: state.rawCollector.observedByteCount,
+          bytesReceived: requireRawCollector(state).observedByteCount,
         });
         finish();
         return;

--- a/packages/core/src/services/shellPtyLifecycle.ts
+++ b/packages/core/src/services/shellPtyLifecycle.ts
@@ -127,49 +127,21 @@ export function createPtyResultPromise(
   });
   headlessTerminal.scrollToTop();
 
-  const exitedGuard = createExitGuard();
-  const inactivityTimeoutMs = shellExecutionConfig.inactivityTimeoutMs;
-  const { reset: resetInactivityTimer, controller: inactivityAbortController } =
-    makeInactivityTimer(inactivityTimeoutMs, exitedGuard);
-
-  const activePtyEntry: ActivePty = {
+  const state = initializePtyExecState({
     ptyProcess,
     headlessTerminal,
-    supportsProcessGroupKill: ptyInfo.name !== 'bun-pty',
-  };
-  activePtys.set(ptyProcess.pid, activePtyEntry);
-  lastActivePtyIdRef.value = ptyProcess.pid;
-
-  const state: PtyExecState = {
-    ptyProcess,
-    headlessTerminal,
-    activePtyEntry,
     isWindows,
     abortSignal,
     onOutputEvent,
     shellExecutionConfig,
     ptyInfo,
-    supportsProcessGroupKill: ptyInfo.name !== 'bun-pty',
-    inactivityAbortController,
-    resetInactivityTimer,
-    exitedGuard,
-    output: null,
-    rawCollector: new BoundedCombinedCollector({ budget }),
-    error: null,
-    isStreamingRawContent: true,
-    sniffedBytes: 0,
-    isWriting: false,
-    hasStartedOutput: false,
-    hasResolved: false,
-    abortFinalizeTimeout: null,
-    processingChain: Promise.resolve(),
-    pendingQueueBytes: 0,
-    pendingQueueItems: 0,
-    supportsBackpressure: ptyInfo.supportsBackpressure,
-    backpressurePaused: false,
-    queueOverflowed: false,
-    ...createTerminalTrackingState(effectiveScrollback, rows),
-  };
+    budget,
+    effectiveScrollback,
+    rows,
+  });
+
+  activePtys.set(ptyProcess.pid, state.activePtyEntry);
+  lastActivePtyIdRef.value = ptyProcess.pid;
 
   return new Promise<ShellExecutionResult>((resolve) => {
     setupPtyEventHandlers(
@@ -180,6 +152,77 @@ export function createPtyResultPromise(
       budget,
     );
   });
+}
+
+/**
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-02
+ * @requirement REQ-3329-03
+ */
+function initializePtyExecState(execution: {
+  ptyProcess: IPty;
+  headlessTerminal: PtyExecState['headlessTerminal'];
+  isWindows: boolean;
+  abortSignal: AbortSignal;
+  onOutputEvent: (event: ShellOutputEvent) => void;
+  shellExecutionConfig: ShellExecutionConfig;
+  ptyInfo: NonNullable<PtyImplementation>;
+  budget: ByteBudget;
+  effectiveScrollback: number;
+  rows: number;
+}): PtyExecState {
+  const exitedGuard = createExitGuard();
+  const inactivityTimeoutMs =
+    execution.shellExecutionConfig.inactivityTimeoutMs;
+  const {
+    reset: resetInactivityTimer,
+    cancel: cancelInactivityTimer,
+    controller: inactivityAbortController,
+  } = makeInactivityTimer(inactivityTimeoutMs, exitedGuard);
+
+  const activePtyEntry: ActivePty = {
+    ptyProcess: execution.ptyProcess,
+    headlessTerminal: execution.headlessTerminal,
+    supportsProcessGroupKill: execution.ptyInfo.name !== 'bun-pty',
+  };
+
+  return {
+    ptyProcess: execution.ptyProcess,
+    headlessTerminal: execution.headlessTerminal,
+    activePtyEntry,
+    isWindows: execution.isWindows,
+    abortSignal: execution.abortSignal,
+    onOutputEvent: execution.onOutputEvent,
+    shellExecutionConfig: execution.shellExecutionConfig,
+    ptyInfo: execution.ptyInfo,
+    supportsProcessGroupKill: execution.ptyInfo.name !== 'bun-pty',
+    inactivityAbortController,
+    resetInactivityTimer,
+    cancelInactivityTimer,
+    inactivityAbortHandler: null,
+    callerAbortHandler: null,
+    exitRaceCleanup: null,
+    exitedGuard,
+    output: null,
+    rawCollector: new BoundedCombinedCollector({ budget: execution.budget }),
+    error: null,
+    isStreamingRawContent: true,
+    sniffedBytes: 0,
+    isWriting: false,
+    hasStartedOutput: false,
+    hasResolved: false,
+    abortFinalizeTimeout: null,
+    processingChain: Promise.resolve(),
+    pendingQueueBytes: 0,
+    pendingQueueItems: 0,
+    supportsBackpressure: execution.ptyInfo.supportsBackpressure,
+    backpressurePaused: false,
+    queueOverflowed: false,
+    ...createTerminalTrackingState(
+      execution.effectiveScrollback,
+      execution.rows,
+    ),
+  };
 }
 
 function setupPtyEventHandlers(
@@ -233,14 +276,43 @@ function setupPtyEventHandlers(
 
   registerPtyExitHandler(state, resolveResult, abortHandler);
 
+  state.callerAbortHandler = abortHandler;
   state.abortSignal.addEventListener('abort', abortHandler, { once: true });
 }
 
+/**
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-01
+ * @requirement REQ-3329-02
+ */
 function teardownPtyState(
   state: PtyExecState,
   activePtys: Map<number, ActivePty>,
   lastActivePtyIdRef: { value: number | null },
 ): void {
+  // Marking the guard here stops every abort/inactivity kill chain that is
+  // still mid-flight (they re-check isExited after each escalation sleep),
+  // so none can schedule a fallback timeout after this execution resolved.
+  state.exitedGuard.markExited();
+  state.cancelInactivityTimer();
+  if (state.callerAbortHandler !== null) {
+    state.abortSignal.removeEventListener('abort', state.callerAbortHandler);
+    state.callerAbortHandler = null;
+  }
+  if (state.exitRaceCleanup !== null) {
+    // ptyExitRace's temporary listener would otherwise stay on the caller
+    // signal until pending output processing settles; a stalled write chain
+    // would retain this execution's closure graph indefinitely.
+    state.exitRaceCleanup();
+    state.exitRaceCleanup = null;
+  }
+  if (state.inactivityAbortHandler !== null) {
+    state.inactivityAbortController.signal.removeEventListener(
+      'abort',
+      state.inactivityAbortHandler,
+    );
+    state.inactivityAbortHandler = null;
+  }
   if (state.abortFinalizeTimeout) {
     clearTimeout(state.abortFinalizeTimeout);
     state.abortFinalizeTimeout = null;
@@ -263,6 +335,7 @@ function teardownPtyState(
   );
 }
 
+/** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-03 */
 function makePtyResolveResult(
   state: PtyExecState,
   resolve: (value: ShellExecutionResult) => void,
@@ -275,6 +348,7 @@ function makePtyResolveResult(
     }
     state.hasResolved = true;
     teardownPtyState(state, activePtys, lastActivePtyIdRef);
+    state.rawCollector = null;
     resolve(resultValue);
   };
 }
@@ -304,6 +378,7 @@ function makePtyRender(
   };
 }
 
+/** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-02 */
 function setupPtyInactivityHandler(
   state: PtyExecState,
   resolveResult: (resultValue: ShellExecutionResult) => void,
@@ -312,11 +387,13 @@ function setupPtyInactivityHandler(
   if (inactivityTimeoutMs === undefined || inactivityTimeoutMs <= 0) {
     return;
   }
+  const inactivityAbortHandler = () => {
+    void ptyInactivityAbortAction(state, resolveResult);
+  };
+  state.inactivityAbortHandler = inactivityAbortHandler;
   state.inactivityAbortController.signal.addEventListener(
     'abort',
-    () => {
-      void ptyInactivityAbortAction(state, resolveResult);
-    },
+    inactivityAbortHandler,
     { once: true },
   );
   state.resetInactivityTimer();
@@ -359,6 +436,34 @@ export async function ptyInactivityAbortAction(
   finalizeInactivityKill(state, resolveResult);
 }
 
+/**
+ * Schedule the post-escalation fallback resolution. Single-owner: a pending
+ * fallback is cleared first so staggered abort/inactivity chains cannot leak
+ * timers past one another. The callback re-checks hasResolved before
+ * building the result because a timeout that already fired can have its
+ * callback queued behind another resolution path, after the collector was
+ * torn down. The aborted flag is evaluated when the timeout fires so an
+ * overlapping caller abort is still reported.
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-03
+ */
+function schedulePtyAbortFallback(
+  state: PtyExecState,
+  resolveResult: (resultValue: ShellExecutionResult) => void,
+  getAborted: () => boolean,
+): void {
+  if (state.abortFinalizeTimeout !== null) {
+    clearTimeout(state.abortFinalizeTimeout);
+  }
+  state.abortFinalizeTimeout = setTimeout(() => {
+    state.abortFinalizeTimeout = null;
+    if (state.hasResolved) {
+      return;
+    }
+    resolveResult(buildPtyResult(state, 1, null, getAborted()));
+  }, SIGKILL_TIMEOUT_MS);
+}
+
 function finalizeInactivityKill(
   state: PtyExecState,
   resolveResult: (resultValue: ShellExecutionResult) => void,
@@ -366,9 +471,11 @@ function finalizeInactivityKill(
   if (state.exitedGuard.isExited()) {
     return;
   }
-  state.abortFinalizeTimeout = setTimeout(() => {
-    resolveResult(buildPtyResult(state, 1, null, state.abortSignal.aborted));
-  }, SIGKILL_TIMEOUT_MS);
+  schedulePtyAbortFallback(
+    state,
+    resolveResult,
+    () => state.abortSignal.aborted,
+  );
 }
 
 function setupPtyAbortHandler(
@@ -428,9 +535,7 @@ export async function ptyAbortAction(
     // PTY may already be terminated.
   }
 
-  state.abortFinalizeTimeout = setTimeout(() => {
-    resolveResult(buildPtyResult(state, 1, null, aborted));
-  }, SIGKILL_TIMEOUT_MS);
+  schedulePtyAbortFallback(state, resolveResult, () => aborted);
 }
 
 function registerPtyExitHandler(
@@ -439,6 +544,9 @@ function registerPtyExitHandler(
   abortHandler: () => void,
 ): void {
   const finalizeResult = (exitCode: number, signal?: number | null) => {
+    if (state.hasResolved) {
+      return;
+    }
     ptyRenderFn(state);
     resolveResult(
       buildPtyResult(
@@ -483,7 +591,11 @@ function ptyExitRace(
       state.abortSignal.removeEventListener('abort', raceAbortListener);
       raceAbortListener = null;
     }
+    state.exitRaceCleanup = null;
   };
+  // Teardown can detach this listener before the race settles (a kill-chain
+  // fallback resolved first); the detacher must stay reachable from state.
+  state.exitRaceCleanup = cleanupRaceListener;
 
   const abortFired = new Promise<'aborted'>((res) => {
     if (state.abortSignal.aborted) {

--- a/packages/core/src/services/shellPtyMemory.bun.test.ts
+++ b/packages/core/src/services/shellPtyMemory.bun.test.ts
@@ -1,0 +1,186 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import EventEmitter from 'node:events';
+import { beforeEach, describe, expect, it, mock, vi } from 'bun:test';
+
+/**
+ * Heap-retention regression coverage for the PTY execution path of
+ * issue #3329: once an execution completes while its inactivity deadline is
+ * still in the future, the per-execution state (inactivity AbortController,
+ * abort listener closure, headless terminal, raw collector) must be
+ * collectable.
+ *
+ * The real (Bun/native) pty is replaced with a fake via mock.module because
+ * sequentially spawning real bun-pty processes in one process wedges the
+ * event loop inside native code (pre-existing, independent of #3329; the
+ * same seam is used by shellPtySignal.bun.test.ts). The full PTY lifecycle
+ * under test — createPtyResultPromise, inactivity timer, teardown — is the
+ * production code; only the native process boundary is faked.
+ *
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-02
+ * @requirement REQ-3329-03
+ */
+
+interface FakePty extends EventEmitter {
+  pid: number;
+  kill: ReturnType<typeof vi.fn>;
+  onData: ReturnType<typeof vi.fn>;
+  onExit: ReturnType<typeof vi.fn>;
+  write: ReturnType<typeof vi.fn>;
+  resize: ReturnType<typeof vi.fn>;
+  emitData: (data: string) => void;
+  emitExit: (exit: { exitCode: number; signal?: number }) => void;
+}
+
+type DataHandler = (data: string) => void;
+type ExitHandler = (exit: { exitCode: number; signal?: number }) => void;
+
+let fakePty: FakePty;
+
+await mock.module('../utils/getPty.js', () => ({
+  getPty: async () => ({
+    module: { spawn: () => fakePty },
+    name: 'node-pty',
+    supportsBackpressure: true,
+  }),
+}));
+
+const { ShellExecutionService } = await import('./shellExecutionService.js');
+
+const PTY_EXECUTION_COUNT = 40;
+// Calibration: a leaked execution retains exactly one collector array per
+// run (delta 40 on pre-fix code). Post-fix residue is ~9 Uint8Arrays from
+// bounded @xterm/headless module-level caches. 16 splits the two regimes.
+const RETAINED_CLASS_THRESHOLD = 16;
+const INACTIVITY_TIMEOUT_MS = 60_000;
+
+function buildFakePty(): FakePty {
+  const pty = new EventEmitter() as FakePty;
+  let dataHandler: DataHandler = () => undefined;
+  let exitHandler: ExitHandler = () => undefined;
+  pty.pid = 4242;
+  pty.kill = vi.fn();
+  pty.onData = vi.fn((handler: DataHandler) => {
+    dataHandler = handler;
+    return { dispose: vi.fn() };
+  });
+  pty.onExit = vi.fn((handler: ExitHandler) => {
+    exitHandler = handler;
+    return { dispose: vi.fn() };
+  });
+  pty.write = vi.fn();
+  pty.resize = vi.fn();
+  pty.emitData = (data: string) => dataHandler(data);
+  pty.emitExit = (exit: { exitCode: number; signal?: number }) =>
+    exitHandler(exit);
+  return pty;
+}
+
+/** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-02 */
+function collectGarbage(): void {
+  Bun.gc(true);
+  Bun.gc(true);
+}
+
+/** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-02 */
+function countHeapClass(name: string): number {
+  const snapshot = Bun.generateHeapSnapshot();
+  // Validate the snapshot layout via a class every JavaScript heap has; a
+  // Bun format change must fail loudly instead of silently counting zero.
+  if (
+    snapshot.nodes.length % 4 !== 0 ||
+    snapshot.nodeClassNames.indexOf('Object') < 0
+  ) {
+    throw new Error(
+      'Unexpected heap snapshot encoding; class counts would be unreliable',
+    );
+  }
+  const classIndex = snapshot.nodeClassNames.indexOf(name);
+  if (classIndex < 0) {
+    return 0;
+  }
+
+  let count = 0;
+  for (let position = 2; position < snapshot.nodes.length; position += 4) {
+    if (snapshot.nodes[position] === classIndex) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function waitFor<T>(promise: Promise<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('Timed out waiting for PTY result'));
+    }, 10_000);
+    void promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timeout);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      },
+    );
+  });
+}
+
+describe('ShellExecutionService completed PTY execution memory (issue #3329)', () => {
+  beforeEach(() => {
+    fakePty = buildFakePty();
+  });
+
+  /**
+   * @plan PLAN-20260825-SHELLMEM.P01
+   * @requirement REQ-3329-02
+   * @requirement REQ-3329-03
+   */
+  it('releases PTY execution state while the inactivity deadline remains in the future', async () => {
+    collectGarbage();
+    const abortControllerBaseline = countHeapClass('AbortController');
+    const uint8ArrayBaseline = countHeapClass('Uint8Array');
+
+    const sharedSignal = new AbortController().signal;
+    for (let index = 0; index < PTY_EXECUTION_COUNT; index += 1) {
+      fakePty = buildFakePty();
+      const handle = await ShellExecutionService.execute(
+        'echo hi',
+        process.cwd(),
+        () => undefined,
+        sharedSignal,
+        true,
+        {
+          showColor: false,
+          scrollback: 600000,
+          terminalWidth: 80,
+          terminalHeight: 24,
+          inactivityTimeoutMs: INACTIVITY_TIMEOUT_MS,
+        },
+      );
+      // Let spawn + handler registration settle before driving the pty.
+      await new Promise((resolve) => setImmediate(resolve));
+      fakePty.emitData('hi\r\n');
+      await new Promise((resolve) => setImmediate(resolve));
+      fakePty.emitExit({ exitCode: 0, signal: 0 });
+
+      const result = await waitFor(handle.result);
+      expect(result.executionMethod).toBe('node-pty');
+      expect(result.output).toContain('hi');
+    }
+
+    collectGarbage();
+    expect(
+      countHeapClass('AbortController') - abortControllerBaseline,
+    ).toBeLessThanOrEqual(RETAINED_CLASS_THRESHOLD);
+    expect(
+      countHeapClass('Uint8Array') - uint8ArrayBaseline,
+    ).toBeLessThanOrEqual(RETAINED_CLASS_THRESHOLD);
+  }, 60_000);
+});

--- a/packages/core/src/services/shellPtyState.ts
+++ b/packages/core/src/services/shellPtyState.ts
@@ -16,7 +16,12 @@ import type { ActivePty } from './shellPtyHelpers.js';
 import type { AnsiOutput } from '../utils/terminalSerializer.js';
 import type { BoundedCombinedCollector } from '@vybestack/llxprt-code-tools/acquisition.js';
 
-/** State bag shared across PTY helper closures. */
+/**
+ * State bag shared across PTY helper closures.
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-02
+ * @requirement REQ-3329-03
+ */
 export interface PtyExecState {
   ptyProcess: IPty;
   headlessTerminal: Terminal;
@@ -34,6 +39,20 @@ export interface PtyExecState {
   supportsProcessGroupKill: boolean;
   inactivityAbortController: AbortController;
   resetInactivityTimer: () => void;
+  cancelInactivityTimer: () => void;
+  inactivityAbortHandler: (() => void) | null;
+  /**
+   * Listener registered on the caller's AbortSignal. Kept on the state so
+   * every resolution path (including synthetic completion without a real
+   * PTY exit event) can detach it during teardown.
+   */
+  callerAbortHandler: (() => void) | null;
+  /**
+   * Detacher for the temporary abort listener ptyExitRace registers while
+   * waiting for pending output processing. Stored so teardown can detach it
+   * when a kill-chain fallback resolves first and processing never settles.
+   */
+  exitRaceCleanup: (() => void) | null;
   exitedGuard: ExitGuard;
   output: string | AnsiOutput | null;
   /**
@@ -41,7 +60,7 @@ export interface PtyExecState {
    * array (Issue #3200). Retains a bounded head/tail of PTY output for
    * rawOutput compatibility without full-size materialization.
    */
-  rawCollector: BoundedCombinedCollector;
+  rawCollector: BoundedCombinedCollector | null;
   error: Error | null;
   isStreamingRawContent: boolean;
   sniffedBytes: number;

--- a/packages/core/src/services/shellPtyTeardown.paths.bun.test.ts
+++ b/packages/core/src/services/shellPtyTeardown.paths.bun.test.ts
@@ -1,0 +1,269 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import EventEmitter from 'node:events';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  vi,
+} from 'bun:test';
+import type { ShellExecutionResult } from './shellExecutionTypes.js';
+
+/**
+ * Deterministic teardown coverage for the PTY resolution paths of
+ * issue #3329 that complete without a real PTY exit event: caller abort,
+ * overlapping inactivity + abort kill chains, and a late exit event after
+ * resolution. These paths must detach the caller abort listener, resolve
+ * exactly once, and must never touch the raw collector after teardown.
+ *
+ * The pty is a fake (same seam as shellPtyMemory.bun.test.ts) and
+ * process.kill is mocked so the escalation chains run against mocks only.
+ *
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-02
+ * @requirement REQ-3329-03
+ */
+
+interface FakePty extends EventEmitter {
+  pid: number;
+  kill: ReturnType<typeof vi.fn>;
+  onData: ReturnType<typeof vi.fn>;
+  onExit: ReturnType<typeof vi.fn>;
+  write: ReturnType<typeof vi.fn>;
+  resize: ReturnType<typeof vi.fn>;
+  emitData: (data: string) => void;
+  emitExit: (exit: { exitCode: number; signal?: number }) => void;
+}
+
+type DataHandler = (data: string) => void;
+type ExitHandler = (exit: { exitCode: number; signal?: number }) => void;
+
+let fakePty: FakePty;
+
+await mock.module('../utils/getPty.js', () => ({
+  getPty: async () => ({
+    module: { spawn: () => fakePty },
+    name: 'node-pty',
+    supportsBackpressure: true,
+  }),
+}));
+
+const { ShellExecutionService } = await import('./shellExecutionService.js');
+
+const mockProcessKill = vi
+  .spyOn(process, 'kill')
+  .mockImplementation(() => true);
+
+/** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-03 */
+function buildFakePty(): FakePty {
+  const pty = new EventEmitter() as FakePty;
+  let dataHandler: DataHandler = () => undefined;
+  let exitHandler: ExitHandler = () => undefined;
+  pty.pid = 4242;
+  pty.kill = vi.fn();
+  pty.onData = vi.fn((handler: DataHandler) => {
+    dataHandler = handler;
+    return { dispose: vi.fn() };
+  });
+  pty.onExit = vi.fn((handler: ExitHandler) => {
+    exitHandler = handler;
+    return { dispose: vi.fn() };
+  });
+  pty.write = vi.fn();
+  pty.resize = vi.fn();
+  pty.emitData = (data: string) => dataHandler(data);
+  pty.emitExit = (exit: { exitCode: number; signal?: number }) =>
+    exitHandler(exit);
+  return pty;
+}
+
+async function tick(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+/**
+ * AbortSignal is an EventTarget without listenerCount, so track the
+ * function listeners production registers/detaches by intercepting the
+ * registration APIs. Once-listeners deregister themselves when they fire.
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-02
+ */
+function trackSignalListeners(controller: AbortController): () => number {
+  const signal = controller.signal;
+  const originalAdd = signal.addEventListener.bind(signal);
+  const originalRemove = signal.removeEventListener.bind(signal);
+  const registered = new Map<EventListener, EventListener>();
+  signal.addEventListener = ((
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: AddEventListenerOptions | boolean,
+  ) => {
+    if (typeof listener === 'function') {
+      const once = typeof options === 'object' && options.once === true;
+      const effective = once
+        ? (...args: Parameters<EventListener>) => {
+            registered.delete(listener);
+            return listener(...args);
+          }
+        : listener;
+      registered.set(listener, effective);
+      return originalAdd(type, effective, options);
+    }
+    return originalAdd(type, listener, options);
+  }) as AbortSignal['addEventListener'];
+  signal.removeEventListener = ((
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+  ) => {
+    if (typeof listener === 'function') {
+      const effective = registered.get(listener) ?? listener;
+      registered.delete(listener);
+      return originalRemove(type, effective);
+    }
+    return originalRemove(type, listener);
+  }) as AbortSignal['removeEventListener'];
+  return () => registered.size;
+}
+
+function startExecution(
+  signal: AbortSignal,
+  inactivityTimeoutMs: number,
+): Promise<{ result: Promise<ShellExecutionResult> }> {
+  return ShellExecutionService.execute(
+    'echo hi',
+    process.cwd(),
+    () => undefined,
+    signal,
+    true,
+    {
+      showColor: false,
+      scrollback: 600000,
+      terminalWidth: 80,
+      terminalHeight: 24,
+      inactivityTimeoutMs,
+    },
+  ).then((handle) => ({ result: handle.result }));
+}
+
+function waitFor<T>(promise: Promise<T>, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`Timed out waiting for ${label}`));
+    }, 5_000);
+    void promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timeout);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      },
+    );
+  });
+}
+
+describe('PTY teardown paths without a real exit event (issue #3329)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProcessKill.mockClear();
+    mockProcessKill.mockImplementation(() => true);
+    fakePty = buildFakePty();
+  });
+
+  afterEach(() => {
+    // Do NOT restore the process.kill spy between tests: restoring
+    // detaches it permanently and later mockImplementation calls become
+    // no-ops, letting real process.kill(-pid, ...) signals escape. The
+    // spy stays installed for this file's lifetime.
+    mockProcessKill.mockClear();
+  });
+
+  /**
+   * @plan PLAN-20260825-SHELLMEM.P01
+   * @requirement REQ-3329-02
+   */
+  it('removes the caller abort listener on synthetic inactivity resolution', async () => {
+    const caller = new AbortController();
+    const listenerCount = trackSignalListeners(caller);
+    // The caller signal never aborts here, so its once-listener cannot
+    // self-remove; only explicit teardown may detach it. Pre-fix, the
+    // listener stayed registered and retained the whole execution state.
+    const { result } = await startExecution(caller.signal, 30);
+    await tick();
+    fakePty.emitData('hi\r\n');
+
+    const resolved = await waitFor(result, 'inactivity resolution');
+    expect(resolved.output).toContain('hi');
+    expect(listenerCount()).toBe(0);
+
+    // A late real exit must not throw into the collected-null raw collector
+    // nor resolve a second time; an uncaught error fails the test run.
+    fakePty.emitExit({ exitCode: 0, signal: 0 });
+    await tick();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  });
+
+  /**
+   * @plan PLAN-20260825-SHELLMEM.P01
+   * @requirement REQ-3329-03
+   */
+  it('stays silent when a late caller abort and exit outlive the resolution', async () => {
+    const caller = new AbortController();
+    const listenerCount = trackSignalListeners(caller);
+    const { result } = await startExecution(caller.signal, 30);
+    await tick();
+    fakePty.emitData('hi\r\n');
+
+    // The inactivity chain resolves first. A promise settles exactly once
+    // by construction, so this test targets what a second internal
+    // finalize would actually break: post-teardown state access. A late
+    // abort chain and a late exit must not throw into the collected-null
+    // raw collector, re-render, or leave listeners behind.
+    const resolved = await waitFor(result, 'inactivity-first resolution');
+    expect(resolved.output).toContain('hi');
+
+    caller.abort();
+    await new Promise((resolve) => setTimeout(resolve, 450));
+    fakePty.emitExit({ exitCode: 0, signal: 0 });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(listenerCount()).toBe(0);
+  });
+
+  /**
+   * @plan PLAN-20260825-SHELLMEM.P01
+   * @requirement REQ-3329-02
+   */
+  it('detaches the exit-race abort listener when a fallback resolves first', async () => {
+    const caller = new AbortController();
+    const listenerCount = trackSignalListeners(caller);
+    const { result } = await startExecution(caller.signal, 30);
+    await tick();
+    fakePty.emitData('hi\r\n');
+
+    // Inactivity fires at ~30ms and arms the kill-chain fallback (~430ms).
+    // A real exit then arrives with the fallback still armed and the final
+    // write's processing pending (data and exit are emitted back-to-back),
+    // so ptyExitRace registers its temporary listener on the caller
+    // signal. Whichever path resolves, teardown must leave no listener:
+    // the race either settles naturally or teardown invokes the stored
+    // exitRaceCleanup detacher.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    fakePty.emitData('x');
+    fakePty.emitExit({ exitCode: 0, signal: 0 });
+
+    const resolved = await waitFor(result, 'fallback-or-exit resolution');
+    expect(resolved.output).toContain('hi');
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(listenerCount()).toBe(0);
+  });
+});

--- a/packages/core/src/utils/shell-parser-lifetime.ts
+++ b/packages/core/src/utils/shell-parser-lifetime.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Scoped tree consumers for the shell parser. Keeping the tree lifetime in
+ * one place (consume, then delete) prevents the tree-sitter heap objects
+ * from outliving the call that parsed them (Issue #3329 secondary leak #4).
+ */
+
+import type { Tree } from 'web-tree-sitter';
+import {
+  parsePwshCommand,
+  parseShellCommand,
+  type ParserLanguage,
+  PARSE_TIMEOUT_MICROS,
+} from './shell-parser.js';
+
+/**
+ * Runs a Bash tree consumer and releases the tree before returning.
+ * @internal
+ * @plan PLAN-20260825-SHELLMEM.P02
+ * @requirement REQ-3329-08
+ */
+export function withParsedTree<TResult>(
+  command: string,
+  consume: (tree: Tree) => TResult,
+  timeoutMicros: number = PARSE_TIMEOUT_MICROS,
+): TResult | null {
+  const tree = parseShellCommand(command, timeoutMicros);
+  if (tree === null) {
+    return null;
+  }
+  try {
+    return consume(tree);
+  } finally {
+    tree.delete();
+  }
+}
+
+/**
+ * Runs a language-specific tree consumer and releases the tree before
+ * returning.
+ * @internal
+ * @plan PLAN-20260825-SHELLMEM.P02
+ * @requirement REQ-3329-08
+ */
+export function withParsedTreeForLanguage<TResult>(
+  command: string,
+  language: ParserLanguage,
+  consume: (tree: Tree) => TResult,
+  timeoutMicros: number = PARSE_TIMEOUT_MICROS,
+): TResult | null {
+  if (language === 'bash') {
+    return withParsedTree(command, consume, timeoutMicros);
+  }
+  const tree = parsePwshCommand(command, timeoutMicros);
+  if (tree === null) {
+    return null;
+  }
+  try {
+    return consume(tree);
+  } finally {
+    tree.delete();
+  }
+}

--- a/packages/core/src/utils/shell-parser-lifetime.ts
+++ b/packages/core/src/utils/shell-parser-lifetime.ts
@@ -8,6 +8,11 @@
  * Scoped tree consumers for the shell parser. Keeping the tree lifetime in
  * one place (consume, then delete) prevents the tree-sitter heap objects
  * from outliving the call that parsed them (Issue #3329 secondary leak #4).
+ *
+ * This module and shell-parser.ts import each other. Every binding imported
+ * across that cycle must be used only inside function bodies or call-time
+ * default-parameter expressions, never at module-evaluation time, or the
+ * cycle throws a TDZ ReferenceError during import.
  */
 
 import type { Tree } from 'web-tree-sitter';

--- a/packages/core/src/utils/shell-parser.tree-lifetime.test.ts
+++ b/packages/core/src/utils/shell-parser.tree-lifetime.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ * @plan PLAN-20260825-SHELLMEM.P02
+ * @requirement REQ-3329-08
+ */
+
+import { afterAll, describe, expect, it } from 'bun:test';
+import type { Tree } from 'web-tree-sitter';
+import { initializeParser, resetParser } from './shell-parser.js';
+import { withParsedTree } from './shell-parser-lifetime.js';
+
+const parserInitialized = await initializeParser();
+
+/**
+ * web-tree-sitter exposes the wasm-side pointer as the numeric property
+ * "0" on the Tree proxy. While the tree is alive the value is a nonzero
+ * heap pointer; tree.delete() zeroes it. Asserting alive-then-zero (rather
+ * than zero alone) proves the deletion actually ran — a tree that was
+ * never deleted keeps its live pointer.
+ * @plan PLAN-20260825-SHELLMEM.P02
+ * @requirement REQ-3329-08
+ */
+function treeHandle(tree: Tree): number {
+  const handle: unknown = Reflect.get(tree, 0);
+  if (typeof handle !== 'number') {
+    throw new Error('Tree handle is not numeric');
+  }
+  return handle;
+}
+
+/** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-08 */
+describe('withParsedTree tree lifetime', () => {
+  afterAll(() => {
+    resetParser();
+  });
+
+  /** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-08 */
+  it.skipIf(!parserInitialized)(
+    'deletes the tree after the consumer returns',
+    () => {
+      const captured: Tree[] = [];
+      let liveHandle = -1;
+
+      const result = withParsedTree('echo hi', (tree) => {
+        captured.push(tree);
+        liveHandle = treeHandle(tree);
+        return tree.rootNode.text;
+      });
+
+      expect(result).toBe('echo hi');
+      expect(captured).toHaveLength(1);
+      expect(liveHandle).toBeGreaterThan(0);
+      expect(treeHandle(captured[0])).toBe(0);
+    },
+  );
+
+  /** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-08 */
+  it.skipIf(!parserInitialized)(
+    'deletes the tree and propagates an error when the consumer throws',
+    () => {
+      const captured: Tree[] = [];
+      let liveHandle = -1;
+
+      expect(() =>
+        withParsedTree('echo hi', (tree) => {
+          captured.push(tree);
+          liveHandle = treeHandle(tree);
+          throw new Error('consumer failed');
+        }),
+      ).toThrow('consumer failed');
+      expect(captured).toHaveLength(1);
+      expect(liveHandle).toBeGreaterThan(0);
+      expect(treeHandle(captured[0])).toBe(0);
+    },
+  );
+});

--- a/packages/core/src/utils/shell-parser.ts
+++ b/packages/core/src/utils/shell-parser.ts
@@ -27,6 +27,14 @@ import { createRequire } from 'node:module';
 import { DebugLogger } from '../debug/DebugLogger.js';
 import { isBunRuntime } from './runtime.js';
 import {
+  hasShellSubstitutionSyntax,
+  hasUnrepresentedHeredocBacktickSubstitution,
+} from './shell-substitution-syntax.js';
+import {
+  withParsedTree,
+  withParsedTreeForLanguage,
+} from './shell-parser-lifetime.js';
+import {
   collectPwshCommandDetailsFromTree,
   hasPwshCommandSubstitution,
   splitPwshCommandsWithTree,
@@ -36,7 +44,7 @@ import { buildPwshCommandParseResult } from './powershell-parse-result.js';
 const require = createRequire(import.meta.url);
 const debugLogger = new DebugLogger('llxprt:shell-parser');
 
-const PARSE_TIMEOUT_MICROS = 1000 * 1000; // 1 second
+export const PARSE_TIMEOUT_MICROS = 1000 * 1000; // 1 second
 
 /**
  * Shape of the dynamically imported `web-tree-sitter` module. In 0.25.x the
@@ -399,7 +407,10 @@ export function parseShellCommandForLanguage(
   return parseShellCommand(command, timeoutMicros);
 }
 
-function parsePwshCommand(command: string, timeoutMicros: number): Tree | null {
+export function parsePwshCommand(
+  command: string,
+  timeoutMicros: number,
+): Tree | null {
   if (!pwshParser || !command.trim()) {
     return null;
   }
@@ -518,168 +529,6 @@ export interface CommandParseResult {
   errorReason?: string;
 }
 
-type SourceRange = {
-  startIndex: number;
-  endIndex: number;
-};
-
-function findNamedChild(node: Node, type: string): Node | null {
-  for (let index = 0; index < node.namedChildCount; index += 1) {
-    const child = node.namedChild(index);
-    if (child?.type === type) {
-      return child;
-    }
-  }
-  return null;
-}
-
-function collectHeredocRedirects(root: Node): Node[] {
-  const redirects: Node[] = [];
-  const stack: Node[] = [root];
-
-  while (stack.length > 0) {
-    const current = stack.pop();
-    if (!current) {
-      continue;
-    }
-
-    if (current.type === 'heredoc_redirect') {
-      redirects.push(current);
-    }
-
-    for (let index = current.namedChildCount - 1; index >= 0; index -= 1) {
-      const child = current.namedChild(index);
-      if (child) {
-        stack.push(child);
-      }
-    }
-  }
-
-  return redirects;
-}
-
-function isQuotedHeredocStart(node: Node, source: string): boolean {
-  const delimiter = source.slice(node.startIndex, node.endIndex);
-  return (
-    delimiter.includes("'") ||
-    delimiter.includes('"') ||
-    delimiter.includes('\\')
-  );
-}
-
-function collectLiteralHeredocBodyRanges(
-  root: Node,
-  source: string,
-): SourceRange[] {
-  const ranges: SourceRange[] = [];
-
-  for (const redirect of collectHeredocRedirects(root)) {
-    const start = findNamedChild(redirect, 'heredoc_start');
-    const body = findNamedChild(redirect, 'heredoc_body');
-    if (start && body && isQuotedHeredocStart(start, source)) {
-      ranges.push({
-        startIndex: body.startIndex,
-        endIndex: body.endIndex,
-      });
-    }
-  }
-
-  return ranges;
-}
-
-function getLiteralRange(
-  ranges: SourceRange[],
-  index: number,
-): SourceRange | null {
-  if (index < 0 || index >= ranges.length) {
-    return null;
-  }
-  return ranges[index];
-}
-
-function hasShellSubstitutionSyntax(command: string, root: Node): boolean {
-  const literalRanges = collectLiteralHeredocBodyRanges(root, command);
-  let literalRangeIndex = 0;
-  let inSingleQuotes = false;
-  let inDoubleQuotes = false;
-  let skipCurrent = false;
-
-  for (let i = 0; i < command.length; i += 1) {
-    const literalRange = getLiteralRange(literalRanges, literalRangeIndex);
-    if (literalRange !== null && i >= literalRange.endIndex) {
-      literalRangeIndex += 1;
-    } else if (literalRange !== null && i >= literalRange.startIndex) {
-      i = literalRange.endIndex - 1;
-      continue;
-    }
-
-    const char = command[i];
-    if (skipCurrent) {
-      skipCurrent = false;
-    } else if (char === '\\' && !inSingleQuotes) {
-      skipCurrent = true;
-    } else if (char === "'" && !inDoubleQuotes) {
-      inSingleQuotes = !inSingleQuotes;
-    } else if (char === '"' && !inSingleQuotes) {
-      inDoubleQuotes = !inDoubleQuotes;
-    } else if (
-      !inSingleQuotes &&
-      isShellSubstitutionStart(command, i, inDoubleQuotes)
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function isShellSubstitutionStart(
-  command: string,
-  index: number,
-  inDoubleQuotes: boolean,
-): boolean {
-  return (
-    isCommandSubstitutionStart(command, index) ||
-    isProcessSubstitutionStart(command, index, inDoubleQuotes) ||
-    command[index] === '`'
-  );
-}
-
-function isCommandSubstitutionStart(command: string, index: number): boolean {
-  if (command[index] !== '$') {
-    return false;
-  }
-  if (command[index + 1] !== '(') {
-    return false;
-  }
-  // Exclude arithmetic expansion $(( )) which is not command substitution
-  if (index + 2 < command.length && command[index + 2] === '(') {
-    return false;
-  }
-  return true;
-}
-
-function isProcessSubstitutionStart(
-  command: string,
-  index: number,
-  inDoubleQuotes: boolean,
-): boolean {
-  if (inDoubleQuotes) {
-    return false;
-  }
-  return (
-    isProcessSubstitutionOperator(command[index]) &&
-    index + 1 < command.length &&
-    command[index + 1] === '('
-  );
-}
-
-function isProcessSubstitutionOperator(char: string | undefined): boolean {
-  return char === '<' || char === '>';
-}
-
-/**
- * Normalize a command name by removing quotes and extracting the base name.
- */
 function normalizeCommandName(raw: string): string {
   if (raw.length >= 2) {
     const first = raw[0];
@@ -815,58 +664,61 @@ function hasPromptTransformInExpansion(node: Node): boolean {
  * Parse a shell command and extract all command details including nested commands.
  * Returns null if parsing fails or tree-sitter is not available.
  */
+/** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-08 */
 export function parseCommandDetails(
   command: string,
 ): CommandParseResult | null {
   if (!parser || !bashLanguage) {
     return null;
   }
+  const activeBashLanguage = bashLanguage;
 
   try {
-    const tree = parseShellCommand(command);
-    if (!tree) {
-      return { details: [], hasError: true };
-    }
+    return (
+      withParsedTree(command, (tree) => {
+        const details = collectCommandDetails(tree, command);
 
-    const details = collectCommandDetails(tree, command);
+        // Check for syntax errors, empty command list, dangerous prompt transformations,
+        // or substitution syntax that the grammar failed to expose as executable commands.
+        const hasMissingSubstitutionDetails =
+          hasUnrepresentedHeredocBacktickSubstitution(tree.rootNode, command) ||
+          (hasShellSubstitutionSyntax(command, tree.rootNode) &&
+            !hasParsedCommandSubstitution(tree));
+        const hasError =
+          tree.rootNode.hasError ||
+          details.length === 0 ||
+          hasPromptCommandTransform(tree.rootNode) ||
+          hasMissingSubstitutionDetails;
 
-    // Check for syntax errors, empty command list, dangerous prompt transformations,
-    // or substitution syntax that the grammar failed to expose as executable commands.
-    const hasMissingSubstitutionDetails =
-      hasUnrepresentedHeredocBacktickSubstitution(tree.rootNode, command) ||
-      (hasShellSubstitutionSyntax(command, tree.rootNode) &&
-        !hasParsedCommandSubstitution(tree));
-    const hasError =
-      tree.rootNode.hasError ||
-      details.length === 0 ||
-      hasPromptCommandTransform(tree.rootNode) ||
-      hasMissingSubstitutionDetails;
+        if (hasError) {
+          let query: QueryType | null = null;
+          try {
+            query = activeBashLanguage.query(
+              '(ERROR) @error (MISSING) @missing',
+            );
+            const captures = query.captures(tree.rootNode) as QueryCapture[];
+            const syntaxErrors = captures.map((capture) => {
+              const { node, name } = capture;
+              const type = name === 'missing' ? 'Missing' : 'Error';
+              return `${type} node: "${node.text}" at ${node.startPosition.row}:${node.startPosition.column}`;
+            });
 
-    if (hasError) {
-      let query: QueryType | null = null;
-      try {
-        query = bashLanguage.query('(ERROR) @error (MISSING) @missing');
-        const captures = query.captures(tree.rootNode) as QueryCapture[];
-        const syntaxErrors = captures.map((capture) => {
-          const { node, name } = capture;
-          const type = name === 'missing' ? 'Missing' : 'Error';
-          return `${type} node: "${node.text}" at ${node.startPosition.row}:${node.startPosition.column}`;
-        });
+            debugLogger.log(
+              'Bash command parsing error detected for command:',
+              command,
+              'Syntax Errors:',
+              syntaxErrors,
+            );
+          } catch {
+            // AST query failed - ignore syntax error detection
+          } finally {
+            query?.delete();
+          }
+        }
 
-        debugLogger.log(
-          'Bash command parsing error detected for command:',
-          command,
-          'Syntax Errors:',
-          syntaxErrors,
-        );
-      } catch {
-        // AST query failed - ignore syntax error detection
-      } finally {
-        query?.delete();
-      }
-    }
-
-    return { details, hasError };
+        return { details, hasError };
+      }) ?? { details: [], hasError: true }
+    );
   } catch {
     return null;
   }
@@ -890,37 +742,6 @@ function hasParsedCommandSubstitution(tree: Tree): boolean {
   } finally {
     query.delete();
   }
-}
-
-function containsUnescapedBacktick(text: string): boolean {
-  for (let index = 0; index < text.length; index += 1) {
-    if (text[index] === '\\') {
-      index += 1;
-    } else if (text[index] === '`') {
-      return true;
-    }
-  }
-  return false;
-}
-
-function hasUnrepresentedHeredocBacktickSubstitution(
-  root: Node,
-  source: string,
-): boolean {
-  for (const redirect of collectHeredocRedirects(root)) {
-    const start = findNamedChild(redirect, 'heredoc_start');
-    const body = findNamedChild(redirect, 'heredoc_body');
-    if (
-      start &&
-      body &&
-      !isQuotedHeredocStart(start, source) &&
-      containsUnescapedBacktick(body.text)
-    ) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
 /**
@@ -1061,34 +882,34 @@ export interface TrailingBackgroundResult {
  * 3. There must be at least one named child before the `&` (the command).
  * 4. Strip ONLY the operator and return the remainder.
  */
+/** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-08 */
 export function detectTrailingBackgroundOperator(
   command: string,
 ): TrailingBackgroundResult {
-  const tree = parseShellCommand(command);
-  if (tree === null) {
-    return { promoted: false, command };
-  }
+  return (
+    withParsedTree(command, (tree) => {
+      const root = tree.rootNode;
+      if (root.type !== 'program' || root.hasError) {
+        return { promoted: false, command };
+      }
 
-  const root = tree.rootNode;
-  if (root.type !== 'program' || root.hasError) {
-    return { promoted: false, command };
-  }
+      const lastChild = root.child(root.childCount - 1);
+      if (lastChild === null || lastChild.type !== '&') {
+        return { promoted: false, command };
+      }
 
-  const lastChild = root.child(root.childCount - 1);
-  if (lastChild === null || lastChild.type !== '&') {
-    return { promoted: false, command };
-  }
+      if (root.namedChildCount === 0) {
+        return { promoted: false, command };
+      }
 
-  if (root.namedChildCount === 0) {
-    return { promoted: false, command };
-  }
+      const stripped = command.slice(0, lastChild.startIndex).trimEnd();
+      if (stripped.length === 0) {
+        return { promoted: false, command };
+      }
 
-  const stripped = command.slice(0, lastChild.startIndex).trimEnd();
-  if (stripped.length === 0) {
-    return { promoted: false, command };
-  }
-
-  return { promoted: true, command: stripped };
+      return { promoted: true, command: stripped };
+    }) ?? { promoted: false, command }
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -1125,15 +946,21 @@ export function splitCommandsWithTreeForLanguage(
  * (returns null = parser-unavailable) rather than propagating (#3181 OCR
  * Finding 7).
  */
+/** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-08 */
 function parsePwshCommandDetails(command: string): CommandParseResult | null {
   if (pwshParser === null || pwshLanguage === null) {
     return null;
   }
   try {
-    return buildPwshCommandParseResult(
-      parsePwshCommand(command, PARSE_TIMEOUT_MICROS),
-      command,
-      parseCommandDetailsForLanguage,
+    return (
+      withParsedTreeForLanguage(command, 'powershell', (tree) =>
+        buildPwshCommandParseResult(
+          tree,
+          command,
+          parseCommandDetailsForLanguage,
+        ),
+      ) ??
+      buildPwshCommandParseResult(null, command, parseCommandDetailsForLanguage)
     );
   } catch (error) {
     debugLogger.error('PowerShell parse threw (command text omitted):', error);

--- a/packages/core/src/utils/shell-substitution-syntax.ts
+++ b/packages/core/src/utils/shell-substitution-syntax.ts
@@ -1,0 +1,213 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Verbatim extraction from shell-parser.ts for the parser-lifetime refactor
+// (no behavior change). All helpers in this module fall under
+// @plan PLAN-20260825-SHELLMEM.P02 / @requirement REQ-3329-08 tree-lifetime
+// ownership; the exported entry points carry the explicit markers.
+
+import type { Node } from 'web-tree-sitter';
+
+type SourceRange = {
+  startIndex: number;
+  endIndex: number;
+};
+
+function findNamedChild(node: Node, type: string): Node | null {
+  for (let index = 0; index < node.namedChildCount; index += 1) {
+    const child = node.namedChild(index);
+    if (child?.type === type) {
+      return child;
+    }
+  }
+  return null;
+}
+
+function collectHeredocRedirects(root: Node): Node[] {
+  const redirects: Node[] = [];
+  const stack: Node[] = [root];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) {
+      continue;
+    }
+
+    if (current.type === 'heredoc_redirect') {
+      redirects.push(current);
+    }
+
+    for (let index = current.namedChildCount - 1; index >= 0; index -= 1) {
+      const child = current.namedChild(index);
+      if (child) {
+        stack.push(child);
+      }
+    }
+  }
+
+  return redirects;
+}
+
+function isQuotedHeredocStart(node: Node, source: string): boolean {
+  const delimiter = source.slice(node.startIndex, node.endIndex);
+  return (
+    delimiter.includes("'") ||
+    delimiter.includes('"') ||
+    delimiter.includes('\\')
+  );
+}
+
+function collectLiteralHeredocBodyRanges(
+  root: Node,
+  source: string,
+): SourceRange[] {
+  const ranges: SourceRange[] = [];
+
+  for (const redirect of collectHeredocRedirects(root)) {
+    const start = findNamedChild(redirect, 'heredoc_start');
+    const body = findNamedChild(redirect, 'heredoc_body');
+    if (start && body && isQuotedHeredocStart(start, source)) {
+      ranges.push({
+        startIndex: body.startIndex,
+        endIndex: body.endIndex,
+      });
+    }
+  }
+
+  return ranges;
+}
+
+function getLiteralRange(
+  ranges: SourceRange[],
+  index: number,
+): SourceRange | null {
+  if (index < 0 || index >= ranges.length) {
+    return null;
+  }
+  return ranges[index];
+}
+
+/**
+ * @plan PLAN-20260825-SHELLMEM.P02
+ * @requirement REQ-3329-08
+ */
+export function hasShellSubstitutionSyntax(
+  command: string,
+  root: Node,
+): boolean {
+  const literalRanges = collectLiteralHeredocBodyRanges(root, command);
+  let literalRangeIndex = 0;
+  let inSingleQuotes = false;
+  let inDoubleQuotes = false;
+  let skipCurrent = false;
+
+  for (let i = 0; i < command.length; i += 1) {
+    const literalRange = getLiteralRange(literalRanges, literalRangeIndex);
+    if (literalRange !== null && i >= literalRange.endIndex) {
+      literalRangeIndex += 1;
+    } else if (literalRange !== null && i >= literalRange.startIndex) {
+      i = literalRange.endIndex - 1;
+      continue;
+    }
+
+    const char = command[i];
+    if (skipCurrent) {
+      skipCurrent = false;
+    } else if (char === '\\' && !inSingleQuotes) {
+      skipCurrent = true;
+    } else if (char === "'" && !inDoubleQuotes) {
+      inSingleQuotes = !inSingleQuotes;
+    } else if (char === '"' && !inSingleQuotes) {
+      inDoubleQuotes = !inDoubleQuotes;
+    } else if (
+      !inSingleQuotes &&
+      isShellSubstitutionStart(command, i, inDoubleQuotes)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isShellSubstitutionStart(
+  command: string,
+  index: number,
+  inDoubleQuotes: boolean,
+): boolean {
+  return (
+    isCommandSubstitutionStart(command, index) ||
+    isProcessSubstitutionStart(command, index, inDoubleQuotes) ||
+    command[index] === '`'
+  );
+}
+
+function isCommandSubstitutionStart(command: string, index: number): boolean {
+  if (command[index] !== '$') {
+    return false;
+  }
+  if (command[index + 1] !== '(') {
+    return false;
+  }
+  // Exclude arithmetic expansion $(( )) which is not command substitution
+  if (index + 2 < command.length && command[index + 2] === '(') {
+    return false;
+  }
+  return true;
+}
+
+function isProcessSubstitutionStart(
+  command: string,
+  index: number,
+  inDoubleQuotes: boolean,
+): boolean {
+  if (inDoubleQuotes) {
+    return false;
+  }
+  return (
+    isProcessSubstitutionOperator(command[index]) &&
+    index + 1 < command.length &&
+    command[index + 1] === '('
+  );
+}
+
+function isProcessSubstitutionOperator(char: string | undefined): boolean {
+  return char === '<' || char === '>';
+}
+
+function containsUnescapedBacktick(text: string): boolean {
+  for (let index = 0; index < text.length; index += 1) {
+    if (text[index] === '\\') {
+      index += 1;
+    } else if (text[index] === '`') {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * @plan PLAN-20260825-SHELLMEM.P02
+ * @requirement REQ-3329-08
+ */
+export function hasUnrepresentedHeredocBacktickSubstitution(
+  root: Node,
+  source: string,
+): boolean {
+  for (const redirect of collectHeredocRedirects(root)) {
+    const start = findNamedChild(redirect, 'heredoc_start');
+    const body = findNamedChild(redirect, 'heredoc_body');
+    if (
+      start &&
+      body &&
+      !isQuotedHeredocStart(start, source) &&
+      containsUnescapedBacktick(body.text)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -39,13 +39,13 @@ import { isWindows } from './runtime.js';
 import { doesToolInvocationMatch } from './tool-utils.js';
 import {
   isParserAvailable,
-  parseShellCommandForLanguage,
   extractCommandNamesForLanguage,
   hasCommandSubstitutionForLanguage,
   splitCommandsWithTreeForLanguage,
   parseCommandDetailsForLanguage,
   hasPromptCommandTransform,
 } from './shell-parser.js';
+import { withParsedTreeForLanguage } from './shell-parser-lifetime.js';
 import type { ParserLanguage, ParsedCommandDetail } from './shell-parser.js';
 import { debugLogger } from './debugLogger.js';
 
@@ -182,6 +182,8 @@ export interface SplitCommandsOptions {
  * @param options Optional settings for split behavior
  * @param shellType Optional shell type override; defaults to bash grammar
  * @returns An array of individual command strings
+ * @plan PLAN-20260825-SHELLMEM.P02
+ * @requirement REQ-3329-08
  */
 export function splitCommands(
   command: string,
@@ -193,14 +195,11 @@ export function splitCommands(
 
   // Try tree-sitter first for accurate parsing
   if (isParserAvailable(language)) {
-    const tree = parseShellCommandForLanguage(command, language);
-    if (tree) {
-      const result = splitCommandsWithTreeForLanguage(tree, language, {
-        splitOnPipes,
-      });
-      if (result.length > 0) {
-        return result;
-      }
+    const result = withParsedTreeForLanguage(command, language, (tree) =>
+      splitCommandsWithTreeForLanguage(tree, language, { splitOnPipes }),
+    );
+    if (result !== null && result.length > 0) {
+      return result;
     }
   }
 
@@ -373,6 +372,7 @@ export function getCommandRoot(command: string): string | undefined {
   return undefined;
 }
 
+/** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-08 */
 export function getCommandRoots(
   command: string,
   shellType?: ShellType,
@@ -385,17 +385,19 @@ export function getCommandRoots(
 
   // Try tree-sitter first for accurate parsing
   if (isParserAvailable(language)) {
-    const tree = parseShellCommandForLanguage(command, language);
-    if (tree) {
+    const parsed = withParsedTreeForLanguage(command, language, (tree) => ({
+      hasPromptTransform:
+        language === 'bash' && hasPromptCommandTransform(tree.rootNode),
+      commandNames: extractCommandNamesForLanguage(tree, language),
+    }));
+    if (parsed !== null) {
       // Prompt transformations (${var@P}) can execute arbitrary commands, so
       // the command is treated as unsafe and no roots are returned.
-      // This is a Bash-specific check; skip for PowerShell.
-      if (language === 'bash' && hasPromptCommandTransform(tree.rootNode)) {
+      if (parsed.hasPromptTransform) {
         return [];
       }
-      const result = extractCommandNamesForLanguage(tree, language);
-      if (result.length > 0) {
-        return result;
+      if (parsed.commandNames.length > 0) {
+        return parsed.commandNames;
       }
       // When the PowerShell parser is available and found no static command
       // names (e.g., a pure .NET expression), do not fall back to regex —
@@ -509,6 +511,8 @@ function matchShellWrapperPrefix(cmd: string): number {
  * **PowerShell**: `$()` subexpressions only.  Backticks are escapes, not
  * substitution.  When the PowerShell parser is unavailable, fail closed
  * (return true) because structural substitution detection cannot be trusted.
+ * @plan PLAN-20260825-SHELLMEM.P02
+ * @requirement REQ-3329-08
  */
 export function detectCommandSubstitution(
   command: string,
@@ -517,17 +521,19 @@ export function detectCommandSubstitution(
   const language = shellTypeToParserLanguage(shellType);
 
   if (isParserAvailable(language)) {
-    const tree = parseShellCommandForLanguage(command, language);
-    if (tree) {
-      const detected = hasCommandSubstitutionForLanguage(tree, language);
+    const parsed = withParsedTreeForLanguage(command, language, (tree) => ({
+      detected: hasCommandSubstitutionForLanguage(tree, language),
+      hasError: tree.rootNode.hasError,
+    }));
+    if (parsed !== null) {
       if (language === 'powershell') {
         // Fail closed on parse errors: a malformed tree may have missed
         // $() subexpressions during error recovery. PowerShell backticks
         // are escapes, not substitution — only valid trees are trusted.
-        return detected || tree.rootNode.hasError;
+        return parsed.detected || parsed.hasError;
       }
-      if (detected || !tree.rootNode.hasError) {
-        return detected;
+      if (parsed.detected || !parsed.hasError) {
+        return parsed.detected;
       }
     }
   }

--- a/packages/mcp/src/auth/oauth-utils.test.ts
+++ b/packages/mcp/src/auth/oauth-utils.test.ts
@@ -11,9 +11,11 @@ import type {
 } from './oauth-utils.js';
 import { OAuthUtils } from './oauth-utils.js';
 
-// Mock fetch globally
+// Mock fetch globally. The assertion keeps the assignment valid whether the
+// program's global fetch type resolves from Node or Bun types (Bun's fetch
+// requires a preconnect member the untyped mock lacks).
 const mockFetch = vi.fn();
-global.fetch = mockFetch;
+global.fetch = mockFetch as unknown as typeof fetch;
 
 describe('OAuthUtils', () => {
   beforeEach(() => {

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -48,6 +48,7 @@
     "../tools/src/__tests__/todo-tools.test.ts",
     "../tools/src/__tests__/tool-key-storage.test.ts",
     "../tools/src/__tests__/tool-registry-mcp-lazy.test.ts",
+    "../tools/src/acquisition/boundedCollectors.lazy.test.ts",
     "../tools/src/tools/activate-skill.test.ts",
     "../tools/src/tools/ast-edit/__tests__/ast-edit-concurrency.test.ts",
     "../tools/src/tools/ast-edit/__tests__/ast-edit-edge-cases.test.ts",

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -48,7 +48,6 @@
     "../tools/src/__tests__/todo-tools.test.ts",
     "../tools/src/__tests__/tool-key-storage.test.ts",
     "../tools/src/__tests__/tool-registry-mcp-lazy.test.ts",
-    "../tools/src/acquisition/boundedCollectors.lazy.test.ts",
     "../tools/src/tools/activate-skill.test.ts",
     "../tools/src/tools/ast-edit/__tests__/ast-edit-concurrency.test.ts",
     "../tools/src/tools/ast-edit/__tests__/ast-edit-edge-cases.test.ts",

--- a/packages/providers/src/logging/ProviderPerformanceTracker.test.ts
+++ b/packages/providers/src/logging/ProviderPerformanceTracker.test.ts
@@ -149,6 +149,46 @@ describe('ProviderPerformanceTracker', () => {
     expect(metrics.errorRate).toBeCloseTo(2 / 3, 2);
   });
 
+  /** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-07 */
+  it('retains the latest 50 errors while calculating the lifetime error rate', () => {
+    const tracker = new ProviderPerformanceTracker('test-provider');
+
+    for (let index = 1; index <= 100; index += 1) {
+      tracker.recordError(index, `Error ${index}`);
+    }
+    for (let index = 0; index < 10; index += 1) {
+      tracker.recordCompletion(100, null, 1, 1, 1);
+    }
+
+    const metrics = tracker.getLatestMetrics();
+    expect(metrics.errors).toHaveLength(50);
+    expect(metrics.errors[0].error).toBe('Error 51');
+    expect(metrics.errors[49].error).toBe('Error 100');
+    expect(metrics.errorRate).toBe(100 / 110);
+  });
+
+  /** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-07 */
+  it('keeps previously returned snapshots intact when the error cap trims', () => {
+    const tracker = new ProviderPerformanceTracker('test-provider');
+
+    for (let index = 1; index <= 50; index += 1) {
+      tracker.recordError(index, `Error ${index}`);
+    }
+    const earlySnapshot = tracker.getLatestMetrics();
+    expect(earlySnapshot.errors).toHaveLength(50);
+    expect(earlySnapshot.errors[0].error).toBe('Error 1');
+
+    // Pushing past the cap trims the tracker's internal buffer; the earlier
+    // snapshot must not lose entries retroactively.
+    for (let index = 51; index <= 60; index += 1) {
+      tracker.recordError(index, `Error ${index}`);
+    }
+
+    expect(earlySnapshot.errors).toHaveLength(50);
+    expect(earlySnapshot.errors[0].error).toBe('Error 1');
+    expect(earlySnapshot.errors[49].error).toBe('Error 50');
+  });
+
   it('should retain partial TTFT and chunk metadata when recording stream errors', () => {
     const tracker = new ProviderPerformanceTracker('test-provider');
 

--- a/packages/providers/src/logging/ProviderPerformanceTracker.ts
+++ b/packages/providers/src/logging/ProviderPerformanceTracker.ts
@@ -29,10 +29,14 @@ function toSafePositiveMs(value: number | null | undefined): number | null {
 }
 
 /**
- * Performance tracking utility for provider operations
+ * Performance tracking utility for provider operations.
+ * @plan PLAN-20260825-SHELLMEM.P02
+ * @requirement REQ-3329-07
  */
 export class ProviderPerformanceTracker {
+  private static readonly MAX_RETAINED_ERRORS = 50;
   private metrics: ProviderPerformanceMetrics;
+  private totalErrors = 0;
   private totalGenerationTimeMs = 0;
   private totalTokensWithMeasuredTime = 0;
   // Complete session TPM accumulators (duration-based, not wall-time)
@@ -102,6 +106,7 @@ export class ProviderPerformanceTracker {
     const safeOutputTokenCount = sanitizeNonNegative(outputTokenCount);
     const safeChunkCount = sanitizeNonNegative(chunkCount);
     this.metrics.totalRequests++;
+    this.updateErrorRate();
     this.metrics.totalTokens += safeTotalTokenCount;
     this.metrics.averageLatency =
       (this.metrics.averageLatency * (this.metrics.totalRequests - 1) +
@@ -167,21 +172,30 @@ export class ProviderPerformanceTracker {
       this.metrics.chunksReceived = sanitizeNonNegative(chunkCount);
     }
 
+    this.totalErrors += 1;
     this.metrics.errors.push({
       timestamp: Date.now(),
       duration: safeDuration,
       error: error.substring(0, 200), // Truncate long errors
     });
+    if (
+      this.metrics.errors.length >
+      ProviderPerformanceTracker.MAX_RETAINED_ERRORS
+    ) {
+      this.metrics.errors.splice(
+        0,
+        this.metrics.errors.length -
+          ProviderPerformanceTracker.MAX_RETAINED_ERRORS,
+      );
+    }
+    this.updateErrorRate();
+  }
 
-    // Update error rate — clamp to [0, 1].
-    // Denominator is total attempts (successes + errors), not just
-    // successes + 1, so multiple errors produce correct ratios.
-    const totalAttempts =
-      this.metrics.totalRequests + this.metrics.errors.length;
-    this.metrics.errorRate = Math.min(
-      1,
-      totalAttempts > 0 ? this.metrics.errors.length / totalAttempts : 0,
-    );
+  /** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-07 */
+  private updateErrorRate(): void {
+    const totalAttempts = this.metrics.totalRequests + this.totalErrors;
+    this.metrics.errorRate =
+      totalAttempts > 0 ? this.totalErrors / totalAttempts : 0;
   }
 
   /**
@@ -202,6 +216,9 @@ export class ProviderPerformanceTracker {
   getLatestMetrics(): ProviderPerformanceMetrics {
     return {
       ...this.metrics,
+      // Copy: the errors array is trimmed in place when the retention cap
+      // is exceeded, and previously returned snapshots must not lose entries.
+      errors: [...this.metrics.errors],
       averageLatency: sanitizeNonNegative(this.metrics.averageLatency),
       tokensPerSecond: sanitizeNonNegative(this.metrics.tokensPerSecond),
       tokensPerMinute: sanitizeNonNegative(this.metrics.tokensPerMinute),
@@ -215,6 +232,7 @@ export class ProviderPerformanceTracker {
    */
   reset(): void {
     this.metrics = this.initializeMetrics();
+    this.totalErrors = 0;
     this.totalGenerationTimeMs = 0;
     this.totalTokensWithMeasuredTime = 0;
     this.completeTpmSumTokens = 0;

--- a/packages/telemetry/src/telemetry/intervalUnion.behavior.test.ts
+++ b/packages/telemetry/src/telemetry/intervalUnion.behavior.test.ts
@@ -247,4 +247,18 @@ describe('IntervalUnion', () => {
       expect(u.count()).toBe(1);
     });
   });
+
+  /** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-06 */
+  describe('bounded interval retention', () => {
+    /** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-06 */
+    it('retains only the newest 8192 disjoint intervals and their duration', () => {
+      for (let index = 0; index < 10_000; index += 1) {
+        u.add(index * 2, index * 2 + 1);
+      }
+
+      expect(u.count()).toBe(8192);
+      expect(u.durationMs()).toBe(8192);
+      expect(u.latestEnd).toBe(19_999);
+    });
+  });
 });

--- a/packages/telemetry/src/telemetry/intervalUnion.ts
+++ b/packages/telemetry/src/telemetry/intervalUnion.ts
@@ -9,6 +9,8 @@ interface Interval {
   end: number;
 }
 
+const MAX_INTERVALS = 8192;
+
 /**
  * Incrementally maintained, sorted, non-overlapping interval list.
  *
@@ -25,6 +27,10 @@ interface Interval {
  * - an interval fully nested inside another adds no duration
  * - gaps are never bridged
  * - degenerate (end <= start), zero-length and non-finite intervals are ignored
+ * - overflow drops the oldest interval, conservatively undercounting activity
+ *
+ * @plan PLAN-20260825-SHELLMEM.P02
+ * @requirement REQ-3329-06
  */
 class IntervalUnion {
   private readonly intervals: Interval[] = [];
@@ -76,6 +82,7 @@ class IntervalUnion {
       // No overlap: pure insert, the full span is net-new.
       list.splice(lo, 0, { start, end });
       this.cachedDurationMs += end - start;
+      this.trimOldestOverflow();
       return;
     }
 
@@ -87,6 +94,20 @@ class IntervalUnion {
     }
     list.splice(from, to - from, { start: mergedStart, end: mergedEnd });
     this.cachedDurationMs += mergedEnd - mergedStart - removedDuration;
+  }
+
+  /** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-06 */
+  private trimOldestOverflow(): void {
+    if (this.intervals.length <= MAX_INTERVALS) {
+      return;
+    }
+    const oldest = this.intervals.shift();
+    if (oldest === undefined) {
+      throw new Error(
+        'Interval retention exceeded its cap without an interval',
+      );
+    }
+    this.cachedDurationMs -= oldest.end - oldest.start;
   }
 
   durationMs(): number {

--- a/packages/telemetry/src/telemetry/sessionMetricsAggregator.advanced.test.ts
+++ b/packages/telemetry/src/telemetry/sessionMetricsAggregator.advanced.test.ts
@@ -346,9 +346,10 @@ describe('SessionMetricsAggregator', () => {
     });
 
     it('exact union across many disjoint intervals (no compaction)', () => {
-      // Insert far more disjoint intervals than any internal limit.
-      // The union must remain exact — every interval contributes its
-      // duration, gaps are never bridged, and no interval is evicted.
+      // Below-cap exactness: 250 disjoint intervals stay under the 8192
+      // interval cap, so the union must remain exact — every interval
+      // contributes its duration, gaps are never bridged, and no interval
+      // is evicted.
       const clockNow = vi.spyOn(performance, 'now');
       const fixedNow = 1_000_000;
       clockNow.mockReturnValue(fixedNow);
@@ -693,6 +694,51 @@ describe('SessionMetricsAggregator', () => {
       );
       const afterInner = agg.getSnapshot();
       expect(afterInner.agentActiveTimeMs).toBe(expectedDisjoint + 5);
+    });
+  });
+
+  /** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-06 */
+  describe('bounded recent-ID deduplication', () => {
+    /** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-06 */
+    it('accepts an evicted attempt ID while retaining recent attempt deduplication', () => {
+      for (let index = 0; index < 2_000; index += 1) {
+        agg.recordApiAttempt(makeAttempt({ attemptId: `attempt-${index}` }));
+      }
+
+      const oldestAcceptedAgain = agg.recordApiAttempt(
+        makeAttempt({ attemptId: 'attempt-0' }),
+      );
+      const newestStillDuplicate = agg.recordApiAttempt(
+        makeAttempt({ attemptId: 'attempt-1999' }),
+      );
+
+      expect(oldestAcceptedAgain).toBe(true);
+      expect(newestStillDuplicate).toBe(false);
+      expect(agg.getSnapshot().totalApiRequests).toBe(2_001);
+    });
+
+    /** @plan PLAN-20260825-SHELLMEM.P02 @requirement REQ-3329-06 */
+    it('accepts an evicted tool call ID while retaining recent tool deduplication', () => {
+      for (let index = 0; index < 2_000; index += 1) {
+        agg.recordToolActivity('tool', 1, true, `call-${index}`);
+      }
+
+      const oldestAcceptedAgain = agg.recordToolActivity(
+        'tool',
+        1,
+        true,
+        'call-0',
+      );
+      const newestStillDuplicate = agg.recordToolActivity(
+        'tool',
+        1,
+        true,
+        'call-1999',
+      );
+
+      expect(oldestAcceptedAgain).toBe(true);
+      expect(newestStillDuplicate).toBe(false);
+      expect(agg.getSnapshot().totalToolCalls).toBe(2_001);
     });
   });
 

--- a/packages/telemetry/src/telemetry/sessionMetricsAggregator.ts
+++ b/packages/telemetry/src/telemetry/sessionMetricsAggregator.ts
@@ -164,10 +164,12 @@ function sanitizeFinite(value: number): number {
   return value;
 }
 
+const MAX_DEDUP_ENTRIES = 1024;
+
 /**
- * Unbounded deduplication set for session-lifetime exactly-once tracking.
- * IDs are retained until reset() so replayed older attempts are not
- * double-counted.
+ * Retains an insertion-ordered recent window for duplicate suppression.
+ * @plan PLAN-20260825-SHELLMEM.P02
+ * @requirement REQ-3329-06
  */
 class DedupSet {
   private readonly entries = new Set<string>();
@@ -178,6 +180,14 @@ class DedupSet {
 
   add(value: string): void {
     this.entries.add(value);
+    if (this.entries.size <= MAX_DEDUP_ENTRIES) {
+      return;
+    }
+    const oldest = this.entries.values().next();
+    if (oldest.done === true) {
+      throw new Error('Dedup retention exceeded its cap without an entry');
+    }
+    this.entries.delete(oldest.value);
   }
 
   clear(): void {

--- a/packages/tools/src/acquisition/boundedCollectors.lazy.test.ts
+++ b/packages/tools/src/acquisition/boundedCollectors.lazy.test.ts
@@ -24,6 +24,8 @@ function countHeapClass(name: string): number {
   // Validate the snapshot layout via a class every JavaScript heap has; a
   // Bun format change must fail loudly instead of silently counting zero.
   if (
+    !Array.isArray(snapshot.nodes) ||
+    !Array.isArray(snapshot.nodeClassNames) ||
     snapshot.nodes.length % 4 !== 0 ||
     snapshot.nodeClassNames.indexOf('Object') < 0
   ) {
@@ -31,6 +33,7 @@ function countHeapClass(name: string): number {
       'Unexpected heap snapshot encoding; class counts would be unreliable',
     );
   }
+  const classCount = snapshot.nodeClassNames.length;
   const classIndex = snapshot.nodeClassNames.indexOf(name);
   if (classIndex < 0) {
     return 0;
@@ -38,7 +41,13 @@ function countHeapClass(name: string): number {
 
   let count = 0;
   for (let position = 2; position < snapshot.nodes.length; position += 4) {
-    if (snapshot.nodes[position] === classIndex) {
+    const nodeClass = snapshot.nodes[position];
+    if (nodeClass >= classCount) {
+      throw new Error(
+        'Unexpected heap snapshot encoding; class index out of bounds',
+      );
+    }
+    if (nodeClass === classIndex) {
       count += 1;
     }
   }

--- a/packages/tools/src/acquisition/boundedCollectors.lazy.test.ts
+++ b/packages/tools/src/acquisition/boundedCollectors.lazy.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-04
+ */
+
+import { generateHeapSnapshot } from 'bun';
+import { describe, expect, it } from 'bun:test';
+import {
+  BoundedCombinedCollector,
+  BoundedStreamCollector,
+  createByteBudget,
+} from './index.js';
+
+const COLLECTOR_COUNT = 200;
+const UINT8_ARRAY_GROWTH_THRESHOLD = 50;
+const BUDGET_BYTES = 512 * 1024;
+
+/** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-04 */
+function countHeapClass(name: string): number {
+  const snapshot = generateHeapSnapshot();
+  // Validate the snapshot layout via a class every JavaScript heap has; a
+  // Bun format change must fail loudly instead of silently counting zero.
+  if (
+    snapshot.nodes.length % 4 !== 0 ||
+    snapshot.nodeClassNames.indexOf('Object') < 0
+  ) {
+    throw new Error(
+      'Unexpected heap snapshot encoding; class counts would be unreliable',
+    );
+  }
+  const classIndex = snapshot.nodeClassNames.indexOf(name);
+  if (classIndex < 0) {
+    return 0;
+  }
+
+  let count = 0;
+  for (let position = 2; position < snapshot.nodes.length; position += 4) {
+    if (snapshot.nodes[position] === classIndex) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-04 */
+function collectGarbage(): void {
+  Bun.gc(true);
+  Bun.gc(true);
+}
+
+/** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-04 */
+describe('bounded collector lazy allocation', () => {
+  /** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-04 */
+  it('does not retain typed-array buffers for combined collectors before append', () => {
+    collectGarbage();
+    const baseline = countHeapClass('Uint8Array');
+    const budget = createByteBudget(BUDGET_BYTES);
+
+    const collectors = Array.from(
+      { length: COLLECTOR_COUNT },
+      () => new BoundedCombinedCollector({ budget }),
+    );
+    collectGarbage();
+
+    expect(collectors).toHaveLength(COLLECTOR_COUNT);
+    expect(countHeapClass('Uint8Array') - baseline).toBeLessThanOrEqual(
+      UINT8_ARRAY_GROWTH_THRESHOLD,
+    );
+  });
+
+  /** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-04 */
+  it('does not retain typed-array buffers for stream collectors before append', () => {
+    collectGarbage();
+    const baseline = countHeapClass('Uint8Array');
+    const budget = createByteBudget(BUDGET_BYTES);
+
+    const collectors = Array.from(
+      { length: COLLECTOR_COUNT },
+      () => new BoundedStreamCollector({ budget }),
+    );
+    collectGarbage();
+
+    expect(collectors).toHaveLength(COLLECTOR_COUNT);
+    expect(countHeapClass('Uint8Array') - baseline).toBeLessThanOrEqual(
+      UINT8_ARRAY_GROWTH_THRESHOLD,
+    );
+  });
+
+  /** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-04 */
+  it('returns an empty combined result without an append', () => {
+    const collector = new BoundedCombinedCollector({
+      budget: createByteBudget(BUDGET_BYTES),
+    });
+
+    const result = collector.getResult();
+    const raw = collector.getBoundedRawBuffer();
+
+    expect(result.text).toBe('');
+    expect(result.metadata).toMatchObject({
+      observedBytes: 0,
+      retainedBytes: 0,
+      omittedBytes: 0,
+      truncated: false,
+    });
+    expect(raw.byteLength).toBe(0);
+  });
+
+  /** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-04 */
+  it('returns an empty stream result without an append', () => {
+    const collector = new BoundedStreamCollector({
+      budget: createByteBudget(BUDGET_BYTES),
+    });
+
+    const result = collector.getResult();
+
+    expect(result.text).toBe('');
+    expect(result.metadata).toMatchObject({
+      observedBytes: 0,
+      retainedBytes: 0,
+      omittedBytes: 0,
+      truncated: false,
+    });
+    expect(collector.isTruncated).toBe(false);
+    expect(collector.observedByteCount).toBe(0);
+  });
+
+  /** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-04 */
+  it('round-trips appended text through both collectors', () => {
+    const budget = createByteBudget(BUDGET_BYTES);
+    const combined = new BoundedCombinedCollector({ budget });
+    const stream = new BoundedStreamCollector({ budget });
+
+    combined.append('hi', 'stdout');
+    stream.append('hi');
+
+    expect(combined.getResult().text).toBe('hi');
+    expect(stream.getResult().text).toBe('hi');
+  });
+});

--- a/packages/tools/src/acquisition/boundedCombinedCollector.ts
+++ b/packages/tools/src/acquisition/boundedCombinedCollector.ts
@@ -28,6 +28,15 @@ interface TaggedBytes {
   readonly stderrBits: Uint8Array;
 }
 
+interface CollectorStorage {
+  readonly headBytes: Buffer;
+  readonly headStderrBits: Uint8Array;
+  readonly tailBytes: Buffer;
+  readonly tailStderrBits: Uint8Array;
+}
+
+const EMPTY_BUFFER = Buffer.alloc(0);
+const EMPTY_BITS = new Uint8Array(0);
 const OUTPUT_BLOCK_SIZE = 64 * 1024;
 
 function normalizedEncoding(encoding: string): string {
@@ -253,17 +262,17 @@ function decodeTagged(
  * source alternation has fixed overhead of budget / 8 instead of one object or
  * byte-sized tag per retained byte. Decoding uses independent streaming
  * decoders per source while preserving the retained combined arrival order.
+ *
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-04
  */
 export class BoundedCombinedCollector {
   private readonly budget: ByteBudget;
   private readonly encoding: string;
   private readonly headCapacity: number;
   private readonly tailCapacity: number;
-  private readonly headBytes: Buffer;
-  private readonly headStderrBits: Uint8Array;
+  private storage: CollectorStorage | null = null;
   private headLength = 0;
-  private readonly tailBytes: Buffer;
-  private readonly tailStderrBits: Uint8Array;
   private tailWritePosition = 0;
   private tailLength = 0;
   private observedBytes = 0;
@@ -275,14 +284,21 @@ export class BoundedCombinedCollector {
     const fraction = Math.min(Math.max(options.headFraction ?? 0.5, 0), 1);
     this.headCapacity = Math.floor(this.budget.bytes * fraction);
     this.tailCapacity = this.budget.bytes - this.headCapacity;
-    this.headBytes = Buffer.allocUnsafe(this.headCapacity);
-    this.headStderrBits = new Uint8Array(Math.ceil(this.headCapacity / 8));
-    this.tailBytes = Buffer.allocUnsafe(this.tailCapacity);
-    this.tailStderrBits = new Uint8Array(Math.ceil(this.tailCapacity / 8));
   }
 
   get observedByteCount(): number {
     return this.observedBytes;
+  }
+
+  /** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-04 */
+  private ensureStorage(): CollectorStorage {
+    this.storage ??= {
+      headBytes: Buffer.allocUnsafe(this.headCapacity),
+      headStderrBits: new Uint8Array(Math.ceil(this.headCapacity / 8)),
+      tailBytes: Buffer.allocUnsafe(this.tailCapacity),
+      tailStderrBits: new Uint8Array(Math.ceil(this.tailCapacity / 8)),
+    };
+    return this.storage;
   }
 
   append(chunk: Buffer | string, source: StreamSource): void {
@@ -290,6 +306,7 @@ export class BoundedCombinedCollector {
     if (bytes.length === 0) {
       return;
     }
+    const storage = this.ensureStorage();
     this.observedBytes += bytes.length;
     this.cachedTail = null;
 
@@ -298,9 +315,9 @@ export class BoundedCombinedCollector {
       this.headCapacity - this.headLength,
     );
     if (headTake > 0) {
-      bytes.copy(this.headBytes, this.headLength, 0, headTake);
+      bytes.copy(storage.headBytes, this.headLength, 0, headTake);
       fillBits(
-        this.headStderrBits,
+        storage.headStderrBits,
         this.headLength,
         headTake,
         sourceBit(source),
@@ -308,7 +325,7 @@ export class BoundedCombinedCollector {
       this.headLength += headTake;
     }
     if (headTake < bytes.length) {
-      this.appendTail(bytes.subarray(headTake), source);
+      this.appendTail(storage, bytes.subarray(headTake), source);
     }
   }
 
@@ -326,8 +343,11 @@ export class BoundedCombinedCollector {
 
   getHeadBytes(maxBytes: number): Buffer {
     const length = Math.min(Math.max(Math.floor(maxBytes), 0), this.headLength);
+    if (this.storage === null || length === 0) {
+      return EMPTY_BUFFER;
+    }
     const output = Buffer.allocUnsafe(length);
-    this.headBytes.copy(output, 0, 0, length);
+    this.storage.headBytes.copy(output, 0, 0, length);
     return output;
   }
 
@@ -386,7 +406,11 @@ export class BoundedCombinedCollector {
     };
   }
 
-  private appendTail(bytes: Buffer, source: StreamSource): void {
+  private appendTail(
+    storage: CollectorStorage,
+    bytes: Buffer,
+    source: StreamSource,
+  ): void {
     if (this.tailCapacity === 0) {
       return;
     }
@@ -395,6 +419,7 @@ export class BoundedCombinedCollector {
     const skipped = sourceOffset;
     const writeStart = (this.tailWritePosition + skipped) % this.tailCapacity;
     this.writeTailSlice(
+      storage,
       bytes,
       sourceOffset,
       retainedLength,
@@ -410,6 +435,7 @@ export class BoundedCombinedCollector {
   }
 
   private writeTailSlice(
+    storage: CollectorStorage,
     sourceBytes: Buffer,
     sourceOffset: number,
     length: number,
@@ -418,28 +444,36 @@ export class BoundedCombinedCollector {
   ): void {
     const firstLength = Math.min(length, this.tailCapacity - writeStart);
     sourceBytes.copy(
-      this.tailBytes,
+      storage.tailBytes,
       writeStart,
       sourceOffset,
       sourceOffset + firstLength,
     );
-    fillBits(this.tailStderrBits, writeStart, firstLength, sourceBit(source));
+    fillBits(
+      storage.tailStderrBits,
+      writeStart,
+      firstLength,
+      sourceBit(source),
+    );
     const remaining = length - firstLength;
     if (remaining > 0) {
       sourceBytes.copy(
-        this.tailBytes,
+        storage.tailBytes,
         0,
         sourceOffset + firstLength,
         sourceOffset + length,
       );
-      fillBits(this.tailStderrBits, 0, remaining, sourceBit(source));
+      fillBits(storage.tailStderrBits, 0, remaining, sourceBit(source));
     }
   }
 
   private headTagged(): TaggedBytes {
+    if (this.storage === null) {
+      return { bytes: EMPTY_BUFFER, stderrBits: EMPTY_BITS };
+    }
     return {
-      bytes: this.headBytes.subarray(0, this.headLength),
-      stderrBits: this.headStderrBits,
+      bytes: this.storage.headBytes.subarray(0, this.headLength),
+      stderrBits: this.storage.headStderrBits,
     };
   }
 
@@ -447,11 +481,12 @@ export class BoundedCombinedCollector {
     if (this.cachedTail !== null) {
       return this.cachedTail;
     }
-    if (this.tailCapacity === 0 || this.tailLength === 0) {
-      this.cachedTail = {
-        bytes: Buffer.alloc(0),
-        stderrBits: new Uint8Array(0),
-      };
+    if (
+      this.storage === null ||
+      this.tailCapacity === 0 ||
+      this.tailLength === 0
+    ) {
+      this.cachedTail = { bytes: EMPTY_BUFFER, stderrBits: EMPTY_BITS };
       return this.cachedTail;
     }
     const bytes = Buffer.allocUnsafe(this.tailLength);
@@ -461,8 +496,8 @@ export class BoundedCombinedCollector {
       this.tailCapacity;
     for (let index = 0; index < this.tailLength; index += 1) {
       const ringIndex = (start + index) % this.tailCapacity;
-      bytes[index] = this.tailBytes[ringIndex];
-      setBit(stderrBits, index, getBit(this.tailStderrBits, ringIndex));
+      bytes[index] = this.storage.tailBytes[ringIndex];
+      setBit(stderrBits, index, getBit(this.storage.tailStderrBits, ringIndex));
     }
     this.cachedTail = { bytes, stderrBits };
     return this.cachedTail;

--- a/packages/tools/src/acquisition/boundedStreamCollector.ts
+++ b/packages/tools/src/acquisition/boundedStreamCollector.ts
@@ -23,6 +23,13 @@ export interface BoundedStreamCollectorOptions {
 
 export const DEFAULT_OMISSION_NOTICE = 'LLXPRT output truncated';
 
+interface CollectorStorage {
+  readonly head: Buffer;
+  readonly tail: Buffer;
+}
+
+const EMPTY_BUFFER = Buffer.alloc(0);
+
 function copySlice(source: Buffer, start: number, end: number): Buffer {
   const copy = Buffer.allocUnsafe(end - start);
   source.copy(copy, 0, start, end);
@@ -122,14 +129,17 @@ function encode(text: string, encoding: string): Buffer {
   return Buffer.from(text, nodeBufferEncoding(encoding) ?? 'utf8');
 }
 
-/** Retains a fixed-size byte head and tail without retaining input buffers. */
+/**
+ * Retains a fixed-size byte head and tail without retaining input buffers.
+ * @plan PLAN-20260825-SHELLMEM.P01
+ * @requirement REQ-3329-04
+ */
 export class BoundedStreamCollector {
   private readonly budget: ByteBudget;
   private readonly encoding: string;
   private readonly headCapacity: number;
   private readonly tailCapacity: number;
-  private readonly head: Buffer;
-  private readonly tail: Buffer;
+  private storage: CollectorStorage | null = null;
   private headLength = 0;
   private tailLength = 0;
   private tailStart = 0;
@@ -141,8 +151,6 @@ export class BoundedStreamCollector {
     const fraction = Math.min(Math.max(options.headFraction ?? 0.5, 0), 1);
     this.headCapacity = Math.floor(this.budget.bytes * fraction);
     this.tailCapacity = this.budget.bytes - this.headCapacity;
-    this.head = Buffer.allocUnsafe(this.headCapacity);
-    this.tail = Buffer.allocUnsafe(this.tailCapacity);
   }
 
   get observedByteCount(): number {
@@ -153,12 +161,22 @@ export class BoundedStreamCollector {
     return this.observedBytes > this.budget.bytes;
   }
 
+  /** @plan PLAN-20260825-SHELLMEM.P01 @requirement REQ-3329-04 */
+  private ensureStorage(): CollectorStorage {
+    this.storage ??= {
+      head: Buffer.allocUnsafe(this.headCapacity),
+      tail: Buffer.allocUnsafe(this.tailCapacity),
+    };
+    return this.storage;
+  }
+
   append(chunk: Buffer | string): void {
     const bytes = Buffer.isBuffer(chunk) ? chunk : encode(chunk, this.encoding);
     if (bytes.length === 0) {
       return;
     }
 
+    const storage = this.ensureStorage();
     this.observedBytes += bytes.length;
     let offset = 0;
     if (this.headLength < this.headCapacity) {
@@ -166,11 +184,11 @@ export class BoundedStreamCollector {
         bytes.length,
         this.headCapacity - this.headLength,
       );
-      bytes.copy(this.head, this.headLength, 0, copied);
+      bytes.copy(storage.head, this.headLength, 0, copied);
       this.headLength += copied;
       offset = copied;
     }
-    this.appendTail(bytes, offset);
+    this.appendTail(storage, bytes, offset);
   }
 
   flushDecoder(): void {
@@ -185,22 +203,26 @@ export class BoundedStreamCollector {
     return this.getResult().tailText;
   }
 
-  private appendTail(bytes: Buffer, offset: number): void {
+  private appendTail(
+    storage: CollectorStorage,
+    bytes: Buffer,
+    offset: number,
+  ): void {
     if (this.tailCapacity === 0 || offset >= bytes.length) {
       return;
     }
     const remaining = bytes.length - offset;
     if (remaining >= this.tailCapacity) {
-      bytes.copy(this.tail, 0, bytes.length - this.tailCapacity);
+      bytes.copy(storage.tail, 0, bytes.length - this.tailCapacity);
       this.tailLength = this.tailCapacity;
       this.tailStart = 0;
       return;
     }
     const writeStart = (this.tailStart + this.tailLength) % this.tailCapacity;
     const firstLength = Math.min(remaining, this.tailCapacity - writeStart);
-    bytes.copy(this.tail, writeStart, offset, offset + firstLength);
+    bytes.copy(storage.tail, writeStart, offset, offset + firstLength);
     if (firstLength < remaining) {
-      bytes.copy(this.tail, 0, offset + firstLength, bytes.length);
+      bytes.copy(storage.tail, 0, offset + firstLength, bytes.length);
     }
     const overwritten = Math.max(
       0,
@@ -211,21 +233,33 @@ export class BoundedStreamCollector {
   }
 
   private copiedHead(): Buffer {
-    return copySlice(this.head, 0, this.headLength);
+    return this.storage === null
+      ? EMPTY_BUFFER
+      : copySlice(this.storage.head, 0, this.headLength);
   }
 
   private copiedTail(): Buffer {
-    if (this.tailLength === 0) {
-      return Buffer.alloc(0);
+    if (this.storage === null || this.tailLength === 0) {
+      return EMPTY_BUFFER;
     }
     const result = Buffer.allocUnsafe(this.tailLength);
     const firstLength = Math.min(
       this.tailLength,
       this.tailCapacity - this.tailStart,
     );
-    this.tail.copy(result, 0, this.tailStart, this.tailStart + firstLength);
+    this.storage.tail.copy(
+      result,
+      0,
+      this.tailStart,
+      this.tailStart + firstLength,
+    );
     if (firstLength < this.tailLength) {
-      this.tail.copy(result, firstLength, 0, this.tailLength - firstLength);
+      this.storage.tail.copy(
+        result,
+        firstLength,
+        0,
+        this.tailLength - firstLength,
+      );
     }
     return result;
   }

--- a/project-plans/issue3329/plan.md
+++ b/project-plans/issue3329/plan.md
@@ -1,0 +1,545 @@
+# Plan: Shell tool-call memory retention + secondary unbounded accumulators (#3329)
+
+Plan ID: PLAN-20260825-SHELLMEM
+Generated: 2026-08-25
+Total Phases: 4 (P0.5 preflight, P01 primary shell leak, P02 secondary accumulators, P03 verification)
+Requirements: REQ-3329-01 … REQ-3329-09
+
+## Scope statement
+
+Fix the primary per-shell-execution memory leak (retained Subprocess + ~2.56 MB
+collector buffers via the armed inactivity timer) on both the `child_process`
+and PTY paths, and bound four secondary unbounded accumulators. A fifth
+secondary item (Ink `fullStaticOutput`) requires a dependency change to the
+`@jrichman/ink` fork and is PENDING USER DECISION — see REQ-3329-09; do not
+implement without explicit approval.
+
+Out of scope: incremental/growth-based collector buffer allocation beyond
+lazy-on-first-write; RSS allocator high-water effects (issue records these as
+not separately fixable); no public API changes to `ShellExecutionResult`,
+`parseShellCommand*`, or collector classes.
+
+## Critical Reminders
+
+1. Phase 0.5 preflight is complete (results recorded below).
+2. Tests are written BEFORE implementation (red → green).
+3. No mock theater: shell tests spawn real child processes; no `vi.mock`
+   fabrications for the code under test. Existing mock-heavy suites are
+   grandfathered; new tests must not copy that style.
+4. Bun test runner only (`bun test path/to/file.test.ts`). All new files are
+   TypeScript. No new .js files, no vitest/node tests.
+
+---
+
+# Phase 0.5: Preflight Verification
+
+## Purpose
+
+All assumptions verified 2026-08-25 on this machine (Bun 1.3.14, darwin arm64).
+
+## Test seam verification (the load-bearing assumption)
+
+The heap-snapshot histogram seam was probed directly (not assumed):
+
+| Probe | Result | Status |
+|---|---|---|
+| `Bun.generateHeapSnapshot()` shape | `{version, type, nodes, nodeClassNames, edges, edgeTypes, edgeNames}` | OK |
+| Flat `nodes` array layout | stride 4; class-name index at offsets `2 + 4k` | OK |
+| Known-count check | 7 retained `new Canary()` → class count 7; after drop + `Bun.gc(true)` → class absent (−1) | OK |
+| `Subprocess` after 10 retained spawns | 11 (10 + probe noise); after drop+gc: 3 (Bun-internal exited-child references — real noise floor) | OK with threshold ≥ 8 |
+| `AbortController` at idle baseline | class absent (−1) — any nonzero count is signal | OK |
+| `process.getActiveResourcesInfo` under Bun | stub, returns `[]` | UNUSABLE (avoid) |
+| web-tree-sitter `Tree.delete()` | calls `_ts_tree_delete` then sets internal handle `this[0] = 0` — deletable observable | OK |
+
+Counting helper contract for tests (derive, do not hardcode, the stride):
+
+```ts
+function countHeapClass(name: string): number {
+  const snap = Bun.generateHeapSnapshot();
+  const idx = snap.nodeClassNames.indexOf(name);
+  if (idx < 0) return 0;
+  let c = 0;
+  for (let p = 2; p < snap.nodes.length; p += 4) if (snap.nodes[p] === idx) c++;
+  return c;
+}
+```
+
+Because `AbortController` is absent at idle baseline, the primary leak signal
+for both CP and PTY paths is `countHeapClass('AbortController')` after N
+completed executions with a large `inactivityTimeoutMs` (timer armed, never
+fires): before fix ≈ N (timer-rooted, uncollectable), after fix ≈ 0–2.
+`Subprocess` and `Uint8Array` counts are secondary assertions with generous
+thresholds (≥ 8 after N=40) to absorb the measured noise floor.
+
+## Call path verification
+
+| Path | Verified |
+|---|---|
+| `ShellExecutionService.execute` → `createCpResultPromise` (CP) / `createPtyResultPromise` (PTY) → `makeInactivityTimer` | YES — `shellExecutionService.ts:130`, `:183`; timer never cancelled anywhere (no `clearTimeout` in `shellCpExecution.ts`/`shellCpHelpers.ts`) |
+| CP cleanup: `cleanupCpResources` removes caller abort listener + child listeners only | YES — `shellCpHelpers.ts:131-153` |
+| PTY teardown: `teardownPtyState` → `cleanupPtyEntryResources` (destroys PTY + terminal, clears termination/render timeouts) but never cancels inactivity timer / removes inactivity abort listener | YES — `shellPtyLifecycle.ts:181-205`, `shellPtyHelpers.ts` |
+| Retainer chain: pending timer (GC root) → callback closure → `controller` → `signal` → abort listener closure → `state` → `child` + `rawCollector` + `sniffBuffer` | YES — heap snapshot walk in issue, confirmed by code read |
+| `BoundedCombinedCollector` (shell path) and `BoundedStreamCollector` eagerly allocate head/tail (and stderr bookkeeping) buffers to full budget in constructor | YES — `boundedCombinedCollector.ts` ctor, `boundedStreamCollector.ts:139-146` |
+| `seenCallIds` unbounded Set, cleared only in `dispose()`/`cancelAll()` | YES — `coreToolScheduler.ts:126`, `:374-378`, `:205`, `:885` |
+| `DedupSet` deliberately unbounded; `IntervalUnion.intervals` uncapped array | YES — `sessionMetricsAggregator.ts:172-186`, `intervalUnion.ts:29-40` |
+| `ProviderPerformanceTracker.errors` push uncapped; `errorRate` derived from `errors.length` | YES — `ProviderPerformanceTracker.ts:60`, `:170`, `:180-183`; external consumers only read metrics |
+| tree-sitter `Tree` never `.delete()`d; `Query`/`Parser` are | YES — `shell-parser.ts:334-369` (`parseWithTimeout`), `:826`, `:1067`; `:469`, `:865`, `:891`; no `tree.delete()` anywhere in `packages/*/src` |
+| Production `parseShellCommand*` consumers: `shell-parser.ts` internal (`:826`, `:1067`) + `shell-utils.ts:196/388/520`; tests use it directly elsewhere | YES — grep 2026-08-25 |
+| Ink fork is published npm package (`npm:@jrichman/ink@6.4.8`), no local source, no `patches/` dir | YES — dependency change approval required |
+
+## Blocking issues
+
+None for P01/P02. REQ-3329-09 (Ink) blocked on user decision.
+
+---
+
+# Phase 01: Primary shell leak — timer cancel, listener teardown, state release, lazy collector allocation
+
+## Phase ID
+
+`PLAN-20260825-SHELLMEM.P01`
+
+## Requirements Implemented (Expanded)
+
+### REQ-3329-01: Inactivity timer is cancellable and cancelled on every completion path
+
+**Full Text**: `makeInactivityTimer` MUST expose a `cancel()` that clears the
+pending timeout, and both the `child_process` and PTY execution paths MUST
+invoke it during teardown (normal exit, caller abort, inactivity-timeout fire,
+child/PTY error).
+
+**Behavior**:
+- GIVEN: `makeInactivityTimer(25, guard)` with `reset()` called
+- WHEN: `cancel()` is called and 50 ms elapse
+- THEN: `controller.signal.aborted` is `false`
+
+- GIVEN: `reset()` called, no `cancel()`
+- WHEN: 50 ms elapse (timeout 25 ms, guard not exited)
+- THEN: `controller.signal.aborted` is `true` (existing abort behavior preserved)
+
+- GIVEN: guard already `markExited()` before `reset()`
+- WHEN: timeout elapses
+- THEN: no abort (existing behavior preserved)
+
+**Why This Matters**: A pending timer is a GC root; today every completed
+execution keeps its entire state graph alive for the timeout duration, and the
+never-cancelled pattern leaks it permanently when timeout is large.
+
+### REQ-3329-02: Inactivity abort listener removed on teardown
+
+**Full Text**: The `abort` listener registered on
+`state.inactivityAbortController.signal` MUST be removed explicitly during
+cleanup on both CP and PTY paths, not left to `{ once: true }` semantics.
+
+**Behavior**:
+- GIVEN: N completed shell executions through `ShellExecutionService.execute`
+  with `inactivityTimeoutMs` large (e.g. 60 000)
+- WHEN: all handles are dropped and `Bun.gc(true)` runs
+- THEN: heap `AbortController` count ≤ 8 (before fix ≈ N; noise floor measured 0–3)
+
+**Why This Matters**: The listener closure is the edge from the timer-rooted
+signal back to the whole `CpExecState`/`PtyExecState`.
+
+### REQ-3329-03: Heavy state released after result construction
+
+**Full Text**: After the final result is built, CP state MUST drop
+`child`, `rawCollector`, and `sniffBuffer` references; PTY state MUST drop
+`rawCollector`. (PTY process/terminal disposal already exists in
+`cleanupPtyEntryResources`.)
+
+**Behavior**:
+- GIVEN: N completed CP executions of `echo hi`
+- WHEN: handles dropped + `Bun.gc(true)`
+- THEN: heap `Subprocess` count ≤ 8 and `Uint8Array` count returns to near
+  baseline (≤ 8 above the pre-loop baseline; before fix ≈ +N collectors)
+
+- GIVEN: N completed PTY executions (PTY actually used — assert the result's
+  execution method indicates PTY)
+- WHEN: handles dropped + `Bun.gc(true)`
+- THEN: heap `AbortController` count ≤ 8 and `Uint8Array` growth vs baseline ≤ 8
+
+**Why This Matters**: A missed teardown path then costs bytes, not megabytes.
+
+### REQ-3329-04: Collector buffers allocated lazily on first write
+
+**Full Text**: `BoundedCombinedCollector` and `BoundedStreamCollector` MUST NOT
+preallocate head/tail retention buffers (or per-stream bookkeeping arrays) in
+the constructor; allocation happens on first non-empty append. Public API
+(`append`, `getResult`, `getHeadText`, `getTailText`, `getBoundedRawBuffer`,
+`observedByteCount`, `isTruncated`) unchanged.
+
+**Behavior**:
+- GIVEN: 200 constructed collectors with a 512 KiB budget, no appends, refs held
+- WHEN: `Bun.gc(true)` + heap snapshot
+- THEN: `Uint8Array` count growth vs a no-collector baseline is ≤ 50 (before
+  fix ≈ +800: 4 buffers × 200)
+
+- GIVEN: a fresh collector with no appends
+- WHEN: `getResult()` / `getBoundedRawBuffer()` are called
+- THEN: empty results, `metadata.truncated === false`, observed/retained bytes 0
+  (lazy path must not crash)
+
+- GIVEN: a collector appended `'hi'`
+- WHEN: `getResult()` is called
+- THEN: text round-trips (`'hi'`), existing semantics intact (existing tests
+  must keep passing)
+
+**Why This Matters**: A command producing no output currently costs the full
+retention budget.
+
+## Implementation Tasks
+
+### Files to Create
+
+- `packages/core/src/services/shellOutputUtils.inactivityTimer.test.ts`
+  - Unit tests for REQ-3329-01 (cancel/no-cancel/exited-guard; real timers,
+    `bun:test`)
+  - MUST include plan/requirement markers per file header + test names
+- `packages/core/src/services/shellExecutionService.memory.test.ts`
+  - THE model-free leak regression test (REQ-3329-02/03). Runs N=40 real
+    `echo hi` executions through `ShellExecutionService.execute` (CP path),
+    shared never-aborted `AbortSignal`, `inactivityTimeoutMs: 60_000`; asserts
+    every result succeeded (`executionMethod: 'child_process'`, output
+    contains `hi`); then drops handles, `Bun.gc(true)` (twice), counts
+    `AbortController` (primary), `Subprocess` + `Uint8Array` (secondary).
+    Includes a PTY variant (`shouldUseNodePty: true`) asserting the PTY
+    execution method to prove the path was exercised, same heap assertions.
+    Reuses the validated counting helper; thresholds ≥ 8 documented against
+    the measured noise floor.
+- `packages/tools/src/acquisition/boundedCombinedCollector.lazy.test.ts` and/or
+  extend existing acquisition tests
+  - REQ-3329-04 tests (no-append construction cost, no-append `getResult()`
+    correctness, appended round-trip)
+
+### Files to Modify
+
+- `packages/core/src/services/shellOutputUtils.ts`
+  - `makeInactivityTimer` returns `{ reset, cancel, controller }`; `cancel()`
+    clears pending timeout (terminal: later `reset()` no-ops — document in
+    JSDoc)
+- `packages/core/src/services/shellCpExecution.ts`
+  - Destructure `cancel`; thread it and the abort-listener function through
+    state so cleanup can use both; remove the inactivity abort listener via
+    stored reference (not `removeAllListeners`)
+- `packages/core/src/services/shellCpHelpers.ts`
+  - `CpExecState`: `child`/`rawCollector`/`sniffBuffer` become nullable;
+    `cleanupCpResources` cancels timer, removes inactivity listener; after
+    `buildCpExitResult` the caller releases heavy refs. Prefer capturing the
+    child in narrow closures/passing parameters over scattered null-checks;
+    fail fast rather than defensive re-checks.
+- `packages/core/src/services/shellPtyLifecycle.ts`
+  - Same teardown wiring in `teardownPtyState`/`makePtyResolveResult`; store
+    inactivity listener ref on `PtyExecState`; drop `rawCollector` after
+    `buildPtyResult` (make nullable in `shellPtyState.ts`)
+- `packages/core/src/services/shellPtyState.ts`
+  - Type updates only as required by the above
+- `packages/tools/src/acquisition/boundedCombinedCollector.ts`,
+  `packages/tools/src/acquisition/boundedStreamCollector.ts`
+  - Lazy buffer allocation; `readonly` fields become assigned-on-first-append;
+  zero-capacity edge cases preserved
+
+### Required Code Markers
+
+Standard `@plan PLAN-20260825-SHELLMEM.P01` + `@requirement REQ-3329-0X`
+markers on every created/modified exported function/class and every test
+case, per repo convention. Private helpers carry markers when they directly
+implement a requirement's semantics; helpers moved verbatim into a new module
+(shell-substitution-syntax.ts) inherit the module-level marker note instead.
+
+## TDD order
+
+1. Write `shellOutputUtils.inactivityTimer.test.ts` (cancel case fails to
+   compile/fail — red).
+2. Write `shellExecutionService.memory.test.ts`; run on unmodified service →
+   counts ≈ N (red, proving the test detects the leak).
+3. Write lazy-allocation tests (red).
+4. Implement timer `cancel` + wiring + teardown + state release + lazy
+   allocation (green).
+5. Full existing suites for touched packages stay green.
+
+---
+
+# Phase 02: Secondary accumulators (excluding Ink — pending user decision)
+
+## Phase ID
+
+`PLAN-20260825-SHELLMEM.P02`
+
+## Requirements Implemented (Expanded)
+
+### REQ-3329-05: `CoreToolScheduler.seenCallIds` bounded
+
+**Full Text**: The duplicate-callId suppression set MUST be bounded
+(insertion-order FIFO cap 1024) so long sessions do not retain one string per
+tool call forever. `dispose()`/`cancelAll()` still clear it. Duplicate
+suppression for recent IDs (same batch + reordering window) unchanged.
+
+**Behavior**:
+- GIVEN: a scheduler that has processed > 1024 distinct callIds
+- WHEN: one more tool call is scheduled
+- THEN: the retained set size stays ≤ 1024 (observable via a new schedule of a
+  pre-cap callId no longer being suppressed — execute harness per existing
+  scheduler tests with a real registry)
+- GIVEN: the same callId scheduled twice in one batch
+- WHEN: the batch is processed
+- THEN: the second is dropped and a warning logged (existing behavior preserved)
+
+**Why This Matters**: Unbounded set grows for the life of the session.
+
+### REQ-3329-06: `SessionMetricsAggregator` dedup sets bounded; `IntervalUnion` capped
+
+**Full Text**: `DedupSet` gains an insertion-order cap (1024) preserving
+recent-ID dedup; `IntervalUnion` gains a max-intervals cap (8192) that drops
+the OLDEST interval on overflow and adjusts cached duration accordingly
+(documented conservative undercount; no gap-bridging).
+
+**Behavior**:
+- GIVEN: 2000 distinct attemptIds recorded
+- WHEN: an old (pre-cap) attemptId is replayed
+- THEN: it is counted again (accepted tradeoff; recent-window dedup intact —
+  replaying the newest 1024 still returns `false`)
+- GIVEN: 10 000 disjoint intervals added
+- WHEN: `count()` is called
+- THEN: `count() ≤ 8192` and `durationMs()` equals the sum of retained
+  intervals only
+- GIVEN: any existing test scenario (≤ 8192 intervals, ≤ 1024 IDs)
+- WHEN: metrics are computed
+- THEN: results identical to before (no behavior change below caps)
+
+**Why This Matters**: Both structures are session-lifetime unbounded today.
+
+### REQ-3329-07: `ProviderPerformanceTracker.errors` capped, rate exact
+
+**Full Text**: Retained error entries cap at 50 (mirroring
+`AttemptRecorder.MAX_RETAINED_ATTEMPTS`), keeping the MOST RECENT 50. A
+separate lifetime counter keeps `errorRate` exact
+(`totalErrors / (totalRequests + totalErrors)`).
+
+**Behavior**:
+- GIVEN: 100 `recordError` calls + 10 successful completions
+- WHEN: `getLatestMetrics()` is called
+- THEN: `errors.length === 50`, `errors[49]` is the 100th error,
+  `errorRate === 100/110`
+- GIVEN: fewer than 50 errors recorded (all existing tests)
+- WHEN: metrics read
+- THEN: identical results to before
+
+**Why This Matters**: Failure-heavy provider sessions currently retain every
+error forever.
+
+### REQ-3329-08: tree-sitter `Tree` lifetime owned on all internal sites
+
+**Full Text**: An internal helper (e.g. `withParsedTree(source, fn, timeout?)`
++ language variant) parses, runs the consumer, and calls `tree.delete()` in a
+`finally`. All production parse sites convert: `shell-parser.ts` internal uses
+(`parseCommandDetails` body, `:1067` site) and `shell-utils.ts:196/388/520`.
+Exported `parseShellCommand*` signatures unchanged (tests/external callers own
+deletion). Conversion MUST verify each site extracts only plain data (no
+`Node`/cursor objects escaping — `Node` holds a tree reference).
+
+**Behavior**:
+- GIVEN: `withParsedTree('echo hi', (tree) => { captured = tree; ... })`
+- WHEN: the callback returns
+- THEN: `captured[0] === 0` (deleted — the observable `Tree.delete()` effect)
+- GIVEN: a consumer callback that throws
+- WHEN: `withParsedTree` runs
+- THEN: the tree is still deleted, and the error propagates
+- GIVEN: the existing parser/shell-utils/prompt-transform suites
+- WHEN: run after conversion
+- THEN: all pass (parse results byte-identical)
+
+**Why This Matters**: web-tree-sitter's Emscripten heap only grows; ~49 KB per
+parse never returns without `delete()`.
+
+### REQ-3329-09: Ink `fullStaticOutput` — PENDING USER DECISION (do not implement)
+
+`@jrichman/ink` is a published npm fork (no local source). Options: (a) bun
+patch of the installed package, (b) fix upstream fork and bump, (c) defer with
+a follow-up issue. Any option is a dependency change → requires explicit user
+approval before implementation.
+
+## Implementation Tasks
+
+Files to modify: `packages/agents/src/core/coreToolScheduler.ts` (+ bounded-set
+test alongside existing scheduler tests), `packages/telemetry/src/telemetry/`
+(`sessionMetricsAggregator.ts`, `intervalUnion.ts`, + tests),
+`packages/providers/src/logging/ProviderPerformanceTracker.ts` (+ tests),
+`packages/core/src/utils/shell-parser.ts`, `shell-utils.ts` (+ tests).
+
+Each change independently revert-safe; no public metric semantics altered
+below caps; no cap implemented as a placeholder — every bounded structure is a
+real FIFO/LRU/cap implementation.
+
+---
+
+# Phase 03: Verification cycle + audit
+
+- `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+  `npm run build`
+- Smoke: `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`
+- Test audit: `bun scripts/test-audit/scan.ts` diff vs main baseline
+- New tests must fail before their fix and pass after (verified during P01/P02
+  TDD order), proving they are behavioral, not theater.
+
+## Success Criteria
+
+- Heap `AbortController`/`Subprocess`/`Uint8Array` counts flat across N
+  completed executions (CP + PTY), model-free.
+- Inactivity timer cancelled + listener removed on all completion paths.
+- Four secondary accumulators bounded; behavior identical below caps.
+- All suites, lint, typecheck, build, smoke, audit pass.
+- PR references `Fixes #3329`; Ink item disposition recorded (pending or
+  user-approved path).
+
+## Findings during verification (2026-08-25)
+
+### CP exit-vs-data race (In-scope-Fix, implemented)
+
+Pre-existing: finalizing at `exit` drops stdout `data` still queued behind the
+exit event (reproduced with pristine code via stash; exposed by bun-test
+scheduling). Fix in `shellCpExecution.ts`: on `exit`/`close`/`error`, defer
+finalization until every stdio stream settles (`end` or `close`; Bun does not
+always emit `close` for child stdio), bounded by a 500 ms grace timer so a
+grandchild holding pipe fds cannot stall resolution. Grace timer and
+once-listeners are cleared in `cleanupCpResources`/`finalize` so no new
+retention is introduced. Objects that do not implement the Readable settle
+contract (test doubles) count as settled, keeping `exit` the prompt
+finalization trigger for them.
+
+### bun test runner loses child_process events (environmental, out of scope)
+
+Minimal repro (tmp/verify3329/minimal-cp.bun.test.ts): `spawn` with
+`detached: true` under `bun test` intermittently delivers NO events for a
+child (no `exit`/`close`/`error`; child confirmed gone from the process
+table; in-process watchdog timers never fire). Bun 1.3.14, standalone runs
+never affected. Consequence: the leak regression tests drive the production
+CP/PTY promise paths through fake child/pty seams (the repo's established
+pattern, e.g. shellPtySignal.bun.test.ts) instead of real sequential spawns.
+Related: sequentially spawning real bun-pty PTYs wedges the event loop inside
+native code (pre-existing on pristine code, iteration 0+). Full
+`bun test packages/core/src/services/` on this machine fails 77 tests on
+PRISTINE code under concurrent sibling-session load; per-file targeted runs
+are the reliable local gate. CI remains the authoritative full-suite gate.
+
+### Heap threshold calibration
+
+PTY fake-pty loop: pre-fix Uint8Array delta = 40 (one per execution);
+post-fix residue ~9 (bounded @xterm/headless module caches). Threshold set
+to 16. CP fake-child loop: threshold 8.
+
+### Pre-existing cross-file batch interference (environmental)
+
+Running the 10-file CP/PTY service batch (fallback, exitcode, selection,
+raceCondition, multibyte, windows.multibyte, boundedAcquisition, terminatePty,
+ptySignal, main) yields an identical 91 pass / 13 fail on PRISTINE code
+(stash comparison, tmp/verify3329/cpbatch-prefix.log) and with the fix. Every
+failing file passes in isolation (boundedAcquisition 11/0, windows.multibyte
+5/0, fallback 26/0). Same interference class as the full-suite failure above:
+local gate is per-file runs; CI is authoritative.
+
+### Module extraction for lint compliance
+
+`shell-parser.ts` exceeded max-lines (813 counted) after the lifetime helper
+split. The heredoc/substitution source-text inspection cluster
+(SourceRange, findNamedChild, collectHeredocRedirects, isQuotedHeredocStart,
+collectLiteralHeredocBodyRanges, getLiteralRange, isShellSubstitutionStart,
+isCommandSubstitutionStart, isProcessSubstitutionStart,
+isProcessSubstitutionOperator, containsUnescapedBacktick) moved verbatim to
+`packages/core/src/utils/shell-substitution-syntax.ts`, exporting
+`hasShellSubstitutionSyntax` and `hasUnrepresentedHeredocBacktickSubstitution`.
+Pure functions over (Node, string); no module state; no behavior change
+(shell-utils suite 68/0 before and after).
+
+### Drain fix interaction with fake-timer tests
+
+The SIGKILL-escalation fallback test uses vi.useFakeTimers: a real 500 ms
+grace timer armed at exit would never fire. Covered by the settle contract
+above: bare EventEmitter stdio doubles (no destroyed/readableEnded) count as
+settled, so finalization stays synchronous on exit and fake-timer tests are
+unaffected (fallback file 26/0, SIGKILL test 0.44 ms).
+
+## Review remediation record (2026-08-25)
+
+Full design review returned FIX-FIRST with three blockers; all were fixed in
+the working tree before the final verification cycle:
+
+1. PTY caller-abort listener leak on synthetic resolution (no exit event):
+   added `callerAbortHandler` capture on PtyExecState; teardownPtyState
+   removes it on every resolution path. Regression:
+   shellPtyTeardown.paths.bun.test.ts (fails at HEAD, passes post-fix).
+2. Staggered abort/inactivity kill chains surviving teardown:
+   teardownPtyState now calls exitedGuard.markExited() first so in-flight
+   chains stop at their post-sleep re-checks; schedulePtyAbortFallback is
+   single-owner (clears any prior abortFinalizeTimeout) and re-checks
+   hasResolved plus a fire-time aborted getter before buildPtyResult.
+3. child_process drain listeners lingering on end-without-close settlement:
+   onSettled detaches both stream listeners before deleting the map entry.
+
+Should-fix items closed alongside: heap-counter layout canary (throws on
+unexpected snapshot encoding instead of silently reporting 0),
+getLatestMetrics returns a copied errors array (snapshots stay intact after
+the 50-error trim; covered by a snapshot-immunity test), seenCallIds cap
+test extended to prove the retained boundary neighbor stays suppressed, and
+the marker policy above was clarified (REQ range corrected to 01-09).
+
+Pre-fix validation: the teardown regression files were run against HEAD via
+git stash (visible pop, verified). The PTY listener-leak test fails at HEAD
+as intended; the remaining cases protect new invariants that do not exist at
+HEAD (drain listeners, collector nulling), so they pass there trivially.
+
+## Round-2 review remediation record (2026-08-25)
+
+Second full design review returned FIX-FIRST with two blockers; both fixed:
+
+1. seenCallIds FIFO eviction mid-batch: [A, 1024 distinct IDs, A] executed
+   both A copies because the first A left the 1024-entry window before the
+   final A was checked. deduplicateRequests now also dedups against a
+   batch-local Set while retaining the capped session window. Regression
+   (coreToolScheduler.seenCallIds.test.ts) fails with the batch-local check
+   removed and passes with it (surgically validated).
+2. ptyExitRace's temporary caller-abort listener could outlive a
+   fallback-first resolution while output processing stayed pending,
+   rooting the execution's closure graph on a shared signal. The detacher
+   is now stored as PtyExecState.exitRaceCleanup and teardownPtyState
+   invokes it. Covered by an exit-vs-fallback overlap guard in
+   shellPtyTeardown.paths.bun.test.ts; the exact fallback-first-with-pending-
+   processing interleaving additionally requires a stalled terminal write
+   callback, which public test seams cannot construct with the real
+   @xterm/headless terminal, so the teardown detacher itself is the
+   defense.
+
+Also removed stray test-audit report artifacts (file-stats.tsv,
+findings.tsv) that an earlier scan run had written into
+packages/core/src/services/, narrowed the PTY post-resolution test to the
+observable no-throw/listener-detachment behavior, and corrected a
+below-cap comment in sessionMetricsAggregator.advanced.test.ts.
+
+Deferred (nice-to-have, follow-up): shell-parser.ts and
+shell-parser-lifetime.ts form a runtime import cycle that today's deferred
+calls keep safe; moving raw parse primitives into a leaf module would
+remove the load-order sensitivity.
+
+## OCR local review record (2026-08-25, run 20260825T220905Z-374bfa05)
+
+StepFun step-3.7-flash via ocr-review-local workspace scope; status
+complete, 28 files reviewed, 9 findings. Dispositions:
+
+- Fixed: unreachable oldest-done guard in rememberCallId simplified to a
+  direct eviction; dead CpExecState.child field removed (never read after
+  the refactor — child flows as a closure parameter); inactivity-timer
+  tests given CI-safe margins (100ms/400ms) plus the missing
+  reset-postpones-a-partially-elapsed-timer contract test; non-null
+  collector assertions replaced with a null-guarded helper in
+  shellPtyExecution.bun.test.ts; the process.kill spy no longer restores
+  between tests (restore detached it and let real group signals escape in
+  later tests); tree-lifetime tests now assert the live handle is a
+  nonzero pointer that becomes 0 only after delete() runs, instead of a
+  bare 0 that could reflect a never-deleted tree.
+- Dismissed (evidence): "stale exit code during drain grace" — the
+  error-first-then-exit sequence keeps the error's exit code on purpose;
+  a Node 'error' event means the execution did not end cleanly, so
+  last-wins would mask real spawn/kill failures.
+- Deferred: unref() on the drain grace timer (a bounded 500ms wait is the
+  designed contract; unref changes settling semantics when no other
+  handles keep the loop alive) and the shell-parser import cycle (already
+  recorded above).


### PR DESCRIPTION
## TLDR

Eliminates per-execution memory retention in the shell execution paths and bounds every secondary accumulator that grew for the process lifetime. Completed child_process and PTY executions now tear down deterministically on first resolution instead of waiting for GC: abort/inactivity kill chains can no longer hold execution state past teardown, caller abort listeners are removed on every resolution path, and stdio drain listeners detach on settlement. Fixes #3329.

## Dive Deeper

**Primary leak (shell executions).** Three retention chains kept a resolved execution's state alive:

- PTY inactivity/abort kill chains ran `await sleep` escalations and scheduled fallback timeouts without re-checking whether the execution had already resolved and torn down. Teardown now marks the exit guard first, so in-flight chains stop at their post-sleep rechecks and nothing schedules post-resolution timers. The abort finalize fallback is single-owner (clears any prior fallback timer) and evaluates the aborted flag at fire time.
- The caller's `AbortSignal` kept a once-listener holding the whole execution state when resolution happened without an exit event (synthetic paths). The handler is now captured on `PtyExecState` and removed in teardown on every path.
- child_process stdio drain listeners stayed attached when a stream settled via `end` without `close`. The drain finalizer detaches both listeners on settlement, and a bounded 500 ms grace timer finalizes streams that never settle.

**Secondary accumulators.** `seenCallIds` in the tool scheduler is now a 1024-entry FIFO (evicted IDs may legitimately re-run; retained neighbors stay suppressed), `ProviderPerformanceTracker` trims to the latest 50 errors with snapshot isolation (returned arrays are copies), interval unions and session metric snapshots are bounded, and the tool-acquisition collectors allocate lazily and cap their buffers.

**Tree lifetime.** tree-sitter `Tree` handles are now deleted under explicit caller ownership via `withParsedTree`/`withParsedTreeForLanguage`, with the substitution-syntax helpers extracted verbatim into `shell-substitution-syntax.ts`.

**Test methodology.** Heap-threshold tests parse v8 snapshot class counts directly and throw on unexpected encoding instead of silently reading zeros. The teardown regression tests were validated pre-fix via `git stash`: the PTY listener-leak test fails on `HEAD` and passes post-fix; the remaining cases protect invariants that do not exist on `HEAD` (drain listeners, collector nulling) and pass there trivially. Details in `project-plans/issue3329/plan.md`, including the review and OCR remediation records.

**Ink fork disposition (REQ-3329-09).** The `fullStaticOutput` retention inside `@jrichman/ink@6.4.8` is not fixed in this PR. Analysis during this issue established that upstream ink fixed this bug family (vadimdemedes/ink #905, #948, #950, #974, #979, plus the unbounded text cache fix) and independently implemented nearly every fork feature we use. Follow-up issue #3345 tracks the decision and phased switch to upstream ink 7.x, which subsumes the fork-side half of this remediation.

## Reviewer Test Plan

- `bun test` each touched test file individually (cross-file runs interfere in this repo): `shellPtyTeardown.paths.bun.test.ts`, `shellCpTeardown.paths.test.ts`, `shellExecutionService.memory.test.ts`, `shellPtyMemory.bun.test.ts`, `shellExecutionService.fallback.test.ts`, `shellOutputUtils.inactivityTimer.test.ts`, `shell-parser.tree-lifetime.test.ts`, `coreToolScheduler.seenCallIds.test.ts`, `boundedCollectors.lazy.test.ts`, `ProviderPerformanceTracker.test.ts`, `intervalUnion.behavior.test.ts`, `sessionMetricsAggregator.advanced.test.ts`.
- The memory tests assert live-heap class counts against thresholds (PTY ≤16, child_process ≤8 executions retained); watch them fail by reverting the teardown changes.
- Reviewer prompts to exercise interactively: run several shell commands to completion, abort one mid-run, let one hit the inactivity timeout, then watch RSS across ~50 more executions.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | ❓  | -   |
| Seatbelt | ❓  | -   | -   |

Full verification on macOS: lint, typecheck, format, build, test-audit scan, and per-file test runs all green. The interactive smoke profile (`stepfun-37`) is blocked by an external provider 400 (`no active step plan subscription`); the local pipeline starts and reaches the API before the external failure, logged in `tmp/verify3329/final/smoke2.log`.

## Linked issues / bugs

Fixes #3329
Tracked follow-up: #3345 (ink fork to upstream migration)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell and PTY execution reliability by preserving trailing output and handling abort, timeout, and teardown events safely.
  * Reduced memory retention during repeated shell and PTY executions.
  * Prevented duplicate tool calls and telemetry records while allowing older entries to be processed again.
  * Improved shell parsing cleanup and substitution detection across Bash and PowerShell commands.
  * Corrected provider error-rate calculations and retained recent error details within bounded limits.

* **Performance**
  * Reduced unnecessary memory allocation for command-output collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->