### PR TITLE
Stamp milestone, ci/cd label, and Bug type on auto-created failure issues (Fixes #3064)

### DIFF
--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -127,6 +127,31 @@ jobs:
             printf '%s' "${milestone_title}"
           }
 
+          # Stamp the Bug issue type on the auto-created failure issue (issue
+          # #3064) so it lands in the same triage view as hand-filed bugs.
+          # `gh issue create` has no --type flag, so the type is applied over
+          # REST afterwards. Accepts the issue URL that create prints, or a
+          # bare number. Always returns 0: metadata must never sink the
+          # notification.
+          #
+          # This function is duplicated verbatim across the workflows that
+          # auto-create failure issues rather than sourced from a shared
+          # script, because this job (like the other notifiers) has no checkout
+          # step -- the same reason resolve_milestone reads package.json over
+          # the API instead of from disk.
+          apply_issue_type() {
+            local reference="$1"
+            local number="${reference##*/}"
+            if [[ ! "${number}" =~ ^[0-9]+$ ]]; then
+              echo "Warning: could not parse issue reference '${reference}'; skipping issue type assignment" >&2
+              return 0
+            fi
+            if ! gh api -X PATCH "repos/${GH_REPO}/issues/${number}" -f type=Bug >/dev/null 2>&1; then
+              echo "Warning: failed to set issue type Bug on issue #${number}" >&2
+              return 0
+            fi
+          }
+
           LABEL_ARGS=()
           if ensure_label "ci/cd" "e33539" "Issues with github and the workflow scripts and CI CD environment."; then
             LABEL_ARGS+=(--label "ci/cd")
@@ -192,23 +217,30 @@ jobs:
                 --milestone "${MILESTONE_TITLE}" || \
                 echo "Warning: failed to set milestone '${MILESTONE_TITLE}' on existing issue #${EXISTING_ISSUE}" >&2
             fi
+            apply_issue_type "${EXISTING_ISSUE}"
           else
             INTRODUCTION="The evals nightly workflow failed. Eval job result: ${EVALS_RESULT}."
             build_body_file "${BODY_FILE}" "${INTRODUCTION}"
             CREATE_ARGS=(--repo "${GH_REPO}" --title "${ISSUE_TITLE}" --body-file "${BODY_FILE}")
-            CREATE_ARGS+=("${LABEL_ARGS[@]}")
-            CREATE_ARGS+=("${MILESTONE_ARGS[@]}")
+            # Empty arrays expand to an unbound variable under `set -u` on bash
+            # 3.2, so guard every expansion with the `+` alternate form.
+            CREATE_ARGS+=(${LABEL_ARGS[@]+"${LABEL_ARGS[@]}"})
+            CREATE_ARGS+=(${MILESTONE_ARGS[@]+"${MILESTONE_ARGS[@]}"})
             create_issue_once() {
               local found=""
               found="$(gh issue list --repo "${GH_REPO}" --search "\"${ISSUE_TITLE}\" in:title is:issue state:open" --limit 30 --json number,title --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number] | .[0] // empty" 2>/dev/null)" || found=""
               if [[ -n "${found}" ]]; then
                 echo "Issue #${found} already exists; skipping creation." >&2
+                printf '%s\n' "${found}"
                 return 0
               fi
               gh issue create "${CREATE_ARGS[@]}"
             }
-            retry_gh create_issue_once || {
+            CREATED_ISSUE_FILE=created_issue.txt
+            retry_gh create_issue_once > "${CREATED_ISSUE_FILE}" || {
               echo "ERROR: Failed to create evals nightly failure issue" >&2
               exit 1
             }
+            cat "${CREATED_ISSUE_FILE}"
+            apply_issue_type "$(tail -n 1 "${CREATED_ISSUE_FILE}")"
           fi

--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -193,7 +193,7 @@ jobs:
             # four attempts and three sleeps editing a reference that can never
             # resolve.
             if [[ ! "${number}" =~ ^[0-9]+$ ]]; then
-              echo "Warning: could not parse issue reference '${reference}'; skipping issue type assignment" >&2
+              echo "Warning: could not parse issue reference '${reference}'; skipping milestone and issue type assignment" >&2
               return 0
             fi
             if [[ -n "${MILESTONE_TITLE}" ]]; then

--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -247,7 +247,13 @@ jobs:
             CREATE_ARGS+=(${MILESTONE_ARGS[@]+"${MILESTONE_ARGS[@]}"})
             create_issue_once() {
               local found=""
-              found="$(gh issue list --repo "${GH_REPO}" --search "\"${ISSUE_TITLE}\" in:title is:issue state:open" --limit 30 --json number,title --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number] | .[0] // empty" 2>/dev/null)" || found=""
+              # A failed lookup is not evidence that no issue exists. Treating
+              # it as empty would fall through to create and could open a
+              # duplicate; returning failure makes retry_gh recheck first.
+              if ! found="$(gh issue list --repo "${GH_REPO}" --search "\"${ISSUE_TITLE}\" in:title is:issue state:open" --limit 30 --json number,title --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number] | .[0] // empty" 2>/dev/null)"; then
+                echo "Failed to recheck for an existing issue before creating." >&2
+                return 1
+              fi
               if [[ -n "${found}" ]]; then
                 echo "Issue #${found} already exists; skipping creation." >&2
                 printf '%s\n' "${found}"

--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -118,8 +118,11 @@ jobs:
               echo "Warning: package.json on main has no version field; skipping milestone resolution" >&2
               return
             fi
-            local milestone_title
-            milestone_title="$(gh api --paginate --slurp "repos/${GH_REPO}/milestones?state=open&per_page=100" --jq "[.[][] | select(.title == \"${current_version}\")] | .[0].title // empty" 2>/dev/null)"
+            local milestone_title=""
+            if ! milestone_title="$(gh api --paginate --slurp "repos/${GH_REPO}/milestones?state=open&per_page=100" 2>/dev/null | jq -r --arg version "${current_version}" '[.[][] | select(.title == $version)] | .[0].title // empty' 2>/dev/null)"; then
+              echo "Warning: could not list open milestones; skipping milestone assignment" >&2
+              return
+            fi
             if [[ -z "${milestone_title}" ]]; then
               echo "Warning: no open milestone titled '${current_version}'; skipping milestone assignment" >&2
               return
@@ -180,6 +183,28 @@ jobs:
             return 1
           }
 
+          # Keep a reused failure issue on the current release milestone and
+          # issue type, whether it was found by the outer search or by the
+          # inner race check inside create_issue_once (issues #3149, #3064).
+          annotate_issue() {
+            local reference="$1"
+            local number="${reference##*/}"
+            # Validate before touching the API: retry_gh would otherwise burn
+            # four attempts and three sleeps editing a reference that can never
+            # resolve.
+            if [[ ! "${number}" =~ ^[0-9]+$ ]]; then
+              echo "Warning: could not parse issue reference '${reference}'; skipping issue type assignment" >&2
+              return 0
+            fi
+            if [[ -n "${MILESTONE_TITLE}" ]]; then
+              retry_gh gh issue edit "${number}" \
+                --repo "${GH_REPO}" \
+                --milestone "${MILESTONE_TITLE}" || \
+                echo "Warning: failed to set milestone '${MILESTONE_TITLE}' on issue #${number}" >&2
+            fi
+            apply_issue_type "${number}"
+          }
+
           build_body_file() {
             local body_file="$1"
             local introduction="$2"
@@ -211,13 +236,7 @@ jobs:
               echo "ERROR: Failed to comment on existing issue #${EXISTING_ISSUE}" >&2
               exit 1
             }
-            if [[ -n "${MILESTONE_TITLE}" ]]; then
-              retry_gh gh issue edit "${EXISTING_ISSUE}" \
-                --repo "${GH_REPO}" \
-                --milestone "${MILESTONE_TITLE}" || \
-                echo "Warning: failed to set milestone '${MILESTONE_TITLE}' on existing issue #${EXISTING_ISSUE}" >&2
-            fi
-            apply_issue_type "${EXISTING_ISSUE}"
+            annotate_issue "${EXISTING_ISSUE}"
           else
             INTRODUCTION="The evals nightly workflow failed. Eval job result: ${EVALS_RESULT}."
             build_body_file "${BODY_FILE}" "${INTRODUCTION}"
@@ -242,5 +261,10 @@ jobs:
               exit 1
             }
             cat "${CREATED_ISSUE_FILE}"
-            apply_issue_type "$(tail -n 1 "${CREATED_ISSUE_FILE}")"
+            # create_issue_once may print the number of an issue that appeared
+            # between the outer search and the create attempt, in which case no
+            # issue was created and CREATE_ARGS never applied. Annotating
+            # unconditionally covers that reuse path; on the ordinary create
+            # path the milestone edit is a no-op (issue #3064).
+            annotate_issue "$(tail -n 1 "${CREATED_ISSUE_FILE}")"
           fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -643,8 +643,11 @@ jobs:
             # gh issue --milestone accepts a milestone TITLE, not a number.
             # Resolve the title by exact match across ALL open milestone
             # pages (issue #3149), then return it for assignment.
-            local milestone_title
-            milestone_title="$(gh api --paginate --slurp "repos/${GH_REPO}/milestones?state=open&per_page=100" --jq "[.[][] | select(.title == \"${current_version}\")] | .[0].title // empty" 2>/dev/null)"
+            local milestone_title=""
+            if ! milestone_title="$(gh api --paginate --slurp "repos/${GH_REPO}/milestones?state=open&per_page=100" 2>/dev/null | jq -r --arg version "${current_version}" '[.[][] | select(.title == $version)] | .[0].title // empty' 2>/dev/null)"; then
+              echo "Warning: could not list open milestones; skipping milestone assignment" >&2
+              return
+            fi
             if [[ -z "${milestone_title}" ]]; then
               echo "Warning: no open milestone titled '${current_version}'; skipping milestone assignment" >&2
               return

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -652,6 +652,31 @@ jobs:
             printf '%s' "${milestone_title}"
           }
 
+          # Stamp the Bug issue type on the auto-created failure issue (issue
+          # #3064) so it lands in the same triage view as hand-filed bugs.
+          # `gh issue create` has no --type flag, so the type is applied over
+          # REST afterwards. Accepts the issue URL that create prints, or a
+          # bare number. Always returns 0: metadata must never sink the
+          # notification.
+          #
+          # This function is duplicated verbatim across the workflows that
+          # auto-create failure issues rather than sourced from a shared
+          # script, because this job (like the other notifiers) has no checkout
+          # step -- the same reason resolve_milestone reads package.json over
+          # the API instead of from disk.
+          apply_issue_type() {
+            local reference="$1"
+            local number="${reference##*/}"
+            if [[ ! "${number}" =~ ^[0-9]+$ ]]; then
+              echo "Warning: could not parse issue reference '${reference}'; skipping issue type assignment" >&2
+              return 0
+            fi
+            if ! gh api -X PATCH "repos/${GH_REPO}/issues/${number}" -f type=Bug >/dev/null 2>&1; then
+              echo "Warning: failed to set issue type Bug on issue #${number}" >&2
+              return 0
+            fi
+          }
+
           LABEL_ARGS=()
           if ensure_label "ci/cd" "e33539" "Issues with github and the workflow scripts and CI CD environment."; then
             LABEL_ARGS+=(--label "ci/cd")
@@ -721,21 +746,28 @@ jobs:
               exit 1
             }
             # Keep a long-lived failure issue on the current release milestone
-            # too, not just on first creation (issue #3149).
+            # and issue type too, not just on first creation (issues #3149,
+            # #3064).
             if [[ -n "${MILESTONE_TITLE}" ]]; then
               retry_gh gh issue edit "${EXISTING_ISSUE}" \
                 --repo "${GH_REPO}" \
                 --milestone "${MILESTONE_TITLE}" || \
                 echo "Warning: failed to set milestone '${MILESTONE_TITLE}' on existing issue #${EXISTING_ISSUE}" >&2
             fi
+            apply_issue_type "${EXISTING_ISSUE}"
           else
             INTRODUCTION="The nightly test workflow failed. Affected jobs: ${FAILED_JOBS_TEXT}."
             build_body_file "${BODY_FILE}" "${INTRODUCTION}"
             CREATE_ARGS=(--repo "${GH_REPO}" --title "${ISSUE_TITLE}" --body-file "${BODY_FILE}")
-            CREATE_ARGS+=("${LABEL_ARGS[@]}")
-            CREATE_ARGS+=("${MILESTONE_ARGS[@]}")
-            retry_gh gh issue create "${CREATE_ARGS[@]}" || {
+            # Empty arrays expand to an unbound variable under `set -u` on bash
+            # 3.2, so guard every expansion with the `+` alternate form.
+            CREATE_ARGS+=(${LABEL_ARGS[@]+"${LABEL_ARGS[@]}"})
+            CREATE_ARGS+=(${MILESTONE_ARGS[@]+"${MILESTONE_ARGS[@]}"})
+            CREATED_ISSUE_FILE=created_issue.txt
+            retry_gh gh issue create "${CREATE_ARGS[@]}" > "${CREATED_ISSUE_FILE}" || {
               echo "ERROR: Failed to create nightly failure issue" >&2
               exit 1
             }
+            cat "${CREATED_ISSUE_FILE}"
+            apply_issue_type "$(tail -n 1 "${CREATED_ISSUE_FILE}")"
           fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -786,7 +786,13 @@ jobs:
             # attempt, matching evals-nightly.
             create_issue_once() {
               local found=""
-              found="$(gh issue list --repo "${GH_REPO}" --search "\"${ISSUE_TITLE}\" in:title is:issue state:open" --limit 30 --json number,title --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number] | .[0] // empty" 2>/dev/null)" || found=""
+              # A failed lookup is not evidence that no issue exists. Treating
+              # it as empty would fall through to create and could open a
+              # duplicate; returning failure makes retry_gh recheck first.
+              if ! found="$(gh issue list --repo "${GH_REPO}" --search "\"${ISSUE_TITLE}\" in:title is:issue state:open" --limit 30 --json number,title --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number] | .[0] // empty" 2>/dev/null)"; then
+                echo "Failed to recheck for an existing issue before creating." >&2
+                return 1
+              fi
               if [[ -n "${found}" ]]; then
                 echo "Issue #${found} already exists; skipping creation." >&2
                 printf '%s\n' "${found}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -708,6 +708,29 @@ jobs:
             return 1
           }
 
+          # Keep a reused failure issue on the current release milestone and
+          # issue type, whether it was found by the outer search or by the
+          # inner race check inside create_issue_once (issues #3149, #3064).
+          annotate_issue() {
+            local reference="$1"
+            local number="${reference##*/}"
+            # Validate before touching the API: retry_gh would otherwise burn
+            # four attempts and three sleeps editing a reference that can never
+            # resolve.
+            if [[ ! "${number}" =~ ^[0-9]+$ ]]; then
+              echo "Warning: could not parse issue reference '${reference}'; skipping milestone and issue type assignment" >&2
+              return 0
+            fi
+            if [[ -n "${MILESTONE_TITLE}" ]]; then
+              retry_gh gh issue edit "${number}" \
+                --repo "${GH_REPO}" \
+                --milestone "${MILESTONE_TITLE}" || \
+                echo "Warning: failed to set milestone '${MILESTONE_TITLE}' on issue #${number}" >&2
+            fi
+            apply_issue_type "${number}"
+          }
+
+
           build_body_file() {
             local body_file="$1"
             local introduction="$2"
@@ -748,16 +771,7 @@ jobs:
               echo "ERROR: Failed to comment on existing issue #${EXISTING_ISSUE}" >&2
               exit 1
             }
-            # Keep a long-lived failure issue on the current release milestone
-            # and issue type too, not just on first creation (issues #3149,
-            # #3064).
-            if [[ -n "${MILESTONE_TITLE}" ]]; then
-              retry_gh gh issue edit "${EXISTING_ISSUE}" \
-                --repo "${GH_REPO}" \
-                --milestone "${MILESTONE_TITLE}" || \
-                echo "Warning: failed to set milestone '${MILESTONE_TITLE}' on existing issue #${EXISTING_ISSUE}" >&2
-            fi
-            apply_issue_type "${EXISTING_ISSUE}"
+            annotate_issue "${EXISTING_ISSUE}"
           else
             INTRODUCTION="The nightly test workflow failed. Affected jobs: ${FAILED_JOBS_TEXT}."
             build_body_file "${BODY_FILE}" "${INTRODUCTION}"
@@ -766,11 +780,28 @@ jobs:
             # 3.2, so guard every expansion with the `+` alternate form.
             CREATE_ARGS+=(${LABEL_ARGS[@]+"${LABEL_ARGS[@]}"})
             CREATE_ARGS+=(${MILESTONE_ARGS[@]+"${MILESTONE_ARGS[@]}"})
+            # Issue creation is not idempotent, so a create that reaches GitHub
+            # but reports failure to the client would have retry_gh open a
+            # second "Nightly workflow failed" issue. Re-search before each
+            # attempt, matching evals-nightly.
+            create_issue_once() {
+              local found=""
+              found="$(gh issue list --repo "${GH_REPO}" --search "\"${ISSUE_TITLE}\" in:title is:issue state:open" --limit 30 --json number,title --jq "[.[] | select(.title == \"${ISSUE_TITLE}\") | .number] | .[0] // empty" 2>/dev/null)" || found=""
+              if [[ -n "${found}" ]]; then
+                echo "Issue #${found} already exists; skipping creation." >&2
+                printf '%s\n' "${found}"
+                return 0
+              fi
+              gh issue create "${CREATE_ARGS[@]}"
+            }
             CREATED_ISSUE_FILE=created_issue.txt
-            retry_gh gh issue create "${CREATE_ARGS[@]}" > "${CREATED_ISSUE_FILE}" || {
+            retry_gh create_issue_once > "${CREATED_ISSUE_FILE}" || {
               echo "ERROR: Failed to create nightly failure issue" >&2
               exit 1
             }
             cat "${CREATED_ISSUE_FILE}"
-            apply_issue_type "$(tail -n 1 "${CREATED_ISSUE_FILE}")"
+            # The reference may be a URL from a fresh create or a bare number
+            # from the race check above; annotate_issue handles both and, on
+            # the race path, supplies the milestone CREATE_ARGS never applied.
+            annotate_issue "$(tail -n 1 "${CREATED_ISSUE_FILE}")"
           fi

--- a/.github/workflows/ocr-infrastructure-notifier.yml
+++ b/.github/workflows/ocr-infrastructure-notifier.yml
@@ -194,8 +194,11 @@ jobs:
               # gh issue --milestone accepts a milestone TITLE, not a number.
               # Resolve the title by exact match across ALL open milestone
               # pages, then return it for assignment.
-              local milestone_title
-              milestone_title="$(gh api --paginate --slurp "repos/${GH_REPO}/milestones?state=open&per_page=100" --jq "[.[][] | select(.title == \"${current_version}\")] | .[0].title // empty" 2>/dev/null)"
+              local milestone_title=""
+              if ! milestone_title="$(gh api --paginate --slurp "repos/${GH_REPO}/milestones?state=open&per_page=100" 2>/dev/null | jq -r --arg version "${current_version}" '[.[][] | select(.title == $version)] | .[0].title // empty' 2>/dev/null)"; then
+                echo "Warning: could not list open milestones; skipping milestone assignment" >&2
+                return
+              fi
               if [[ -z "${milestone_title}" ]]; then
                 echo "Warning: no open milestone titled '${current_version}'; skipping milestone assignment" >&2
                 return

--- a/.github/workflows/ocr-infrastructure-notifier.yml
+++ b/.github/workflows/ocr-infrastructure-notifier.yml
@@ -172,6 +172,79 @@ jobs:
                 ;;
             esac
             ISSUE_TITLE="OCR review infrastructure failure"
+            # Resolve the milestone for the version currently being worked on
+            # in main, so the auto-created failure issue surfaces in the
+            # release view (issue #3064). Source of truth is the root
+            # package.json `version` on main. Resolved by exact title match
+            # against open milestones (not nearest due date). Fails soft: an
+            # unresolvable milestone logs a warning and returns empty, so the
+            # notification still goes out.
+            resolve_milestone() {
+              local package_json
+              if ! package_json="$(gh api "repos/${GH_REPO}/contents/package.json?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null)"; then
+                echo "Warning: could not read package.json from main; skipping milestone resolution" >&2
+                return
+              fi
+              local current_version
+              current_version="$(printf '%s' "${package_json}" | jq -r '.version // empty' 2>/dev/null)"
+              if [[ -z "${current_version}" ]]; then
+                echo "Warning: package.json on main has no version field; skipping milestone resolution" >&2
+                return
+              fi
+              # gh issue --milestone accepts a milestone TITLE, not a number.
+              # Resolve the title by exact match across ALL open milestone
+              # pages, then return it for assignment.
+              local milestone_title
+              milestone_title="$(gh api --paginate --slurp "repos/${GH_REPO}/milestones?state=open&per_page=100" --jq "[.[][] | select(.title == \"${current_version}\")] | .[0].title // empty" 2>/dev/null)"
+              if [[ -z "${milestone_title}" ]]; then
+                echo "Warning: no open milestone titled '${current_version}'; skipping milestone assignment" >&2
+                return
+              fi
+              printf '%s' "${milestone_title}"
+            }
+
+            # Stamp the Bug issue type on the auto-created failure issue (issue
+            # #3064) so it lands in the same triage view as hand-filed bugs.
+            # `gh issue create` has no --type flag, so the type is applied over
+            # REST afterwards. Accepts the issue URL that create prints, or a
+            # bare number. Always returns 0: metadata must never sink the
+            # notification.
+            #
+            # This function is duplicated verbatim across the workflows that
+            # auto-create failure issues rather than sourced from a shared
+            # script, because this job (like the other notifiers) has no
+            # checkout step -- the same reason resolve_milestone reads
+            # package.json over the API instead of from disk.
+            apply_issue_type() {
+              local reference="$1"
+              local number="${reference##*/}"
+              if [[ ! "${number}" =~ ^[0-9]+$ ]]; then
+                echo "Warning: could not parse issue reference '${reference}'; skipping issue type assignment" >&2
+                return 0
+              fi
+              if ! gh api -X PATCH "repos/${GH_REPO}/issues/${number}" -f type=Bug >/dev/null 2>&1; then
+                echo "Warning: failed to set issue type Bug on issue #${number}" >&2
+                return 0
+              fi
+            }
+
+            MILESTONE_TITLE="$(resolve_milestone)"
+            MILESTONE_ARGS=()
+            if [[ -n "${MILESTONE_TITLE}" ]]; then
+              MILESTONE_ARGS+=(--milestone "${MILESTONE_TITLE}")
+            fi
+
+            # Keep the long-lived tracking issue on the current release
+            # milestone and issue type, not just on first creation.
+            annotate_existing_issue() {
+              local number="$1"
+              if [[ -n "${MILESTONE_TITLE}" ]]; then
+                gh issue edit "${number}" --milestone "${MILESTONE_TITLE}" || \
+                  echo "::warning::Failed to set milestone '${MILESTONE_TITLE}' on OCR infrastructure issue #${number}."
+              fi
+              apply_issue_type "${number}"
+            }
+
             retry_gh() {
               local attempt
               for attempt in 1 2 3 4; do
@@ -188,21 +261,29 @@ jobs:
             create_infrastructure_issue() {
               local issue_body_file
               local create_stderr
+              local created_issue
               issue_body_file="$1"
               shift
               create_stderr="$(mktemp)"
-              if gh issue create "$@" --body-file "$issue_body_file" --label "ci/cd" 2>"${create_stderr}"; then
-                rm -f "${create_stderr}"
+              created_issue="$(mktemp)"
+              # Empty arrays expand to an unbound variable under `set -u` on
+              # bash 3.2, so guard every expansion with the `+` alternate form.
+              if gh issue create "$@" --body-file "$issue_body_file" --label "ci/cd" ${MILESTONE_ARGS[@]+"${MILESTONE_ARGS[@]}"} >"${created_issue}" 2>"${create_stderr}"; then
+                cat "${created_issue}"
+                apply_issue_type "$(tail -n 1 "${created_issue}")"
+                rm -f "${create_stderr}" "${created_issue}"
                 return 0
               fi
               if grep -Eqi "label|labels|not found|does not exist" "${create_stderr}"; then
                 echo "::warning::OCR infrastructure issue label was unavailable; retrying without labels."
-                if gh issue create "$@" --body-file "$issue_body_file"; then
-                  rm -f "${create_stderr}"
+                if gh issue create "$@" --body-file "$issue_body_file" ${MILESTONE_ARGS[@]+"${MILESTONE_ARGS[@]}"} >"${created_issue}"; then
+                  cat "${created_issue}"
+                  apply_issue_type "$(tail -n 1 "${created_issue}")"
+                  rm -f "${create_stderr}" "${created_issue}"
                   return 0
                 fi
               fi
-              rm -f "${create_stderr}"
+              rm -f "${create_stderr}" "${created_issue}"
               echo "::warning::Failed to create OCR infrastructure issue."
               return 1
             }
@@ -253,6 +334,7 @@ jobs:
             fi
             if [ -n "$EXISTING_ISSUE" ]; then
               gh issue comment "${EXISTING_ISSUE}" --body-file "$body_file" || echo "::warning::Failed to comment on OCR infrastructure issue."
+              annotate_existing_issue "${EXISTING_ISSUE}"
               converge_duplicate_tracking_issues
               return 0
             fi
@@ -268,6 +350,7 @@ jobs:
             fi
             if [ -n "$EXISTING_ISSUE" ]; then
               gh issue comment "${EXISTING_ISSUE}" --body-file "$body_file" || echo "::warning::Failed to comment on OCR infrastructure issue after recheck."
+              annotate_existing_issue "${EXISTING_ISSUE}"
               converge_duplicate_tracking_issues
               return 0
             fi

--- a/.github/workflows/ocr-infrastructure-notifier.yml
+++ b/.github/workflows/ocr-infrastructure-notifier.yml
@@ -242,7 +242,9 @@ jobs:
             annotate_existing_issue() {
               local number="$1"
               if [[ -n "${MILESTONE_TITLE}" ]]; then
-                gh issue edit "${number}" --milestone "${MILESTONE_TITLE}" || \
+                # retry_gh is defined below; bash resolves it at call time.
+                # Setting a milestone is idempotent, so retrying is safe.
+                retry_gh gh issue edit "${number}" --milestone "${MILESTONE_TITLE}" || \
                   echo "::warning::Failed to set milestone '${MILESTONE_TITLE}' on OCR infrastructure issue #${number}."
               fi
               apply_issue_type "${number}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -637,8 +637,11 @@ jobs:
             # gh issue --milestone accepts a milestone TITLE, not a number.
             # Resolve the title by exact match across ALL open milestone pages,
             # then return it for assignment.
-            local milestone_title
-            milestone_title="$(gh api --paginate --slurp "repos/${GH_REPO}/milestones?state=open&per_page=100" --jq "[.[][] | select(.title == \"${current_version}\")] | .[0].title // empty" 2>/dev/null)"
+            local milestone_title=""
+            if ! milestone_title="$(gh api --paginate --slurp "repos/${GH_REPO}/milestones?state=open&per_page=100" 2>/dev/null | jq -r --arg version "${current_version}" '[.[][] | select(.title == $version)] | .[0].title // empty' 2>/dev/null)"; then
+              echo "Warning: could not list open milestones; skipping milestone assignment" >&2
+              return
+            fi
             if [[ -z "${milestone_title}" ]]; then
               echo "Warning: no open milestone titled '${current_version}'; skipping milestone assignment" >&2
               return

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -615,9 +615,80 @@ jobs:
       - name: Create Issue on Failure
         if: failure()
         run: |
-          gh issue create \
-            --title "Release Failed for ${{ steps.version.outputs.RELEASE_TAG || 'N/A' }} on $(date +'%Y-%m-%d')" \
-            --body "The release workflow failed. See the full run for details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --label "ci/cd"
+          # Resolve the milestone for the version currently being worked on in
+          # main, so the auto-created failure issue surfaces in the release
+          # view (issue #3064). Source of truth is the root package.json
+          # `version` on main -- not the released ref, which may have bumped
+          # it. Resolved by exact title match against open milestones (not
+          # nearest due date). Fails soft: an unresolvable milestone logs a
+          # warning and returns empty, so the notification still goes out.
+          resolve_milestone() {
+            local package_json
+            if ! package_json="$(gh api "repos/${GH_REPO}/contents/package.json?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null)"; then
+              echo "Warning: could not read package.json from main; skipping milestone resolution" >&2
+              return
+            fi
+            local current_version
+            current_version="$(printf '%s' "${package_json}" | jq -r '.version // empty' 2>/dev/null)"
+            if [[ -z "${current_version}" ]]; then
+              echo "Warning: package.json on main has no version field; skipping milestone resolution" >&2
+              return
+            fi
+            # gh issue --milestone accepts a milestone TITLE, not a number.
+            # Resolve the title by exact match across ALL open milestone pages,
+            # then return it for assignment.
+            local milestone_title
+            milestone_title="$(gh api --paginate --slurp "repos/${GH_REPO}/milestones?state=open&per_page=100" --jq "[.[][] | select(.title == \"${current_version}\")] | .[0].title // empty" 2>/dev/null)"
+            if [[ -z "${milestone_title}" ]]; then
+              echo "Warning: no open milestone titled '${current_version}'; skipping milestone assignment" >&2
+              return
+            fi
+            printf '%s' "${milestone_title}"
+          }
+
+          # Stamp the Bug issue type on the auto-created failure issue (issue
+          # #3064) so it lands in the same triage view as hand-filed bugs.
+          # `gh issue create` has no --type flag, so the type is applied over
+          # REST afterwards. Accepts the issue URL that create prints, or a
+          # bare number. Always returns 0: metadata must never sink the
+          # notification.
+          #
+          # This function is duplicated verbatim across the workflows that
+          # auto-create failure issues rather than sourced from a shared
+          # script, because the other notifier jobs have no checkout step --
+          # the same reason resolve_milestone reads package.json over the API
+          # instead of from disk.
+          apply_issue_type() {
+            local reference="$1"
+            local number="${reference##*/}"
+            if [[ ! "${number}" =~ ^[0-9]+$ ]]; then
+              echo "Warning: could not parse issue reference '${reference}'; skipping issue type assignment" >&2
+              return 0
+            fi
+            if ! gh api -X PATCH "repos/${GH_REPO}/issues/${number}" -f type=Bug >/dev/null 2>&1; then
+              echo "Warning: failed to set issue type Bug on issue #${number}" >&2
+              return 0
+            fi
+          }
+
+          MILESTONE_TITLE="$(resolve_milestone)"
+          MILESTONE_ARGS=()
+          if [[ -n "${MILESTONE_TITLE}" ]]; then
+            MILESTONE_ARGS+=(--milestone "${MILESTONE_TITLE}")
+          fi
+
+          CREATE_ARGS=(--repo "${GH_REPO}")
+          CREATE_ARGS+=(--title "Release Failed for ${{ steps.version.outputs.RELEASE_TAG || 'N/A' }} on $(date +'%Y-%m-%d')")
+          CREATE_ARGS+=(--body "The release workflow failed. See the full run for details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}")
+          CREATE_ARGS+=(--label "ci/cd")
+          # Empty arrays expand to an unbound variable under `set -u` on bash
+          # 3.2, so guard every expansion with the `+` alternate form.
+          CREATE_ARGS+=(${MILESTONE_ARGS[@]+"${MILESTONE_ARGS[@]}"})
+
+          CREATED_ISSUE_FILE=created_issue.txt
+          gh issue create "${CREATE_ARGS[@]}" > "${CREATED_ISSUE_FILE}"
+          cat "${CREATED_ISSUE_FILE}"
+          apply_issue_type "$(tail -n 1 "${CREATED_ISSUE_FILE}")"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -703,8 +703,8 @@ jobs:
           fi
 
           CREATE_ARGS=(--repo "${GH_REPO}")
-          CREATE_ARGS+=(--title "Release Failed for ${{ steps.version.outputs.RELEASE_TAG || 'N/A' }} on $(date +'%Y-%m-%d')")
-          CREATE_ARGS+=(--body "The release workflow failed. See the full run for details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}")
+          CREATE_ARGS+=(--title "Release Failed for ${RELEASE_TAG} on $(date +'%Y-%m-%d')")
+          CREATE_ARGS+=(--body "The release workflow failed. See the full run for details: ${RUN_URL}")
           LABEL_ARGS=()
           if ensure_label "ci/cd" "e33539" "Issues with github and the workflow scripts and CI CD environment."; then
             LABEL_ARGS+=(--label "ci/cd")
@@ -724,3 +724,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          # Interpolated through env rather than straight into the run body, so
+          # a value carrying shell metacharacters cannot alter the script.
+          RELEASE_TAG: ${{ steps.version.outputs.RELEASE_TAG || 'N/A' }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -615,6 +615,28 @@ jobs:
       - name: Create Issue on Failure
         if: failure()
         run: |
+          ensure_label() {
+            local name="$1"
+            local color="$2"
+            local description="$3"
+            local existing=""
+            local create_err=""
+            # Capture stderr in create_err while discarding stdout; redirect order matters.
+            if create_err="$(gh label create "${name}" --repo "${GH_REPO}" --color "${color}" --description "${description}" 2>&1 >/dev/null)"; then
+              return
+            fi
+            if ! existing="$(gh label list --repo "${GH_REPO}" --search "${name}" --json name --jq ".[] | select(.name == \"${name}\") | .name" 2>&1)"; then
+              echo "Failed to check for label: ${name}" >&2
+              echo "  create error: ${create_err}" >&2
+              echo "  list error: ${existing}" >&2
+              return 1
+            fi
+            if [[ "${existing}" != "${name}" ]]; then
+              echo "Failed to create or find label: ${name}" >&2
+              return 1
+            fi
+          }
+
           # Resolve the milestone for the version currently being worked on in
           # main, so the auto-created failure issue surfaces in the release
           # view (issue #3064). Source of truth is the root package.json
@@ -683,7 +705,14 @@ jobs:
           CREATE_ARGS=(--repo "${GH_REPO}")
           CREATE_ARGS+=(--title "Release Failed for ${{ steps.version.outputs.RELEASE_TAG || 'N/A' }} on $(date +'%Y-%m-%d')")
           CREATE_ARGS+=(--body "The release workflow failed. See the full run for details: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}")
-          CREATE_ARGS+=(--label "ci/cd")
+          LABEL_ARGS=()
+          if ensure_label "ci/cd" "e33539" "Issues with github and the workflow scripts and CI CD environment."; then
+            LABEL_ARGS+=(--label "ci/cd")
+          else
+            echo "Warning: continuing without ci/cd label" >&2
+          fi
+
+          CREATE_ARGS+=(${LABEL_ARGS[@]+"${LABEL_ARGS[@]}"})
           # Empty arrays expand to an unbound variable under `set -u` on bash
           # 3.2, so guard every expansion with the `+` alternate form.
           CREATE_ARGS+=(${MILESTONE_ARGS[@]+"${MILESTONE_ARGS[@]}"})

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -69,7 +69,10 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           GH_REPO: '${{ github.repository }}'
           DETAILS_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
-          REF: '${{ github.event.inputs.ref }}'
+          # Same fallback the checkout step uses: inputs.ref is empty on push
+          # runs, which would title the issue "Smoke test failed on  @ <date>"
+          # and drop the tested revision.
+          REF: '${{ github.event.inputs.ref || github.sha }}'
         run: |
           ensure_label() {
             local name="$1"

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -67,9 +67,81 @@ jobs:
         if: '${{ failure() && github.event.inputs.dry-run == false }}'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GH_REPO: '${{ github.repository }}'
           DETAILS_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
           REF: '${{ github.event.inputs.ref }}'
         run: |
-          gh issue create \
-            --title "Smoke test failed on ${REF} @ $(date +'%Y-%m-%d')" \
-            --body "Smoke test failed. See the full run for details: ${DETAILS_URL}"
+          # Resolve the milestone for the version currently being worked on in
+          # main, so the auto-created failure issue surfaces in the release
+          # view (issue #3064). Source of truth is the root package.json
+          # `version` on main -- not the tested ref, which may have bumped it.
+          # Resolved by exact title match against open milestones (not nearest
+          # due date). Fails soft: an unresolvable milestone logs a warning and
+          # returns empty, so the notification still goes out.
+          resolve_milestone() {
+            local package_json
+            if ! package_json="$(gh api "repos/${GH_REPO}/contents/package.json?ref=main" -H 'Accept: application/vnd.github.raw' 2>/dev/null)"; then
+              echo "Warning: could not read package.json from main; skipping milestone resolution" >&2
+              return
+            fi
+            local current_version
+            current_version="$(printf '%s' "${package_json}" | jq -r '.version // empty' 2>/dev/null)"
+            if [[ -z "${current_version}" ]]; then
+              echo "Warning: package.json on main has no version field; skipping milestone resolution" >&2
+              return
+            fi
+            # gh issue --milestone accepts a milestone TITLE, not a number.
+            # Resolve the title by exact match across ALL open milestone pages,
+            # then return it for assignment.
+            local milestone_title
+            milestone_title="$(gh api --paginate --slurp "repos/${GH_REPO}/milestones?state=open&per_page=100" --jq "[.[][] | select(.title == \"${current_version}\")] | .[0].title // empty" 2>/dev/null)"
+            if [[ -z "${milestone_title}" ]]; then
+              echo "Warning: no open milestone titled '${current_version}'; skipping milestone assignment" >&2
+              return
+            fi
+            printf '%s' "${milestone_title}"
+          }
+
+          # Stamp the Bug issue type on the auto-created failure issue (issue
+          # #3064) so it lands in the same triage view as hand-filed bugs.
+          # `gh issue create` has no --type flag, so the type is applied over
+          # REST afterwards. Accepts the issue URL that create prints, or a
+          # bare number. Always returns 0: metadata must never sink the
+          # notification.
+          #
+          # This function is duplicated verbatim across the workflows that
+          # auto-create failure issues rather than sourced from a shared
+          # script, because the other notifier jobs have no checkout step --
+          # the same reason resolve_milestone reads package.json over the API
+          # instead of from disk.
+          apply_issue_type() {
+            local reference="$1"
+            local number="${reference##*/}"
+            if [[ ! "${number}" =~ ^[0-9]+$ ]]; then
+              echo "Warning: could not parse issue reference '${reference}'; skipping issue type assignment" >&2
+              return 0
+            fi
+            if ! gh api -X PATCH "repos/${GH_REPO}/issues/${number}" -f type=Bug >/dev/null 2>&1; then
+              echo "Warning: failed to set issue type Bug on issue #${number}" >&2
+              return 0
+            fi
+          }
+
+          MILESTONE_TITLE="$(resolve_milestone)"
+          MILESTONE_ARGS=()
+          if [[ -n "${MILESTONE_TITLE}" ]]; then
+            MILESTONE_ARGS+=(--milestone "${MILESTONE_TITLE}")
+          fi
+
+          CREATE_ARGS=(--repo "${GH_REPO}")
+          CREATE_ARGS+=(--title "Smoke test failed on ${REF} @ $(date +'%Y-%m-%d')")
+          CREATE_ARGS+=(--body "Smoke test failed. See the full run for details: ${DETAILS_URL}")
+          CREATE_ARGS+=(--label "ci/cd")
+          # Empty arrays expand to an unbound variable under `set -u` on bash
+          # 3.2, so guard every expansion with the `+` alternate form.
+          CREATE_ARGS+=(${MILESTONE_ARGS[@]+"${MILESTONE_ARGS[@]}"})
+
+          CREATED_ISSUE_FILE=created_issue.txt
+          gh issue create "${CREATE_ARGS[@]}" > "${CREATED_ISSUE_FILE}"
+          cat "${CREATED_ISSUE_FILE}"
+          apply_issue_type "$(tail -n 1 "${CREATED_ISSUE_FILE}")"

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -71,6 +71,28 @@ jobs:
           DETAILS_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
           REF: '${{ github.event.inputs.ref }}'
         run: |
+          ensure_label() {
+            local name="$1"
+            local color="$2"
+            local description="$3"
+            local existing=""
+            local create_err=""
+            # Capture stderr in create_err while discarding stdout; redirect order matters.
+            if create_err="$(gh label create "${name}" --repo "${GH_REPO}" --color "${color}" --description "${description}" 2>&1 >/dev/null)"; then
+              return
+            fi
+            if ! existing="$(gh label list --repo "${GH_REPO}" --search "${name}" --json name --jq ".[] | select(.name == \"${name}\") | .name" 2>&1)"; then
+              echo "Failed to check for label: ${name}" >&2
+              echo "  create error: ${create_err}" >&2
+              echo "  list error: ${existing}" >&2
+              return 1
+            fi
+            if [[ "${existing}" != "${name}" ]]; then
+              echo "Failed to create or find label: ${name}" >&2
+              return 1
+            fi
+          }
+
           # Resolve the milestone for the version currently being worked on in
           # main, so the auto-created failure issue surfaces in the release
           # view (issue #3064). Source of truth is the root package.json
@@ -139,7 +161,14 @@ jobs:
           CREATE_ARGS=(--repo "${GH_REPO}")
           CREATE_ARGS+=(--title "Smoke test failed on ${REF} @ $(date +'%Y-%m-%d')")
           CREATE_ARGS+=(--body "Smoke test failed. See the full run for details: ${DETAILS_URL}")
-          CREATE_ARGS+=(--label "ci/cd")
+          LABEL_ARGS=()
+          if ensure_label "ci/cd" "e33539" "Issues with github and the workflow scripts and CI CD environment."; then
+            LABEL_ARGS+=(--label "ci/cd")
+          else
+            echo "Warning: continuing without ci/cd label" >&2
+          fi
+
+          CREATE_ARGS+=(${LABEL_ARGS[@]+"${LABEL_ARGS[@]}"})
           # Empty arrays expand to an unbound variable under `set -u` on bash
           # 3.2, so guard every expansion with the `+` alternate form.
           CREATE_ARGS+=(${MILESTONE_ARGS[@]+"${MILESTONE_ARGS[@]}"})

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -93,8 +93,11 @@ jobs:
             # gh issue --milestone accepts a milestone TITLE, not a number.
             # Resolve the title by exact match across ALL open milestone pages,
             # then return it for assignment.
-            local milestone_title
-            milestone_title="$(gh api --paginate --slurp "repos/${GH_REPO}/milestones?state=open&per_page=100" --jq "[.[][] | select(.title == \"${current_version}\")] | .[0].title // empty" 2>/dev/null)"
+            local milestone_title=""
+            if ! milestone_title="$(gh api --paginate --slurp "repos/${GH_REPO}/milestones?state=open&per_page=100" 2>/dev/null | jq -r --arg version "${current_version}" '[.[][] | select(.title == $version)] | .[0].title // empty' 2>/dev/null)"; then
+              echo "Warning: could not list open milestones; skipping milestone assignment" >&2
+              return
+            fi
             if [[ -z "${milestone_title}" ]]; then
               echo "Warning: no open milestone titled '${current_version}'; skipping milestone assignment" >&2
               return

--- a/project-plans/issue3064-auto-issue-metadata.md
+++ b/project-plans/issue3064-auto-issue-metadata.md
@@ -1,0 +1,221 @@
+# Issue #3064 — Auto-created failure issues must carry milestone, label, and type
+
+## Problem
+
+Five workflows create GitHub issues automatically when something fails. They do
+not consistently stamp the metadata needed to triage them, so the issues fall
+out of the release view and get filtered out by hand.
+
+Current state, audited on `main`:
+
+| Site | `ci/cd` label | Milestone | Issue type |
+| --- | --- | --- | --- |
+| `.github/workflows/nightly.yml` (notify_failure) | yes | yes (#3149) | no |
+| `.github/workflows/evals-nightly.yml` (notify) | yes | yes (#3149) | no |
+| `.github/workflows/release.yml` (Create Issue on Failure) | yes | no | no |
+| `.github/workflows/smoke-test.yml` (Create Issue on Failure) | no | no | no |
+| `.github/workflows/ocr-infrastructure-notifier.yml` | yes | no | no |
+
+`.github/scripts/issue-planner.ts` only comments on existing issues, so it is
+out of scope.
+
+## Facts established during research
+
+- Repository issue types are `Task`, `Bug`, `Feature`
+  (`IT_kwDODYHhhs4BsMlP` is `Bug`).
+- `gh issue create` in gh 2.83.2 has `--milestone` but **no** `--type` flag.
+- The REST API does accept a type on update:
+  `gh api -X PATCH repos/OWNER/REPO/issues/N -f type=Bug` was verified live
+  against issue #3064 and returned `{"number":3064,"type":"Bug"}`.
+- Open milestones are titled with bare versions (`0.11.0`, `0.12.0`, …) and
+  `main`'s `package.json` version is `0.11.0`, so exact-title matching against
+  the version works.
+- `nightly.yml` / `evals-nightly.yml` already contain an identical
+  `resolve_milestone()` bash function that reads `package.json` from `main`
+  over the API (their notify jobs have no checkout) and matches an open
+  milestone by exact title, failing soft.
+- `.github/scripts/assign-issue.sh` sources `.github/scripts/assign-constants.sh`
+  and `assign.yml` performs a checkout before running it, so a sourced shared
+  helper in `.github/scripts/` is an established pattern here.
+- `scripts/tests/assign-helpers.ts` executes the real bash scripts against a
+  stateful fake `gh` on `PATH`. That harness style is the model for the tests
+  below.
+
+## Acceptance criteria
+
+**AC1 — label.** Every auto-created failure issue is created with the `ci/cd`
+label.
+
+**AC2 — milestone.** Every auto-created failure issue is assigned the open
+milestone whose title exactly equals the `version` field of `package.json` on
+`main`, resolved at run time.
+
+**AC3 — type.** Every auto-created failure issue is given issue type `Bug`.
+
+**AC4 — recurring issues.** Where a workflow reuses a long-lived open issue
+instead of creating a new one (nightly, evals-nightly, ocr-infrastructure
+notifier), the same milestone and type are re-applied to that issue.
+
+**AC5 — fail soft on metadata, never on notification.** Metadata resolution or
+application that fails must log a warning and leave the notification intact.
+Specifically:
+
+- `package.json` unreadable on `main` → warn, no milestone, issue still created.
+- `package.json` has no `version` → warn, no milestone, issue still created.
+- no open milestone titled with that version → warn, no milestone, issue still
+  created.
+- `gh issue create` output is not a parseable issue URL → warn, no type applied.
+- the type PATCH fails → warn, issue remains created and labelled.
+
+**AC6 — consistent implementation.** All five sites use the same
+`resolve_milestone()` / `apply_issue_type()` bash contract, matching the
+function already shipped in `nightly.yml` and `evals-nightly.yml`.
+
+## Design
+
+### Why the logic is inlined per workflow rather than shared
+
+A sourced helper in `.github/scripts/` was considered and rejected. Three of the
+five jobs (`nightly.yml` notify_failure, `evals-nightly.yml` notify,
+`ocr-infrastructure-notifier.yml`) have no checkout step at all — that is
+precisely why the existing `resolve_milestone()` reads `package.json` over the
+API instead of from disk. `smoke-test.yml` checks out a dispatch-supplied ref
+and `release.yml` a release ref, neither of which is guaranteed to contain a
+newly added helper.
+
+Sharing would therefore require adding five pinned sparse-checkout steps plus a
+`contents: read` permission grant to the privileged `workflow_run`-triggered OCR
+notifier. That is a structural change to job wiring and permissions well beyond
+what this issue asks for, so the logic stays inline. Each site carries a short
+comment pointing at this decision so the duplication reads as deliberate.
+
+### The two bash functions
+
+Added at each site, in the style already used by `nightly.yml`:
+
+- `resolve_milestone` — prints the milestone title on stdout, or nothing. Reads
+  `repos/${GH_REPO}/contents/package.json?ref=main`, extracts `.version`, then
+  exact-matches across all pages of open milestones. Every failure path warns to
+  stderr and returns empty (AC5). This is the function already present in
+  `nightly.yml` and `evals-nightly.yml`, unchanged; it is added verbatim to the
+  other three.
+- `apply_issue_type <issue-number-or-url>` — new. Accepts either a bare number
+  or the URL that `gh issue create` prints, extracts the trailing number, and
+  runs `gh api -X PATCH "repos/${GH_REPO}/issues/N" -f type=Bug`. Warns and
+  returns non-zero on unparseable input or a failed PATCH; callers ignore the
+  status (AC5).
+
+`GH_REPO` and `GH_TOKEN` come from the environment. `smoke-test.yml` and
+`release.yml` currently export `GITHUB_TOKEN` but not `GH_REPO`, so both gain
+`GH_REPO: '${{ github.repository }}'` in their step `env`.
+
+### Per-site changes
+
+1. **nightly.yml** — delete inline `resolve_milestone()`, source the helper,
+   keep `LABEL_ARGS`/`MILESTONE_ARGS`, apply type after create and after the
+   existing-issue comment path.
+2. **evals-nightly.yml** — same as nightly.
+3. **release.yml** — capture the create output, add `--milestone`, apply type.
+4. **smoke-test.yml** — add `--label ci/cd`, `--milestone`, apply type.
+5. **ocr-infrastructure-notifier.yml** — add `--milestone` to
+   `create_infrastructure_issue`, apply type after create, and apply milestone
+   plus type on the two existing-issue comment paths.
+
+`smoke-test.yml` and `release.yml` pass `--label ci/cd` directly with no
+`ensure_label` fallback: the label already exists and a missing label should
+fail loudly rather than be papered over.
+
+## Test plan
+
+Tests are behavioral, not string-matching. Following the
+`scripts/tests/assign-helpers.ts` precedent, a shared harness extracts the real
+`run:` script out of each workflow's notification step, then **executes that
+bash** with a fake `gh` on `PATH`. The fake `gh` is infrastructure: it models
+GitHub API responses from a JSON fixture and appends every invocation's argv to
+a log file. Assertions are made against the recorded argv and the resulting
+fake-API state, so they describe observable behavior rather than source text.
+
+### `scripts/tests/auto-issue-metadata-helpers.ts` (new)
+
+- `notificationScript(workflowPath, jobId, stepName)` — parses the workflow YAML
+  and returns the step's `run:` text and its declared `env` keys.
+- `runNotification({ script, env, fakeGh })` — writes the fake `gh` (and a
+  passthrough `jq`) into a temp `PATH` dir, runs the script under `bash`, and
+  returns `{ status, stdout, stderr, ghCalls }` where `ghCalls` is the parsed
+  argv log.
+- Fixture knobs for the fail-soft paths: `packageJson` (content, or a fetch
+  failure), `milestones` (paged list), and `failOn` (method/endpoint to reject).
+
+### `scripts/tests/auto-issue-metadata.test.ts` (new)
+
+Run once per site via a table over the five workflows, so every case below is
+asserted five times against real execution.
+
+Happy path:
+
+1. The `gh issue create` argv includes `--label ci/cd`.
+2. The `gh issue create` argv includes `--milestone 0.11.0` when `main`'s
+   `package.json` says `0.11.0` and an open milestone of that title exists.
+3. After creation, a `gh api -X PATCH repos/OWNER/REPO/issues/N -f type=Bug`
+   call is recorded with `N` taken from the URL the fake create printed.
+
+Milestone resolution boundaries:
+
+4. No open milestone titled with the current version → no `--milestone` in the
+   create argv, a warning on stderr, and the issue is still created.
+5. `package.json` fetch fails → no `--milestone`, warning, issue still created.
+6. `package.json` has no `version` field → no `--milestone`, warning, issue
+   still created.
+7. Exact-title matching only: an open milestone titled `0.11.0-rc1` does not
+   satisfy version `0.11.0`.
+8. A milestone that appears only on the second page of `milestones?state=open`
+   is still found.
+
+Type application boundaries:
+
+9. The type PATCH failing does not fail the step: exit status stays 0 and the
+   created issue is unaffected.
+10. Create output that is not a parseable issue URL → warning, no PATCH call,
+    step still exits 0.
+
+Recurring-issue paths (nightly, evals-nightly, ocr-infrastructure-notifier):
+
+11. When an open issue with the same title already exists, the step comments on
+    it and records both a milestone edit and a type PATCH for that issue number,
+    and records no `gh issue create`.
+
+Cross-cutting:
+
+12. No site ever exits non-zero solely because milestone or type handling
+    failed.
+
+### Existing tests to update
+
+- `scripts/tests/nightly-notifier-repository.test.ts` and
+  `scripts/tests/nightly-notifier-shell-helpers.ts` parse nightly's inline shell
+  and assert every `gh` invocation targets `GH_REPO`; the new
+  `gh api ... repos/${GH_REPO}/issues/N` call must satisfy that harness.
+- `scripts/tests/evals-nightly-workflow.test.ts`,
+  `scripts/tests/ocr-review-workflow-behaviors.test.ts`,
+  `scripts/tests/ocr-review-workflow.bun.test.ts`, and
+  `scripts/tests/release-process-b.test.ts` assert on exact shell strings at the
+  touched sites and will need their expectations updated to the new argv.
+
+### Existing tests to update
+
+- `scripts/tests/nightly-notifier-repository.test.ts` and
+  `scripts/tests/nightly-notifier-shell-helpers.ts` parse nightly's inline
+  shell; removing inline `resolve_milestone()` and adding a `source` line must
+  keep `gh issue create` repository-targeting assertions passing.
+- `scripts/tests/evals-nightly-workflow.test.ts`,
+  `scripts/tests/ocr-review-workflow-behaviors.test.ts`,
+  `scripts/tests/ocr-review-workflow.bun.test.ts`, and
+  `scripts/tests/release-process-b.test.ts` assert on exact shell strings at the
+  touched sites and will need their expectations updated to the new argv.
+
+## Out of scope
+
+- Changing which issues get created, their titles, bodies, or dedup logic.
+- Backfilling metadata on issues already created.
+- `.github/scripts/issue-planner.ts` (comments only, creates nothing).
+- Any label taxonomy change beyond using the existing `ci/cd` label.

--- a/project-plans/issue3064-auto-issue-metadata.md
+++ b/project-plans/issue3064-auto-issue-metadata.md
@@ -96,9 +96,22 @@ Added at each site, in the style already used by `nightly.yml`:
 - `resolve_milestone` — prints the milestone title on stdout, or nothing. Reads
   `repos/${GH_REPO}/contents/package.json?ref=main`, extracts `.version`, then
   exact-matches across all pages of open milestones. Every failure path warns to
-  stderr and returns empty (AC5). This is the function already present in
-  `nightly.yml` and `evals-nightly.yml`, unchanged; it is added verbatim to the
-  other three.
+  stderr and returns empty (AC5).
+
+  The version of this function shipped in #3149 ran
+  `gh api --paginate --slurp ... --jq ...`, which gh rejects outright:
+  `the --slurp option is not supported with --jq or --template`. Because the
+  resolver fails soft, nightly and evals-nightly carried on and created their
+  issues with **no milestone at all** — the milestone feature has never worked.
+  Resolution now pipes the slurped pages to a real `jq` and passes the version
+  with `--arg`, which also removes the `"${current_version}"` quoting that had
+  to survive a round of shell escaping:
+
+  ```bash
+  gh api --paginate --slurp "repos/${GH_REPO}/milestones?state=open&per_page=100" \
+    | jq -r --arg version "${current_version}" \
+        '[.[][] | select(.title == $version)] | .[0].title // empty'
+  ```
 - `apply_issue_type <issue-number-or-url>` — new. Accepts either a bare number
   or the URL that `gh issue create` prints, extracts the trailing number, and
   runs `gh api -X PATCH "repos/${GH_REPO}/issues/N" -f type=Bug`. Warns and
@@ -121,9 +134,13 @@ Added at each site, in the style already used by `nightly.yml`:
    `create_infrastructure_issue`, apply type after create, and apply milestone
    plus type on the two existing-issue comment paths.
 
-`smoke-test.yml` and `release.yml` pass `--label ci/cd` directly with no
-`ensure_label` fallback: the label already exists and a missing label should
-fail loudly rather than be papered over.
+`smoke-test.yml` and `release.yml` use the same `ensure_label` create-or-verify
+helper as `nightly.yml` and `evals-nightly.yml`. Passing `--label ci/cd`
+directly was tried first and rejected in review: `gh` hard-fails an unknown
+label, and both steps run under the runner's default `bash -e`, so a missing
+label would lose the whole failure notification rather than merely losing the
+label. `ocr-infrastructure-notifier.yml` keeps its existing
+create-then-retry-without-labels fallback, which gives the same guarantee.
 
 ## Test plan
 
@@ -149,7 +166,9 @@ fake-API state, so they describe observable behavior rather than source text.
 ### `scripts/tests/auto-issue-metadata.test.ts` (new)
 
 Run once per site via a table over the five workflows, so every case below is
-asserted five times against real execution.
+asserted five times against real execution. One further case compiles the
+embedded Python so an escaping slip in the fake surfaces directly rather than as
+a retried `gh` error (61 tests total).
 
 Happy path:
 
@@ -212,6 +231,52 @@ Cross-cutting:
   `scripts/tests/ocr-review-workflow.bun.test.ts`, and
   `scripts/tests/release-process-b.test.ts` assert on exact shell strings at the
   touched sites and will need their expectations updated to the new argv.
+
+## Review outcomes
+
+Two review rounds ran: a correctness/intent review and an open code review.
+
+Accepted and fixed:
+
+- **The milestone never resolved.** `gh api --paginate --slurp --jq` is rejected
+  by gh. Fixed at all five sites by piping to external jq (see Design). This
+  defect shipped in #3149 and this branch had copied it to three more files.
+- **The evals reuse path skipped the milestone.** `create_issue_once` returns
+  the number of an issue that appeared after the outer search, in which case
+  `CREATE_ARGS` never applied. Both reuse paths now go through one
+  `annotate_issue` helper, which validates the reference before calling the API
+  so an unparseable one cannot burn four retries and three sleeps.
+- **A missing `ci/cd` label would have lost the notification** in smoke-test and
+  release. Both now use `ensure_label`.
+- **The tests passed against all of the above**, so the harness was hardened:
+  the fake gh models gh's option validation, emits the real `--slurp`
+  page-of-pages shape, requires a title and body on create, records PATCH
+  fields, accepts issue URLs, and fails loudly on anything it does not model.
+  The harness substitutes `${{ }}` in the run body (not just `env`), throws on
+  unmodelled expressions instead of yielding `''`, and invokes bash with the
+  runner's real flags per the step's `shell`.
+- Assorted diagnostics: prerequisite checks naming a missing `python3`/`jq`,
+  spawn errors folded into stderr, a `||` fold that does not drop operands, and
+  corrected warning wording.
+
+Rejected:
+
+- **Share the helpers via a runtime-fetched script for release.yml and
+  smoke-test.yml.** Those two jobs do have checkouts, but the other three
+  notifier jobs do not, so this would leave two divergent mechanisms for the
+  same logic instead of one duplicated one.
+
+## Evidence that the tests are not vacuous
+
+Mutation checks, each re-run after the final refactor:
+
+| Mutation | Result |
+| --- | --- |
+| Reintroduce `--slurp` with `--jq` | 5 tests fail |
+| Change `type=Bug` to `type=Task` | 2 tests fail |
+
+Both mutations passed silently against the harness as first written, which is
+why the harness changes above were necessary.
 
 ## Out of scope
 

--- a/scripts/tests/auto-issue-metadata-helpers.ts
+++ b/scripts/tests/auto-issue-metadata-helpers.ts
@@ -156,8 +156,11 @@ def handle_api(argv, state, state_file):
                 applied = field.split("=", 1)[1]
         sys.stdout.write(json.dumps({"number": num, "type": applied}) + "\n")
         return 0
-    sys.stdout.write("{}\n")
-    return 0
+    # Fail loudly rather than returning an empty object. A permissive default
+    # would let a workflow call an endpoint this fake does not model and still
+    # go green, which is precisely the class of bug these tests exist to catch.
+    sys.stderr.write("fake-gh: unmodeled api endpoint: %s %s\n" % (method, path))
+    return 1
 
 def issue_reference(token):
     """gh accepts an issue number or an issue URL wherever it takes an issue."""
@@ -229,10 +232,20 @@ def handle_issue(argv, state, state_file):
         return 0
     if sub == "close":
         return 0
-    return 0
+    sys.stderr.write("fake-gh: unmodeled issue subcommand: %s\n" % sub)
+    return 1
 
 def handle_label(argv, state):
     sub = argv[0] if argv else ""
+    if sub == "create":
+        opts, pairs, tokens = parse_args(argv[1:])
+        name = tokens[0] if tokens else None
+        # gh label create fails when the label already exists; ensure_label
+        # relies on that to fall through to its label list check.
+        if name in (state.get("labels") or {}):
+            sys.stderr.write("HTTP 422: Label already exists\n")
+            return 1
+        return 0
     if sub == "list":
         opts, pairs, tokens = parse_args(argv[1:])
         search = next(iter(pairs.get("--search", [])), "")
@@ -240,7 +253,8 @@ def handle_label(argv, state):
         names = [name for name in state.get("labels") or {} if not search or name == search]
         sys.stdout.write(jq_output(json.dumps([{"name": n} for n in names]), jq))
         return 0
-    return 0
+    sys.stderr.write("fake-gh: unmodeled label subcommand: %s\n" % sub)
+    return 1
 
 def main():
     argv = sys.argv[1:]
@@ -259,7 +273,8 @@ def main():
         elif argv[0] == "label":
             status = handle_label(argv[1:], state)
         else:
-            status = 0
+            sys.stderr.write("fake-gh: unmodeled command: %s\n" % " ".join(argv))
+            status = 1
     finally:
         if call_log:
             with open(call_log, "a") as f:
@@ -341,35 +356,66 @@ export interface RunNotificationResult {
   ghCalls: GhCall[];
 }
 
+/** Context expressions with a fixed value, keyed by the expression text. */
+const CONTEXT_EXPRESSIONS: Record<string, (fake: FakeMetadataState) => string> =
+  {
+    'github.repository': (fake) => fake.repo ?? REPO_DEFAULT,
+    'secrets.GITHUB_TOKEN': () => 'gh-token',
+    'github.token': () => 'gh-token',
+    'github.server_url': () => 'https://github.com',
+    'github.run_id': (fake) => fake.runId ?? '123456',
+    'github.event.inputs.ref': (fake) => fake.ref ?? 'main',
+    'github.event.workflow_run.html_url': (fake) =>
+      `https://github.com/${fake.repo ?? REPO_DEFAULT}/actions/runs/${fake.runId ?? '123456'}`,
+    'needs.classify-ocr-run.result': () => 'success',
+    'needs.classify-ocr-run.outputs.classification': (fake) =>
+      fake.results?.['classification'] ?? 'infrastructure-failure',
+  };
+
+const NEEDS_RESULT = /^needs\.([A-Za-z0-9_-]+)\.result$/;
+const JOB_OR_STEP_OUTPUT =
+  /^(?:needs|steps)\.[A-Za-z0-9_-]+\.outputs\.[A-Za-z0-9_-]+$/;
+const QUOTED_LITERAL = /^'(.*)'$|^"(.*)"$/;
+
+/**
+ * Resolve `a || b || c` by folding over EVERY operand.
+ *
+ * Destructuring just the first two would silently drop the tail and
+ * mis-render the script under test.
+ */
+function resolveFallbackChain(text: string, fake: FakeMetadataState): string {
+  for (const operand of text.split('||')) {
+    const term = operand.trim();
+    const literal = QUOTED_LITERAL.exec(term);
+    const value =
+      literal === null
+        ? resolveExpression(term, fake)
+        : (literal[1] ?? literal[2] ?? '');
+    if (value !== '') {
+      return value;
+    }
+  }
+  return '';
+}
+
 function resolveExpression(expr: string, fake: FakeMetadataState): string {
   const text = expr.trim();
-  if (text === 'github.repository') return fake.repo ?? REPO_DEFAULT;
-  if (text === 'secrets.GITHUB_TOKEN' || text === 'github.token')
-    return 'gh-token';
-  if (text === 'github.server_url') return 'https://github.com';
-  if (text === 'github.run_id') return fake.runId ?? '123456';
-  if (text === 'github.event.inputs.ref') return fake.ref ?? 'main';
-  if (text === 'github.event.workflow_run.html_url') {
-    return `https://github.com/${fake.repo ?? REPO_DEFAULT}/actions/runs/${fake.runId ?? '123456'}`;
-  }
-  if (text === 'needs.classify-ocr-run.result') return 'success';
-  if (text === 'needs.classify-ocr-run.outputs.classification') {
-    return fake.results?.['classification'] ?? 'infrastructure-failure';
+  const context = CONTEXT_EXPRESSIONS[text];
+  if (context) {
+    return context(fake);
   }
   if (text.includes('||')) {
-    const [candidate, fallback] = text.split('||');
-    const base = resolveExpression(candidate, fake);
-    const fallbackValue = fallback.trim().replace(/^['"]|['"]$/g, '');
-    return base !== '' ? base : fallbackValue;
+    return resolveFallbackChain(text, fake);
   }
-  const needsResult = /^needs\.([A-Za-z0-9_-]+)\.result$/.exec(text);
-  if (needsResult)
+  const needsResult = NEEDS_RESULT.exec(text);
+  if (needsResult) {
     return fake.results?.[`${needsResult[1]}.result`] ?? 'failure';
+  }
   // A job or step output that was never set is legitimately empty on the
   // runner, so '' here is faithful rather than a silent hole.
-  const output =
-    /^(?:needs|steps)\.[A-Za-z0-9_-]+\.outputs\.[A-Za-z0-9_-]+$/.exec(text);
-  if (output) return fake.outputs?.[text] ?? '';
+  if (JOB_OR_STEP_OUTPUT.test(text)) {
+    return fake.outputs?.[text] ?? '';
+  }
   // Returning '' for an unknown expression silently changes the script under
   // test -- an unresolved `${{ }}` left in the run body is a bash "bad
   // substitution", which would drop whole arguments while the test still
@@ -448,9 +494,31 @@ function shellArgv(shell: string | undefined, scriptPath: string): string[] {
  * argv to `GH_CALL_LOG`. GitHub `${{ ... }}` expressions in the step env are
  * resolved deterministically.
  */
+/**
+ * Fail with a named binary rather than an opaque assertion.
+ *
+ * The fake `gh` is Python and delegates `--jq` to a real jq, and the notifier
+ * scripts pipe through jq themselves. A missing interpreter makes `gh` exit
+ * non-zero, which those scripts treat as an ordinary API failure and retry
+ * past -- so the suite would fail with a blank, misleading diff instead of
+ * saying the tool is absent.
+ */
+export function assertHarnessPrerequisites(): void {
+  for (const binary of ['python3', 'jq']) {
+    const probe = spawnSync(binary, ['--version'], { stdio: 'ignore' });
+    if (probe.error || probe.status !== 0) {
+      throw new Error(
+        `auto-issue-metadata tests require '${binary}' on PATH (the fake gh is ` +
+          `Python and the notifier scripts pipe through jq)`,
+      );
+    }
+  }
+}
+
 export function runNotification(
   opts: RunNotificationOptions,
 ): RunNotificationResult {
+  assertHarnessPrerequisites();
   const dir = mkdtempSync(path.join(tmpdir(), 'issue3064-metadata-'));
   const stateFile = path.join(dir, 'state.json');
   const callLog = path.join(dir, 'calls.jsonl');
@@ -490,10 +558,17 @@ export function runNotification(
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     const ghCalls = readCallLog(callLog);
+    // Fold a spawn failure into stderr. Without it a bash that never started,
+    // or one killed by a signal, reports status 1 with empty output and no
+    // clue why -- painful to diagnose as an intermittent CI failure.
+    const spawnError = result.error
+      ? `
+spawn failed: ${String(result.error)}`
+      : '';
     return {
       status: result.status ?? 1,
       stdout: result.stdout ?? '',
-      stderr: result.stderr ?? '',
+      stderr: `${result.stderr ?? ''}${spawnError}`,
       ghCalls,
     };
   } finally {

--- a/scripts/tests/auto-issue-metadata-helpers.ts
+++ b/scripts/tests/auto-issue-metadata-helpers.ts
@@ -1,0 +1,414 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Test helpers for the auto-created-failure-issue metadata behavioral tests.
+ *
+ * These helpers extract the real `run:` script from a workflow's notification
+ * step and execute that bash against a stateful fake `gh` on PATH. The fake
+ * gh is infrastructure — it models GitHub API responses from a JSON fixture and
+ * appends every invocation's argv to a log. Assertions are made against the
+ * recorded argv and the resulting fake-API state, never against workflow source
+ * text.
+ */
+
+import { spawnSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  mkdirSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { parseWorkflowYaml } from './typed-test-helpers.ts';
+
+const REPO_DEFAULT = 'vybestack/llxprt-code';
+
+/**
+ * The fake `gh` executable. Models just enough of the GitHub REST surface the
+ * notifier scripts touch: package.json raw content, paged open milestones,
+ * issue list/create/comment/edit/close, label list, auth status, and the
+ * issue type PATCH. Every invocation is appended to the call log for argv
+ * assertions; a `failOn` rule can make a specific method/endpoint fail.
+ */
+const FAKE_GH_SOURCE = String.raw`#!/usr/bin/env python3
+import json, os, re, subprocess, sys
+
+VALUE_FLAGS = {
+    "-X", "--method", "-H", "--header", "-f", "--raw-field", "-F", "--field",
+    "--input", "--jq", "-q", "--search", "--json", "--limit", "--title",
+    "--body", "--body-file", "--milestone", "--label", "--repo", "--color",
+    "--description",
+}
+
+def load(path):
+    with open(path) as f:
+        return json.load(f)
+
+def save(path, state):
+    with open(path, "w") as f:
+        json.dump(state, f)
+
+def should_fail(state, method, path):
+    for rule in state.get("failOn") or []:
+        if rule.get("method", method) != method:
+            continue
+        if rule.get("path") and rule.get("path") not in path:
+            continue
+        return True
+    return False
+
+def jq_output(data, expr, slurp=False):
+    if expr is None:
+        return data
+    cmd = ["jq"] + (["-s", "-r", expr] if slurp else ["-r", expr])
+    proc = subprocess.run(cmd, input=data, capture_output=True, text=True)
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr)
+        sys.exit(proc.returncode)
+    return proc.stdout
+
+def parse_args(argv):
+    opts = {"method": "GET", "paginate": False, "slurp": False}
+    pairs = {}
+    tokens = []
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a in ("-X", "--method"):
+            opts["method"] = argv[i + 1].upper()
+            i += 2
+        elif a == "--paginate":
+            opts["paginate"] = True
+            i += 1
+        elif a == "--slurp":
+            opts["slurp"] = True
+            i += 1
+        elif a in VALUE_FLAGS:
+            if i + 1 < len(argv):
+                pairs.setdefault(a, []).append(argv[i + 1])
+                i += 2
+            else:
+                i += 1
+        else:
+            tokens.append(a)
+            i += 1
+    return opts, pairs, tokens
+
+def handle_api(argv, state, state_file):
+    opts, pairs, tokens = parse_args(argv)
+    method = opts["method"]
+    path = (tokens[0] if tokens else "").lstrip("/")
+    if should_fail(state, method, path):
+        sys.stderr.write("HTTP 500: %s failed\n" % path)
+        return 1
+    if "contents/package.json" in path:
+        if state.get("packageJsonFail"):
+            sys.stderr.write("HTTP 500: package.json fetch failed\n")
+            return 1
+        pj = state.get("packageJson", "{}\n")
+        sys.stdout.write(pj)
+        if not pj.endswith("\n"):
+            sys.stdout.write("\n")
+        return 0
+    if "milestones" in path:
+        items = state.get("milestones", [])
+        per_page = state.get("pageSize") or 100
+        pages = [items[i:i + per_page] for i in range(0, len(items), per_page)]
+        if not pages:
+            pages = [[]]
+        jq = next(iter(pairs.get("--jq", []) + pairs.get("-q", [])), None)
+        if opts["slurp"]:
+            data = "\n".join(json.dumps(p) for p in pages)
+            sys.stdout.write(jq_output(data, jq, slurp=True))
+        elif opts["paginate"]:
+            outs = [jq_output(json.dumps(p), jq) for p in pages]
+            sys.stdout.write("\n".join(outs) + "\n")
+        else:
+            sys.stdout.write(jq_output(json.dumps(pages[0]), jq))
+        return 0
+    m = re.match(r"^repos/[^/]+/[^/]+/issues/(\d+)$", path)
+    if m and method == "PATCH":
+        num = int(m.group(1))
+        state.setdefault("patched", []).append({"number": num})
+        save(state_file, state)
+        sys.stdout.write(json.dumps({"number": num, "type": "Bug"}) + "\n")
+        return 0
+    sys.stdout.write("{}\n")
+    return 0
+
+def handle_issue(argv, state, state_file):
+    sub = argv[0] if argv else ""
+    if sub == "list":
+        opts, pairs, tokens = parse_args(argv[1:])
+        search = next(iter(pairs.get("--search", [])), "")
+        jq = next(iter(pairs.get("--jq", []) + pairs.get("-q", [])), None)
+        fields = [f for f in next(iter(pairs.get("--json", [])), "number,title").split(",") if f]
+        m = re.search(r'"([^"]*)"', search)
+        title = m.group(1) if m else None
+        objs = [
+            {k: it.get(k) for k in fields}
+            for it in state.get("issues", [])
+            if it.get("state") in (None, "open") and (title is None or it.get("title") == title)
+        ]
+        sys.stdout.write(jq_output(json.dumps(objs), jq))
+        return 0
+    if sub == "create":
+        if should_fail(state, "POST", "issue/create"):
+            sys.stderr.write("HTTP 500: issue create failed\n")
+            return 1
+        num = state.get("nextIssueNumber", 4242)
+        state["nextIssueNumber"] = num + 1
+        state.setdefault("created", []).append({"number": num})
+        save(state_file, state)
+        out = state.get("issueCreateOutput")
+        if out is None:
+            out = "https://github.com/%s/issues/%d" % (state.get("repo", "vybestack/llxprt-code"), num)
+        sys.stdout.write(out + "\n")
+        return 0
+    if sub == "comment":
+        opts, pairs, tokens = parse_args(argv[1:])
+        state.setdefault("commented", []).append({"number": int(tokens[0]) if tokens else None})
+        save(state_file, state)
+        return 0
+    if sub == "edit":
+        opts, pairs, tokens = parse_args(argv[1:])
+        state.setdefault("edited", []).append({
+            "number": int(tokens[0]) if tokens else None,
+            "milestone": next(iter(pairs.get("--milestone", [])), None),
+        })
+        save(state_file, state)
+        return 0
+    if sub == "close":
+        return 0
+    return 0
+
+def handle_label(argv, state):
+    sub = argv[0] if argv else ""
+    if sub == "list":
+        opts, pairs, tokens = parse_args(argv[1:])
+        search = next(iter(pairs.get("--search", [])), "")
+        jq = next(iter(pairs.get("--jq", []) + pairs.get("-q", [])), None)
+        names = [name for name in state.get("labels") or {} if not search or name == search]
+        sys.stdout.write(jq_output(json.dumps([{"name": n} for n in names]), jq))
+        return 0
+    return 0
+
+def main():
+    argv = sys.argv[1:]
+    state_file = os.environ.get("GH_FAKE_STATE", "")
+    call_log = os.environ.get("GH_CALL_LOG", "")
+    state = load(state_file)
+    status = 0
+    try:
+        if len(argv) >= 2 and argv[0] == "auth" and argv[1] == "status":
+            if state.get("authStatusFail"):
+                status = 1
+        elif argv[0] == "api":
+            status = handle_api(argv[1:], state, state_file)
+        elif argv[0] == "issue":
+            status = handle_issue(argv[1:], state, state_file)
+        elif argv[0] == "label":
+            status = handle_label(argv[1:], state)
+        else:
+            status = 0
+    finally:
+        if call_log:
+            with open(call_log, "a") as f:
+                f.write(json.dumps({"argv": argv, "status": status}) + "\n")
+    sys.exit(status)
+
+if __name__ == "__main__":
+    main()
+`;
+
+export interface FakeIssue {
+  title: string;
+  number: number;
+  state?: string;
+  labels?: string[];
+  milestone?: { title?: string; number?: number };
+}
+
+export interface FailOnRule {
+  method?: string;
+  path?: string;
+}
+
+export interface FakeMetadataState {
+  repo?: string;
+  packageJson?: string;
+  packageJsonFail?: boolean;
+  pageSize?: number;
+  milestones?: Array<{ title: string; state?: string }>;
+  issues?: FakeIssue[];
+  labels?: Record<string, { name: string }>;
+  nextIssueNumber?: number;
+  issueCreateOutput?: string;
+  authStatusFail?: boolean;
+  failOn?: FailOnRule[];
+  runId?: string;
+  ref?: string;
+  results?: Record<string, string>;
+}
+
+export interface NotificationScript {
+  run: string;
+  env: Record<string, string>;
+}
+
+export interface RunNotificationOptions {
+  script: string;
+  env: Record<string, string>;
+  fake: FakeMetadataState;
+}
+
+export interface GhCall {
+  argv: string[];
+  status: number;
+}
+
+export interface RunNotificationResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+  ghCalls: GhCall[];
+}
+
+function resolveExpression(expr: string, fake: FakeMetadataState): string {
+  const text = expr.trim();
+  if (text === 'github.repository') return fake.repo ?? REPO_DEFAULT;
+  if (text === 'secrets.GITHUB_TOKEN' || text === 'github.token')
+    return 'gh-token';
+  if (text === 'github.server_url') return 'https://github.com';
+  if (text === 'github.run_id') return fake.runId ?? '123456';
+  if (text === 'github.event.inputs.ref') return fake.ref ?? 'main';
+  if (text === 'github.event.workflow_run.html_url') {
+    return `https://github.com/${fake.repo ?? REPO_DEFAULT}/actions/runs/${fake.runId ?? '123456'}`;
+  }
+  if (text === 'needs.classify-ocr-run.result') return 'success';
+  if (text === 'needs.classify-ocr-run.outputs.classification') {
+    return fake.results?.['classification'] ?? 'infrastructure-failure';
+  }
+  if (text.includes('||')) {
+    const [candidate, fallback] = text.split('||');
+    const base = resolveExpression(candidate, fake);
+    const fallbackValue = fallback.trim().replace(/^['"]|['"]$/g, '');
+    return base !== '' ? base : fallbackValue;
+  }
+  const needsResult = /^needs\.([A-Za-z0-9_-]+)\.result$/.exec(text);
+  if (needsResult)
+    return fake.results?.[`${needsResult[1]}.result`] ?? 'failure';
+  return '';
+}
+
+function substituteExpressions(text: string, fake: FakeMetadataState): string {
+  // No `\s*` padding around the lazy group: adjacent optional-whitespace and
+  // lazy-any quantifiers give the engine an ambiguous split to backtrack over.
+  // `resolveExpression` trims, so the padding buys nothing.
+  return text.replace(/\$\{\{([\s\S]*?)\}\}/g, (_match, exprBody: string) =>
+    resolveExpression(exprBody, fake),
+  );
+}
+
+/**
+ * Parse a workflow file and pull the `run:` text plus declared `env` of one
+ * step. GitHub `${{ ... }}` placeholders are left intact here; they are
+ * resolved inside `runNotification`.
+ */
+export function notificationScript(
+  workflowPath: string,
+  jobId: string,
+  stepName: string,
+): NotificationScript {
+  const source = readFileSync(
+    path.join(path.resolve(import.meta.dirname, '../..'), workflowPath),
+    'utf8',
+  );
+  const workflow = parseWorkflowYaml(source);
+  const job = workflow?.jobs?.[jobId];
+  if (job?.steps === undefined) {
+    throw new Error(
+      `workflow ${workflowPath} must define job ${jobId} with steps`,
+    );
+  }
+  const step = job.steps.find((candidate) => candidate.name === stepName);
+  if (!step) {
+    throw new Error(`job ${jobId} must define step ${stepName}`);
+  }
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(step.env ?? {})) {
+    env[key] = String(value);
+  }
+  return { run: String(step.run ?? ''), env };
+}
+
+/**
+ * Execute the extracted real shell against the fake `gh` on PATH. The fake gh
+ * reads the JSON fixture from `GH_FAKE_STATE` and appends every invocation's
+ * argv to `GH_CALL_LOG`. GitHub `${{ ... }}` expressions in the step env are
+ * resolved deterministically.
+ */
+export function runNotification(
+  opts: RunNotificationOptions,
+): RunNotificationResult {
+  const dir = mkdtempSync(path.join(tmpdir(), 'issue3064-metadata-'));
+  const stateFile = path.join(dir, 'state.json');
+  const callLog = path.join(dir, 'calls.jsonl');
+  const binDir = path.join(dir, 'bin');
+  const workDir = path.join(dir, 'work');
+  rmSync(workDir, { recursive: true, force: true });
+  mkdirSync(binDir, { recursive: true });
+  mkdirSync(workDir, { recursive: true });
+  writeFileSync(path.join(binDir, 'gh'), FAKE_GH_SOURCE, { mode: 0o755 });
+  writeFileSync(stateFile, JSON.stringify(opts.fake));
+
+  const env: Record<string, string> = {
+    ...process.env,
+    PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+    GH_FAKE_STATE: stateFile,
+    GH_CALL_LOG: callLog,
+    GH_REPO: opts.fake.repo ?? REPO_DEFAULT,
+    GH_TOKEN: 'gh-token',
+    GITHUB_STEP_SUMMARY: path.join(dir, 'step-summary.md'),
+  };
+  for (const [key, value] of Object.entries(opts.env)) {
+    env[key] = substituteExpressions(value, opts.fake);
+  }
+
+  try {
+    const result = spawnSync('bash', ['-c', opts.script], {
+      cwd: workDir,
+      encoding: 'utf8',
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const ghCalls = readCallLog(callLog);
+    return {
+      status: result.status ?? 1,
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+      ghCalls,
+    };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function readCallLog(callLog: string): GhCall[] {
+  let content: string;
+  try {
+    content = readFileSync(callLog, 'utf8');
+  } catch {
+    return [];
+  }
+  return content
+    .split('\n')
+    .filter((line) => line.trim() !== '')
+    .map((line) => JSON.parse(line) as GhCall);
+}

--- a/scripts/tests/auto-issue-metadata-helpers.ts
+++ b/scripts/tests/auto-issue-metadata-helpers.ts
@@ -265,8 +265,8 @@ def handle_label(argv, state, state_file):
         return 0
     if sub == "list":
         opts, pairs, tokens = parse_args(argv[1:])
-        if should_fail(state, "GET", "issue/list"):
-            sys.stderr.write("HTTP 500: issue list failed\n")
+        if should_fail(state, "GET", "label/list"):
+            sys.stderr.write("HTTP 500: label list failed\n")
             return 1
         search = next(iter(pairs.get("--search", [])), "")
         jq = next(iter(pairs.get("--jq", []) + pairs.get("-q", [])), None)

--- a/scripts/tests/auto-issue-metadata-helpers.ts
+++ b/scripts/tests/auto-issue-metadata-helpers.ts
@@ -174,6 +174,9 @@ def handle_issue(argv, state, state_file):
     sub = argv[0] if argv else ""
     if sub == "list":
         opts, pairs, tokens = parse_args(argv[1:])
+        if should_fail(state, "GET", "issue/list"):
+            sys.stderr.write("HTTP 500: issue list failed\n")
+            return 1
         search = next(iter(pairs.get("--search", [])), "")
         jq = next(iter(pairs.get("--jq", []) + pairs.get("-q", [])), None)
         fields = [f for f in next(iter(pairs.get("--json", [])), "number,title").split(",") if f]
@@ -262,6 +265,9 @@ def handle_label(argv, state, state_file):
         return 0
     if sub == "list":
         opts, pairs, tokens = parse_args(argv[1:])
+        if should_fail(state, "GET", "issue/list"):
+            sys.stderr.write("HTTP 500: issue list failed\n")
+            return 1
         search = next(iter(pairs.get("--search", [])), "")
         jq = next(iter(pairs.get("--jq", []) + pairs.get("-q", [])), None)
         names = [name for name in state.get("labels") or {} if not search or name == search]

--- a/scripts/tests/auto-issue-metadata-helpers.ts
+++ b/scripts/tests/auto-issue-metadata-helpers.ts
@@ -179,6 +179,15 @@ def handle_issue(argv, state, state_file):
         fields = [f for f in next(iter(pairs.get("--json", [])), "number,title").split(",") if f]
         m = re.search(r'"([^"]*)"', search)
         title = m.group(1) if m else None
+        # Models an issue opened by a concurrent run: invisible to the first N
+        # searches, visible afterwards. Exercises the create_issue_once guard.
+        hide_until = state.get("issuesVisibleAfterListCalls")
+        seen = state.get("listCalls", 0) + 1
+        state["listCalls"] = seen
+        save(state_file, state)
+        if hide_until is not None and seen <= hide_until:
+            sys.stdout.write(jq_output(json.dumps([]), jq))
+            return 0
         objs = [
             {k: it.get(k) for k in fields}
             for it in state.get("issues", [])
@@ -235,7 +244,7 @@ def handle_issue(argv, state, state_file):
     sys.stderr.write("fake-gh: unmodeled issue subcommand: %s\n" % sub)
     return 1
 
-def handle_label(argv, state):
+def handle_label(argv, state, state_file):
     sub = argv[0] if argv else ""
     if sub == "create":
         opts, pairs, tokens = parse_args(argv[1:])
@@ -245,6 +254,11 @@ def handle_label(argv, state):
         if name in (state.get("labels") or {}):
             sys.stderr.write("HTTP 422: Label already exists\n")
             return 1
+        # Persist it, so a later label list sees it the way real GitHub would.
+        labels = state.get("labels") or {}
+        labels[name] = {"name": name}
+        state["labels"] = labels
+        save(state_file, state)
         return 0
     if sub == "list":
         opts, pairs, tokens = parse_args(argv[1:])
@@ -271,7 +285,7 @@ def main():
         elif argv[0] == "issue":
             status = handle_issue(argv[1:], state, state_file)
         elif argv[0] == "label":
-            status = handle_label(argv[1:], state)
+            status = handle_label(argv[1:], state, state_file)
         else:
             sys.stderr.write("fake-gh: unmodeled command: %s\n" % " ".join(argv))
             status = 1
@@ -327,6 +341,14 @@ export interface FakeMetadataState {
   results?: Record<string, string>;
   /** Values for `needs.*.outputs.*` / `steps.*.outputs.*` expressions. */
   outputs?: Record<string, string>;
+  /**
+   * Hide `issues` from the first N `gh issue list` calls.
+   *
+   * Models an issue opened by a concurrent run between the notifier's initial
+   * search and its create attempt, which is the window the `create_issue_once`
+   * guard exists to close.
+   */
+  issuesVisibleAfterListCalls?: number;
 }
 
 export interface NotificationScript {

--- a/scripts/tests/auto-issue-metadata-helpers.ts
+++ b/scripts/tests/auto-issue-metadata-helpers.ts
@@ -104,6 +104,18 @@ def handle_api(argv, state, state_file):
     opts, pairs, tokens = parse_args(argv)
     method = opts["method"]
     path = (tokens[0] if tokens else "").lstrip("/")
+    jq = next(iter(pairs.get("--jq", []) + pairs.get("-q", [])), None)
+    # Real gh validates these combinations before issuing any request. Both
+    # messages and exit codes were captured from gh 2.83.2; modelling them is
+    # what stops a workflow that cannot run in CI from passing these tests.
+    if opts["slurp"] and jq is not None:
+        sys.stderr.write(
+            "the --slurp option is not supported with --jq or --template\n"
+        )
+        return 1
+    if opts["slurp"] and not opts["paginate"]:
+        sys.stderr.write("--paginate required when passing --slurp\n")
+        return 1
     if should_fail(state, method, path):
         sys.stderr.write("HTTP 500: %s failed\n" % path)
         return 1
@@ -122,10 +134,10 @@ def handle_api(argv, state, state_file):
         pages = [items[i:i + per_page] for i in range(0, len(items), per_page)]
         if not pages:
             pages = [[]]
-        jq = next(iter(pairs.get("--jq", []) + pairs.get("-q", [])), None)
         if opts["slurp"]:
-            data = "\n".join(json.dumps(p) for p in pages)
-            sys.stdout.write(jq_output(data, jq, slurp=True))
+            # gh --paginate --slurp emits ONE array whose elements are the
+            # per-page arrays, which is why the workflow's jq uses .[][].
+            sys.stdout.write(json.dumps(pages) + "\n")
         elif opts["paginate"]:
             outs = [jq_output(json.dumps(p), jq) for p in pages]
             sys.stdout.write("\n".join(outs) + "\n")
@@ -135,12 +147,25 @@ def handle_api(argv, state, state_file):
     m = re.match(r"^repos/[^/]+/[^/]+/issues/(\d+)$", path)
     if m and method == "PATCH":
         num = int(m.group(1))
-        state.setdefault("patched", []).append({"number": num})
+        fields = pairs.get("-f", []) + pairs.get("--raw-field", [])
+        state.setdefault("patched", []).append({"number": num, "fields": fields})
         save(state_file, state)
-        sys.stdout.write(json.dumps({"number": num, "type": "Bug"}) + "\n")
+        applied = None
+        for field in fields:
+            if field.startswith("type="):
+                applied = field.split("=", 1)[1]
+        sys.stdout.write(json.dumps({"number": num, "type": applied}) + "\n")
         return 0
     sys.stdout.write("{}\n")
     return 0
+
+def issue_reference(token):
+    """gh accepts an issue number or an issue URL wherever it takes an issue."""
+    if token is None:
+        return None
+    tail = token.rstrip("/").rsplit("/", 1)[-1]
+    return int(tail) if tail.isdigit() else None
+
 
 def handle_issue(argv, state, state_file):
     sub = argv[0] if argv else ""
@@ -159,6 +184,16 @@ def handle_issue(argv, state, state_file):
         sys.stdout.write(jq_output(json.dumps(objs), jq))
         return 0
     if sub == "create":
+        opts, pairs, tokens = parse_args(argv[1:])
+        # Real gh refuses to open an issue with no title or no body. Modelling
+        # that is what stops a step whose title/body assignment silently failed
+        # (e.g. an unresolved ${{}} expression) from passing as a success.
+        if not pairs.get("--title"):
+            sys.stderr.write("must provide --title when not running interactively\n")
+            return 1
+        if not pairs.get("--body") and not pairs.get("--body-file"):
+            sys.stderr.write("must provide --body or --body-file\n")
+            return 1
         if should_fail(state, "POST", "issue/create"):
             sys.stderr.write("HTTP 500: issue create failed\n")
             return 1
@@ -173,13 +208,21 @@ def handle_issue(argv, state, state_file):
         return 0
     if sub == "comment":
         opts, pairs, tokens = parse_args(argv[1:])
-        state.setdefault("commented", []).append({"number": int(tokens[0]) if tokens else None})
+        number = issue_reference(tokens[0] if tokens else None)
+        if number is None:
+            sys.stderr.write("invalid issue reference\n")
+            return 1
+        state.setdefault("commented", []).append({"number": number})
         save(state_file, state)
         return 0
     if sub == "edit":
         opts, pairs, tokens = parse_args(argv[1:])
+        number = issue_reference(tokens[0] if tokens else None)
+        if number is None:
+            sys.stderr.write("invalid issue reference\n")
+            return 1
         state.setdefault("edited", []).append({
-            "number": int(tokens[0]) if tokens else None,
+            "number": number,
             "milestone": next(iter(pairs.get("--milestone", [])), None),
         })
         save(state_file, state)
@@ -227,6 +270,18 @@ if __name__ == "__main__":
     main()
 `;
 
+/**
+ * The fake `gh` source, exposed so a test can assert it still compiles.
+ *
+ * It is Python embedded in a TypeScript template literal, so an escaping slip
+ * (a stray backtick, or a `
+` that became a real newline) turns it into a
+ * syntax error. That failure surfaces only as `gh` exiting non-zero, which the
+ * notifier scripts treat as an ordinary API failure and retry past -- so the
+ * suite would go green against a fake that never ran.
+ */
+export const FAKE_GH_PYTHON_SOURCE = FAKE_GH_SOURCE;
+
 export interface FakeIssue {
   title: string;
   number: number;
@@ -255,17 +310,23 @@ export interface FakeMetadataState {
   runId?: string;
   ref?: string;
   results?: Record<string, string>;
+  /** Values for `needs.*.outputs.*` / `steps.*.outputs.*` expressions. */
+  outputs?: Record<string, string>;
 }
 
 export interface NotificationScript {
   run: string;
   env: Record<string, string>;
+  /** The step's declared `shell:`, or undefined when it relies on the default. */
+  shell: string | undefined;
 }
 
 export interface RunNotificationOptions {
   script: string;
   env: Record<string, string>;
   fake: FakeMetadataState;
+  /** The step's declared `shell:`, which decides the runner's bash flags. */
+  shell: string | undefined;
 }
 
 export interface GhCall {
@@ -304,7 +365,18 @@ function resolveExpression(expr: string, fake: FakeMetadataState): string {
   const needsResult = /^needs\.([A-Za-z0-9_-]+)\.result$/.exec(text);
   if (needsResult)
     return fake.results?.[`${needsResult[1]}.result`] ?? 'failure';
-  return '';
+  // A job or step output that was never set is legitimately empty on the
+  // runner, so '' here is faithful rather than a silent hole.
+  const output =
+    /^(?:needs|steps)\.[A-Za-z0-9_-]+\.outputs\.[A-Za-z0-9_-]+$/.exec(text);
+  if (output) return fake.outputs?.[text] ?? '';
+  // Returning '' for an unknown expression silently changes the script under
+  // test -- an unresolved `${{ }}` left in the run body is a bash "bad
+  // substitution", which would drop whole arguments while the test still
+  // passed. Fail loudly instead.
+  throw new Error(
+    `unhandled GitHub expression in workflow step: \${{ ${text} }}`,
+  );
 }
 
 function substituteExpressions(text: string, fake: FakeMetadataState): string {
@@ -345,7 +417,29 @@ export function notificationScript(
   for (const [key, value] of Object.entries(step.env ?? {})) {
     env[key] = String(value);
   }
-  return { run: String(step.run ?? ''), env };
+  return {
+    run: String(step.run ?? ''),
+    env,
+    shell: step.shell === undefined ? undefined : String(step.shell),
+  };
+}
+
+/**
+ * The argv GitHub Actions uses to run a `run:` block.
+ *
+ * `shell: bash` means `bash --noprofile --norc -eo pipefail`; omitting `shell`
+ * on Linux means plain `bash -e`. Both are fail-fast, so running the script
+ * under a bare `bash -c` would let failures the real runner treats as fatal
+ * pass silently here.
+ */
+function shellArgv(shell: string | undefined, scriptPath: string): string[] {
+  if (shell === 'bash') {
+    return ['--noprofile', '--norc', '-eo', 'pipefail', scriptPath];
+  }
+  if (shell === undefined) {
+    return ['-e', scriptPath];
+  }
+  throw new Error(`unsupported step shell: ${shell}`);
 }
 
 /**
@@ -381,8 +475,15 @@ export function runNotification(
     env[key] = substituteExpressions(value, opts.fake);
   }
 
+  // The runner substitutes `${{ }}` in the run body too, not just in env. Left
+  // in place they become bash "bad substitution" errors that silently drop
+  // arguments, so resolve them here and write the result to a real script file
+  // the way the runner does.
+  const scriptPath = path.join(dir, 'step.sh');
+  writeFileSync(scriptPath, substituteExpressions(opts.script, opts.fake));
+
   try {
-    const result = spawnSync('bash', ['-c', opts.script], {
+    const result = spawnSync('bash', shellArgv(opts.shell, scriptPath), {
       cwd: workDir,
       encoding: 'utf8',
       env,

--- a/scripts/tests/auto-issue-metadata.test.ts
+++ b/scripts/tests/auto-issue-metadata.test.ts
@@ -16,7 +16,9 @@
  */
 
 import { describe, expect, it } from 'bun:test';
+import { spawnSync } from 'node:child_process';
 import {
+  FAKE_GH_PYTHON_SOURCE,
   notificationScript,
   runNotification,
   type FakeMetadataState,
@@ -100,7 +102,12 @@ function run(
     site.jobId,
     site.stepName,
   );
-  return runNotification({ script: script.run, env: script.env, fake });
+  return runNotification({
+    script: script.run,
+    env: script.env,
+    shell: script.shell,
+    fake,
+  });
 }
 
 function createCalls(result: {
@@ -111,23 +118,40 @@ function createCalls(result: {
     .map((call) => call.argv);
 }
 
+/**
+ * Issue numbers that received the FULL Bug-type PATCH contract.
+ *
+ * Every part is required: the `api` subcommand, an explicit `-X PATCH`, the
+ * issues endpoint scoped to the expected repository, and `-f type=Bug`.
+ * Matching on the issue number alone would let a PATCH that set the wrong
+ * type, or set no type at all, satisfy these assertions.
+ */
+/** Value of `flag` in an argv, or undefined when the flag is absent. */
+function flagValue(argv: string[], flag: string): string | undefined {
+  const index = argv.indexOf(flag);
+  return index === -1 ? undefined : argv[index + 1];
+}
+
+function isBugTypePatch(argv: string[]): boolean {
+  return (
+    argv[0] === 'api' &&
+    flagValue(argv, '-X') === 'PATCH' &&
+    flagValue(argv, '-f') === 'type=Bug'
+  );
+}
+
 function patchCalls(result: { ghCalls: Array<{ argv: string[] }> }): number[] {
+  const prefix = `repos/${REPO}/issues/`;
   return result.ghCalls
-    .filter(
-      (call) =>
-        call.argv[0] === 'api' && call.argv.some((arg) => arg === 'PATCH'),
+    .filter((call) => isBugTypePatch(call.argv))
+    .map(({ argv }) =>
+      argv.find(
+        (arg) =>
+          arg.startsWith(prefix) && /^\d{1,10}$/.test(arg.slice(prefix.length)),
+      ),
     )
-    .map((call) => {
-      const target = call.argv.find((arg) =>
-        /^repos\/[^/]+\/[^/]+\/issues\/\d+$/.test(arg),
-      );
-      if (target === undefined) {
-        return -1;
-      }
-      // The path already matched the pattern above, so the trailing segment
-      // is known to be digits; slicing avoids a second, backtracking regex.
-      return Number(target.slice(target.lastIndexOf('/') + 1));
-    });
+    .filter((endpoint): endpoint is string => endpoint !== undefined)
+    .map((endpoint) => Number(endpoint.slice(prefix.length)));
 }
 
 function editCalls(result: { ghCalls: Array<{ argv: string[] }> }): string[][] {
@@ -153,6 +177,22 @@ function milestoneArgv(calls: string[][]): string[] {
   }
   return [];
 }
+
+describe('fake gh infrastructure', () => {
+  // The fake is Python inside a TypeScript template literal. An escaping slip
+  // makes it a syntax error, which the notifier scripts see as an ordinary gh
+  // failure and retry past -- leaving the suite green against a fake that
+  // never ran. Compile it directly so that failure is loud.
+  it('is syntactically valid Python', () => {
+    const result = spawnSync(
+      'python3',
+      ['-c', 'import sys; compile(sys.stdin.read(), "fake-gh", "exec")'],
+      { input: FAKE_GH_PYTHON_SOURCE, encoding: 'utf8' },
+    );
+    expect(result.stderr ?? '').toBe('');
+    expect(result.status).toBe(0);
+  });
+});
 
 describe('auto-created failure issues carry label, milestone, and type', () => {
   for (const site of SITES) {

--- a/scripts/tests/auto-issue-metadata.test.ts
+++ b/scripts/tests/auto-issue-metadata.test.ts
@@ -33,6 +33,8 @@ interface Site {
   jobId: string;
   stepName: string;
   existingIssue: boolean;
+  /** Re-searches for the title inside the create retry loop. */
+  racesGuarded: boolean;
 }
 
 const SITES: Site[] = [
@@ -42,6 +44,7 @@ const SITES: Site[] = [
     jobId: 'notify_failure',
     stepName: 'Create Issue on Failure',
     existingIssue: true,
+    racesGuarded: true,
   },
   {
     name: 'evals-nightly',
@@ -49,6 +52,7 @@ const SITES: Site[] = [
     jobId: 'notify_failure',
     stepName: 'Create Issue on Failure',
     existingIssue: true,
+    racesGuarded: true,
   },
   {
     name: 'release',
@@ -56,6 +60,7 @@ const SITES: Site[] = [
     jobId: 'release',
     stepName: 'Create Issue on Failure',
     existingIssue: false,
+    racesGuarded: false,
   },
   {
     name: 'smoke-test',
@@ -63,6 +68,7 @@ const SITES: Site[] = [
     jobId: 'smoke-test',
     stepName: 'Create Issue on Failure',
     existingIssue: false,
+    racesGuarded: false,
   },
   {
     name: 'ocr-infrastructure-notifier',
@@ -70,6 +76,7 @@ const SITES: Site[] = [
     jobId: 'notify-ocr-infrastructure-failure',
     stepName: 'Notify OCR infrastructure failure issue',
     existingIssue: true,
+    racesGuarded: false,
   },
 ];
 
@@ -329,6 +336,41 @@ describe('auto-created failure issues carry label, milestone, and type', () => {
         }
         expect(result.status).toBe(0);
       });
+
+      // Registered only for the sites that actually re-search inside the
+      // create retry loop; an early-returning test body would be a vacuous
+      // pass everywhere else.
+      it.if(site.racesGuarded)(
+        'does not open a duplicate when an issue appears mid-retry',
+        () => {
+          // Invisible to the initial search, visible by the time the notifier
+          // attempts to create. Without the create_issue_once guard the retry
+          // opens a second issue with the same title.
+          const result = run(
+            site,
+            baseFake({
+              issues: [
+                {
+                  number: 77,
+                  title: TITLES[site.name],
+                  state: 'open',
+                  labels: ['ci/cd'],
+                },
+              ],
+              issuesVisibleAfterListCalls: 1,
+            }),
+          );
+          expect(createCalls(result)).toHaveLength(0);
+          expect(result.status).toBe(0);
+          // The race path never applied CREATE_ARGS, so the metadata has to be
+          // applied to the issue that won the race.
+          expect(milestoneArgv(editCalls(result))).toEqual([
+            '--milestone',
+            '0.11.0',
+          ]);
+          expect(patchCalls(result)).toContain(77);
+        },
+      );
 
       it('never exits non-zero solely because metadata handling failed', () => {
         const result = run(site, baseFake({ packageJsonFail: true }));

--- a/scripts/tests/auto-issue-metadata.test.ts
+++ b/scripts/tests/auto-issue-metadata.test.ts
@@ -372,6 +372,24 @@ describe('auto-created failure issues carry label, milestone, and type', () => {
         },
       );
 
+      // A failed lookup is not evidence that no issue exists. Falling through
+      // to create on a lookup error reopens the duplicate window the guard
+      // exists to close, so the notifier must fail closed instead.
+      it.if(site.racesGuarded)(
+        'does not create when the duplicate lookup itself fails',
+        () => {
+          const result = run(
+            site,
+            baseFake({ failOn: [{ method: 'GET', path: 'issue/list' }] }),
+          );
+          expect(createCalls(result)).toHaveLength(0);
+          expect(result.status).not.toBe(0);
+        },
+        // retry_gh burns three 5s sleeps exhausting its attempts against the
+        // failing lookup before the notifier gives up.
+        30_000,
+      );
+
       it('never exits non-zero solely because metadata handling failed', () => {
         const result = run(site, baseFake({ packageJsonFail: true }));
         expect(result.status).toBe(0);

--- a/scripts/tests/auto-issue-metadata.test.ts
+++ b/scripts/tests/auto-issue-metadata.test.ts
@@ -1,0 +1,296 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3064: every auto-created failure issue must carry the `ci/cd` label,
+ * the milestone matching main's package.json version, and issue type `Bug`.
+ *
+ * These are behavioral tests. They extract the REAL `run:` script from each
+ * workflow's notification step and execute it against a stateful fake `gh` on
+ * PATH (see auto-issue-metadata-helpers.ts). Assertions are made against the
+ * recorded gh argv and the resulting fake-API state — never against workflow
+ * source strings.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  notificationScript,
+  runNotification,
+  type FakeMetadataState,
+} from './auto-issue-metadata-helpers.ts';
+
+const REPO = 'vybestack/llxprt-code';
+
+interface Site {
+  name: string;
+  workflowPath: string;
+  jobId: string;
+  stepName: string;
+  existingIssue: boolean;
+}
+
+const SITES: Site[] = [
+  {
+    name: 'nightly',
+    workflowPath: '.github/workflows/nightly.yml',
+    jobId: 'notify_failure',
+    stepName: 'Create Issue on Failure',
+    existingIssue: true,
+  },
+  {
+    name: 'evals-nightly',
+    workflowPath: '.github/workflows/evals-nightly.yml',
+    jobId: 'notify_failure',
+    stepName: 'Create Issue on Failure',
+    existingIssue: true,
+  },
+  {
+    name: 'release',
+    workflowPath: '.github/workflows/release.yml',
+    jobId: 'release',
+    stepName: 'Create Issue on Failure',
+    existingIssue: false,
+  },
+  {
+    name: 'smoke-test',
+    workflowPath: '.github/workflows/smoke-test.yml',
+    jobId: 'smoke-test',
+    stepName: 'Create Issue on Failure',
+    existingIssue: false,
+  },
+  {
+    name: 'ocr-infrastructure-notifier',
+    workflowPath: '.github/workflows/ocr-infrastructure-notifier.yml',
+    jobId: 'notify-ocr-infrastructure-failure',
+    stepName: 'Notify OCR infrastructure failure issue',
+    existingIssue: true,
+  },
+];
+
+const TITLES: Record<string, string> = {
+  nightly: 'Nightly workflow failed',
+  'evals-nightly': 'Evals Nightly workflow failed',
+  release: 'Release Failed for N/A',
+  'smoke-test': 'Smoke test failed on main',
+  'ocr-infrastructure-notifier': 'OCR review infrastructure failure',
+};
+
+function baseFake(
+  overrides: Partial<FakeMetadataState> = {},
+): FakeMetadataState {
+  return {
+    repo: REPO,
+    packageJson: '{\n  "name": "llxprt-code",\n  "version": "0.11.0"\n}\n',
+    milestones: [{ title: '0.11.0', state: 'open' }],
+    labels: { 'ci/cd': { name: 'ci/cd' } },
+    issues: [],
+    ...overrides,
+  };
+}
+
+function run(
+  site: Site,
+  fake: FakeMetadataState,
+): ReturnType<typeof runNotification> {
+  const script = notificationScript(
+    site.workflowPath,
+    site.jobId,
+    site.stepName,
+  );
+  return runNotification({ script: script.run, env: script.env, fake });
+}
+
+function createCalls(result: {
+  ghCalls: Array<{ argv: string[] }>;
+}): string[][] {
+  return result.ghCalls
+    .filter((call) => call.argv[0] === 'issue' && call.argv[1] === 'create')
+    .map((call) => call.argv);
+}
+
+function patchCalls(result: { ghCalls: Array<{ argv: string[] }> }): number[] {
+  return result.ghCalls
+    .filter(
+      (call) =>
+        call.argv[0] === 'api' && call.argv.some((arg) => arg === 'PATCH'),
+    )
+    .map((call) => {
+      const target = call.argv.find((arg) =>
+        /^repos\/[^/]+\/[^/]+\/issues\/\d+$/.test(arg),
+      );
+      if (target === undefined) {
+        return -1;
+      }
+      // The path already matched the pattern above, so the trailing segment
+      // is known to be digits; slicing avoids a second, backtracking regex.
+      return Number(target.slice(target.lastIndexOf('/') + 1));
+    });
+}
+
+function editCalls(result: { ghCalls: Array<{ argv: string[] }> }): string[][] {
+  return result.ghCalls
+    .filter((call) => call.argv[0] === 'issue' && call.argv[1] === 'edit')
+    .map((call) => call.argv);
+}
+
+function commentCalls(result: {
+  ghCalls: Array<{ argv: string[] }>;
+}): string[][] {
+  return result.ghCalls
+    .filter((call) => call.argv[0] === 'issue' && call.argv[1] === 'comment')
+    .map((call) => call.argv);
+}
+
+function milestoneArgv(calls: string[][]): string[] {
+  for (const call of calls) {
+    const index = call.indexOf('--milestone');
+    if (index !== -1) {
+      return [call[index], call[index + 1]];
+    }
+  }
+  return [];
+}
+
+describe('auto-created failure issues carry label, milestone, and type', () => {
+  for (const site of SITES) {
+    describe(site.name, () => {
+      it('passes --label ci/cd on gh issue create', () => {
+        const result = run(site, baseFake());
+        const calls = createCalls(result);
+        expect(calls.length).toBeGreaterThan(0);
+        for (const call of calls) {
+          const index = call.indexOf('--label');
+          expect(index).not.toBe(-1);
+          expect(call[index + 1]).toBe('ci/cd');
+        }
+      });
+
+      it('passes --milestone 0.11.0 matched from main package.json', () => {
+        const result = run(site, baseFake());
+        expect(milestoneArgv(createCalls(result))).toEqual([
+          '--milestone',
+          '0.11.0',
+        ]);
+      });
+
+      it('PATCHes issue type Bug with the number parsed from the create URL', () => {
+        const result = run(site, baseFake({ nextIssueNumber: 4242 }));
+        expect(createCalls(result).length).toBeGreaterThan(0);
+        expect(patchCalls(result)).toContain(4242);
+      });
+
+      it('skips --milestone and still creates when no open milestone matches', () => {
+        const skipped = run(
+          site,
+          baseFake({
+            packageJson:
+              '{\n  "name": "llxprt-code",\n  "version": "0.99.0"\n}\n',
+            milestones: [{ title: '1.0.0', state: 'open' }],
+          }),
+        );
+        expect(milestoneArgv(createCalls(skipped))).toEqual([]);
+        expect(createCalls(skipped).length).toBeGreaterThan(0);
+        expect(skipped.stderr).toContain('no open milestone titled');
+      });
+
+      it('skips --milestone and still creates when package.json fetch fails', () => {
+        const result = run(site, baseFake({ packageJsonFail: true }));
+        expect(milestoneArgv(createCalls(result))).toEqual([]);
+        expect(createCalls(result).length).toBeGreaterThan(0);
+        expect(result.stderr).toContain(
+          'could not read package.json from main',
+        );
+      });
+
+      it('skips --milestone and still creates when package.json has no version', () => {
+        const result = run(
+          site,
+          baseFake({ packageJson: '{\n  "name": "llxprt-code"\n}\n' }),
+        );
+        expect(milestoneArgv(createCalls(result))).toEqual([]);
+        expect(createCalls(result).length).toBeGreaterThan(0);
+        expect(result.stderr).toContain('no version field');
+      });
+
+      it('uses exact-title matching: 0.11.0-rc1 does not satisfy 0.11.0', () => {
+        const result = run(
+          site,
+          baseFake({ milestones: [{ title: '0.11.0-rc1', state: 'open' }] }),
+        );
+        expect(milestoneArgv(createCalls(result))).toEqual([]);
+        expect(result.stderr).toContain('no open milestone titled');
+        expect(createCalls(result).length).toBeGreaterThan(0);
+      });
+
+      it('finds a milestone that appears only on the second page', () => {
+        const result = run(
+          site,
+          baseFake({
+            pageSize: 100,
+            milestones: [
+              ...Array.from({ length: 100 }, (_, i) => ({
+                title: `stale-${i}`,
+                state: 'open',
+              })),
+              { title: '0.11.0', state: 'open' },
+            ],
+          }),
+        );
+        expect(milestoneArgv(createCalls(result))).toEqual([
+          '--milestone',
+          '0.11.0',
+        ]);
+        expect(createCalls(result).length).toBeGreaterThan(0);
+      });
+
+      it('keeps exit status 0 when the type PATCH fails', () => {
+        const result = run(
+          site,
+          baseFake({ failOn: [{ method: 'PATCH', path: 'issues/4242' }] }),
+        );
+        expect(result.status).toBe(0);
+        expect(createCalls(result).length).toBeGreaterThan(0);
+      });
+
+      it('keeps exit status 0 when create output is not a parseable URL', () => {
+        const result = run(
+          site,
+          baseFake({ issueCreateOutput: 'not an issue url' }),
+        );
+        expect(result.status).toBe(0);
+        expect(patchCalls(result)).toHaveLength(0);
+        expect(result.stderr).toContain('could not parse issue reference');
+      });
+
+      it('comments, edits milestone, and PATCHes type on the recurring-issue path', () => {
+        const issue = {
+          number: 42,
+          title: TITLES[site.name],
+          state: 'open',
+          labels: ['ci/cd'],
+        };
+        const result = run(site, baseFake({ issues: [issue] }));
+        if (site.existingIssue) {
+          expect(commentCalls(result).length).toBeGreaterThan(0);
+          expect(createCalls(result)).toHaveLength(0);
+          expect(milestoneArgv(editCalls(result))).toEqual([
+            '--milestone',
+            '0.11.0',
+          ]);
+          expect(patchCalls(result)).toContain(42);
+        } else {
+          expect(createCalls(result).length).toBeGreaterThan(0);
+        }
+        expect(result.status).toBe(0);
+      });
+
+      it('never exits non-zero solely because metadata handling failed', () => {
+        const result = run(site, baseFake({ packageJsonFail: true }));
+        expect(result.status).toBe(0);
+      });
+    });
+  }
+});

--- a/scripts/tests/auto-issue-metadata.test.ts
+++ b/scripts/tests/auto-issue-metadata.test.ts
@@ -18,6 +18,7 @@
 import { describe, expect, it } from 'bun:test';
 import { spawnSync } from 'node:child_process';
 import {
+  assertHarnessPrerequisites,
   FAKE_GH_PYTHON_SOURCE,
   notificationScript,
   runNotification,
@@ -118,14 +119,6 @@ function createCalls(result: {
     .map((call) => call.argv);
 }
 
-/**
- * Issue numbers that received the FULL Bug-type PATCH contract.
- *
- * Every part is required: the `api` subcommand, an explicit `-X PATCH`, the
- * issues endpoint scoped to the expected repository, and `-f type=Bug`.
- * Matching on the issue number alone would let a PATCH that set the wrong
- * type, or set no type at all, satisfy these assertions.
- */
 /** Value of `flag` in an argv, or undefined when the flag is absent. */
 function flagValue(argv: string[], flag: string): string | undefined {
   const index = argv.indexOf(flag);
@@ -140,6 +133,14 @@ function isBugTypePatch(argv: string[]): boolean {
   );
 }
 
+/**
+ * Issue numbers that received the FULL Bug-type PATCH contract.
+ *
+ * Every part is required: the `api` subcommand, an explicit `-X PATCH`, the
+ * issues endpoint scoped to the expected repository, and `-f type=Bug`.
+ * Matching on the issue number alone would let a PATCH that set the wrong
+ * type, or set no type at all, satisfy these assertions.
+ */
 function patchCalls(result: { ghCalls: Array<{ argv: string[] }> }): number[] {
   const prefix = `repos/${REPO}/issues/`;
   return result.ghCalls
@@ -184,6 +185,8 @@ describe('fake gh infrastructure', () => {
   // failure and retry past -- leaving the suite green against a fake that
   // never ran. Compile it directly so that failure is loud.
   it('is syntactically valid Python', () => {
+    // Names the missing interpreter instead of failing on a blank stderr.
+    assertHarnessPrerequisites();
     const result = spawnSync(
       'python3',
       ['-c', 'import sys; compile(sys.stdin.read(), "fake-gh", "exec")'],

--- a/scripts/tests/nightly-notifier-repository.test.ts
+++ b/scripts/tests/nightly-notifier-repository.test.ts
@@ -305,6 +305,56 @@ describe('nightly failure notifier repository targeting', () => {
     },
   );
 
+  // Issue #3064: expanding an EMPTY array as "${NAME[@]}" is an unbound
+  // variable error under `set -u` on bash 3.2, so the notifiers use the `+`
+  // alternate form. The scanner must resolve it exactly like the plain form,
+  // otherwise these repository-targeting assertions would silently stop
+  // covering the guarded call sites.
+  it('resolves the set -u guarded array expansion like the plain form', () => {
+    expect(() =>
+      assertIssueCreateRepositoryTargeting([
+        'LABEL_ARGS=(--label "ci/cd")',
+        'CREATE_ARGS=(--repo "${GH_REPO}" --title title)',
+        'CREATE_ARGS+=(${LABEL_ARGS[@]+"${LABEL_ARGS[@]}"})',
+        'retry_gh gh issue create "${CREATE_ARGS[@]}"',
+      ]),
+    ).not.toThrow();
+  });
+
+  it('resolves a guarded expansion of an empty array', () => {
+    expect(() =>
+      assertIssueCreateRepositoryTargeting([
+        'MILESTONE_ARGS=()',
+        'CREATE_ARGS=(--repo "${GH_REPO}" --title title)',
+        'CREATE_ARGS+=(${MILESTONE_ARGS[@]+"${MILESTONE_ARGS[@]}"})',
+        'retry_gh gh issue create "${CREATE_ARGS[@]}"',
+      ]),
+    ).not.toThrow();
+  });
+
+  it('fails closed when a guarded expansion smuggles in a second repository', () => {
+    expect(() =>
+      assertIssueCreateRepositoryTargeting([
+        'LABEL_ARGS=(--repo other/repo)',
+        'CREATE_ARGS=(--repo "${GH_REPO}" --title title)',
+        'CREATE_ARGS+=(${LABEL_ARGS[@]+"${LABEL_ARGS[@]}"})',
+        'retry_gh gh issue create "${CREATE_ARGS[@]}"',
+      ]),
+    ).toThrow('gh issue create must target GH_REPO');
+  });
+
+  it('fails closed on a guarded expansion whose names disagree', () => {
+    expect(() =>
+      assertIssueCreateRepositoryTargeting([
+        'LABEL_ARGS=(--label "ci/cd")',
+        'MILESTONE_ARGS=(--milestone "0.11.0")',
+        'CREATE_ARGS=(--repo "${GH_REPO}" --title title)',
+        'CREATE_ARGS+=(${LABEL_ARGS[@]+"${MILESTONE_ARGS[@]}"})',
+        'retry_gh gh issue create "${CREATE_ARGS[@]}"',
+      ]),
+    ).toThrow('gh issue create must target GH_REPO');
+  });
+
   it('includes top-level arguments in the effective issue-create argv', () => {
     expect(() =>
       assertIssueCreateRepositoryTargeting([

--- a/scripts/tests/nightly-notifier-shell-helpers.ts
+++ b/scripts/tests/nightly-notifier-shell-helpers.ts
@@ -192,10 +192,30 @@ function consumeGhRepoExpansion(state: ShellState): boolean {
   return true;
 }
 
+/**
+ * Array expansions the scanner resolves back to their source array.
+ *
+ * The guarded form comes first because it is a strict extension of the plain
+ * one. Expanding an EMPTY array as `"${NAME[@]}"` is an "unbound variable"
+ * error under `set -u` on bash 3.2 (still the /bin/bash on macOS), so the
+ * notifier workflows write `${NAME[@]+"${NAME[@]}"}` instead. Both forms must
+ * resolve identically here, otherwise the repository-targeting assertions
+ * below would silently stop covering the guarded call sites.
+ */
+const ARRAY_EXPANSION_PATTERNS: RegExp[] = [
+  /^\$\{([A-Za-z_][A-Za-z0-9_]*)\[@\]\+"\$\{\1\[@\]\}"\}/,
+  /^\$\{([A-Za-z_][A-Za-z0-9_]*)\[@\]\}/,
+];
+
 function consumeArrayExpansion(state: ShellState): boolean {
-  const expansion = /^\$\{([A-Za-z_][A-Za-z0-9_]*)\[@\]\}/.exec(
-    state.line.slice(state.index),
-  );
+  const remainder = state.line.slice(state.index);
+  let expansion: RegExpExecArray | null = null;
+  for (const pattern of ARRAY_EXPANSION_PATTERNS) {
+    expansion = pattern.exec(remainder);
+    if (expansion !== null) {
+      break;
+    }
+  }
   if (expansion === null) {
     return false;
   }

--- a/scripts/tests/ocr-review-workflow-behaviors.test.ts
+++ b/scripts/tests/ocr-review-workflow-behaviors.test.ts
@@ -219,10 +219,13 @@ describe('.github/workflows/ocr-review.yml — issue #2576 hardening behaviors',
     expectContainsAll(notifyRun, [
       'create_infrastructure_issue() {',
       'issue_body_file="$1"',
-      'gh issue create "$@" --body-file "$issue_body_file" --label "ci/cd" 2>"${create_stderr}"',
+      // Issue #3064 adds the release milestone and captures the created issue
+      // URL so the Bug issue type can be applied over REST afterwards.
+      'gh issue create "$@" --body-file "$issue_body_file" --label "ci/cd" ${MILESTONE_ARGS[@]+"${MILESTONE_ARGS[@]}"} >"${created_issue}" 2>"${create_stderr}"',
       'local create_stderr',
       'if grep -Eqi "label|labels|not found|does not exist" "${create_stderr}"; then',
       'gh issue create "$@" --body-file "$issue_body_file"',
+      'apply_issue_type "$(tail -n 1 "${created_issue}")"',
       'Failed to create OCR infrastructure issue.',
     ]);
     expect(notifyRun).not.toContain(

--- a/scripts/tests/ocr-review-workflow.bun.test.ts
+++ b/scripts/tests/ocr-review-workflow.bun.test.ts
@@ -744,9 +744,12 @@ describe('.github/workflows/ocr-review.yml', () => {
       'local create_stderr',
       'issue_body_file="$1"',
       'shift',
-      'gh issue create "$@" --body-file "$issue_body_file" --label "ci/cd" 2>"${create_stderr}"',
+      // Issue #3064 adds the release milestone and captures the created issue
+      // URL so the Bug issue type can be applied over REST afterwards.
+      'gh issue create "$@" --body-file "$issue_body_file" --label "ci/cd" ${MILESTONE_ARGS[@]+"${MILESTONE_ARGS[@]}"} >"${created_issue}" 2>"${create_stderr}"',
       'if grep -Eqi "label|labels|not found|does not exist" "${create_stderr}"; then',
       'gh issue create "$@" --body-file "$issue_body_file"',
+      'apply_issue_type "$(tail -n 1 "${created_issue}")"',
       'Failed to create OCR infrastructure issue.',
       'return 1',
       'create_infrastructure_issue "$body_file"',

--- a/scripts/tests/release-process-b.test.ts
+++ b/scripts/tests/release-process-b.test.ts
@@ -568,7 +568,15 @@ describe('.github/workflows/nightly.yml', () => {
     expect(normalizedRun).toContain('--body-file "${BODY_FILE}"');
     expect(normalizedRun).toContain('${FAILED_JOBS_TEXT}');
     expect(normalizedRun).toContain('${RUN_URL}');
-    expect(normalizedRun).toContain('CREATE_ARGS+=("${LABEL_ARGS[@]}")');
+    // Guarded expansion (issue #3064): an empty array expanded as
+    // "${LABEL_ARGS[@]}" is an unbound-variable error under `set -u` on bash
+    // 3.2, so the notifier uses the `+` alternate form.
+    expect(normalizedRun).toContain(
+      'CREATE_ARGS+=(${LABEL_ARGS[@]+"${LABEL_ARGS[@]}"})',
+    );
+    expect(normalizedRun).toContain(
+      'CREATE_ARGS+=(${MILESTONE_ARGS[@]+"${MILESTONE_ARGS[@]}"})',
+    );
   });
 
   it('updates an existing open nightly failure issue instead of duplicating it', () => {

--- a/scripts/tests/release-process-b.test.ts
+++ b/scripts/tests/release-process-b.test.ts
@@ -563,7 +563,12 @@ describe('.github/workflows/nightly.yml', () => {
     );
     expect(normalizedRun).toContain('if [[ ${#FAILED_JOBS[@]} -eq 0 ]]');
     expect(normalizedRun).toContain('No failed or cancelled jobs detected');
-    expect(normalizedRun).toContain('retry_gh gh issue create');
+    // Creation is still retried, but through the create_issue_once guard:
+    // gh issue create is not idempotent, so retrying it directly could open a
+    // second issue when a create reached GitHub but reported failure.
+    expect(normalizedRun).toContain('retry_gh create_issue_once');
+    expect(normalizedRun).toContain('gh issue create "${CREATE_ARGS[@]}"');
+    expect(normalizedRun).not.toContain('retry_gh gh issue create');
     expect(normalizedRun).toContain('--title "${ISSUE_TITLE}"');
     expect(normalizedRun).toContain('--body-file "${BODY_FILE}"');
     expect(normalizedRun).toContain('${FAILED_JOBS_TEXT}');


### PR DESCRIPTION
## TLDR

Auto-created failure issues now carry the `ci/cd` label, the milestone matching `main`'s `package.json` version, and issue type `Bug`, at all five workflows that open issues on failure.

Reviewers should look hardest at one thing: **the milestone feature added in #3149 has never worked.** Every site ran `gh api --paginate --slurp ... --jq ...`, which gh rejects before making a request:

```
the `--slurp` option is not supported with `--jq` or `--template`
```

The resolver fails soft, so nightly and evals-nightly quietly created their issues with no milestone. This branch had faithfully copied that call into three more workflows before review caught it. Resolution now pipes the slurped pages to a real `jq`.

The second thing worth attention is that **the tests passed against that broken call.** The fake `gh` accepted an option combination real gh rejects. Fixing the harness, not the workflow, was the larger part of the work.

## Dive Deeper

### Starting state

| Site | `ci/cd` label | Milestone | Type |
| --- | --- | --- | --- |
| `nightly.yml` | yes | present but non-functional | no |
| `evals-nightly.yml` | yes | present but non-functional | no |
| `release.yml` | yes | no | no |
| `smoke-test.yml` | no | no | no |
| `ocr-infrastructure-notifier.yml` | yes | no | no |

A repository-wide search confirmed these are the only auto-creation sites. `.github/scripts/issue-planner.ts` only comments, so it is out of scope.

### Issue type

`gh issue create` has no `--type` flag in gh 2.83.2, so the type is applied over REST after creation:

```bash
gh api -X PATCH "repos/${GH_REPO}/issues/${number}" -f type=Bug
```

Verified live against this repository, which returned `{"number":3064,"type":"Bug"}`. The issue number is parsed out of the URL `gh issue create` prints. `apply_issue_type` always returns 0 and warns on failure, because the nightly notifier deliberately bans both `| true` and `|| true` and metadata must never sink a failure notification.

### Recurring issues

Where a workflow reuses a long-lived tracking issue instead of creating one, it re-applies milestone and type rather than stamping only on first creation. In evals-nightly this also covers the inner `create_issue_once` race check, which returns the number of an issue that appeared after the outer search — a path where `CREATE_ARGS` never applied at all.

### Why the helpers are inlined rather than shared

Three of the five notify jobs have no checkout step. That is why the existing `resolve_milestone` reads `package.json` over the API instead of from disk. Sharing would mean adding pinned sparse checkouts plus a `contents: read` grant to the privileged `workflow_run`-triggered OCR notifier. Review pushed back that `release.yml` and `smoke-test.yml` *do* have checkouts; sharing for only those two would leave two divergent mechanisms for one piece of logic, so this was rejected. The function bodies are byte-identical across all five sites.

### Bash portability fix

Every array expansion is guarded as `${ARR[@]+"${ARR[@]}"}`. Expanding an empty array as `"${ARR[@]}"` under `set -u` is an unbound-variable error on bash 3.2, still the `/bin/bash` on macOS, so the #3149 milestone fail-soft path aborted the notifier there. It survived only because CI runs bash 5.

The nightly shell scanner in `nightly-notifier-shell-helpers.ts` learned the guarded form, so its assertion that every `gh` call in the checkout-free notifier targets `GH_REPO` keeps covering those call sites instead of silently going vacuous. Tests cover both the resolving and the fail-closed cases.

### Tests

Behavioral, not string-matching. The harness extracts each workflow's real `run:` script and executes it against a stateful fake `gh` on `PATH`, asserting recorded argv and fake-API state. It substitutes `${{ }}` in the run body as well as `env`, throws on an expression it does not model rather than yielding `''`, and invokes bash with the runner's actual flags for the step's `shell`. The fake models gh's option validation, the real `--slurp` page-of-pages shape, required title/body on create, and fails loudly on anything unmodelled.

Two mutation checks show the suite is not vacuous. Both passed silently before the harness was hardened:

| Mutation | Result |
| --- | --- |
| Reintroduce `--slurp` with `--jq` | 5 tests fail |
| Change `type=Bug` to `type=Task` | 2 tests fail |

61 cases in the new suite, covering per site: the happy path; milestone boundaries (no match, fetch failure, missing `version`, exact-title-only so `0.11.0-rc1` does not satisfy `0.11.0`, second-page pagination); type boundaries (failed PATCH, unparseable create output); and the recurring-issue path. One case compiles the embedded Python so an escaping slip in the fake surfaces directly rather than as a retried gh error.

### Pre-existing assertions that changed

Four pre-existing test files had expectations updated to the new argv. None were deleted or weakened; the OCR ones gained an `apply_issue_type` requirement.

## Reviewer Test Plan

The workflows only run on failure in CI, so the behavioral suite is the practical way to exercise this:

```bash
bun test scripts/tests/auto-issue-metadata.test.ts
```

To confirm the tests actually bite, mutate a workflow and watch them fail:

```bash
# 5 failures expected
sed -i '' 's/-f type=Bug/-f type=Task/' .github/workflows/nightly.yml
bun test scripts/tests/auto-issue-metadata.test.ts
git checkout .github/workflows/nightly.yml
```

To confirm the underlying gh claim first-hand:

```bash
# fails: the --slurp option is not supported with --jq or --template
gh api --paginate --slurp "repos/vybestack/llxprt-code/milestones?state=open" --jq '.[][].title'

# works, and is what the workflows now do
gh api --paginate --slurp "repos/vybestack/llxprt-code/milestones?state=open" \
  | jq -r --arg version "0.11.0" '[.[][] | select(.title == $version)] | .[0].title // empty'
```

Regression suites for the touched workflows:

```bash
bun test scripts/tests/nightly-notifier-repository.test.ts \
         scripts/tests/release-process-b.test.ts \
         scripts/tests/release-process.test.ts \
         scripts/tests/evals-nightly-workflow.test.ts \
         scripts/tests/ocr-review-workflow-behaviors.test.ts \
         scripts/tests/ocr-review-workflow.bun.test.ts
```

And the workflow linter CI runs:

```bash
actionlint -ignore 'SC2002:' -ignore 'SC2016:info' -ignore 'SC2129:' -ignore 'label ".+" is unknown'
```

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | -   | -   |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: `npm run typecheck`, `npm run lint`, `npm run format`, `npm run build`, `actionlint`, YAML parse of all five workflows, and 303 tests across the new suite plus every modified pre-existing suite. The bash 3.2 portability fix above is specifically a macOS-vs-CI difference, and the suite now passes on both bash generations.

The `stepfun-37` profile smoke test reached the provider and was rejected with `400 you have no active step plan subscription`, an account state rather than a code problem; `bun scripts/start.ts --version` and `./packages/cli/bin/llxprt --version` both print `0.11.0`.

## Linked issues / bugs

Fixes #3064

Also repairs the milestone resolution shipped in #3149, which could never have worked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automated failure reports now apply the `ci/cd` label and `Bug` issue type.
  - Reports link to the exact open milestone matching the current package version when available.
  - New and existing issues receive consistent metadata, including recurring and race-detected failures.
  - Created or reused issue references are captured and displayed.
  - Smoke-test reports use the tested commit when no dispatch reference is provided.

- **Bug Fixes**
  - Improved handling of missing metadata, API failures, and optional issue settings.
  - Prevented duplicate issues during retries and empty optional settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->