### PR TITLE
Make slash commands cancellable and keep the prompt live (Fixes #2976)

### DIFF
--- a/packages/cli/src/nonInteractiveCliCommands.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.ts
@@ -64,6 +64,7 @@ export const handleSlashCommand = async (
     const logger = new Logger(config?.getSessionId() ?? '', loggerStorage);
 
     const context: CommandContext = {
+      signal: abortController.signal,
       services: {
         config,
         agent: null,

--- a/packages/cli/src/services/prompt-processors/shellProcessor.test.ts
+++ b/packages/cli/src/services/prompt-processors/shellProcessor.test.ts
@@ -173,6 +173,30 @@ describe('ShellProcessor', () => {
     expect(executionSignal).toBe(invocation.signal);
   });
 
+  it('stops spawning later injections once the invocation is cancelled', async () => {
+    // Cancelling must not keep launching processes for the abandoned prompt.
+    const invocation = new AbortController();
+    const cancellableContext = createMockCommandContext({
+      signal: invocation.signal,
+      invocation: { raw: '/cmd', name: 'cmd', args: '' },
+      services: { config: mockConfig as Config },
+      session: { sessionShellAllowlist: new Set() },
+    });
+    const spawned: string[] = [];
+    mockShellExecute.mockImplementation((command: string) => {
+      spawned.push(command);
+      invocation.abort();
+      return { result: Promise.resolve({ ...SUCCESS_RESULT, aborted: true }) };
+    });
+
+    await new ShellProcessor('test-command').process(
+      '!{git status} then !{pwd} then !{whoami}',
+      cancellableContext,
+    );
+
+    expect(spawned).toEqual(['git status']);
+  });
+
   it('should process multiple valid shell injections if all are allowed', async () => {
     const processor = new ShellProcessor('test-command');
     const prompt = '!{git status} in !{pwd}';

--- a/packages/cli/src/services/prompt-processors/shellProcessor.test.ts
+++ b/packages/cli/src/services/prompt-processors/shellProcessor.test.ts
@@ -139,6 +139,40 @@ describe('ShellProcessor', () => {
     expect(result).toBe('The current status is: On branch main');
   });
 
+  it('hands the injected shell command the live invocation signal', async () => {
+    // Before issue #2976 this was a throwaway controller, so Esc could never
+    // reach the injected process. Aborting the invocation must be observable
+    // at the shell boundary through the very signal it was handed.
+    const invocation = new AbortController();
+    const cancellableContext = createMockCommandContext({
+      signal: invocation.signal,
+      invocation: { raw: '/cmd', name: 'cmd', args: '' },
+      services: { config: mockConfig as Config },
+      session: { sessionShellAllowlist: new Set() },
+    });
+    let executionSignal: AbortSignal | undefined;
+    mockShellExecute.mockImplementation(
+      (
+        _command: string,
+        _cwd: string,
+        _onOutput: () => void,
+        signal: AbortSignal,
+      ) => {
+        executionSignal = signal;
+        return { result: Promise.resolve(SUCCESS_RESULT) };
+      },
+    );
+
+    await new ShellProcessor('test-command').process(
+      'status: !{git status}',
+      cancellableContext,
+    );
+
+    // Identity, not shape: the shell boundary must receive the very signal the
+    // framework will abort, so Esc reaches the running process.
+    expect(executionSignal).toBe(invocation.signal);
+  });
+
   it('should process multiple valid shell injections if all are allowed', async () => {
     const processor = new ShellProcessor('test-command');
     const prompt = '!{git status} in !{pwd}';

--- a/packages/cli/src/services/prompt-processors/shellProcessor.ts
+++ b/packages/cli/src/services/prompt-processors/shellProcessor.ts
@@ -110,6 +110,7 @@ export class ShellProcessor implements IPromptProcessor {
       resolvedInjections,
       config,
       userArgsRaw,
+      context.signal,
     );
   }
 
@@ -168,6 +169,7 @@ export class ShellProcessor implements IPromptProcessor {
     resolvedInjections: ShellInjection[],
     config: ShellProcessorRuntime,
     userArgsRaw: string,
+    signal: AbortSignal,
   ): Promise<string> {
     // Resolve the aggregate injection-output budget from the configured shell
     // acquisition setting so prompt injection is bounded by the same finite
@@ -182,6 +184,9 @@ export class ShellProcessor implements IPromptProcessor {
     let lastIndex = 0;
 
     for (const injection of resolvedInjections) {
+      // Once the invocation is cancelled, spawning the remaining injections
+      // would start processes for work the user just abandoned.
+      if (signal.aborted) break;
       // Literal text BEFORE this injection, substituting {{args}} with RAW input.
       const segment = prompt.substring(lastIndex, injection.startIndex);
       builder.appendLiteral(
@@ -196,7 +201,9 @@ export class ShellProcessor implements IPromptProcessor {
           injection.resolvedCommand,
           config.getTargetDir(),
           () => {},
-          new AbortController().signal,
+          // The invocation's cancellation signal, so Esc actually kills the
+          // injected shell command instead of orphaning it (issue #2976).
+          signal,
           config.getShouldUseNodePtyShell(),
           config.getShellExecutionConfig(),
         );

--- a/packages/cli/src/test-utils/mockCommandContext.ts
+++ b/packages/cli/src/test-utils/mockCommandContext.ts
@@ -25,6 +25,7 @@ type DeepPartial<T> = T extends object
  * @returns A complete, mocked CommandContext object.
  */
 const buildDefaultMocks = (): CommandContext => ({
+  signal: new AbortController().signal,
   invocation: {
     raw: '',
     name: '',

--- a/packages/cli/src/ui/commands/authCommand.codex.test.ts
+++ b/packages/cli/src/ui/commands/authCommand.codex.test.ts
@@ -45,6 +45,7 @@ describe('AuthCommand Codex OAuth Integration', () => {
     executor = new AuthCommandExecutor(mockOAuthManager);
 
     mockContext = {
+      signal: new AbortController().signal,
       services: {
         config: null,
         agent: null,

--- a/packages/cli/src/ui/commands/imageCommand.test.ts
+++ b/packages/cli/src/ui/commands/imageCommand.test.ts
@@ -240,13 +240,15 @@ describe('imageCommand', () => {
     expect(capturedSignal?.aborted).toBe(true);
   });
 
-  it('reports nothing when the runner rejects because the invocation was cancelled', async () => {
-    // The framework already added the cancellation notice; a second error item
-    // would be noise.
+  it('reports nothing for any rejection once the invocation is cancelled', async () => {
+    // Cancellation discards the invocation's outcome uniformly: the framework
+    // already added the cancellation notice, and a failure that merely raced
+    // the Esc describes work the user abandoned. Deliberately a non-abort
+    // error so the rule is not mistaken for abort-error sniffing.
     const invocation = new AbortController();
     const runner = vi.fn().mockImplementation(async () => {
       invocation.abort();
-      throw new Error('The operation was aborted.');
+      throw new Error('provider returned 500');
     });
     const ctx = makeMockContext({
       runImageOperation: runner,

--- a/packages/cli/src/ui/commands/imageCommand.test.ts
+++ b/packages/cli/src/ui/commands/imageCommand.test.ts
@@ -7,6 +7,7 @@
 import { waitFor } from '@vybestack/llxprt-code-test-utils';
 import { describe, it, expect, vi } from 'bun:test';
 import { imageCommand } from './imageCommand.js';
+import { assertTruthy } from '../../test-utils/assertions.js';
 import { MessageType } from '../types.js';
 import type { CommandContext } from './types.js';
 
@@ -48,12 +49,14 @@ function makeMockContext(overrides?: {
     outputPath: string;
     inputPaths: readonly string[];
   }) => Promise<{ absoluteOutputPath: string }>;
+  signal?: AbortSignal;
 }): CommandContext {
   const capability =
     overrides?.runImageOperation !== undefined
       ? new ImageCapabilityHolder(overrides.runImageOperation)
       : new ImageCapabilityHolder();
   return {
+    signal: overrides?.signal ?? new AbortController().signal,
     services: {
       // The holder INSTANCE is the config, so `getRunImageOperation` is reached
       // through the prototype with the instance as receiver. It is deliberately
@@ -154,7 +157,8 @@ describe('imageCommand', () => {
       prompt: 'draw a cat',
       outputPath: 'out.png',
       inputPaths: [],
-      signal: expect.any(AbortSignal),
+      // The framework's invocation signal, not one the command minted itself.
+      signal: ctx.signal,
     });
     const calls = (ctx.ui.addItem as ReturnType<typeof vi.fn>).mock.calls;
     const infoCall = calls.find(
@@ -176,7 +180,7 @@ describe('imageCommand', () => {
       prompt: 'fix the text',
       outputPath: 'fixed.png',
       inputPaths: ['original.png'],
-      signal: expect.any(AbortSignal),
+      signal: ctx.signal,
     });
   });
 
@@ -192,7 +196,7 @@ describe('imageCommand', () => {
     expect((errorCall![0] as { text: string }).text).toContain('provider down');
   });
 
-  it('aborts the runner signal when SIGINT is emitted during the operation', async () => {
+  it('aborts the runner mid-operation when the invocation is cancelled', async () => {
     let capturedSignal: AbortSignal | undefined;
     let releaseRunner: () => void = () => {};
     const gate = new Promise<void>((resolve) => {
@@ -208,7 +212,7 @@ describe('imageCommand', () => {
           signal: AbortSignal;
         }) => {
           capturedSignal = req.signal;
-          // Hold until SIGINT is emitted so the abort happens mid-operation.
+          // Hold until the invocation is cancelled so the abort lands mid-run.
           await gate;
           if (req.signal.aborted) {
             throw new Error('The operation was aborted.');
@@ -216,7 +220,11 @@ describe('imageCommand', () => {
           return { absoluteOutputPath: '/workspace/out.png' };
         },
       );
-    const ctx = makeMockContext({ runImageOperation: runner });
+    const invocation = new AbortController();
+    const ctx = makeMockContext({
+      runImageOperation: runner,
+      signal: invocation.signal,
+    });
     const actionPromise = imageCommand.action?.(
       ctx,
       'out.png "draw a cat"',
@@ -225,31 +233,68 @@ describe('imageCommand', () => {
     // Wait for the runner to capture the signal.
     await waitFor(() => expect(capturedSignal).toBeDefined());
     expect(capturedSignal?.aborted).toBe(false);
-    process.emit('SIGINT');
+    invocation.abort();
     releaseRunner();
     await actionPromise;
 
     expect(capturedSignal?.aborted).toBe(true);
   });
 
-  it('removes the SIGINT listener after a successful operation (no leak)', async () => {
-    const runner = vi.fn().mockResolvedValue({
-      absoluteOutputPath: '/workspace/out.png',
+  it('reports nothing when the runner rejects because the invocation was cancelled', async () => {
+    // The framework already added the cancellation notice; a second error item
+    // would be noise.
+    const invocation = new AbortController();
+    const runner = vi.fn().mockImplementation(async () => {
+      invocation.abort();
+      throw new Error('The operation was aborted.');
     });
-    const ctx = makeMockContext({ runImageOperation: runner });
-    const before = process.listenerCount('SIGINT');
+    const ctx = makeMockContext({
+      runImageOperation: runner,
+      signal: invocation.signal,
+    });
+
     await imageCommand.action?.(ctx, 'out.png "draw a cat"');
-    const after = process.listenerCount('SIGINT');
-    expect(after).toBe(before);
+
+    expect((ctx.ui.addItem as ReturnType<typeof vi.fn>).mock.calls).toEqual([]);
   });
 
-  it('removes the SIGINT listener after a failed operation (no leak)', async () => {
-    const runner = vi.fn().mockRejectedValue(new Error('fail'));
+  it('no longer reacts to a process SIGINT, only to the framework signal', async () => {
+    // The command used to abort on its own SIGINT listener, which never fires
+    // for Esc in the Ink UI and leaked across invocations. Emitting SIGINT
+    // mid-operation must now leave the operation untouched.
+    let capturedSignal: AbortSignal | undefined;
+    let releaseRunner: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseRunner = resolve;
+    });
+    const runner = vi
+      .fn()
+      .mockImplementation(async (req: { signal: AbortSignal }) => {
+        capturedSignal = req.signal;
+        await gate;
+        return { absoluteOutputPath: '/workspace/out.png' };
+      });
     const ctx = makeMockContext({ runImageOperation: runner });
-    const before = process.listenerCount('SIGINT');
-    await imageCommand.action?.(ctx, 'out.png "draw a cat"');
-    const after = process.listenerCount('SIGINT');
-    expect(after).toBe(before);
+    // Keep node from applying its default SIGINT behaviour to the emit below.
+    const keepAlive = () => {};
+    process.on('SIGINT', keepAlive);
+    try {
+      const pending = imageCommand.action?.(ctx, 'out.png "draw a cat"');
+      await waitFor(() => expect(capturedSignal).toBeDefined());
+      process.emit('SIGINT');
+      releaseRunner();
+      await pending;
+    } finally {
+      process.removeListener('SIGINT', keepAlive);
+    }
+
+    assertTruthy(capturedSignal);
+    expect(capturedSignal.aborted).toBe(false);
+    const calls = (ctx.ui.addItem as ReturnType<typeof vi.fn>).mock.calls;
+    const infoCall = calls.find(
+      (c) => (c[0] as { type: string }).type === MessageType.INFO,
+    );
+    expect(infoCall).toBeDefined();
   });
 
   it('exercises receiver binding: a prototype-method capability works via the runtime wrapper', async () => {

--- a/packages/cli/src/ui/commands/imageCommand.test.ts
+++ b/packages/cli/src/ui/commands/imageCommand.test.ts
@@ -260,6 +260,32 @@ describe('imageCommand', () => {
     expect((ctx.ui.addItem as ReturnType<typeof vi.fn>).mock.calls).toEqual([]);
   });
 
+  it('reports nothing when the runner wins a race with the cancellation', async () => {
+    // The framework already said the command was cancelled; announcing a saved
+    // path on top of that contradicts it.
+    const invocation = new AbortController();
+    let releaseRunner: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseRunner = resolve;
+    });
+    const runner = vi.fn().mockImplementation(async () => {
+      await gate;
+      return { absoluteOutputPath: '/workspace/out.png' };
+    });
+    const ctx = makeMockContext({
+      runImageOperation: runner,
+      signal: invocation.signal,
+    });
+
+    const pending = imageCommand.action?.(ctx, 'out.png "draw a cat"');
+    await waitFor(() => expect(runner).toHaveBeenCalled());
+    invocation.abort();
+    releaseRunner();
+    await pending;
+
+    expect((ctx.ui.addItem as ReturnType<typeof vi.fn>).mock.calls).toEqual([]);
+  });
+
   it('no longer reacts to a process SIGINT, only to the framework signal', async () => {
     // The command used to abort on its own SIGINT listener, which never fires
     // for Esc in the Ink UI and leaked across invocations. Emitting SIGINT

--- a/packages/cli/src/ui/commands/imageCommand.ts
+++ b/packages/cli/src/ui/commands/imageCommand.ts
@@ -81,6 +81,10 @@ export const imageCommand: SlashCommand = {
         signal: context.signal,
       });
 
+      // The runner can win a race with the abort. Reporting success on top of
+      // the framework's cancellation notice would contradict it.
+      if (context.signal.aborted) return;
+
       context.ui.addItem(
         {
           type: MessageType.INFO,

--- a/packages/cli/src/ui/commands/imageCommand.ts
+++ b/packages/cli/src/ui/commands/imageCommand.ts
@@ -69,21 +69,16 @@ export const imageCommand: SlashCommand = {
     }
 
     const verb = parsed.operation === 'generate' ? 'Generated' : 'Edited';
-    // The slash-command action API has no cancellation signal. Follow the
-    // established process SIGINT pattern (cf. imageModeDispatch): register a
-    // one-shot SIGINT listener that aborts a controller scoped to this
-    // operation's lifetime. The signal is forwarded to the common runner so
-    // the backend/write honor it. The listener is ALWAYS removed (finally) so
-    // no listener leaks across success/failure/cancellation.
-    const controller = new AbortController();
-    const onSigInt = () => controller.abort();
-    process.once('SIGINT', onSigInt);
+    // context.signal is the framework's per-invocation cancellation signal: it
+    // aborts on Esc in the interactive UI and on the process abort controller
+    // in non-interactive mode. Forwarding it to the common runner is what makes
+    // the backend request and the output write stop.
     try {
       const result = await runner({
         prompt: parsed.prompt,
         outputPath: parsed.outputPath,
         inputPaths: parsed.inputPaths,
-        signal: controller.signal,
+        signal: context.signal,
       });
 
       context.ui.addItem(
@@ -94,6 +89,9 @@ export const imageCommand: SlashCommand = {
         Date.now(),
       );
     } catch (error) {
+      // A rejection after cancellation is the expected shape of "the user
+      // pressed Esc"; the framework already reported it in history.
+      if (context.signal.aborted) return;
       const message = error instanceof Error ? error.message : String(error);
       context.ui.addItem(
         {
@@ -102,8 +100,6 @@ export const imageCommand: SlashCommand = {
         },
         Date.now(),
       );
-    } finally {
-      process.removeListener('SIGINT', onSigInt);
     }
   },
 

--- a/packages/cli/src/ui/commands/setupGithubCommand.test.ts
+++ b/packages/cli/src/ui/commands/setupGithubCommand.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { automock } from '@vybestack/llxprt-code-test-utils';
+import { automock, waitFor } from '@vybestack/llxprt-code-test-utils';
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs/promises';
@@ -58,6 +58,16 @@ void vi.mock('../../utils/gitUtils.js', () => ({
 void vi.mock('../utils/commandUtils.js', () => ({
   getUrlOpenCommand: vi.fn(),
 }));
+
+/**
+ * The command only reads `signal` off the context, so a minimal context with a
+ * real signal is enough and keeps the fixture honest about what is required.
+ */
+function makeContext(signal?: AbortSignal): CommandContext {
+  return {
+    signal: signal ?? new AbortController().signal,
+  } as CommandContext;
+}
 
 describe('setupGithubCommand', () => {
   let scratchDir = '';
@@ -118,7 +128,7 @@ describe('setupGithubCommand', () => {
     ).mockReturnValueOnce('fakeOpenCommand');
 
     const result = (await setupGithubCommand.action?.(
-      {} as CommandContext,
+      makeContext(),
       '',
     )) as ToolActionReturn;
 
@@ -199,7 +209,7 @@ describe('setupGithubCommand', () => {
     ).mockReturnValueOnce('fakeOpenCommand');
 
     const result = (await setupGithubCommand.action?.(
-      {} as CommandContext,
+      makeContext(),
       '',
     )) as ToolActionReturn;
 
@@ -267,8 +277,55 @@ describe('setupGithubCommand', () => {
     });
 
     await expect(
-      setupGithubCommand.action?.({} as CommandContext, ''),
+      setupGithubCommand.action?.(makeContext(), ''),
     ).rejects.toThrow(/Invalid response code downloading.*404 - Not Found/);
+  });
+
+  it('aborts the in-flight downloads when the invocation is cancelled', async () => {
+    const fakeRepoRoot = scratchDir;
+    const invocation = new AbortController();
+    let downloadSignal: AbortSignal | undefined;
+
+    // Behave like a real fetch: stay pending until the caller's signal aborts.
+    (global.fetch as Mock<typeof global.fetch>).mockImplementation(
+      (_url, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          if (!signal) throw new Error('fetch was called without a signal');
+          downloadSignal = signal;
+          signal.addEventListener('abort', () => {
+            reject(new Error('This operation was aborted'));
+          });
+        }),
+    );
+
+    (
+      gitUtils.isGitHubRepository as Mock<typeof gitUtils.isGitHubRepository>
+    ).mockReturnValueOnce(true);
+    (
+      gitUtils.getGitRepoRoot as Mock<typeof gitUtils.getGitRepoRoot>
+    ).mockReturnValueOnce(fakeRepoRoot);
+    (
+      gitUtils.getLatestGitHubRelease as Mock<
+        typeof gitUtils.getLatestGitHubRelease
+      >
+    ).mockResolvedValueOnce('v1.2.3');
+    (
+      gitUtils.getGitHubRepoInfo as Mock<typeof gitUtils.getGitHubRepoInfo>
+    ).mockReturnValue({ owner: 'fake', repo: 'repo' });
+
+    const pending = setupGithubCommand.action?.(
+      makeContext(invocation.signal),
+      '',
+    );
+    // The download is genuinely in flight; nothing has settled it yet.
+    await waitFor(() => expect(downloadSignal).toBeDefined());
+
+    invocation.abort();
+
+    // The download can only unwind here because the invocation signal is part
+    // of the composed signal handed to fetch.
+    await expect(pending).rejects.toThrow(/aborted/i);
   });
 });
 

--- a/packages/cli/src/ui/commands/setupGithubCommand.ts
+++ b/packages/cli/src/ui/commands/setupGithubCommand.ts
@@ -106,12 +106,17 @@ async function downloadFiles({
   targetDir,
   proxy,
   abortController,
+  signal,
 }: {
   paths: string[];
   releaseTag: string;
   targetDir: string;
   proxy: string | undefined;
+  /** Shared per-batch controller; aborted once the batch settles so the
+   * outstanding fetch timeouts are released. */
   abortController: AbortController;
+  /** The command invocation's cancellation signal (Esc / process abort). */
+  signal: AbortSignal;
 }): Promise<void> {
   const downloads = [];
   for (const fileBasename of paths) {
@@ -124,6 +129,7 @@ async function downloadFiles({
           signal: AbortSignal.any([
             AbortSignal.timeout(30_000),
             abortController.signal,
+            signal,
           ]),
         } as RequestInit);
 
@@ -177,10 +183,12 @@ async function downloadSetupFiles({
   configs,
   releaseTag,
   proxy,
+  signal,
 }: {
   configs: Array<{ paths: string[]; targetDir: string }>;
   releaseTag: string;
   proxy: string | undefined;
+  signal: AbortSignal;
 }): Promise<void> {
   try {
     await Promise.all(
@@ -192,6 +200,7 @@ async function downloadSetupFiles({
           targetDir,
           proxy,
           abortController,
+          signal,
         });
       }),
     );
@@ -247,6 +256,7 @@ export const setupGithubCommand: SlashCommand = {
       ],
       releaseTag,
       proxy,
+      signal: context.signal,
     });
 
     // Add entries to .gitignore file

--- a/packages/cli/src/ui/commands/tasksCommand.test.ts
+++ b/packages/cli/src/ui/commands/tasksCommand.test.ts
@@ -32,6 +32,7 @@ describe('tasksCommand', () => {
     addItemMock = vi.fn();
 
     context = {
+      signal: new AbortController().signal,
       services: {
         config: {
           getAsyncTaskManager: () => asyncTaskManager,

--- a/packages/cli/src/ui/commands/test/subagentCommand.test.ts
+++ b/packages/cli/src/ui/commands/test/subagentCommand.test.ts
@@ -171,6 +171,7 @@ const createTestContext = ({
   };
 
   return {
+    signal: new AbortController().signal,
     invocation: {
       raw: '',
       name: '',

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -39,6 +39,15 @@ import type { SubagentView } from '../components/SubagentManagement/types.js';
 
 // Grouped dependencies for clarity and easier mocking
 export interface CommandContext {
+  /**
+   * Aborted when the user cancels this slash-command invocation with Esc in
+   * the interactive UI. In non-interactive mode this is the run-level abort
+   * controller's signal, which that path aborts on its own terms.
+   *
+   * Long-running actions must forward this to whatever they await so the work
+   * actually stops instead of being abandoned in the background.
+   */
+  signal: AbortSignal;
   // Invocation properties for when commands are called.
   invocation?: {
     /** The raw, untrimmed input string from the user. */

--- a/packages/cli/src/ui/containers/AppContainer/hooks/useAppInput.inputActive.test.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useAppInput.inputActive.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the composer-visibility rule. InlineContent renders no
+ * Composer when this returns false, so these cases are literally "is the input
+ * prompt on screen".
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  computeIsInputActive,
+  computeIsAwaitingSlashCommandConfirmation,
+} from './useAppInput.js';
+import type { IsInputActiveInputs } from './useAppInput.js';
+import { StreamingState, ToolCallStatus } from '../../../types.js';
+import type { HistoryItemWithoutId } from '../../../types.js';
+
+const idleAndReady: IsInputActiveInputs = {
+  streamingState: StreamingState.Idle,
+  initError: null,
+  hasSlashCommands: true,
+  isAwaitingSlashCommandConfirmation: false,
+};
+
+function toolGroup(status: ToolCallStatus): HistoryItemWithoutId {
+  return {
+    type: 'tool_group',
+    tools: [
+      {
+        callId: 'call-1',
+        name: 'Expansion',
+        description: 'Command expansion needs shell access',
+        status,
+        resultDisplay: undefined,
+        confirmationDetails: undefined,
+      },
+    ],
+  };
+}
+
+describe('computeIsInputActive', () => {
+  it('shows the prompt when the session is idle and ready', () => {
+    expect(computeIsInputActive(idleAndReady)).toBe(true);
+  });
+
+  it('hides the prompt while a slash command waits on a confirmation', () => {
+    expect(
+      computeIsInputActive({
+        ...idleAndReady,
+        isAwaitingSlashCommandConfirmation: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps the prompt up while the model is responding', () => {
+    expect(
+      computeIsInputActive({
+        ...idleAndReady,
+        streamingState: StreamingState.Responding,
+      }),
+    ).toBe(true);
+  });
+
+  it('hides the prompt while a tool call awaits confirmation', () => {
+    expect(
+      computeIsInputActive({
+        ...idleAndReady,
+        streamingState: StreamingState.WaitingForConfirmation,
+      }),
+    ).toBe(false);
+  });
+
+  it('hides the prompt when initialization failed', () => {
+    expect(computeIsInputActive({ ...idleAndReady, initError: 'boom' })).toBe(
+      false,
+    );
+  });
+
+  it('hides the prompt before the slash commands have loaded', () => {
+    expect(
+      computeIsInputActive({ ...idleAndReady, hasSlashCommands: false }),
+    ).toBe(false);
+  });
+});
+
+describe('computeIsAwaitingSlashCommandConfirmation', () => {
+  it('is false when nothing is pending', () => {
+    expect(computeIsAwaitingSlashCommandConfirmation([])).toBe(false);
+  });
+
+  it('is true while a shell-expansion approval is on screen', () => {
+    expect(
+      computeIsAwaitingSlashCommandConfirmation([
+        toolGroup(ToolCallStatus.Confirming),
+      ]),
+    ).toBe(true);
+  });
+
+  it('is false for a pending item that is merely progress, not a question', () => {
+    // Commands may park a pending item as a progress indicator; that must not
+    // take the prompt away (issue #2976).
+    expect(
+      computeIsAwaitingSlashCommandConfirmation([
+        toolGroup(ToolCallStatus.Executing),
+      ]),
+    ).toBe(false);
+  });
+
+  it('is false for pending items that are not tool groups', () => {
+    expect(
+      computeIsAwaitingSlashCommandConfirmation([
+        { type: 'info', text: 'working' },
+      ]),
+    ).toBe(false);
+  });
+});

--- a/packages/cli/src/ui/containers/AppContainer/hooks/useAppInput.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useAppInput.ts
@@ -17,7 +17,12 @@ import { useVim } from '../../../hooks/vim.js';
 import { useTextBuffer } from '../../../components/shared/text-buffer.js';
 import { useInputHistoryStore } from '../../../hooks/useInputHistoryStore.js';
 import { shouldClearTodos } from '../../../hooks/useTodoPausePreserver.js';
-import { StreamingState, type HistoryItem } from '../../../types.js';
+import {
+  StreamingState,
+  ToolCallStatus,
+  type HistoryItem,
+  type HistoryItemWithoutId,
+} from '../../../types.js';
 import { submitOAuthCode } from '../../../oauth-submission.js';
 import { getPendingOAuthProvider } from '../../../oauthGlobalState.js';
 import type { EditorType } from '@vybestack/llxprt-code-core';
@@ -358,6 +363,7 @@ function useInputStreamSetup(
     p.subagentManager,
     removeItems,
     p.operationLifecycle,
+    core.cancelActiveSlashCommand,
   );
   return { ...bufferSetup, agentStreamResult };
 }
@@ -440,12 +446,57 @@ function useInputStream(
   return { ...setupRest, ...wiring };
 }
 
+export interface IsInputActiveInputs {
+  streamingState: StreamingState;
+  initError: string | null;
+  hasSlashCommands: boolean;
+  /** True while a slash command is blocked on a shell-expansion approval. */
+  isAwaitingSlashCommandConfirmation: boolean;
+}
+
+/**
+ * True when a slash command has put a confirmation on screen that owns the
+ * keyboard. `confirm_action` renders through the dialog manager, which
+ * replaces the whole inline layout; `confirm_shell_commands` instead parks a
+ * Confirming tool group in the processor's pending items, which is what this
+ * detects.
+ */
+export function computeIsAwaitingSlashCommandConfirmation(
+  pendingItems: readonly HistoryItemWithoutId[],
+): boolean {
+  return pendingItems.some(
+    (item) =>
+      item.type === 'tool_group' &&
+      item.tools.some((tool) => tool.status === ToolCallStatus.Confirming),
+  );
+}
+
+/**
+ * Decides whether the composer is rendered.
+ *
+ * This deliberately does NOT key off the slash-command pipeline being busy.
+ * Doing so hid the prompt for the entire duration of a long command
+ * (issue #2976). The composer only has to stand down when something else owns
+ * the keyboard, which is what the streaming and confirmation terms cover.
+ */
+export function computeIsInputActive(inputs: IsInputActiveInputs): boolean {
+  const isStreamingIdleOrResponding =
+    inputs.streamingState === StreamingState.Idle ||
+    inputs.streamingState === StreamingState.Responding;
+  return (
+    isStreamingIdleOrResponding &&
+    !inputs.initError &&
+    inputs.hasSlashCommands &&
+    !inputs.isAwaitingSlashCommandConfirmation
+  );
+}
+
 function useInputFinish(
   p: AppInputParams,
   core: ReturnType<typeof useInputCore>,
   stream: ReturnType<typeof useInputStream>,
 ) {
-  const { settings, setIdePromptAnswered, isProcessing } = p;
+  const { settings, setIdePromptAnswered } = p;
   const { handleSlashCommand, vimModeEnabled, vimMode, toggleVimEnabled } =
     core;
   const {
@@ -496,14 +547,13 @@ function useInputFinish(
   const handleSettingsRestart = useCallback(() => {
     void handleSlashCommand('/quit');
   }, [handleSlashCommand]);
-  const isStreamingIdleOrResponding =
-    streamingState === StreamingState.Idle ||
-    streamingState === StreamingState.Responding;
-  const isInputActive =
-    isStreamingIdleOrResponding &&
-    !initError &&
-    !isProcessing &&
-    !!slashCommands;
+  const isInputActive = computeIsInputActive({
+    streamingState,
+    initError,
+    hasSlashCommands: !!slashCommands,
+    isAwaitingSlashCommandConfirmation:
+      computeIsAwaitingSlashCommandConfirmation(core.pendingHistoryItems),
+  });
   return {
     handleIdePromptComplete,
     vimHandleInput,

--- a/packages/cli/src/ui/contexts/__tests__/todoProvider.observation.bun.tsx
+++ b/packages/cli/src/ui/contexts/__tests__/todoProvider.observation.bun.tsx
@@ -170,6 +170,7 @@ function commandContextFrom(
   errors: string[],
 ): CommandContext {
   return {
+    signal: new AbortController().signal,
     services: {
       config: null,
       agent: null,

--- a/packages/cli/src/ui/hooks/agentStream/__tests__/useCancellation.slashCommand.test.tsx
+++ b/packages/cli/src/ui/hooks/agentStream/__tests__/useCancellation.slashCommand.test.tsx
@@ -104,6 +104,9 @@ describe('useCancellation — slash-command cancellation on ESC', () => {
     expect(cancellationNotices(harness.addedItems)).toEqual([
       SLASH_COMMAND_CANCELLED,
     ]);
+    // Cancelling a slash command must not also cancel the (idle) turn.
+    expect(harness.setTurnCancelled).not.toHaveBeenCalled();
+    expect(harness.turnAbortController.signal.aborted).toBe(false);
   });
 
   it('reports the cancellation only once when ESC is pressed repeatedly', () => {

--- a/packages/cli/src/ui/hooks/agentStream/__tests__/useCancellation.slashCommand.test.tsx
+++ b/packages/cli/src/ui/hooks/agentStream/__tests__/useCancellation.slashCommand.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests proving that cancelOngoingRequest (ESC) cancels an in-flight
+ * slash command even though a slash command never puts the stream into
+ * Responding (issue #2976). A REAL useSlashCommandCancellation registry drives
+ * the abort, so the assertions are on actual AbortSignal state and on the
+ * history items the handler produced.
+ */
+
+import { describe, it, expect, vi } from 'bun:test';
+import React, { act } from 'react';
+import { renderHook } from '../../../../test-utils/render.js';
+import { createSlashCommandCancellation } from '../../useSlashCommandCancellation.js';
+import {
+  useCancellation,
+  SLASH_COMMAND_CANCELLED,
+} from '../useAgentStreamLifecycle.js';
+import { StreamingState, MessageType } from '../../../types.js';
+import { KeypressProvider } from '../../../contexts/KeypressContext.js';
+import type { HistoryItemWithoutId } from '../../../types.js';
+
+interface Harness {
+  addedItems: HistoryItemWithoutId[];
+  setTurnCancelled: ReturnType<typeof vi.fn>;
+  turnAbortController: AbortController;
+  beginSlashCommandAction: () => AbortController;
+  pressEscape: () => void;
+}
+
+function renderHarness(streamingState: StreamingState): Harness {
+  const addedItems: HistoryItemWithoutId[] = [];
+  const setTurnCancelled = vi.fn();
+  const turnAbortController = new AbortController();
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <KeypressProvider>{children}</KeypressProvider>
+  );
+
+  const cancellation = createSlashCommandCancellation();
+  const { result } = renderHook(
+    () => {
+      const { cancelOngoingRequest } = useCancellation(
+        streamingState,
+        { current: false },
+        setTurnCancelled,
+        { current: turnAbortController },
+        () => {}, // cancelAllToolCalls
+        { current: null },
+        () => {}, // flushPendingHistoryItem
+        (item: HistoryItemWithoutId) => {
+          addedItems.push(item);
+          return addedItems.length;
+        },
+        () => {}, // setPendingHistoryItem
+        () => {}, // onCancelSubmit
+        () => {}, // setIsResponding
+        () => {}, // setShellInputFocused
+        { current: false }, // drainSuppressedRef
+        () => {}, // cancelRunningAsyncTasks
+        cancellation.cancelActiveSlashCommand,
+      );
+      return { cancelOngoingRequest };
+    },
+    { wrapper },
+  );
+
+  return {
+    addedItems,
+    setTurnCancelled,
+    turnAbortController,
+    beginSlashCommandAction: () => cancellation.beginSlashCommandAction(),
+    pressEscape: () => {
+      act(() => {
+        result.current.cancelOngoingRequest();
+      });
+    },
+  };
+}
+
+function cancellationNotices(items: HistoryItemWithoutId[]): string[] {
+  return items
+    .filter(
+      (item): item is HistoryItemWithoutId & { text: string } =>
+        item.type === MessageType.INFO && 'text' in item,
+    )
+    .map((item) => item.text)
+    .filter((text) => text === SLASH_COMMAND_CANCELLED);
+}
+
+describe('useCancellation — slash-command cancellation on ESC', () => {
+  it('aborts the in-flight slash command while the stream is Idle', () => {
+    const harness = renderHarness(StreamingState.Idle);
+    const controller = harness.beginSlashCommandAction();
+
+    expect(controller.signal.aborted).toBe(false);
+    harness.pressEscape();
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(cancellationNotices(harness.addedItems)).toEqual([
+      SLASH_COMMAND_CANCELLED,
+    ]);
+  });
+
+  it('reports the cancellation only once when ESC is pressed repeatedly', () => {
+    const harness = renderHarness(StreamingState.Idle);
+    harness.beginSlashCommandAction();
+
+    harness.pressEscape();
+    harness.pressEscape();
+    harness.pressEscape();
+
+    expect(cancellationNotices(harness.addedItems)).toEqual([
+      SLASH_COMMAND_CANCELLED,
+    ]);
+  });
+
+  it('leaves an idle session untouched when no slash command is in flight', () => {
+    const harness = renderHarness(StreamingState.Idle);
+
+    harness.pressEscape();
+
+    expect(harness.addedItems).toEqual([]);
+    expect(harness.setTurnCancelled).not.toHaveBeenCalled();
+    expect(harness.turnAbortController.signal.aborted).toBe(false);
+  });
+
+  it('still cancels the turn when a slash command is in flight during a response', () => {
+    const harness = renderHarness(StreamingState.Responding);
+    const controller = harness.beginSlashCommandAction();
+
+    harness.pressEscape();
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(harness.turnAbortController.signal.aborted).toBe(true);
+    expect(harness.setTurnCancelled).toHaveBeenCalledWith(true);
+  });
+});

--- a/packages/cli/src/ui/hooks/agentStream/useAgentStream.ts
+++ b/packages/cli/src/ui/hooks/agentStream/useAgentStream.ts
@@ -63,6 +63,7 @@ export const useAgentStream = (
   subagentManager?: UiSubagentManager,
   removeItems?: RemoveHistoryItems,
   operationLifecycle?: OperationLifecycleRegistry,
+  cancelActiveSlashCommand?: () => boolean,
 ) => {
   const orchestration = useAgentStreamOrchestration({
     agent,
@@ -86,6 +87,7 @@ export const useAgentStream = (
     runtimeMessageBus,
     subagentManager,
     operationLifecycle,
+    cancelActiveSlashCommand,
   } satisfies AgentStreamOrchestrationDeps);
 
   return useAgentStreamReturn(

--- a/packages/cli/src/ui/hooks/agentStream/useAgentStreamLifecycle.ts
+++ b/packages/cli/src/ui/hooks/agentStream/useAgentStreamLifecycle.ts
@@ -32,6 +32,12 @@ import { useKeypress, type Key } from '../useKeypress.js';
 import { type UseHistoryManagerReturn } from '../useHistoryManager.js';
 import type { StreamRuntime } from '../../cliUiRuntime.js';
 
+/**
+ * History text used when Esc aborts an in-flight slash command. Distinct from
+ * the turn-level 'Request cancelled.' so the two are tellable apart.
+ */
+export const SLASH_COMMAND_CANCELLED = 'Command cancelled.';
+
 export function useStreamingState(
   isResponding: boolean,
   toolCalls: TrackedToolCall[],
@@ -233,8 +239,19 @@ export function useCancellation(
   setShellInputFocused: (value: boolean) => void,
   drainSuppressedRef: React.MutableRefObject<boolean>,
   cancelRunningAsyncTasks: () => void = () => {},
+  cancelActiveSlashCommand: () => boolean = () => false,
 ) {
   const cancelOngoingRequest = useCallback(() => {
+    // Slash commands run outside the streaming lifecycle: they set neither
+    // isResponding nor toolCalls, so streamingState is Idle while one is in
+    // flight and the gate below would swallow the Esc (issue #2976). Cancel
+    // the slash command first, then fall through to turn cancellation.
+    if (cancelActiveSlashCommand()) {
+      addItem(
+        { type: MessageType.INFO, text: SLASH_COMMAND_CANCELLED },
+        Date.now(),
+      );
+    }
     if (
       streamingState !== StreamingState.Responding &&
       streamingState !== StreamingState.WaitingForConfirmation
@@ -260,6 +277,7 @@ export function useCancellation(
     setShellInputFocused(false);
   }, [
     streamingState,
+    cancelActiveSlashCommand,
     turnCancelledRef,
     setTurnCancelled,
     drainSuppressedRef,

--- a/packages/cli/src/ui/hooks/agentStream/useAgentStreamLifecycle.ts
+++ b/packages/cli/src/ui/hooks/agentStream/useAgentStreamLifecycle.ts
@@ -244,8 +244,10 @@ export function useCancellation(
   const cancelOngoingRequest = useCallback(() => {
     // Slash commands run outside the streaming lifecycle: they set neither
     // isResponding nor toolCalls, so streamingState is Idle while one is in
-    // flight and the gate below would swallow the Esc (issue #2976). Cancel
-    // the slash command first, then fall through to turn cancellation.
+    // flight and the gate below would swallow the Esc (issue #2976). Hence
+    // this runs ahead of the gate. In the usual case the state IS Idle and the
+    // gate then returns, leaving turn cancellation untouched; the turn is only
+    // cancelled as well when one is genuinely in flight.
     if (cancelActiveSlashCommand()) {
       addItem(
         { type: MessageType.INFO, text: SLASH_COMMAND_CANCELLED },

--- a/packages/cli/src/ui/hooks/agentStream/useAgentStreamOrchestration.ts
+++ b/packages/cli/src/ui/hooks/agentStream/useAgentStreamOrchestration.ts
@@ -70,6 +70,11 @@ export interface AgentStreamOrchestrationDeps {
    * integration wiring.
    */
   operationLifecycle?: OperationLifecycleRegistry;
+  /**
+   * Aborts an in-flight slash-command action on Esc. Returns true iff one was
+   * aborted, so the Esc handler can report it once (issue #2976).
+   */
+  cancelActiveSlashCommand?: () => boolean;
 }
 
 export interface AgentStreamOrchestrationResult {
@@ -143,6 +148,7 @@ export function useAgentStreamOrchestration(
     args.setShellInputFocused,
     st.drainSuppressedRef,
     cancelRunningAsyncTasks,
+    args.cancelActiveSlashCommand,
   );
   // Refs to break the circular dependency between useSubmitQuery (which
   // creates useStreamEventHandlers → processAgentEvent) and useAgentEventStream

--- a/packages/cli/src/ui/hooks/slashCommandHandlers.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandHandlers.test.ts
@@ -266,4 +266,22 @@ describe('processSlashCommand cancellation', () => {
 
     expect(cancel()).toBe(false);
   });
+
+  it('deregisters even when the invocation fails before the action runs', async () => {
+    // Otherwise the registry keeps a controller nothing is waiting on, and a
+    // later Esc reports a cancellation that did not happen.
+    const addItem = vi.fn();
+    const { deps, cancel } = createCancellableDeps(addItem);
+    deps.commandContext = new Proxy(deps.commandContext, {
+      get() {
+        throw new Error('context construction exploded');
+      },
+    });
+    deps.commands = createCommands(() => {});
+
+    await processSlashCommand(deps, '/help');
+
+    expect(errorTexts(addItem)).toEqual(['context construction exploded']);
+    expect(cancel()).toBe(false);
+  });
 });

--- a/packages/cli/src/ui/hooks/slashCommandHandlers.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandHandlers.test.ts
@@ -5,33 +5,50 @@
  */
 
 import { describe, expect, it, vi } from 'bun:test';
+import { waitFor } from '@vybestack/llxprt-code-test-utils';
 import { DebugLogger } from '@vybestack/llxprt-code-core';
 import type { Logger } from '@vybestack/llxprt-code-core';
+import type { CommandContext, SlashCommand } from '../commands/types.js';
 import { CommandKind } from '../commands/types.js';
 import { MessageType } from '../types.js';
 import {
   processSlashCommand,
   type SlashCommandHandlerDeps,
 } from './slashCommandHandlers.js';
+import { createSlashCommandCancellation } from './useSlashCommandCancellation.js';
+import { computeIsAwaitingSlashCommandConfirmation } from '../containers/AppContainer/hooks/useAppInput.js';
+import type { HistoryItemWithoutId } from '../types.js';
 
-function createDeps(
-  addItem: ReturnType<typeof vi.fn>,
-): SlashCommandHandlerDeps {
-  return {
-    commands: [
-      {
-        name: 'help',
-        description: 'Show help',
-        kind: CommandKind.BUILT_IN,
-        action: vi.fn(() => ({
+type HistoryCall = [{ type: MessageType; text: string }, number];
+
+function createCommands(
+  action: SlashCommand['action'],
+): readonly SlashCommand[] {
+  return [
+    {
+      name: 'help',
+      description: 'Show help',
+      kind: CommandKind.BUILT_IN,
+      action:
+        action ??
+        vi.fn(() => ({
           type: 'message' as const,
           messageType: 'info' as const,
           content: 'ok',
         })),
-      },
-    ],
+    },
+  ];
+}
+
+function createDeps(
+  addItem: ReturnType<typeof vi.fn>,
+  overrides: Partial<SlashCommandHandlerDeps> = {},
+): SlashCommandHandlerDeps {
+  return {
+    commands: createCommands(undefined),
     config: null,
     commandContext: {
+      signal: new AbortController().signal,
       services: {
         config: null,
         agent: null,
@@ -73,7 +90,38 @@ function createDeps(
     setConfirmationRequest: vi.fn(),
     confirmationLogger: new DebugLogger('test-confirmation'),
     slashCommandLogger: new DebugLogger('test-slash'),
+    beginSlashCommandAction: () => new AbortController(),
+    endSlashCommandAction: () => {},
+    ...overrides,
   };
+}
+
+/**
+ * Wires the REAL cancellation registry into the handler deps so the tests
+ * exercise the same begin/cancel/end contract the app uses.
+ */
+function createCancellableDeps(addItem: ReturnType<typeof vi.fn>): {
+  deps: SlashCommandHandlerDeps;
+  cancel: () => boolean;
+  registered: AbortController[];
+} {
+  const registry = createSlashCommandCancellation();
+  const registered: AbortController[] = [];
+  const deps = createDeps(addItem, {
+    beginSlashCommandAction: () => {
+      const controller = registry.beginSlashCommandAction();
+      registered.push(controller);
+      return controller;
+    },
+    endSlashCommandAction: registry.endSlashCommandAction,
+  });
+  return { deps, cancel: registry.cancelActiveSlashCommand, registered };
+}
+
+function errorTexts(addItem: ReturnType<typeof vi.fn>): string[] {
+  return (addItem.mock.calls as HistoryCall[])
+    .filter(([item]) => item.type === MessageType.ERROR)
+    .map(([item]) => item.text);
 }
 
 describe('processSlashCommand', () => {
@@ -83,12 +131,139 @@ describe('processSlashCommand', () => {
     await processSlashCommand(createDeps(addItem), '/key\tsk-abc123456');
 
     expect(addItem).toHaveBeenCalled();
-    const [historyItem] = addItem.mock.calls[0] as [
-      { type: MessageType; text: string },
-      number,
-    ];
+    const [historyItem] = addItem.mock.calls[0] as HistoryCall;
     expect(historyItem.type).toBe(MessageType.USER);
     expect(historyItem.text).toContain('/key');
     expect(historyItem.text).not.toContain('sk-abc123456');
+  });
+});
+
+describe('processSlashCommand cancellation', () => {
+  it('hands the action the signal of the controller registered for it', async () => {
+    const addItem = vi.fn();
+    let observedSignal: AbortSignal | undefined;
+    const { deps, registered } = createCancellableDeps(addItem);
+    deps.commands = createCommands((context: CommandContext) => {
+      observedSignal = context.signal;
+    });
+
+    await processSlashCommand(deps, '/help');
+
+    // Identity, not shape: a per-invocation signal, not the base context's.
+    expect(registered).toHaveLength(1);
+    expect(observedSignal).toBe(registered[0].signal);
+  });
+
+  it('aborts the signal the running action is awaiting on when cancelled', async () => {
+    const addItem = vi.fn();
+    const { deps, cancel } = createCancellableDeps(addItem);
+    let abortedDuringAction = false;
+    let releaseAction: (() => void) | undefined;
+    deps.commands = createCommands(async (context: CommandContext) => {
+      await new Promise<void>((resolve) => {
+        releaseAction = resolve;
+        context.signal.addEventListener('abort', () => {
+          abortedDuringAction = true;
+          resolve();
+        });
+      });
+    });
+
+    const pending = processSlashCommand(deps, '/help');
+    await Promise.resolve();
+    expect(cancel()).toBe(true);
+    releaseAction?.();
+    await pending;
+
+    expect(abortedDuringAction).toBe(true);
+  });
+
+  it('does not report an error when the action rejects because it was cancelled', async () => {
+    const addItem = vi.fn();
+    const { deps, cancel } = createCancellableDeps(addItem);
+    let rejectAction: ((reason: Error) => void) | undefined;
+    deps.commands = createCommands(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectAction = reject;
+        }),
+    );
+
+    const pending = processSlashCommand(deps, '/help');
+    await Promise.resolve();
+    cancel();
+    rejectAction?.(new Error('This operation was aborted'));
+    const result = await pending;
+
+    expect(result).toEqual({ type: 'handled' });
+    expect(errorTexts(addItem)).toEqual([]);
+  });
+
+  it('discards the result of an action that resolves after being cancelled', async () => {
+    // A command that notices the abort and unwinds cleanly still returns a
+    // result. Acting on it would carry out the work the user just cancelled —
+    // e.g. submitting a prompt built from a killed shell injection.
+    const addItem = vi.fn();
+    const { deps, cancel } = createCancellableDeps(addItem);
+    let releaseAction: (() => void) | undefined;
+    deps.commands = createCommands(async () => {
+      await new Promise<void>((resolve) => {
+        releaseAction = resolve;
+      });
+      return { type: 'submit_prompt' as const, content: 'partial work' };
+    });
+
+    const pending = processSlashCommand(deps, '/help');
+    await Promise.resolve();
+    cancel();
+    releaseAction?.();
+
+    expect(await pending).toEqual({ type: 'handled' });
+  });
+
+  it('still reports an error when the action rejects without being cancelled', async () => {
+    const addItem = vi.fn();
+    const { deps } = createCancellableDeps(addItem);
+    deps.commands = createCommands(async () => {
+      throw new Error('backend exploded');
+    });
+
+    await processSlashCommand(deps, '/help');
+
+    expect(errorTexts(addItem)).toEqual(['backend exploded']);
+  });
+
+  it('parks a confirming tool group that takes the prompt away', async () => {
+    // Links the two halves of the composer-visibility rule: the shell-expansion
+    // approval this pipeline produces is exactly what
+    // computeIsAwaitingSlashCommandConfirmation looks for.
+    const addItem = vi.fn();
+    const setPendingItem = vi.fn();
+    const { deps } = createCancellableDeps(addItem);
+    deps.setPendingItem = setPendingItem;
+    deps.commands = createCommands(() => ({
+      type: 'confirm_shell_commands' as const,
+      commandsToConfirm: ['echo hi'],
+      originalInvocation: { raw: '/help' },
+    }));
+
+    void processSlashCommand(deps, '/help');
+    await waitFor(() => expect(setPendingItem).toHaveBeenCalled());
+
+    const pendingItems = setPendingItem.mock.calls
+      .map(([item]) => item as HistoryItemWithoutId | null)
+      .filter((item): item is HistoryItemWithoutId => item !== null);
+    expect(pendingItems.length).toBeGreaterThan(0);
+    expect(computeIsAwaitingSlashCommandConfirmation(pendingItems)).toBe(true);
+  });
+
+  it('deregisters the action once it settles so a later Esc cancels nothing', async () => {
+    const addItem = vi.fn();
+    const { deps, cancel } = createCancellableDeps(addItem);
+    deps.commands = createCommands(() => {});
+
+    await processSlashCommand(deps, '/help');
+
+    expect(cancel()).toBe(false);
   });
 });

--- a/packages/cli/src/ui/hooks/slashCommandHandlers.ts
+++ b/packages/cli/src/ui/hooks/slashCommandHandlers.ts
@@ -154,24 +154,22 @@ async function executeParsedCommand(
 ): Promise<SlashCommandProcessorResult | false> {
   const { commandToExecute } = parsed;
   if (commandToExecute?.action) {
-    const controller = deps.beginSlashCommandAction();
-    const context = buildInvocationContext(
-      deps.commandContext,
-      parsed,
-      oneTimeShellAllowlist,
-      overwriteConfirmed,
-      controller.signal,
-    );
     const outcome = await runCommandAction(
       deps,
       commandToExecute.action,
-      context,
-      parsed.args,
-      controller,
+      parsed,
+      (signal) =>
+        buildInvocationContext(
+          deps.commandContext,
+          parsed,
+          oneTimeShellAllowlist,
+          overwriteConfirmed,
+          signal,
+        ),
     );
     if (outcome.cancelled) return { type: 'handled' };
     return outcome.result
-      ? handleActionResult(deps, context, outcome.result)
+      ? handleActionResult(deps, outcome.context, outcome.result)
       : { type: 'handled' };
   }
   if (commandToExecute?.subCommands) {
@@ -185,8 +183,12 @@ async function executeParsedCommand(
 type CommandAction = NonNullable<SlashCommand['action']>;
 
 type CommandActionOutcome =
-  | { cancelled: true; result?: undefined }
-  | { cancelled: false; result: Awaited<ReturnType<CommandAction>> };
+  | { cancelled: true; context?: undefined; result?: undefined }
+  | {
+      cancelled: false;
+      context: CommandContext;
+      result: Awaited<ReturnType<CommandAction>>;
+    };
 
 /**
  * Awaits the action while it is registered as cancellable.
@@ -197,32 +199,50 @@ type CommandActionOutcome =
  * and unwound cleanly, and acting on its result would carry out work the user
  * just cancelled (for example submitting a prompt built from a shell injection
  * that was killed mid-flight).
+ *
+ * Context construction happens inside the try so that every registration has a
+ * matching deregistration even if building it throws.
  */
 async function runCommandAction(
   deps: SlashCommandHandlerDeps,
   action: CommandAction,
-  context: CommandContext,
-  args: string,
-  controller: AbortController,
+  parsed: ParsedCommandState,
+  buildContext: (signal: AbortSignal) => CommandContext,
 ): Promise<CommandActionOutcome> {
+  const controller = deps.beginSlashCommandAction();
   try {
-    const result = await action(context, args);
-    if (controller.signal.aborted) return { cancelled: true };
-    return { cancelled: false, result };
+    const context = buildContext(controller.signal);
+    const result = await action(context, parsed.args);
+    if (controller.signal.aborted) {
+      logDiscarded(deps, parsed, 'result', undefined);
+      return { cancelled: true };
+    }
+    return { cancelled: false, context, result };
   } catch (error) {
     if (!controller.signal.aborted) throw error;
-    // The discard is intentional, but an unrelated bug can land in the same
+    // The discard is intentional, but an unrelated failure can land in the same
     // window, so leave a trace rather than losing it entirely.
-    deps.slashCommandLogger.debug(
-      () =>
-        `discarded error from cancelled ${context.invocation?.raw ?? 'command'}: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-    );
+    logDiscarded(deps, parsed, 'error', error);
     return { cancelled: true };
   } finally {
     deps.endSlashCommandAction(controller);
   }
+}
+
+function logDiscarded(
+  deps: SlashCommandHandlerDeps,
+  parsed: ParsedCommandState,
+  kind: 'result' | 'error',
+  error: unknown,
+): void {
+  deps.slashCommandLogger.debug(() => {
+    const detail = kind === 'error' ? `: ${describeError(error)}` : '';
+    return `discarded ${kind} from cancelled ${parsed.trimmed}${detail}`;
+  });
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function buildInvocationContext(

--- a/packages/cli/src/ui/hooks/slashCommandHandlers.ts
+++ b/packages/cli/src/ui/hooks/slashCommandHandlers.ts
@@ -67,6 +67,10 @@ export interface SlashCommandHandlerDeps {
   recordingSwapCallbacks?: RecordingSwapCallbacks;
   confirmationLogger: DebugLogger;
   slashCommandLogger: DebugLogger;
+  /** Registers the action about to be awaited and returns its controller. */
+  beginSlashCommandAction: () => AbortController;
+  /** Deregisters an action once it has settled. */
+  endSlashCommandAction: (controller: AbortController) => void;
 }
 
 interface ParsedCommandState {
@@ -150,15 +154,24 @@ async function executeParsedCommand(
 ): Promise<SlashCommandProcessorResult | false> {
   const { commandToExecute } = parsed;
   if (commandToExecute?.action) {
+    const controller = deps.beginSlashCommandAction();
     const context = buildInvocationContext(
       deps.commandContext,
       parsed,
       oneTimeShellAllowlist,
       overwriteConfirmed,
+      controller.signal,
     );
-    const result = await commandToExecute.action(context, parsed.args);
-    return result
-      ? handleActionResult(deps, context, result)
+    const outcome = await runCommandAction(
+      deps,
+      commandToExecute.action,
+      context,
+      parsed.args,
+      controller,
+    );
+    if (outcome.cancelled) return { type: 'handled' };
+    return outcome.result
+      ? handleActionResult(deps, context, outcome.result)
       : { type: 'handled' };
   }
   if (commandToExecute?.subCommands) {
@@ -169,14 +182,59 @@ async function executeParsedCommand(
   return { type: 'handled' };
 }
 
+type CommandAction = NonNullable<SlashCommand['action']>;
+
+type CommandActionOutcome =
+  | { cancelled: true; result?: undefined }
+  | { cancelled: false; result: Awaited<ReturnType<CommandAction>> };
+
+/**
+ * Awaits the action while it is registered as cancellable.
+ *
+ * Once the invocation is aborted its outcome is discarded either way. A
+ * rejection is the expected shape of "the user pressed Esc" and must not also
+ * surface as a command error; a resolution is a command that noticed the abort
+ * and unwound cleanly, and acting on its result would carry out work the user
+ * just cancelled (for example submitting a prompt built from a shell injection
+ * that was killed mid-flight).
+ */
+async function runCommandAction(
+  deps: SlashCommandHandlerDeps,
+  action: CommandAction,
+  context: CommandContext,
+  args: string,
+  controller: AbortController,
+): Promise<CommandActionOutcome> {
+  try {
+    const result = await action(context, args);
+    if (controller.signal.aborted) return { cancelled: true };
+    return { cancelled: false, result };
+  } catch (error) {
+    if (!controller.signal.aborted) throw error;
+    // The discard is intentional, but an unrelated bug can land in the same
+    // window, so leave a trace rather than losing it entirely.
+    deps.slashCommandLogger.debug(
+      () =>
+        `discarded error from cancelled ${context.invocation?.raw ?? 'command'}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+    );
+    return { cancelled: true };
+  } finally {
+    deps.endSlashCommandAction(controller);
+  }
+}
+
 function buildInvocationContext(
   baseContext: CommandContext,
   parsed: ParsedCommandState,
   oneTimeShellAllowlist: Set<string> | undefined,
   overwriteConfirmed: boolean | undefined,
+  signal: AbortSignal,
 ): CommandContext {
   const fullCommandContext: CommandContext = {
     ...baseContext,
+    signal,
     invocation: {
       raw: parsed.trimmed,
       name: parsed.commandToExecute?.name ?? '',

--- a/packages/cli/src/ui/hooks/slashCommandProcessorSupport.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessorSupport.ts
@@ -177,11 +177,21 @@ export function usePendingHistory(
   return { pendingItem, setPendingItem, pendingHistoryItems, addMessage };
 }
 
+/**
+ * The base context is used for completions and as the template for
+ * invocations; it is never the context an action runs under, because
+ * `processSlashCommand` always overrides `signal` with the controller it
+ * registered for that invocation. Completions are not cancellable, so a signal
+ * that never aborts is the correct value here.
+ */
+const NEVER_ABORTED_SIGNAL = new AbortController().signal;
+
 export function useCommandContext(
   inputs: CommandContextInputs,
 ): CommandContext {
   return useMemo(
     (): CommandContext => ({
+      signal: NEVER_ABORTED_SIGNAL,
       services: {
         config: inputs.config,
         agent: inputs.agent,

--- a/packages/cli/src/ui/hooks/useSlashCommandCancellation.test.ts
+++ b/packages/cli/src/ui/hooks/useSlashCommandCancellation.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the in-flight slash-command registry. Real
+ * AbortControllers are used throughout, so aborting actually flips
+ * signal.aborted rather than merely recording a call.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { createSlashCommandCancellation } from './useSlashCommandCancellation.js';
+
+describe('slash-command cancellation registry', () => {
+  it('reports nothing to cancel before any action starts', () => {
+    const registry = createSlashCommandCancellation();
+
+    expect(registry.cancelActiveSlashCommand()).toBe(false);
+  });
+
+  it('aborts the registered controller and reports that it did so', () => {
+    const registry = createSlashCommandCancellation();
+
+    const controller = registry.beginSlashCommandAction();
+
+    expect(controller.signal.aborted).toBe(false);
+    expect(registry.cancelActiveSlashCommand()).toBe(true);
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it('reports nothing to cancel on a second attempt at the same action', () => {
+    const registry = createSlashCommandCancellation();
+
+    registry.beginSlashCommandAction();
+
+    expect(registry.cancelActiveSlashCommand()).toBe(true);
+    expect(registry.cancelActiveSlashCommand()).toBe(false);
+  });
+
+  it('reports nothing to cancel once the action has settled', () => {
+    const registry = createSlashCommandCancellation();
+
+    const controller = registry.beginSlashCommandAction();
+    registry.endSlashCommandAction(controller);
+
+    expect(registry.cancelActiveSlashCommand()).toBe(false);
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  it('registers a fresh, non-aborted controller for each action', () => {
+    const registry = createSlashCommandCancellation();
+
+    const first = registry.beginSlashCommandAction();
+    const second = registry.beginSlashCommandAction();
+
+    expect(first.signal.aborted).toBe(false);
+    expect(second.signal.aborted).toBe(false);
+    expect(first.signal).not.toBe(second.signal);
+  });
+
+  it('cancels every concurrently running action, not just the newest', () => {
+    // The prompt stays live during a command, so a second command can be
+    // submitted while a long one runs. Tracking only the newest would let the
+    // short command evict the long one and leave it uncancellable — the exact
+    // bug this whole change is fixing.
+    const registry = createSlashCommandCancellation();
+
+    const longRunning = registry.beginSlashCommandAction();
+    const shortLived = registry.beginSlashCommandAction();
+
+    expect(registry.cancelActiveSlashCommand()).toBe(true);
+    expect(longRunning.signal.aborted).toBe(true);
+    expect(shortLived.signal.aborted).toBe(true);
+  });
+
+  it('keeps the long-running action cancellable after a short one finishes', () => {
+    const registry = createSlashCommandCancellation();
+
+    const longRunning = registry.beginSlashCommandAction();
+    const shortLived = registry.beginSlashCommandAction();
+    registry.endSlashCommandAction(shortLived);
+
+    expect(registry.cancelActiveSlashCommand()).toBe(true);
+    expect(longRunning.signal.aborted).toBe(true);
+    expect(shortLived.signal.aborted).toBe(false);
+  });
+
+  it('leaves a cancelled action registered until it actually unwinds', () => {
+    const registry = createSlashCommandCancellation();
+
+    const controller = registry.beginSlashCommandAction();
+    registry.cancelActiveSlashCommand();
+    const later = registry.beginSlashCommandAction();
+
+    // The still-unwinding action must not be re-aborted, but the new one must.
+    expect(registry.cancelActiveSlashCommand()).toBe(true);
+    expect(later.signal.aborted).toBe(true);
+    registry.endSlashCommandAction(controller);
+    registry.endSlashCommandAction(later);
+    expect(registry.cancelActiveSlashCommand()).toBe(false);
+  });
+});

--- a/packages/cli/src/ui/hooks/useSlashCommandCancellation.ts
+++ b/packages/cli/src/ui/hooks/useSlashCommandCancellation.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useMemo } from 'react';
+
+/**
+ * Registry of the slash-command actions that are currently in flight
+ * (issue #2976).
+ *
+ * A slash-command action is awaited inline by `processSlashCommand`, so before
+ * this registry existed there was nothing for the Esc handler to cancel.
+ *
+ * Every in-flight action is held, not just the most recent one. The same issue
+ * keeps the input prompt live while a command runs, so the user can submit a
+ * second command before the first finishes; a single slot would let the short
+ * command's completion evict the long one and leave it uncancellable, which is
+ * the exact bug being fixed.
+ */
+export interface SlashCommandCancellation {
+  /** Registers a new in-flight action and returns its controller. */
+  beginSlashCommandAction: () => AbortController;
+  /** Deregisters an action once it has settled. */
+  endSlashCommandAction: (controller: AbortController) => void;
+  /** Aborts every in-flight action. Returns true iff any was aborted. */
+  cancelActiveSlashCommand: () => boolean;
+}
+
+export function createSlashCommandCancellation(): SlashCommandCancellation {
+  const inFlight = new Set<AbortController>();
+  return {
+    beginSlashCommandAction: () => {
+      const controller = new AbortController();
+      inFlight.add(controller);
+      return controller;
+    },
+    // Deregistration is the caller's `finally`; cancellation deliberately
+    // leaves the entry in place so an aborted action that is still unwinding
+    // is not mistaken for a new one.
+    endSlashCommandAction: (controller) => {
+      inFlight.delete(controller);
+    },
+    cancelActiveSlashCommand: () => {
+      let cancelled = false;
+      for (const controller of inFlight) {
+        if (controller.signal.aborted) continue;
+        controller.abort();
+        cancelled = true;
+      }
+      return cancelled;
+    },
+  };
+}
+
+export function useSlashCommandCancellation(): SlashCommandCancellation {
+  return useMemo(() => createSlashCommandCancellation(), []);
+}

--- a/packages/cli/src/ui/hooks/useSlashCommandProcessorCore.ts
+++ b/packages/cli/src/ui/hooks/useSlashCommandProcessorCore.ts
@@ -22,7 +22,10 @@ import type {
 import type { LoadedSettings } from '../../config/settings.js';
 import type { SlashCommand } from '../commands/types.js';
 import type { ExtensionUpdateState } from '../state/extensions.js';
-import { processSlashCommand } from './slashCommandHandlers.js';
+import {
+  processSlashCommand,
+  type SlashCommandHandlerDeps,
+} from './slashCommandHandlers.js';
 import {
   confirmationLogger,
   slashCommandLogger,
@@ -35,6 +38,10 @@ import {
   useManagers,
   usePendingHistory,
 } from './slashCommandProcessorSupport.js';
+import {
+  useSlashCommandCancellation,
+  type SlashCommandCancellation,
+} from './useSlashCommandCancellation.js';
 
 interface TodoContextValue {
   todos: Todo[];
@@ -56,6 +63,8 @@ export type SlashCommandProcessorCoreResult = {
     prompt: React.ReactNode;
     onConfirm: (confirmed: boolean) => void;
   } | null;
+  /** Aborts every in-flight slash command. Returns true iff any was aborted. */
+  cancelActiveSlashCommand: () => boolean;
 };
 
 export interface UseSlashCommandProcessorCoreArgs {
@@ -133,11 +142,40 @@ function useSlashCommandProcessorState(
   };
 }
 
+function buildHandlerDeps(
+  args: UseSlashCommandProcessorCoreArgs,
+  state: SlashCommandProcessorState,
+  pending: ReturnType<typeof usePendingHistory>,
+  commandContext: ReturnType<typeof useCommandContext>,
+  cancellation: SlashCommandCancellation,
+): SlashCommandHandlerDeps {
+  return {
+    commands: state.commands,
+    config: args.config,
+    commandContext,
+    actions: args.actions,
+    addItem: args.addItem,
+    addMessage: pending.addMessage,
+    setIsProcessing: args.setIsProcessing,
+    setLocalIsProcessing: state.setLocalIsProcessing,
+    setPendingItem: pending.setPendingItem,
+    setSessionShellAllowlist: state.setSessionShellAllowlist,
+    setConfirmationRequest: state.setConfirmationRequest,
+    recordingIntegration: args.recordingIntegration,
+    recordingSwapCallbacks: args.recordingSwapCallbacks,
+    confirmationLogger,
+    slashCommandLogger,
+    beginSlashCommandAction: cancellation.beginSlashCommandAction,
+    endSlashCommandAction: cancellation.endSlashCommandAction,
+  };
+}
+
 export function useSlashCommandProcessorCore(
   args: UseSlashCommandProcessorCoreArgs,
 ): SlashCommandProcessorCoreResult {
   const session = useSessionStats();
   const state = useSlashCommandProcessorState(args.config);
+  const cancellation = useSlashCommandCancellation();
   const managers = useManagers(args.config);
   const pending = usePendingHistory(args.addItem);
   const commandContext = useCommandContext({
@@ -180,29 +218,13 @@ export function useSlashCommandProcessorCore(
       addToHistory: boolean = true,
     ): Promise<SlashCommandProcessorResult | false> =>
       processSlashCommand(
-        {
-          commands: state.commands,
-          config: args.config,
-          commandContext,
-          actions: args.actions,
-          addItem: args.addItem,
-          addMessage: pending.addMessage,
-          setIsProcessing: args.setIsProcessing,
-          setLocalIsProcessing: state.setLocalIsProcessing,
-          setPendingItem: pending.setPendingItem,
-          setSessionShellAllowlist: state.setSessionShellAllowlist,
-          setConfirmationRequest: state.setConfirmationRequest,
-          recordingIntegration: args.recordingIntegration,
-          recordingSwapCallbacks: args.recordingSwapCallbacks,
-          confirmationLogger,
-          slashCommandLogger,
-        },
+        buildHandlerDeps(args, state, pending, commandContext, cancellation),
         rawQuery,
         oneTimeShellAllowlist,
         overwriteConfirmed,
         addToHistory,
       ),
-    [args, commandContext, pending, state],
+    [args, commandContext, pending, state, cancellation],
   );
   return {
     handleSlashCommand,
@@ -210,5 +232,6 @@ export function useSlashCommandProcessorCore(
     pendingHistoryItems: pending.pendingHistoryItems,
     commandContext,
     confirmationRequest: state.confirmationRequest,
+    cancelActiveSlashCommand: cancellation.cancelActiveSlashCommand,
   };
 }

--- a/project-plans/issue2976/plan.md
+++ b/project-plans/issue2976/plan.md
@@ -368,7 +368,34 @@ Findings from the independent design review, with dispositions.
   resolve-side discard a cancelled command still submitted its prompt to the
   model.
 
+### Fixed after the open-code review
+
+- **The loop guard that stops spawning injections after an abort had no test.**
+  Covered by "stops spawning later injections once the invocation is cancelled".
+- **A controller could stay registered if context construction threw** between
+  `beginSlashCommandAction` and the try block, so a later Esc would report a
+  cancellation that never happened. Registration and context construction now
+  live inside the same try/finally. Covered by "deregisters even when the
+  invocation fails before the action runs".
+- **A discarded result left no trace** while a discarded error did. Both are
+  logged now.
+- **The abort-discard rule read as abort-error sniffing.** The `/image` test now
+  rejects with an unrelated provider error to make the uniform rule explicit:
+  once the invocation is cancelled, its outcome is discarded whatever it was.
+  Narrowing the suppression to `AbortError` was considered and rejected —
+  reporting a provider failure for a request the user just abandoned is noise,
+  and the framework already applies the same rule one level up.
+
 ### Deferred (follow-up, not this issue)
+
+- **Esc does not dismiss a pending shell-expansion confirmation.** By the time
+  the confirmation is on screen the action has settled and its controller is
+  deregistered, so Esc is a no-op there (it neither aborts nor reports, so the
+  single-command case shows no misleading notice). The confirmation carries its
+  own Cancel option, and this is unchanged from before: Esc did nothing during a
+  slash-command confirmation previously either. Closing it means keeping the
+  controller registered across the confirmation and racing the confirmation
+  promise against the signal, which is its own behavioural change.
 
 - **Only `/image`, `/setup-github` and the shell processor honour
   `context.signal`.** Long-running built-ins such as `/compress` and

--- a/project-plans/issue2976/plan.md
+++ b/project-plans/issue2976/plan.md
@@ -1,0 +1,389 @@
+# Issue 2976 — Cancellable slash commands with a live input prompt
+
+Follow-up from #2128 / PR #2813. Reported against `/image`, but the defect is in
+the slash-command execution model.
+
+## Problem restated
+
+1. `processSlashCommand` holds `isProcessing` true for the whole invocation,
+   including the awaited command action. `useAppInput` folds `!isProcessing`
+   into `isInputActive`, and `InlineContent` renders no `Composer` when
+   `isInputActive` is false. The prompt disappears for the duration of the
+   command.
+2. `useCancellation.cancelOngoingRequest` early-returns unless `streamingState`
+   is `Responding` or `WaitingForConfirmation`. A slash command sets neither, so
+   Esc is a no-op.
+3. `CommandContext` carries no `AbortSignal`, so commands invent their own:
+   `imageCommand.ts` registers a one-shot `process.once('SIGINT', ...)`,
+   `setupGithubCommand.ts` builds a private `AbortController`, and
+   `services/prompt-processors/shellProcessor.ts` passes
+   `new AbortController().signal` into `ShellExecutionService.execute`.
+
+## Direction chosen
+
+Option 1 from the issue: thread a real `AbortSignal` through `CommandContext`,
+make the existing Esc handler aware of in-flight slash commands, and revisit
+`isInputActive` so the prompt stays up while a command runs.
+
+Option 2 (route long commands through the tool-call scheduler) is rejected for
+this issue: it requires a product decision about slash commands synthesising
+tool calls and how that renders in history, and it would not by itself give the
+generic slash-command layer a cancellation signal. Option 3 (async-task
+manager) has the same problem and adds a second lifecycle owner.
+
+The fix is applied at the slash-command layer, not patched into `/image`.
+
+## Acceptance criteria
+
+AC1. While a slash-command action is in flight, the input prompt (Composer)
+remains rendered.
+
+AC2. While the slash-command pipeline is waiting on the *user* (the
+`confirm_shell_commands` pending tool-group and the `confirm_action`
+confirmation), the Composer stays hidden exactly as it is today. AC1 must not
+regress this.
+
+AC3. Pressing Esc while a slash-command action is in flight aborts it and adds a
+single INFO history item reporting the cancellation.
+
+AC4. Pressing Esc twice does not add a second cancellation item for the same
+invocation.
+
+AC5. Pressing Esc when no slash command is in flight behaves exactly as today
+(turn cancellation when streaming, no-op when idle — no spurious history item).
+
+AC6. Every slash-command action receives `context.signal`, an `AbortSignal` that
+is aborted by AC3 and is not aborted otherwise. The non-interactive path
+supplies its existing process-level `AbortController` signal.
+
+AC7. The cancelled operation actually aborts the underlying work: the signal
+reaches the image runner, the `/setup-github` downloads, and the shell
+injection executed by `shellProcessor`.
+
+AC8. When an action rejects *because* its invocation was aborted, the framework
+does not add an error history item on top of the cancellation notice. When an
+action rejects for any other reason, the existing error item is still added.
+
+AC9. `imageCommand.ts` registers no `SIGINT` listener, `setupGithubCommand.ts`
+threads the framework signal into its downloads, and `shellProcessor.ts` stops
+manufacturing a throwaway `AbortController`.
+
+### Out of scope
+
+- What `/image` generates or how the Codex backend is called.
+- The non-interactive CLI path's own SIGINT handling (`-O` / `-P`), which works.
+- Any change to how tool calls, async tasks, or turn cancellation behave when no
+  slash command is in flight.
+
+## Design
+
+### 1. `CommandContext.signal`
+
+`packages/cli/src/ui/commands/types.ts`
+
+```ts
+export interface CommandContext {
+  /**
+   * Aborted when the user cancels this slash-command invocation (Esc in the
+   * interactive UI, the process abort controller in non-interactive mode).
+   * Long-running actions must forward it to whatever they await.
+   */
+  signal: AbortSignal;
+  invocation?: { ... };
+  ...
+}
+```
+
+Required, not optional — commands should not have to write `context.signal?`.
+
+Providers of the field:
+
+- `slashCommandHandlers.buildInvocationContext` — the per-invocation controller's
+  signal (see 2).
+- `slashCommandProcessorSupport.useCommandContext` — the base context is used for
+  completions and as the template for invocations; it gets a module-level
+  never-aborted signal. Every real invocation overrides it.
+- `nonInteractiveCliCommands.handleSlashCommand` — `abortController.signal`, which
+  it already has in hand.
+- `test-utils/mockCommandContext.ts` — a fresh `new AbortController().signal`,
+  overridable through the existing deep-merge.
+
+### 2. Slash-command cancellation registry
+
+New file `packages/cli/src/ui/hooks/useSlashCommandCancellation.ts`:
+
+```ts
+export interface SlashCommandCancellation {
+  /** Registers a new in-flight action and returns its controller. */
+  beginSlashCommandAction: () => AbortController;
+  /** Deregisters an action once it has settled. */
+  endSlashCommandAction: (controller: AbortController) => void;
+  /** Aborts every in-flight action. Returns true iff any was aborted. */
+  cancelActiveSlashCommand: () => boolean;
+}
+```
+
+Semantics:
+
+- The registry holds a `Set` of every in-flight controller, not just the newest.
+  Keeping the prompt live means the user can submit a second command while a
+  long one runs; with a single slot the short command's completion would evict
+  the long one and leave it uncancellable — the exact bug being fixed.
+- `cancelActiveSlashCommand` aborts every controller that is not already
+  aborted and returns whether it aborted any, so a second Esc is a no-op (AC4).
+  It does not deregister: an aborted action that is still unwinding must not be
+  mistaken for a new one.
+- `endSlashCommandAction(controller)` removes that controller by identity.
+- No React state, so it is a plain factory (`createSlashCommandCancellation`)
+  with a `useMemo` wrapper. Nothing about the registry drives rendering.
+
+Nesting: `confirm_shell_commands` / `confirm_action` re-enter
+`processSlashCommand`. Because begin/end bracket only the action await, the
+outer invocation has already ended before the inner one begins.
+
+### 3. `processSlashCommand`
+
+`executeParsedCommand` brackets only the action:
+
+```ts
+const controller = deps.beginSlashCommandAction();
+const context = buildInvocationContext(..., controller.signal);
+let result;
+try {
+  result = await commandToExecute.action(context, parsed.args);
+} catch (error) {
+  if (controller.signal.aborted) return { type: 'handled' }; // AC8
+  throw error;
+} finally {
+  deps.endSlashCommandAction(controller);
+}
+return result ? handleActionResult(deps, context, result) : { type: 'handled' };
+```
+
+`setIsProcessing` / `setLocalIsProcessing` keep their current lifetimes; nothing
+else about the pipeline changes.
+
+### 4. Esc
+
+`useCancellation` (packages/cli/src/ui/hooks/agentStream/useAgentStreamLifecycle.ts)
+takes a new `cancelActiveSlashCommand: () => boolean = () => false` parameter,
+mirroring the existing `cancelRunningAsyncTasks` parameter, and runs it *before*
+the streaming-state gate:
+
+```ts
+const cancelOngoingRequest = useCallback(() => {
+  if (cancelActiveSlashCommand()) {
+    addItem({ type: MessageType.INFO, text: SLASH_COMMAND_CANCELLED }, Date.now());
+  }
+  if (streamingState !== Responding && streamingState !== WaitingForConfirmation) return;
+  ... unchanged turn cancellation ...
+}, [...]);
+```
+
+Message text: `Command cancelled.` (distinct from the existing turn-level
+`Request cancelled.`). Reported immediately on Esc rather than when the aborted
+work unwinds.
+
+### 5. Input visibility
+
+`useAppInput` extracts the predicate into a pure helper and stops keying it off
+the slash-command pipeline being busy at all:
+
+```ts
+export function computeIsInputActive(p: {
+  streamingState: StreamingState;
+  initError: string | null;
+  hasSlashCommands: boolean;
+  isAwaitingSlashCommandConfirmation: boolean;
+}): boolean;
+```
+
+Rule: `(streamingState is Idle or Responding) && !initError && hasSlashCommands
+&& !isAwaitingSlashCommandConfirmation`.
+
+`isProcessing` was only ever a proxy for "something else owns the keyboard",
+and a bad one: it is a plain boolean shared by overlapping invocations, so
+inferring the confirmation phase from it is not sound once concurrent commands
+are possible. AC2 is instead satisfied directly:
+
+- `confirm_action` renders through `hasActiveDialog`, which replaces the whole
+  inline layout, so the Composer cannot appear regardless of this predicate.
+- `confirm_shell_commands` parks a Confirming tool group in the processor's
+  pending items, which `computeIsAwaitingSlashCommandConfirmation` detects.
+  A pending item that is merely progress (any non-Confirming status) does not
+  take the prompt away.
+
+### 6. Wiring
+
+`useSlashCommandProcessorCore` calls `useSlashCommandCancellation()`, passes
+`beginSlashCommandAction` / `endSlashCommandAction` into the
+`SlashCommandHandlerDeps`, and returns `cancelActiveSlashCommand` on its result
+(so `useSlashCommandProcessor` forwards it unchanged).
+
+`useAppInput`:
+
+- `useInputFinish` derives `isAwaitingSlashCommandConfirmation` from
+  `core.pendingHistoryItems` for `computeIsInputActive`.
+- `useInputStreamSetup` passes `core.cancelActiveSlashCommand` into
+  `useAgentStream` as a new trailing optional parameter, which forwards it via
+  `AgentStreamOrchestrationDeps.cancelActiveSlashCommand` into `useCancellation`.
+
+`core` is constructed before `stream` in `useAppInput`, so no new refs or
+circular-dependency plumbing are needed.
+
+### 7. Removing the workarounds
+
+- `imageCommand.ts`: drop the `AbortController` + `process.once('SIGINT')` +
+  `removeListener`; pass `context.signal` to the runner. In the catch, if
+  `context.signal.aborted`, return without adding an error item (AC8 — the
+  framework already reported the cancellation).
+- `setupGithubCommand.ts`: `downloadSetupFiles` and `downloadFiles` take the
+  command `signal` and include it in the existing
+  `AbortSignal.any([...])`. The private controller stays only for its real
+  purpose (aborting the shared timeout once all downloads settle).
+- `services/prompt-processors/shellProcessor.ts`: replace
+  `new AbortController().signal` with `context.signal` in the
+  `ShellExecutionService.execute` call.
+
+  In scope because it is the same defect in the same layer, it is a one-line
+  change, and the issue asks for the fix to be applied to the slash-command
+  layer generally rather than to `/image`. It is also what makes a deterministic
+  tmux repro possible (a custom command containing `!{sleep N}`).
+
+## Tests (write first, all `bun:test`, behavioural)
+
+1. `packages/cli/src/ui/hooks/useSlashCommandCancellation.test.tsx` — begin sets
+   running; cancel aborts the returned controller's signal and returns true;
+   second cancel returns false and the signal stays aborted (AC4); cancel with
+   nothing active returns false (AC5); end clears running; end with a stale
+   controller does not clear a newer one.
+
+2. `packages/cli/src/ui/hooks/slashCommandHandlers.test.ts` —
+   - a command action observes a non-aborted `context.signal`, and aborting the
+     registry mid-action fires the action's own `signal` abort listener (AC6);
+   - `isSlashCommandRunning` is true only while the action is pending and false
+     during a `confirm_shell_commands` round-trip (AC2);
+   - an action that rejects after its invocation was aborted adds no ERROR item
+     (AC8);
+   - an action that rejects without an abort still adds the ERROR item.
+
+3. `packages/cli/src/ui/hooks/agentStream/__tests__/useCancellation.slashCommand.test.tsx`
+   (mirrors the existing `useCancellation.asyncTasks.test.tsx`) — Esc with an
+   in-flight slash command and `streamingState` Idle aborts it and adds exactly
+   one `Command cancelled.` INFO item (AC3); a second Esc adds none (AC4); Esc
+   with nothing in flight adds none and leaves turn cancellation untouched
+   (AC5).
+
+4. `packages/cli/src/ui/containers/AppContainer/hooks/useAppInput.inputActive.test.ts`
+   — table over `computeIsInputActive`: visible while a slash command runs
+   (AC1), hidden while processing without a running action (AC2), plus the
+   pre-existing streaming/initError/no-commands cases as regression guards.
+
+5. `packages/cli/src/ui/commands/imageCommand.test.ts` — the runner receives the
+   context signal (aborting `context.signal` aborts the signal the runner saw,
+   AC7); `process.listenerCount('SIGINT')` is unchanged across the invocation
+   (AC9); a runner rejection after abort adds no error item.
+
+6. `packages/cli/src/ui/commands/setupGithubCommand.test.ts` — aborting
+   `context.signal` aborts the in-flight download (AC7) with `fetch` stubbed at
+   the network boundary only.
+
+7. `packages/cli/src/services/prompt-processors/shellProcessor.test.ts` —
+   aborting `context.signal` terminates the injected shell command (AC7).
+
+No mock theater: the hook, the handler, and the commands under test are all
+real; only the network (`fetch`) and the image runner are stubbed, and they are
+stubbed as boundaries that record the signal they were handed rather than
+returning the assertion's literal.
+
+## Manual verification (tmux harness)
+
+The issue requires harness verification, not just unit tests. `/image` needs
+Codex OAuth, which is not available in this checkout, so the deterministic repro
+uses a custom command with a shell injection.
+
+`scripts/tmux-script.issue2976-slash-cancel.llxprt.json` runs against the fake
+provider (`scripts/fixtures/issue2976-slash-cancel.responses.jsonl`). It writes
+a temporary user command whose prompt embeds `!{sleep 90}`, removes it on exit,
+and asserts:
+
+1. after `/issue2976-slowtest` is submitted, the composer is still on screen
+   while the sleep runs (AC1);
+2. Esc produces `Command cancelled.` (AC3);
+3. the fake model's marker never appears afterwards, i.e. the cancelled command
+   did not go on to submit its prompt (AC7);
+4. the session is still usable (`/quit` exits normally).
+
+Harness gotcha worth recording: a literal `!` does not survive the harness's
+argument quoting into the tmux pane (it arrives as `\!`, which is an invalid
+TOML escape and silently drops the command), so the script builds the shell
+injection trigger from its octal code.
+
+### What the harness caught that the unit tests did not
+
+The first green-on-AC1/AC3 run still showed the fake model replying after Esc.
+`shellProcessor` handles an aborted execution gracefully rather than throwing,
+so the command action resolved normally with `submit_prompt` and the framework
+went on to submit it. Discarding a rejection was therefore not enough:
+`runCommandAction` now discards the outcome whenever the invocation was
+aborted, resolved or rejected. Covered by "discards the result of an action
+that resolves after being cancelled".
+
+## Review triage
+
+Findings from the independent design review, with dispositions.
+
+### Fixed
+
+- **Concurrent invocations orphaned the first controller.** The single-slot
+  registry was overwritten by a second command, so a short `/help` submitted
+  during a long `/image` left the long one uncancellable — the reported bug,
+  reintroduced by the fix, and reachable precisely because the prompt is now
+  live. The registry now holds every in-flight controller. Covered by "cancels
+  every concurrently running action, not just the newest" and "keeps the
+  long-running action cancellable after a short one finishes".
+- **The AC2 invariant was a comment, not a property.** `isProcessing` is a plain
+  boolean shared by overlapping invocations, so "processing and no action in
+  flight" does not reliably mean "waiting on the user". Replaced with a direct
+  test for a Confirming tool group (design section 5).
+- **An unrelated error landing in the abort window vanished silently.**
+  `runCommandAction` now logs the discarded error through the slash-command
+  debug logger before dropping it.
+- **`shellProcessor` kept spawning later `!{...}` injections after an abort.**
+  The loop now breaks on `signal.aborted`.
+- **A test passed with the production change reverted.** "hands the action the
+  signal of the controller registered for it" now asserts identity against the
+  registered controller rather than merely that a non-aborted signal exists.
+- **The tmux script leaked its temporary command on a failed run.** It now
+  removes it from a `trap ... EXIT INT TERM`.
+- **`CommandContext.signal`'s doc overstated non-interactive behaviour.**
+  Reworded: the non-interactive path aborts its run-level controller on its own
+  terms; it is not a SIGINT-to-abort bridge.
+
+### Rejected
+
+- **"Discarding a resolved-after-abort result is wrong."** It is deliberate and
+  is what the tmux run proved necessary: `shellProcessor` handles an aborted
+  execution by returning a status suffix rather than throwing, so without the
+  resolve-side discard a cancelled command still submitted its prompt to the
+  model.
+
+### Deferred (follow-up, not this issue)
+
+- **Only `/image`, `/setup-github` and the shell processor honour
+  `context.signal`.** Long-running built-ins such as `/compress` and
+  `/extensions update` keep running after Esc, so for them "Command cancelled."
+  describes the invocation rather than the underlying work. This issue's scope
+  is the mechanism plus the two named workarounds; migrating the remaining
+  commands is separate work.
+- **Telemetry cannot distinguish a cancelled invocation from a completed one.**
+  `finalizeCommand` still emits a plain `SlashCommandEvent`. Changing the event
+  shape is outside this issue.
+- **`hasActiveDialog` omits `confirmUpdateLlxprtExtensionRequests`** even though
+  `DialogManager` renders it. Pre-existing and unrelated to this change.
+
+## Verification cycle
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+`npm run build`, then
+`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.

--- a/scripts/fixtures/issue2976-slash-cancel.responses.jsonl
+++ b/scripts/fixtures/issue2976-slash-cancel.responses.jsonl
@@ -1,0 +1,1 @@
+{"chunks":[{"speaker":"ai","blocks":[{"type":"text","text":"LLXPRT2976_MODEL_REPLY"}]}]}

--- a/scripts/tmux-script.issue2976-slash-cancel.llxprt.json
+++ b/scripts/tmux-script.issue2976-slash-cancel.llxprt.json
@@ -10,7 +10,7 @@
   "startCommand": [
     "bash",
     "-lc",
-    "set -e; repo=$PWD; cmddir=\"$HOME/Library/Preferences/llxprt-code/commands\"; [ -d \"$cmddir\" ] || cmddir=\"$HOME/.llxprt/commands\"; mkdir -p \"$cmddir\"; trap 'rm -f \"$cmddir/issue2976-slowtest.toml\"' EXIT INT TERM; bang=$(printf \"\\047\\041\\047\" | tr -d \"\\047\"); printf 'description = \"issue2976 harness: deliberately long-running slash command\"\\nprompt = \"sleep output: %s{sleep 90}\"\\n' \"$bang\" > \"$cmddir/issue2976-slowtest.toml\"; env LLXPRT_FAKE_RESPONSES=\"$repo/scripts/fixtures/issue2976-slash-cancel.responses.jsonl\" bun scripts/start.ts --provider fake --model fake-model --yolo"
+    "set -e; repo=$PWD; cmddir=$(bun -e 'import {Storage} from \"@vybestack/llxprt-code-settings\"; process.stdout.write(Storage.getUserCommandsDir());'); mkdir -p \"$cmddir\"; trap 'rm -f \"$cmddir/issue2976-slowtest.toml\"' EXIT INT TERM; bang=$(printf \"\\047\\041\\047\" | tr -d \"\\047\"); printf 'description = \"issue2976 harness: deliberately long-running slash command\"\\nprompt = \"sleep output: %s{sleep 90}\"\\n' \"$bang\" > \"$cmddir/issue2976-slowtest.toml\"; env LLXPRT_FAKE_RESPONSES=\"$repo/scripts/fixtures/issue2976-slash-cancel.responses.jsonl\" bun scripts/start.ts --provider fake --model fake-model --yolo"
   ],
   "steps": [
     {

--- a/scripts/tmux-script.issue2976-slash-cancel.llxprt.json
+++ b/scripts/tmux-script.issue2976-slash-cancel.llxprt.json
@@ -1,0 +1,100 @@
+{
+  "tmux": {
+    "cols": 120,
+    "rows": 35,
+    "historyLimit": 50000,
+    "scrollbackLines": 6000,
+    "initialWaitMs": 6000
+  },
+  "yolo": true,
+  "startCommand": [
+    "bash",
+    "-lc",
+    "set -e; repo=$PWD; cmddir=\"$HOME/Library/Preferences/llxprt-code/commands\"; [ -d \"$cmddir\" ] || cmddir=\"$HOME/.llxprt/commands\"; mkdir -p \"$cmddir\"; trap 'rm -f \"$cmddir/issue2976-slowtest.toml\"' EXIT INT TERM; bang=$(printf \"\\047\\041\\047\" | tr -d \"\\047\"); printf 'description = \"issue2976 harness: deliberately long-running slash command\"\\nprompt = \"sleep output: %s{sleep 90}\"\\n' \"$bang\" > \"$cmddir/issue2976-slowtest.toml\"; env LLXPRT_FAKE_RESPONSES=\"$repo/scripts/fixtures/issue2976-slash-cancel.responses.jsonl\" bun scripts/start.ts --provider fake --model fake-model --yolo"
+  ],
+  "steps": [
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Type your message",
+      "timeoutMs": 40000
+    },
+    {
+      "type": "line",
+      "text": "/issue2976-slowtest",
+      "submitKeys": ["Escape"]
+    },
+    {
+      "type": "wait",
+      "ms": 500
+    },
+    {
+      "type": "key",
+      "key": "Enter"
+    },
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "regex": "esc to cancel|sleep output|> /issue2976-slowtest",
+      "timeoutMs": 15000
+    },
+    {
+      "type": "wait",
+      "ms": 5000
+    },
+    {
+      "type": "capture",
+      "label": "during-slash-command",
+      "scope": "screen"
+    },
+    {
+      "type": "expect",
+      "scope": "screen",
+      "contains": "Type your message"
+    },
+    {
+      "type": "line",
+      "text": "\u001b[27u",
+      "submitKeys": [],
+      "postTypeMs": 0
+    },
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Command cancelled.",
+      "timeoutMs": 15000
+    },
+    {
+      "type": "wait",
+      "ms": 3000
+    },
+    {
+      "type": "waitForNot",
+      "scope": "scrollback",
+      "contains": "LLXPRT2976_MODEL_REPLY",
+      "timeoutMs": 3000
+    },
+    {
+      "type": "capture",
+      "label": "after-cancel",
+      "scope": "screen"
+    },
+    {
+      "type": "line",
+      "text": "/quit",
+      "submitKeys": ["Escape"]
+    },
+    {
+      "type": "wait",
+      "ms": 500
+    },
+    {
+      "type": "key",
+      "key": "Enter"
+    },
+    {
+      "type": "waitForExit",
+      "timeoutMs": 30000
+    }
+  ]
+}


### PR DESCRIPTION
## TLDR

A long slash command used to take the input prompt away for its whole duration, and Esc did nothing. Reported against `/image`, which can run for a minute against gpt-image-2, but the gap is in the slash-command execution model, not the image feature.

This threads a real `AbortSignal` through `CommandContext`, lets Esc abort in-flight slash commands, and stops keying composer visibility off "the slash-command pipeline is busy". The `SIGINT` and throwaway-`AbortController` workarounds in `imageCommand.ts`, `setupGithubCommand.ts` and `shellProcessor.ts` are gone.

Reviewers: the interesting parts are `runCommandAction` in `slashCommandHandlers.ts` (what happens to a cancelled invocation's outcome), the multi-controller registry in `useSlashCommandCancellation.ts` (why it is not a single slot), and `computeIsInputActive` in `useAppInput.ts` (why `isProcessing` is no longer an input).

## Dive Deeper

### The two original defects

`processSlashCommand` awaited the command action between `setIsProcessing(true)` and `setIsProcessing(false)`, and `useAppInput` folded `!isProcessing` into `isInputActive`, which `InlineContent` uses to decide whether to render the composer. So the prompt vanished for the whole command.

`useCancellation.cancelOngoingRequest` returned early unless `streamingState` was `Responding` or `WaitingForConfirmation`. `useStreamingState` derives that from `isResponding` and `toolCalls`; a slash command sets neither, so the state was `Idle` and Esc was a no-op. There was also no signal to hand the command even if Esc had fired.

### Direction

Option 1 from the issue: thread the signal, make the existing Esc handler aware of in-flight commands, and revisit `isInputActive`. Option 2 (route long commands through the tool-call scheduler) was rejected here: it needs a product decision about slash commands synthesising tool calls and how that renders in history, and it would not by itself give the generic slash-command layer a cancellation signal. Option 3 (async-task manager) has the same problem and adds a second lifecycle owner.

### What changed

- **`CommandContext.signal`** is a new required field. The interactive path supplies a fresh per-invocation controller's signal; the non-interactive path supplies its existing run-level controller's signal; the base context (used for completions, which are not cancellable) gets a never-aborting one.
- **A registry of in-flight command controllers** (`useSlashCommandCancellation.ts`) that Esc can abort. It holds *every* in-flight controller, not just the newest: keeping the prompt live means a user can submit a second command while a long one runs, and a single slot would let the short command's completion evict the long one and leave it uncancellable, which is the bug this PR is fixing.
- **`cancelOngoingRequest` cancels slash commands before the streaming-state gate** and adds one `Command cancelled.` INFO item, distinct from the turn-level `Request cancelled.`. A second Esc adds nothing.
- **A cancelled invocation's outcome is discarded**, whether the action resolved or rejected. The rejection case stops a cancelled command reporting an error on top of the cancellation notice; the resolution case stops it carrying out the work the user just abandoned. Both are logged at debug so nothing vanishes without a trace.
- **Composer visibility no longer uses `isProcessing`.** That was only ever a proxy for "something else owns the keyboard", and a poor one: it is a plain boolean shared by overlapping invocations. `confirm_action` renders through the dialog manager, which already replaces the whole inline layout; `confirm_shell_commands` parks a Confirming tool group in the processor's pending items, which is now tested for directly. A pending item that is merely progress does not take the prompt away.
- **Workarounds removed.** `imageCommand.ts` drops `process.once('SIGINT', ...)`; `setupGithubCommand.ts` composes the invocation signal into its download `AbortSignal.any` (its own controller keeps its real job of releasing the per-batch fetch timeouts); `shellProcessor.ts` passes the invocation signal to `ShellExecutionService.execute` instead of `new AbortController().signal`, and stops spawning later `!{...}` injections once the signal aborts.

### What the tmux harness caught that unit tests did not

The first harness run showed the prompt staying visible and `Command cancelled.` appearing correctly, and then the model replying anyway. `shellProcessor` handles an aborted execution by returning a status suffix rather than throwing, so the action resolved normally with `submit_prompt` and the framework submitted it. Discarding only rejections was not enough; hence the resolve-side discard above.

### Known follow-ups, deliberately not in this PR

- Only `/image`, `/setup-github` and the shell processor actually honour `context.signal` today. Long-running built-ins such as `/compress` and `/extensions update` keep running after Esc, so for them the notice describes the invocation rather than the underlying work. The mechanism now exists for all of them; migrating them is separate work.
- Esc does not dismiss a pending shell-expansion confirmation. By that point the action has settled and its controller is deregistered, so Esc is a no-op there rather than misleading, and the confirmation carries its own Cancel option. This is unchanged from before the PR.
- Telemetry still records a cancelled invocation as an ordinary `SlashCommandEvent`.

## Reviewer Test Plan

**Automated**, from the repo root:

```
npm run test && npm run lint && npm run typecheck && npm run build
```

**Interactive, via the tmux harness** (this is the reproduction from the issue, made deterministic):

```
bun scripts/tmux-harness.ts --script scripts/tmux-script.issue2976-slash-cancel.llxprt.json
```

It provisions a temporary user command whose prompt embeds `!{sleep 90}` (removed again by a `trap`), runs against the fake provider, and asserts that the composer is still on screen while the command runs, that Esc produces `Command cancelled.`, that the fake model's marker never appears afterwards, and that `/quit` still exits. Exit code 0 means all of that held.

**By hand**, if you have Codex OAuth set up, the original repro:

1. Start llxprt interactively.
2. Run `/image out.png "a photorealistic cat"`.
3. The prompt should stay visible and you should be able to type.
4. Press Esc. You should get `Command cancelled.` promptly, no `out.png` should be written, and the session should stay usable.

Worth poking at specifically:

- Run a slash command that needs shell-expansion approval and confirm the prompt is still hidden while the approval is on screen.
- Submit a second slash command while a long one is running, then press Esc, and confirm both stop.
- Press Esc while the model is streaming, with no slash command running, and confirm turn cancellation is unchanged.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: full monorepo test suite, lint, typecheck, build, the tmux harness scenario above, and an interactive startup smoke run. Nothing here is platform-specific beyond the harness script's use of a POSIX shell.

## Linked issues / bugs

Fixes #2976

Follow-up from #2128 / PR #2813.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Escape-based cancellation for active slash commands.
  * Shows a cancellation notice and suppresses results from cancelled actions.
  * Propagates cancellation through shell commands, image generation, and setup downloads.
  * Improved input availability while awaiting command confirmations.

* **Bug Fixes**
  * Prevented additional work from starting after cancellation.
  * Removed unintended SIGINT-based cancellation for image operations.

* **Tests**
  * Added coverage for cancellation, confirmation states, signal propagation, and input behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->