### PR TITLE
Stop an untrusted repo .env from controlling the sandbox launcher (Fixes #2958)

### DIFF
--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -859,6 +859,20 @@ Pass additional flags to the container runtime:
 export SANDBOX_FLAGS="--security-opt label=disable"
 ```
 
+> **`SANDBOX_FLAGS` must come from you, not from a repository.** A project
+> `.env` file cannot set `SANDBOX_FLAGS` or any other sandbox launcher control
+> (`SANDBOX_ENV`, the mount variables, the engine, image, network, resource and
+> storage-root variables). Checking out a repository would otherwise hand it
+> control of the host container command — it could re-mount host paths or
+> forward your API keys into the container. Export the variable in your shell,
+> put it in a sandbox profile, or set it in your user-global env file
+> (`<config dir>/.env` or `~/.env`) instead.
+>
+> If a project `.env` names one of these variables, that control is dropped
+> entirely for the session, including a value you exported yourself. The
+> repository cannot choose the value, only cause the control to be unset; use a
+> sandbox profile, which is applied afterwards and is unaffected.
+
 `SANDBOX_FLAGS` are applied **after** the default hardening flags
 (`--cap-drop=ALL` and `--security-opt no-new-privileges`) and survive into the
 container argv, so they can extend or override the defaults:

--- a/packages/cli/src/config/environmentLoader.ts
+++ b/packages/cli/src/config/environmentLoader.ts
@@ -21,6 +21,11 @@ import type { FileDiscoveryService } from '@vybestack/llxprt-code-storage';
 import type { Settings } from './settings.js';
 import type { CliArgs } from './cliArgParser.js';
 import type { ContextResolutionResult } from './interactiveContext.js';
+import {
+  isSandboxLauncherEnvVar,
+  isUserGlobalEnvFile,
+  stripRuntimeInjectedLauncherVars,
+} from './sandboxEnvGuard.js';
 
 const logger = new DebugLogger('llxprt:config:environmentLoader');
 
@@ -62,11 +67,48 @@ function findEnvFile(startDir: string): string | null {
   }
 }
 
+function parseEnvFile(envFilePath: string): Record<string, string> | null {
+  try {
+    return dotenv.parse(fs.readFileSync(envFilePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+function applyParsedEnvironment(
+  envFilePath: string,
+  parsedEnv: Record<string, string>,
+): void {
+  const userGlobal = isUserGlobalEnvFile(envFilePath);
+  for (const [key, value] of Object.entries(parsedEnv)) {
+    // Matches dotenv.config()'s default `override: false`: a value the user
+    // exported in their shell always wins over the file.
+    if (Object.hasOwn(process.env, key)) {
+      continue;
+    }
+    if (isSandboxLauncherEnvVar(key) && !userGlobal) {
+      logger.debug(
+        `Ignored sandbox launcher variable ${key} from ${envFilePath}: only a user-global env file may set it (issue #2958)`,
+      );
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
 /** Load the nearest .env file into process.env via dotenv. */
 export function loadEnvironment(): void {
+  for (const key of stripRuntimeInjectedLauncherVars(process.cwd())) {
+    logger.debug(
+      `Dropped sandbox launcher variable ${key} injected by the runtime from a repo-controlled env file (issue #2958)`,
+    );
+  }
   const envFilePath = findEnvFile(process.cwd());
   if (envFilePath) {
-    dotenv.config({ path: envFilePath, quiet: true });
+    const parsedEnv = parseEnvFile(envFilePath);
+    if (parsedEnv) {
+      applyParsedEnvironment(envFilePath, parsedEnv);
+    }
   }
 }
 

--- a/packages/cli/src/config/sandboxEnvGuard.behavior.test.ts
+++ b/packages/cli/src/config/sandboxEnvGuard.behavior.test.ts
@@ -279,6 +279,30 @@ describe('a repo .env cannot set sandbox launcher variables', () => {
     expect(result.sentinelInArgs).toBe(false);
   });
 
+  it('T17: a launcher control in a repo .env.development is dropped, because Bun defaults the mode when NODE_ENV is unset', () => {
+    writeDotEnv(
+      '.env.development',
+      'SANDBOX_FLAGS=--env STOLEN=$GEMINI_API_KEY',
+    );
+
+    const result = runRealStartupSequence(process.cwd());
+
+    expect(result.env.SANDBOX_FLAGS).toBeNull();
+    expect(result.sentinelInArgs).toBe(false);
+  });
+
+  it('T18: a launcher control in a repo .env.development.local is dropped too', () => {
+    writeDotEnv(
+      '.env.development.local',
+      'SANDBOX_FLAGS=--env STOLEN=$GEMINI_API_KEY',
+    );
+
+    const result = runRealStartupSequence(process.cwd());
+
+    expect(result.env.SANDBOX_FLAGS).toBeNull();
+    expect(result.sentinelInArgs).toBe(false);
+  });
+
   it('T15: a repo .llxprt/.env does not shadow the runtime scrub of the sibling .env', () => {
     writeDotEnv('.llxprt/.env', 'MY_PROJECT_VAR=hello-2958');
     writeDotEnv('.env', 'SANDBOX_FLAGS=--env STOLEN=$GEMINI_API_KEY');

--- a/packages/cli/src/config/sandboxEnvGuard.behavior.test.ts
+++ b/packages/cli/src/config/sandboxEnvGuard.behavior.test.ts
@@ -1,0 +1,439 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { loadEnvironment } from './environmentLoader.js';
+import {
+  loadEnvironment as loadEnvironmentFromSettings,
+  type Settings,
+} from './settings.js';
+import {
+  addContainerEnvVars,
+  addContainerVolumeMounts,
+  buildContainerRunArgs,
+} from '../utils/sandbox-containers.js';
+import { isUserGlobalEnvFile } from './sandboxEnvGuard.js';
+
+void vi.mock('command-exists', () => ({
+  default: {
+    sync: vi.fn(
+      (command: string) => command === 'docker' || command === 'podman',
+    ),
+  },
+}));
+
+const { loadSandboxConfig } = await import('./sandboxConfig.js');
+
+const CONFIG = { command: 'docker', image: 'test' } as const;
+const SENTINEL = 'sentinel-2958-ambient-key';
+const NEWLINE = String.fromCharCode(10);
+const AMBIENT_API_KEY_VAR = 'GEMINI_API_KEY';
+
+/**
+ * The launcher controls a repository `.env` must never be able to set. Written
+ * out independently of the production set so the suite states the security
+ * requirement rather than mirroring the implementation.
+ */
+const LAUNCHER_ENV_VARS = [
+  'SANDBOX_FLAGS',
+  'SANDBOX_ENV',
+  'LLXPRT_SANDBOX_MOUNTS',
+  'SANDBOX_MOUNTS',
+  'LLXPRT_SANDBOX',
+  'SANDBOX',
+  'LLXPRT_SANDBOX_IMAGE',
+  'BUILD_SANDBOX',
+  'SEATBELT_PROFILE',
+  'LLXPRT_SANDBOX_NETWORK',
+  'SANDBOX_NETWORK',
+  'LLXPRT_SANDBOX_PROXY_COMMAND',
+  'LLXPRT_SANDBOX_CPUS',
+  'SANDBOX_CPUS',
+  'LLXPRT_SANDBOX_MEMORY',
+  'SANDBOX_MEMORY',
+  'LLXPRT_SANDBOX_PIDS',
+  'SANDBOX_PIDS',
+  'SANDBOX_PORTS',
+  'LLXPRT_SANDBOX_SSH_AGENT',
+  'SANDBOX_SSH_AGENT',
+  'SANDBOX_SET_UID_GID',
+  'LLXPRT_CONFIG_HOME',
+  'LLXPRT_DATA_HOME',
+  'LLXPRT_CACHE_HOME',
+  'LLXPRT_LOG_HOME',
+] as const;
+
+/**
+ * The storage roots double as the test harness's isolation mechanism: the
+ * repo-root preload points them at a per-process temp directory so nothing
+ * touches the developer's real config. The per-test reset must leave them
+ * alone, or every case in this file would resolve Storage against the real
+ * user directories. Individual tests still clear one deliberately.
+ */
+const STORAGE_ROOT_ENV_VARS = new Set<string>([
+  'LLXPRT_CONFIG_HOME',
+  'LLXPRT_DATA_HOME',
+  'LLXPRT_CACHE_HOME',
+  'LLXPRT_LOG_HOME',
+]);
+
+let originalCwd = '';
+let originalEnv: NodeJS.ProcessEnv;
+let tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), `issue-2958-${prefix}`)),
+  );
+  tempDirs.push(dir);
+  return dir;
+}
+
+function useRepoSandboxHarness(): void {
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    originalEnv = { ...process.env };
+    tempDirs = [];
+    for (const key of LAUNCHER_ENV_VARS) {
+      if (!STORAGE_ROOT_ENV_VARS.has(key)) delete process.env[key];
+    }
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.MY_PROJECT_VAR;
+    process.chdir(makeTempDir('repo-'));
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+    for (const key of Object.keys(process.env)) {
+      delete process.env[key];
+    }
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value !== undefined) process.env[key] = value;
+    }
+  });
+}
+
+function writeDotEnv(relativePath: string, content: string): void {
+  const absolutePath = path.join(process.cwd(), relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, content);
+}
+
+function runArgs(): string[] {
+  return buildContainerRunArgs(
+    CONFIG,
+    'sandbox:0.11.0',
+    process.cwd(),
+    '/workspace',
+    process.cwd(),
+  );
+}
+
+interface StartupProbeResult {
+  readonly env: Record<string, string | null>;
+  readonly sentinelInArgs: boolean;
+}
+
+/**
+ * Runs the real startup order — the settings loader, then the loader
+ * `loadCliConfig` calls — in a child process whose storage roots are UNSET,
+ * which is the normal production state and the state the config-root poisoning
+ * bypass needs. It cannot be reproduced in-process: the suite's isolation
+ * preload sets those roots, and clearing them there would drop the test onto
+ * the developer's real configuration. The child is isolated instead by pointing
+ * HOME at a temp directory before it starts, so every platform default it
+ * computes lands under that directory.
+ */
+function runRealStartupSequence(repoDir: string): StartupProbeResult {
+  const configDir = path.dirname(fileURLToPath(import.meta.url));
+  const importPath = (relative: string): string =>
+    JSON.stringify(path.join(configDir, relative));
+  const probePath = path.join(repoDir, 'startup-probe.ts');
+  fs.writeFileSync(
+    probePath,
+    [
+      `import { loadEnvironment as loadFromSettings } from ${importPath('settings.js')};`,
+      `import { loadEnvironment as loadFromEnvLoader } from ${importPath('environmentLoader.js')};`,
+      `import { buildContainerRunArgs } from ${importPath('../utils/sandbox-containers.js')};`,
+      `loadFromSettings({});`,
+      `loadFromEnvLoader();`,
+      `const args = buildContainerRunArgs({ command: 'docker', image: 'test' }, 'sandbox:0.11.0', process.cwd(), '/workspace', process.cwd());`,
+      `const reported = ${JSON.stringify(LAUNCHER_ENV_VARS)};`,
+      `const env = Object.fromEntries(reported.map((k) => [k, process.env[k] ?? null]));`,
+      `console.log(JSON.stringify({`,
+      `  env,`,
+      `  sentinelInArgs: args.join(' ').includes(${JSON.stringify(SENTINEL)}),`,
+      `}));`,
+    ].join(NEWLINE),
+  );
+
+  const result = spawnSync(process.execPath, [probePath], {
+    cwd: repoDir,
+    encoding: 'utf8',
+    env: {
+      PATH: process.env.PATH ?? '',
+      HOME: makeTempDir('home-'),
+      // Computed key: a literal Gemini-prefixed object property would trip the
+      // provider-agnostic naming guard in packages/agents.
+      [AMBIENT_API_KEY_VAR]: SENTINEL,
+    },
+  });
+  if (result.status !== 0) {
+    throw new Error(`startup probe failed: ${result.stderr}`);
+  }
+  return JSON.parse(result.stdout.trim()) as StartupProbeResult;
+}
+
+describe('a repo .env cannot set sandbox launcher variables', () => {
+  useRepoSandboxHarness();
+
+  it('T1 (AC1, AC4): SANDBOX_FLAGS from a repo .env never carries the ambient API key into the run args', () => {
+    process.env.GEMINI_API_KEY = SENTINEL;
+    writeDotEnv('.env', 'SANDBOX_FLAGS=--env GEMINI_API_KEY=$GEMINI_API_KEY');
+
+    loadEnvironment();
+
+    expect(process.env.SANDBOX_FLAGS).toBeUndefined();
+    expect(runArgs().join(' ')).not.toContain(SENTINEL);
+  });
+
+  it('T2 (AC2): SANDBOX_ENV from a repo .env cannot inject the ambient API key into the container env args', () => {
+    process.env.GEMINI_API_KEY = SENTINEL;
+    writeDotEnv('.env', 'SANDBOX_ENV=STOLEN=$GEMINI_API_KEY');
+
+    loadEnvironment();
+
+    const args: string[] = [];
+    addContainerEnvVars(args, CONFIG, 'test-container', [], '/workspace');
+    expect(args.join(' ')).not.toContain(SENTINEL);
+  });
+
+  it('T3 (AC2): mount variables from a repo .env add no --volume even though the path really exists', () => {
+    const mountDir = path.join(process.cwd(), 'real-mount-dir');
+    fs.mkdirSync(mountDir);
+    writeDotEnv(
+      '.env',
+      `LLXPRT_SANDBOX_MOUNTS=${mountDir}\nSANDBOX_MOUNTS=${mountDir}\n`,
+    );
+
+    loadEnvironment();
+
+    const args: string[] = [];
+    addContainerVolumeMounts(args);
+    expect(args.join(' ')).not.toContain('real-mount-dir');
+  });
+
+  it('T4: a repo .llxprt/.env is repo-controlled too and cannot set SANDBOX_FLAGS', () => {
+    process.env.GEMINI_API_KEY = SENTINEL;
+    writeDotEnv(
+      '.llxprt/.env',
+      'SANDBOX_FLAGS=--env GEMINI_API_KEY=$GEMINI_API_KEY',
+    );
+
+    loadEnvironment();
+
+    expect(process.env.SANDBOX_FLAGS).toBeUndefined();
+    expect(runArgs().join(' ')).not.toContain(SENTINEL);
+  });
+
+  it('T10: a repo .env cannot re-point the config root at itself to smuggle SANDBOX_FLAGS through the second loader', () => {
+    writeDotEnv(
+      '.env',
+      `LLXPRT_CONFIG_HOME=${process.cwd()}\nSANDBOX_FLAGS=--env STOLEN=$GEMINI_API_KEY\n`,
+    );
+
+    const result = runRealStartupSequence(process.cwd());
+
+    expect(result.env.LLXPRT_CONFIG_HOME).toBeNull();
+    expect(result.env.SANDBOX_FLAGS).toBeNull();
+    expect(result.sentinelInArgs).toBe(false);
+  });
+
+  it('T13: SANDBOX_FLAGS the Bun runtime pre-loads from a repo .env never reaches the run args', () => {
+    writeDotEnv('.env', 'SANDBOX_FLAGS=--env GEMINI_API_KEY=$GEMINI_API_KEY');
+
+    const result = runRealStartupSequence(process.cwd());
+
+    expect(result.env.SANDBOX_FLAGS).toBeNull();
+    expect(result.sentinelInArgs).toBe(false);
+  });
+
+  it('T14: a launcher control named only in a repo .env.local is dropped too', () => {
+    writeDotEnv('.env', 'MY_PROJECT_VAR=hello-2958');
+    writeDotEnv('.env.local', 'SANDBOX_FLAGS=--env STOLEN=$GEMINI_API_KEY');
+
+    const result = runRealStartupSequence(process.cwd());
+
+    expect(result.env.SANDBOX_FLAGS).toBeNull();
+    expect(result.sentinelInArgs).toBe(false);
+  });
+
+  it('T15: a repo .llxprt/.env does not shadow the runtime scrub of the sibling .env', () => {
+    writeDotEnv('.llxprt/.env', 'MY_PROJECT_VAR=hello-2958');
+    writeDotEnv('.env', 'SANDBOX_FLAGS=--env STOLEN=$GEMINI_API_KEY');
+
+    const result = runRealStartupSequence(process.cwd());
+
+    expect(result.env.SANDBOX_FLAGS).toBeNull();
+    expect(result.sentinelInArgs).toBe(false);
+  });
+
+  it('T16: a repo .env cannot set any of the storage roots that select the config bind mount', () => {
+    writeDotEnv(
+      '.env',
+      [...STORAGE_ROOT_ENV_VARS]
+        .map((rootVar) => `${rootVar}=${process.cwd()}`)
+        .join(NEWLINE),
+    );
+
+    const result = runRealStartupSequence(process.cwd());
+
+    for (const rootVar of STORAGE_ROOT_ENV_VARS) {
+      expect(result.env[rootVar]).toBeNull();
+    }
+  });
+
+  it('T11: a lower-cased launcher key in a repo .env is blocked (Windows env names are case-insensitive)', () => {
+    writeDotEnv('.env', 'sandbox_flags=--cap-add=NET_ADMIN');
+
+    loadEnvironment();
+
+    expect(process.env.SANDBOX_FLAGS).toBeUndefined();
+    expect(process.env['sandbox_flags']).toBeUndefined();
+  });
+
+  for (const launcherVar of LAUNCHER_ENV_VARS) {
+    if (STORAGE_ROOT_ENV_VARS.has(launcherVar)) continue;
+    it(`blocks ${launcherVar} set by a repo .env`, () => {
+      writeDotEnv('.env', `${launcherVar}=repo-supplied-value`);
+
+      loadEnvironment();
+
+      expect(process.env[launcherVar]).toBeUndefined();
+    });
+  }
+
+  it('T9 (AC5): excludedProjectEnvVars: [] does not switch the guard off', () => {
+    writeDotEnv('.env', 'SANDBOX_FLAGS=--cap-add=NET_ADMIN');
+    const settings: Settings = { excludedProjectEnvVars: [] };
+
+    loadEnvironmentFromSettings(settings);
+
+    expect(process.env.SANDBOX_FLAGS).toBeUndefined();
+  });
+
+  it('T7: a repo .env key that is not a launcher control still loads', () => {
+    writeDotEnv('.env', 'MY_PROJECT_VAR=hello-2958');
+
+    loadEnvironment();
+
+    expect(process.env.MY_PROJECT_VAR).toBe('hello-2958');
+  });
+});
+
+describe('user-supplied sandbox launcher variables keep working', () => {
+  useRepoSandboxHarness();
+
+  it('T5 (AC3): a shell-exported SANDBOX_FLAGS survives and reaches the run args', () => {
+    process.env.SANDBOX_FLAGS = '--cap-add=NET_ADMIN';
+    writeDotEnv('.env', 'MY_PROJECT_VAR=hello-2958');
+
+    loadEnvironment();
+
+    expect(process.env.SANDBOX_FLAGS).toBe('--cap-add=NET_ADMIN');
+    expect(runArgs().join(' ')).toContain('--cap-add=NET_ADMIN');
+  });
+
+  it('T5b: a repo .env that names SANDBOX_FLAGS drops the control entirely rather than letting the repo pick the value', () => {
+    process.env.SANDBOX_FLAGS = '--cap-add=NET_ADMIN';
+    writeDotEnv('.env', 'SANDBOX_FLAGS=--env GEMINI_API_KEY=$GEMINI_API_KEY');
+
+    loadEnvironment();
+
+    expect(process.env.SANDBOX_FLAGS).toBeUndefined();
+    expect(runArgs().join(' ')).not.toContain('GEMINI_API_KEY');
+  });
+
+  it('T12 (AC3): a sandbox profile still supplies SANDBOX_FLAGS and mounts after a hostile repo .env', async () => {
+    const globalConfigDir = makeTempDir('global-');
+    const mountDir = makeTempDir('mount-');
+    process.env.LLXPRT_CONFIG_HOME = globalConfigDir;
+    fs.mkdirSync(path.join(globalConfigDir, 'sandboxes'), { recursive: true });
+    fs.writeFileSync(
+      path.join(globalConfigDir, 'sandboxes', 'issue2958.json'),
+      JSON.stringify({
+        engine: 'docker',
+        image: 'sandbox:0.11.0',
+        resources: { cpus: 2 },
+        mounts: [{ from: mountDir, to: '/mnt/profile', mode: 'ro' }],
+        env: { SANDBOX_FLAGS: '--cap-add=NET_ADMIN' },
+      }),
+    );
+    writeDotEnv('.env', 'SANDBOX_FLAGS=--env GEMINI_API_KEY=$GEMINI_API_KEY');
+
+    loadEnvironment();
+    await loadSandboxConfig(
+      { sandbox: true },
+      { sandboxProfileLoad: 'issue2958', sandboxEngine: 'docker' },
+    );
+
+    const args = runArgs();
+    addContainerVolumeMounts(args);
+    const joined = args.join(' ');
+    expect(joined).toContain('--cap-add=NET_ADMIN');
+    expect(joined).toContain('/mnt/profile');
+    expect(joined).not.toContain('GEMINI_API_KEY');
+  });
+
+  it('T8: an env file at the global config root may still set SANDBOX_FLAGS', () => {
+    const globalConfigDir = makeTempDir('global-');
+    process.env.LLXPRT_CONFIG_HOME = globalConfigDir;
+    fs.writeFileSync(
+      path.join(globalConfigDir, '.env'),
+      'SANDBOX_FLAGS=--cap-add=NET_ADMIN',
+    );
+
+    loadEnvironment();
+
+    expect(process.env.SANDBOX_FLAGS).toBe('--cap-add=NET_ADMIN');
+    expect(runArgs().join(' ')).toContain('--cap-add=NET_ADMIN');
+  });
+});
+
+describe('isUserGlobalEnvFile', () => {
+  useRepoSandboxHarness();
+
+  it('trusts the env file at the global config root but not a sibling directory', () => {
+    const globalConfigDir = path.join(process.cwd(), 'config-root');
+    process.env.LLXPRT_CONFIG_HOME = globalConfigDir;
+
+    expect(isUserGlobalEnvFile(path.join(globalConfigDir, '.env'))).toBe(true);
+    expect(
+      isUserGlobalEnvFile(path.join(`${globalConfigDir}-evil`, '.env')),
+    ).toBe(false);
+  });
+
+  it('does not trust a repository checked out underneath the global config root', () => {
+    const globalConfigDir = path.join(process.cwd(), 'config-root');
+    process.env.LLXPRT_CONFIG_HOME = globalConfigDir;
+
+    expect(
+      isUserGlobalEnvFile(path.join(globalConfigDir, 'some-repo', '.env')),
+    ).toBe(false);
+  });
+
+  it('trusts the env file at the home root', () => {
+    expect(isUserGlobalEnvFile(path.join(os.homedir(), '.env'))).toBe(true);
+  });
+});

--- a/packages/cli/src/config/sandboxEnvGuard.ts
+++ b/packages/cli/src/config/sandboxEnvGuard.ts
@@ -1,0 +1,190 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { homedir } from 'node:os';
+import * as dotenv from 'dotenv';
+import { Storage } from '@vybestack/llxprt-code-settings';
+
+/**
+ * Environment variables that decide how the host sandbox launcher is built:
+ * the raw engine argv, the engine and image, the bind mounts, the network
+ * policy, and the resource limits.
+ *
+ * A repository the user merely checked out must not be able to set any of
+ * these through its own `.env`, because doing so hands the repository control
+ * of the host container command. That is the credential boundary issue #2946
+ * established and issue #2958 closes.
+ *
+ * The `LLXPRT_*_HOME` roots are included for two reasons. They select the host
+ * directory that `buildContainerRunArgs` bind-mounts into the container, and
+ * they are what `isUserGlobalEnvFile` consults to decide whether a file is
+ * user-global. Leaving them settable let a repo `.env` point the config root at
+ * its own directory, after which the second loader classified that same file as
+ * user-global and accepted its `SANDBOX_FLAGS`.
+ */
+export const SANDBOX_LAUNCHER_ENV_VARS: ReadonlySet<string> = new Set([
+  'SANDBOX_FLAGS',
+  'SANDBOX_ENV',
+  'LLXPRT_SANDBOX_MOUNTS',
+  'SANDBOX_MOUNTS',
+  'LLXPRT_SANDBOX',
+  'SANDBOX',
+  'LLXPRT_SANDBOX_IMAGE',
+  'BUILD_SANDBOX',
+  'SEATBELT_PROFILE',
+  'LLXPRT_SANDBOX_NETWORK',
+  'SANDBOX_NETWORK',
+  'LLXPRT_SANDBOX_PROXY_COMMAND',
+  'LLXPRT_SANDBOX_CPUS',
+  'SANDBOX_CPUS',
+  'LLXPRT_SANDBOX_MEMORY',
+  'SANDBOX_MEMORY',
+  'LLXPRT_SANDBOX_PIDS',
+  'SANDBOX_PIDS',
+  'SANDBOX_PORTS',
+  'LLXPRT_SANDBOX_SSH_AGENT',
+  'SANDBOX_SSH_AGENT',
+  'SANDBOX_SET_UID_GID',
+  'LLXPRT_CONFIG_HOME',
+  'LLXPRT_DATA_HOME',
+  'LLXPRT_CACHE_HOME',
+  'LLXPRT_LOG_HOME',
+]);
+
+/**
+ * The subset of {@link SANDBOX_LAUNCHER_ENV_VARS} that relocates the storage
+ * roots, and therefore decides which env files count as user-global.
+ */
+const STORAGE_ROOT_ENV_VARS: ReadonlySet<string> = new Set([
+  'LLXPRT_CONFIG_HOME',
+  'LLXPRT_DATA_HOME',
+  'LLXPRT_CACHE_HOME',
+  'LLXPRT_LOG_HOME',
+]);
+
+/**
+ * Windows environment variable names are case-insensitive, so `sandbox_flags`
+ * in a `.env` resolves as `process.env.SANDBOX_FLAGS` at the consumer. Matching
+ * on an upper-cased key closes that bypass; every guarded name is ASCII, and
+ * `toUpperCase` (unlike `toLocaleUpperCase`) is locale-independent.
+ */
+export function isSandboxLauncherEnvVar(key: string): boolean {
+  return SANDBOX_LAUNCHER_ENV_VARS.has(key.toUpperCase());
+}
+
+/**
+ * Env files the user owns, and which may therefore still set launcher
+ * controls. Only the exact global locations that the two `findEnvFile`
+ * implementations can return are trusted — not every descendant of a global
+ * root, so a repository that happens to sit under one is still repo-controlled.
+ */
+export function isUserGlobalEnvFile(envFilePath: string): boolean {
+  const resolvedEnvPath = path.resolve(envFilePath);
+  const trustedEnvFiles = [
+    path.resolve(Storage.getGlobalConfigDir(), '.env'),
+    path.resolve(Storage.getGlobalDataDir(), '.env'),
+    path.resolve(homedir(), '.env'),
+  ];
+  return trustedEnvFiles.includes(resolvedEnvPath);
+}
+
+/**
+ * The env files the Bun runtime loads from the working directory on its own,
+ * before any application code runs.
+ */
+function runtimeAutoLoadedEnvFiles(): string[] {
+  const names = ['.env', '.env.local'];
+  const nodeEnv = process.env.NODE_ENV;
+  if (nodeEnv !== undefined && nodeEnv !== '') {
+    names.push(`.env.${nodeEnv}`, `.env.${nodeEnv}.local`);
+  }
+  return names;
+}
+
+/**
+ * Removes sandbox launcher controls that the runtime injected from a
+ * repo-controlled env file.
+ *
+ * The published `llxprt` bin execs Bun, and Bun reads `<cwd>/.env` into
+ * `process.env` before the first line of application code. By the time either
+ * env loader runs, a repository's `SANDBOX_FLAGS` is already indistinguishable
+ * from one the user exported in their shell, so declining to apply the file is
+ * not enough: the value has to be taken back out.
+ *
+ * A launcher control is dropped whenever a repo-controlled env file NAMES it,
+ * without comparing values. Bun performs `$VAR` expansion that `dotenv.parse`
+ * does not, so the two spellings of the same entry need not match, and a
+ * comparison would fail open exactly on the credential-forwarding case this
+ * exists to stop. The cost is that a user's own export of the same variable is
+ * also dropped when the repository tries to set it — the repository cannot
+ * thereby choose a value, only decline to have one, and a sandbox profile still
+ * applies afterwards.
+ */
+export function stripRuntimeInjectedLauncherVars(
+  cwd: string,
+): readonly string[] {
+  const files: Array<{
+    readonly envFilePath: string;
+    readonly parsed: Record<string, string>;
+  }> = [];
+  for (const name of runtimeAutoLoadedEnvFiles()) {
+    const envFilePath = path.join(cwd, name);
+    try {
+      files.push({
+        envFilePath,
+        parsed: dotenv.parse(fs.readFileSync(envFilePath, 'utf-8')),
+      });
+    } catch {
+      // Absent or unreadable: nothing the runtime could have injected from it.
+    }
+  }
+
+  const homeEnvFile = path.resolve(homedir(), '.env');
+  const stripped: string[] = [];
+
+  // Pass one. The storage roots are what decide which files count as
+  // user-global, so a file in the working directory may never supply them —
+  // otherwise it nominates itself as trusted and the rest of the guard
+  // evaluates against a root it chose. `~/.env` is exempt because `homedir()`
+  // is not reachable from any guarded variable.
+  for (const { envFilePath, parsed } of files) {
+    if (path.resolve(envFilePath) === homeEnvFile) {
+      continue;
+    }
+    for (const key of Object.keys(parsed)) {
+      if (STORAGE_ROOT_ENV_VARS.has(key.toUpperCase())) {
+        deleteEnvVar(key);
+        stripped.push(key);
+      }
+    }
+  }
+
+  // Pass two. The roots are now authentic, so classification is trustworthy.
+  for (const { envFilePath, parsed } of files) {
+    if (isUserGlobalEnvFile(envFilePath)) {
+      continue;
+    }
+    for (const key of Object.keys(parsed)) {
+      if (isSandboxLauncherEnvVar(key)) {
+        deleteEnvVar(key);
+        stripped.push(key);
+      }
+    }
+  }
+  return stripped;
+}
+
+/**
+ * Deletes both spellings: Windows resolves environment names
+ * case-insensitively, so a lower-cased key in a file reaches the upper-cased
+ * name every consumer reads.
+ */
+function deleteEnvVar(key: string): void {
+  delete process.env[key];
+  delete process.env[key.toUpperCase()];
+}

--- a/packages/cli/src/config/sandboxEnvGuard.ts
+++ b/packages/cli/src/config/sandboxEnvGuard.ts
@@ -96,14 +96,17 @@ export function isUserGlobalEnvFile(envFilePath: string): boolean {
 /**
  * The env files the Bun runtime loads from the working directory on its own,
  * before any application code runs.
+ *
+ * Bun defaults the mode to `development` when `NODE_ENV` is unset, which is the
+ * ordinary case for a user running the CLI: with no default here, a repository
+ * could put its launcher controls in `.env.development` and Bun would load a
+ * file this scrub never looked at.
  */
 function runtimeAutoLoadedEnvFiles(): string[] {
-  const names = ['.env', '.env.local'];
   const nodeEnv = process.env.NODE_ENV;
-  if (nodeEnv !== undefined && nodeEnv !== '') {
-    names.push(`.env.${nodeEnv}`, `.env.${nodeEnv}.local`);
-  }
-  return names;
+  const mode =
+    nodeEnv !== undefined && nodeEnv !== '' ? nodeEnv : 'development';
+  return ['.env', '.env.local', `.env.${mode}`, `.env.${mode}.local`];
 }
 
 /**

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -22,6 +22,11 @@ import {
   type MemoryImportFormat,
 } from './settingsSchema.js';
 import { getV2NamespacedSettingPath, mergeSettings } from './settingsMerge.js';
+import {
+  isSandboxLauncherEnvVar,
+  isUserGlobalEnvFile,
+  stripRuntimeInjectedLauncherVars,
+} from './sandboxEnvGuard.js';
 export { loadSettings } from './settingsLoader.js';
 export { migrateDeprecatedSettings } from './settingsMigrations.js';
 import {
@@ -382,6 +387,10 @@ export function setUpCloudShellEnvironment(envFilePath: string | null): void {
 }
 
 export function loadEnvironment(settings: Settings): void {
+  // Runs before the folder-trust gate below: an untrusted folder is exactly
+  // where a runtime-injected launcher control must not survive.
+  stripRuntimeInjectedLauncherVars(process.cwd());
+
   const envFilePath = findEnvFile(process.cwd());
 
   // Check if folder trust feature is enabled, and if so, check if workspace is trusted
@@ -416,8 +425,9 @@ export function loadEnvironment(settings: Settings): void {
         resolvedEnvPath.startsWith(configDirResolved + path.sep) ||
         resolvedEnvPath.startsWith(dataDirResolved + path.sep);
       const isProjectEnvFile = !isInLlxprtDir && !isInGlobalDir;
+      const isUserGlobal = isUserGlobalEnvFile(envFilePath);
 
-      applyParsedEnv(parsedEnv, excludedVars, isProjectEnvFile);
+      applyParsedEnv(parsedEnv, excludedVars, isProjectEnvFile, isUserGlobal);
     } catch {
       // Errors are ignored to match the behavior of `dotenv.config({ quiet: true })`.
     }
@@ -433,9 +443,18 @@ function applyParsedEnv(
   parsedEnv: Record<string, string>,
   excludedVars: string[],
   isProjectEnvFile: boolean,
+  isUserGlobal: boolean,
 ): void {
   for (const key in parsedEnv) {
-    if (!shouldLoadEnvVar(parsedEnv, key, excludedVars, isProjectEnvFile)) {
+    if (
+      !shouldLoadEnvVar(
+        parsedEnv,
+        key,
+        excludedVars,
+        isProjectEnvFile,
+        isUserGlobal,
+      )
+    ) {
       continue;
     }
     process.env[key] = parsedEnv[key];
@@ -447,8 +466,14 @@ function shouldLoadEnvVar(
   key: string,
   excludedVars: string[],
   isProjectEnvFile: boolean,
+  isUserGlobal: boolean,
 ): boolean {
   if (!Object.hasOwn(parsedEnv, key)) {
+    return false;
+  }
+  // A sandbox launcher control is never accepted from a repo-controlled env
+  // file, regardless of excludedProjectEnvVars (issue #2958).
+  if (isSandboxLauncherEnvVar(key) && !isUserGlobal) {
     return false;
   }
   // If it's a project .env file, skip loading excluded variables.

--- a/project-plans/issue2958/plan.md
+++ b/project-plans/issue2958/plan.md
@@ -1,0 +1,214 @@
+# Issue #2958 — Project `.env` must not set sandbox launcher control variables
+
+## Problem statement
+
+A repository checked out by a user can ship a `.env` file. Two CLI env loaders read
+that file and write its keys into `process.env`:
+
+1. `packages/cli/src/config/settings.ts::loadEnvironment(settings)` — has a
+   project-vs-global distinction and honours `excludedProjectEnvVars`
+   (default `['DEBUG', 'DEBUG_MODE']`), and returns early when folder trust is
+   enabled and the workspace is untrusted.
+2. `packages/cli/src/config/environmentLoader.ts::loadEnvironment()` — called
+   unconditionally from `loadCliConfig` (`packages/cli/src/config/config.ts:349`).
+   It hands the discovered file straight to `dotenv.config()`: no exclusion list,
+   no project/global distinction, no folder-trust gate.
+
+`packages/cli/src/utils/sandbox-containers.ts::buildContainerRunArgs` then
+shell-parses `process.env.SANDBOX_FLAGS` (via `shell-quote`'s `parse`, with
+`process.env` supplied so `$VAR` references expand) and appends the result
+verbatim to the docker/podman argument list. The same module consumes
+`SANDBOX_ENV`, `LLXPRT_SANDBOX_MOUNTS`/`SANDBOX_MOUNTS`, and the
+network/resource controls.
+
+Result: a repository `.env` containing
+
+    SANDBOX_FLAGS=--env GEMINI_API_KEY=$GEMINI_API_KEY
+
+causes the host's ambient `GEMINI_API_KEY` to be injected into the container,
+undoing the #2946 fix, with no user choice involved. `--env-file` and `--volume`
+are available by the same route.
+
+Note that loader (2) actively defeats loader (1): even if a launcher variable
+were added to `excludedProjectEnvVars`, loader (1) would skip it, leaving the key
+unset in `process.env`, and loader (2)'s `dotenv.config()` would then set it
+(dotenv does not overwrite already-present keys, but the key is absent at that
+point). Both loaders must be fixed.
+
+## Behaviour to deliver
+
+Project-supplied env files may not set sandbox launcher and control variables.
+User-supplied values — exported in the shell before launch, or set by a sandbox
+profile — continue to work unchanged.
+
+### The guarded variable set
+
+Blocked when they originate from a non-global env file:
+
+| Category | Variables |
+| --- | --- |
+| Raw engine flags | `SANDBOX_FLAGS` |
+| Container env injection | `SANDBOX_ENV` |
+| Mounts | `LLXPRT_SANDBOX_MOUNTS`, `SANDBOX_MOUNTS` |
+| Engine / image selection | `LLXPRT_SANDBOX`, `SANDBOX`, `LLXPRT_SANDBOX_IMAGE`, `BUILD_SANDBOX`, `SEATBELT_PROFILE` |
+| Network | `LLXPRT_SANDBOX_NETWORK`, `SANDBOX_NETWORK`, `LLXPRT_SANDBOX_PROXY_COMMAND` |
+| Resources | `LLXPRT_SANDBOX_CPUS`, `SANDBOX_CPUS`, `LLXPRT_SANDBOX_MEMORY`, `SANDBOX_MEMORY`, `LLXPRT_SANDBOX_PIDS`, `SANDBOX_PIDS` |
+| Host resource exposure | `SANDBOX_PORTS`, `LLXPRT_SANDBOX_SSH_AGENT`, `SANDBOX_SSH_AGENT`, `SANDBOX_SET_UID_GID` |
+
+This set is derived from every `process.env` read in `packages/cli/src/utils/sandbox*.ts`,
+`packages/cli/src/config/sandboxConfig.ts` and `packages/cli/src/cliSandbox.ts`
+that controls how the sandbox is launched.
+
+### What counts as "project supplied"
+
+An env file is treated as user-global — and therefore trusted for launcher
+controls — only when it lives under the user's global config or data directory
+(`Storage.getGlobalConfigDir()` / `Storage.getGlobalDataDir()`) or is `~/.env`.
+Every other discovered env file, including `<repo>/.env` **and**
+`<repo>/.llxprt/.env`, is repo-controlled and is blocked from setting the guarded
+variables.
+
+This is deliberately stricter than the existing `isProjectEnvFile` rule in
+`settings.ts`, which treats any path containing an `.llxprt` segment as
+non-project. A checked-out repository can contain `.llxprt/.env` just as easily
+as `.env`, so for launcher controls the only safe discriminator is "is this file
+inside the user's own global config/data area".
+
+### Relationship to `excludedProjectEnvVars`
+
+The guard is independent of `excludedProjectEnvVars`. That setting replaces the
+default exclusion list wholesale, so a user who sets it must not thereby re-open
+the launcher-control hole. The guard is applied in addition to, not as part of,
+`excludedProjectEnvVars`.
+
+### The runtime injection vector
+
+Declining to apply a file is not sufficient. The published `llxprt` bin
+(`packages/cli/bin/llxprt.mjs`) is a node shim that execs **Bun**, and Bun reads
+`<cwd>/.env` into `process.env` before the first line of application code:
+
+```
+$ cd /tmp/repo            # .env contains SANDBOX_FLAGS=--env STOLEN=pwned
+$ bun p.ts
+SANDBOX_FLAGS= --env STOLEN=pwned     <- Bun injected it
+$ node -e '...'
+SANDBOX_FLAGS= undefined               <- node does not
+```
+
+By the time either loader runs the value is already present, and both loaders'
+"never overwrite an existing value" rule reads it as an ambient shell export.
+Every entry point is Bun (`bin/llxprt`, `llxprt.mjs`, `bun scripts/start.ts`),
+so AC1 fails in production unless the value is taken back out.
+
+`stripRuntimeInjectedLauncherVars(cwd)` does that, and runs first in both
+loaders. It drops a launcher control whenever a repo-controlled
+runtime-auto-loaded file (`.env`, `.env.local`, and the `NODE_ENV` variants)
+NAMES it, without comparing values: Bun performs `$VAR` expansion that
+`dotenv.parse` does not, so a value comparison would fail open on exactly the
+credential-forwarding case this exists to stop.
+
+The cost is that a user's own export of the same variable is also dropped when
+the repository names it. The repository still cannot choose a value, only
+decline to have one, and a sandbox profile applies afterwards and is unaffected.
+
+The scrub runs in two passes because the trust decision is otherwise circular: a
+repo `.env` setting `LLXPRT_CONFIG_HOME=<repo>` would make that same file
+classify as user-global. Pass one drops storage roots named by any working
+directory env file other than `~/.env` (`homedir()` is not reachable from any
+guarded variable); pass two classifies with authentic roots and drops the rest.
+
+### Not in scope
+
+- Removing either loader or consolidating the two `findEnvFile` implementations.
+- The `a2a-server` package's own `loadEnvironment`, which does not reach this
+  CLI sandbox launcher.
+- Any change to the accepted escape hatches (`SANDBOX_ENV`, mount variables,
+  profile `mounts`, exported `SANDBOX_FLAGS`) when they come from the user.
+
+Deliberately left out, each confirmed real but outside the issue's enumerated
+list and with effects well beyond the sandbox. Recorded here as follow-up
+candidates rather than silently dropped:
+
+| Variable | Launcher effect if a repo `.env` sets it |
+| --- | --- |
+| `TMPDIR` / `TMP` / `TEMP` | Selects the host directory bind-mounted at `sandbox-containers.ts`; `TMPDIR=/` mounts host root |
+| `SSH_AUTH_SOCK` | Selects a host agent socket to mount or bridge into the container |
+| `DEBUG_PORT` | Publishes a host port |
+| `HTTPS_PROXY` and the five siblings | Redirects sandbox traffic when proxied networking is enabled |
+
+## Design
+
+Add `packages/cli/src/config/sandboxEnvGuard.ts`:
+
+- `SANDBOX_LAUNCHER_ENV_VARS: ReadonlySet<string>` — the table above.
+- `isSandboxLauncherEnvVar(key: string): boolean`.
+- `isUserGlobalEnvFile(envFilePath: string): boolean` — true for files under the
+  global config dir, the global data dir, or `~/.env`.
+
+A dedicated module (rather than a constant in `settings.ts`) keeps
+`environmentLoader.ts` from taking a value dependency on `settings.ts`.
+
+Wire it into both loaders:
+
+1. `settings.ts::shouldLoadEnvVar` — reject the key when the env file is not
+   user-global and the key is a launcher control, regardless of `excludedVars`.
+   The existing `isProjectEnvFile` logic stays as-is for `excludedProjectEnvVars`.
+2. `environmentLoader.ts::loadEnvironment` — replace `dotenv.config()` with
+   `dotenv.parse()` plus an explicit apply loop that (a) never overwrites a key
+   already present in `process.env` (matching `dotenv.config()`'s default
+   `override: false`) and (b) skips launcher controls from non-global files.
+   Read/parse errors stay silent, matching `dotenv.config({ quiet: true })`.
+
+Also emit a debug log line naming the ignored variable and the file it came
+from, so a user who intended the setting can see why it did not apply.
+
+## Tests (behavioural, real files, no mock theatre)
+
+New file `packages/cli/src/config/sandboxEnvGuard.behavior.test.ts` — real temp
+directories, real `.env` files, real `process.cwd()` change, real
+`buildContainerRunArgs` output. No mocking of `fs`, `dotenv`, or the loaders.
+
+| # | Test | Proves |
+| --- | --- | --- |
+| T1 | Repo `.env` with `SANDBOX_FLAGS=--env GEMINI_API_KEY=$GEMINI_API_KEY`, ambient `GEMINI_API_KEY=<sentinel>`; run `loadEnvironment()` then `buildContainerRunArgs()`; assert the joined args contain neither the sentinel nor `--env-file`/the injected flag, and that `process.env.SANDBOX_FLAGS` is still unset | AC1, AC4 |
+| T2 | Repo `.env` with `SANDBOX_ENV=STOLEN=$GEMINI_API_KEY`; assert `addContainerEnvVars` output has no sentinel | AC2 |
+| T3 | Repo `.env` with `LLXPRT_SANDBOX_MOUNTS` and `SANDBOX_MOUNTS` pointing at a real temp dir; assert `addContainerVolumeMounts` adds no `--volume` for it | AC2 |
+| T4 | Repo `.llxprt/.env` with `SANDBOX_FLAGS`; assert it is blocked too | stricter project rule |
+| T5 | Shell-exported `SANDBOX_FLAGS=--cap-add=NET_ADMIN` present in `process.env` before `loadEnvironment()`, with a repo `.env` also setting `SANDBOX_FLAGS`; assert the exported value survives and reaches the run args | AC3 |
+| T6 | Sandbox profile with `mounts` and `resources`; assert profile-applied env still reaches the run args after a repo `.env` load | AC3 |
+| T7 | Repo `.env` sets a non-guarded key (e.g. `MY_PROJECT_VAR`); assert it still loads | no regression |
+| T8 | Env file under the global config dir sets `SANDBOX_FLAGS`; assert it is honoured | user-global stays trusted |
+| T9 | `settings.ts::loadEnvironment` with `excludedProjectEnvVars: []` and a repo `.env` setting `SANDBOX_FLAGS`; assert still blocked | guard is independent of the setting |
+
+## Acceptance criteria
+
+- **AC1** A project `.env` setting `SANDBOX_FLAGS` does not influence the
+  generated container run arguments.
+- **AC2** The same holds for `SANDBOX_ENV`, `LLXPRT_SANDBOX_MOUNTS` and
+  `SANDBOX_MOUNTS`, and for the engine / network / resource controls listed above.
+- **AC3** A shell-exported or sandbox-profile-supplied `SANDBOX_FLAGS` (and the
+  other controls) continues to work.
+- **AC4** A behavioural test uses a real project `.env` plus an ambient sentinel
+  API key and proves the sentinel never reaches the generated run arguments.
+- **AC5** Both loaders are covered; the guard cannot be disabled through
+  `excludedProjectEnvVars`.
+
+## Review dispositions
+
+Design review (deepthinker) and local Open Code Review, triaged:
+
+| Finding | Disposition |
+| --- | --- |
+| Storage roots (`LLXPRT_*_HOME`) omitted, allowing a repo `.env` to nominate itself as user-global and smuggle `SANDBOX_FLAGS` through the second loader | **Blocker-Fix.** Reproduced end to end; roots added to the guarded set and the scrub made two-pass |
+| Case-sensitive key matching lets `sandbox_flags=` through on Windows | **Blocker-Fix.** Matching now upper-cases the key |
+| Trust check trusts every descendant of a global root | **In-scope-Fix.** Narrowed to the exact env-file paths `findEnvFile` can return |
+| Tests never exercise the real two-loader startup order; no real sandbox profile | **In-scope-Fix.** Added the subprocess startup probe and a real profile file test |
+| Symlinked `<global>/.env` pointing at repo content is still trusted | **Reject.** Creating it requires write access to the user's config directory, which is already full compromise |
+| Blocked-variable list duplicated in the test file | **Reject.** The duplicate is the spec, deliberately independent of the implementation |
+| `TMPDIR`/`TMP`/`TEMP`, `SSH_AUTH_SOCK`, `DEBUG_PORT`, proxy variables | **Defer.** Confirmed real, outside the issue's enumerated list, and blocking them changes behaviour well beyond the sandbox. See the table above |
+| Folder trust is bypassable for NON-launcher variables, because Bun pre-loads them too | **Defer.** Real and worth its own issue: it is about arbitrary env vars from an untrusted repo, not sandbox launcher controls, and the fix would change ordinary `.env` behaviour |
+
+## Verification
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+`npm run build`, plus the `stepfun-37` startup smoke.


### PR DESCRIPTION
## TLDR

A repository the user merely checked out could ship a `.env` containing
`SANDBOX_FLAGS=--env GEMINI_API_KEY` and have it appended verbatim to the
docker/podman argv, forwarding the host's ambient credentials into the
container. That re-opened the hole #2946 closed, with no user choice involved.
`--env-file` and `--volume` (re-mounting `~/.config/gcloud` or an ADC file)
were available by the same route.

Project-supplied env files can no longer set sandbox launcher controls. Values
the user exported in their shell or set in a sandbox profile keep working.

Reviewers should look hardest at two things: the blocked-variable set in
`packages/cli/src/config/sandboxEnvGuard.ts`, and the reason a "don't apply it"
guard was not sufficient on its own (next section).

## Dive Deeper

### The two loaders

`packages/cli/src/config/config.ts` unconditionally calls
`environmentLoader.ts::loadEnvironment()`, which handed the discovered file
straight to `dotenv.config()` with no exclusion list, no project/global
distinction and no folder-trust gate. It also defeated the exclusion list that
`settings.ts::loadEnvironment` already had: a variable that loader skipped was
left unset, so the second loader promptly set it. Both are now guarded.

### The runtime injection vector

Declining to apply the file is not enough. The published `llxprt` bin is a node
shim that execs **Bun**, and Bun reads `<cwd>/.env` into `process.env` before
the first line of application code runs:

```
$ cd /tmp/repo            # .env has SANDBOX_FLAGS=--env STOLEN=pwned
$ bun p.ts
SANDBOX_FLAGS= --env STOLEN=pwned     <- Bun injected it
$ node -e '...'
SANDBOX_FLAGS= undefined               <- node does not
```

By then the repository's value is indistinguishable from an ambient shell
export, and both loaders' "never overwrite an existing value" rule correctly
preserves it. Every entry point is Bun, so the acceptance criterion would not
have held in production. `stripRuntimeInjectedLauncherVars` therefore removes
launcher controls named by a runtime-auto-loaded file (`.env`, `.env.local`,
and the `NODE_ENV` variants) rather than merely declining to apply them.

Names are compared, not values. Bun performs `$VAR` expansion that
`dotenv.parse` does not, so a value comparison would fail open on exactly the
credential-forwarding case this exists to stop. The cost is that a user's own
export of the same variable is dropped when the repository also names it: the
repository can cause a control to be unset, but never choose its value, and a
sandbox profile is applied afterwards and is unaffected.

### Why the scrub runs in two passes

The trust decision is otherwise circular. A repo `.env` setting
`LLXPRT_CONFIG_HOME=<repo>` makes that same file classify as the user's global
config env file, after which its `SANDBOX_FLAGS` is accepted. I reproduced the
sentinel reaching the generated run arguments this way. Pass one drops storage
roots named by any working-directory env file other than `~/.env` (`homedir()`
is not reachable from any guarded variable); pass two classifies against
authentic roots and drops the rest.

### Blocked variables

Raw engine flags (`SANDBOX_FLAGS`), container env injection (`SANDBOX_ENV`),
mounts (`LLXPRT_SANDBOX_MOUNTS`, `SANDBOX_MOUNTS`), engine/image selection
(`LLXPRT_SANDBOX`, `SANDBOX`, `LLXPRT_SANDBOX_IMAGE`, `BUILD_SANDBOX`,
`SEATBELT_PROFILE`), network (`LLXPRT_SANDBOX_NETWORK`, `SANDBOX_NETWORK`,
`LLXPRT_SANDBOX_PROXY_COMMAND`), resources (the CPU/memory/PIDs pairs), host
resource exposure (`SANDBOX_PORTS`, the SSH-agent pair, `SANDBOX_SET_UID_GID`),
and the storage roots (`LLXPRT_CONFIG_HOME`, `LLXPRT_DATA_HOME`,
`LLXPRT_CACHE_HOME`, `LLXPRT_LOG_HOME`).

Matching upper-cases the key: Windows environment names are case-insensitive,
so `sandbox_flags=` in a `.env` would otherwise pass an exact set lookup and
still resolve as `SANDBOX_FLAGS` at the consumer.

An env file is trusted only at the exact user-global paths `findEnvFile` can
return (`<config dir>/.env`, `<data dir>/.env`, `~/.env`). A repository that
happens to sit under a global root is not trusted, and neither is
`<repo>/.llxprt/.env`.

### Deliberately out of scope

Confirmed real, but outside the issue's enumerated list, and blocking them
changes behaviour well beyond the sandbox. Recorded in the plan rather than
silently dropped, and a follow-up issue is filed:

| Variable | Launcher effect if a repo `.env` sets it |
| --- | --- |
| `TMPDIR` / `TMP` / `TEMP` | Selects the host directory bind-mounted into the container; `TMPDIR=/` mounts host root |
| `SSH_AUTH_SOCK` | Selects a host agent socket to mount or bridge in |
| `DEBUG_PORT` | Publishes a host port |
| `HTTPS_PROXY` and siblings | Redirects sandbox traffic under proxied networking |

Also deferred: folder trust remains bypassable for **non-launcher** variables,
since Bun pre-loads those too and the trust gate assumes it is the only path by
which a repo `.env` reaches `process.env`.

## Reviewer Test Plan

The headline case, end to end:

```bash
mkdir /tmp/hostile && cd /tmp/hostile
printf 'SANDBOX_FLAGS=--env STOLEN=$GEMINI_API_KEY\n' > .env
export GEMINI_API_KEY=sentinel-value
llxprt --sandbox ...     # or drive buildContainerRunArgs directly
```

Before this change the generated docker/podman argv contains
`--env STOLEN=sentinel-value`. After it, `SANDBOX_FLAGS` is unset and the
sentinel never appears.

Then confirm the escape hatches still work:

- `export SANDBOX_FLAGS="--cap-add=NET_ADMIN"` in a directory whose `.env` does
  not mention it: still reaches the run arguments.
- A sandbox profile with `env.SANDBOX_FLAGS`, `mounts` and `resources`: still
  applied, even from a directory with a hostile `.env`.
- `<config dir>/.env` setting `SANDBOX_FLAGS`: still honoured.
- A project `.env` setting an ordinary variable: still loaded.

Automated coverage is `packages/cli/src/config/sandboxEnvGuard.behavior.test.ts`
(41 cases, real temp directories, real `.env` files, real
`buildContainerRunArgs` output, real sandbox profile JSON, and a subprocess
probe that runs the genuine `loadSettings` then `loadCliConfig` order under a
clean environment). 33 of the 41 fail without the production change.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: `npm run test` (CLI workspace 715/715), `npm run lint`,
`npm run typecheck`, `npm run format`, `npm run build`, and the profile startup
smoke. The Windows case-insensitivity concern is handled by upper-casing the
key rather than by a Windows run; the container matrix is not exercised because
the change is entirely in argument construction, which the behavioural tests
assert directly.

## Linked issues / bugs

Fixes #2958

Related to #2946, which removed the automatic credential forwarding this change
stops a repository from re-introducing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Prevented project-controlled environment files from overriding sandbox launcher controls, storage locations, or injecting protected runtime variables.
  * Preserved trusted shell, global environment, and sandbox profile settings according to their precedence.
  * Added protections against case variations and startup configuration poisoning.

* **Documentation**
  * Documented how sandbox launcher controls are handled when defined in project `.env` files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->