### PR TITLE
Stop retaining a compiled Ajv validator per tool call (Fixes #3361)

### DIFF
--- a/packages/core/src/utils/schemaValidator.compileCache.test.ts
+++ b/packages/core/src/utils/schemaValidator.compileCache.test.ts
@@ -61,6 +61,24 @@ function collectGarbage(): void {
 }
 
 describe('SchemaValidator compiled-validator retention', () => {
+  it('validates a boolean schema without throwing', () => {
+    // `true` and `false` are valid JSON Schema and reach the derivation path.
+    // A WeakMap key must be an object, so caching them would throw
+    // `Invalid value used as weak map key`; the cache must skip them.
+    //
+    // Both currently return null because the derivation spreads the primitive
+    // into `{}`, an empty schema that accepts anything. That loses `false`'s
+    // reject-everything meaning, but it is the behaviour on `main` and this
+    // change preserves it exactly. Asserted so the no-throw guarantee is
+    // pinned without silently claiming full JSON Schema boolean semantics.
+    expect(() => SchemaValidator.validate(true, { anything: 1 })).not.toThrow();
+    expect(() =>
+      SchemaValidator.validate(false, { anything: 1 }),
+    ).not.toThrow();
+    expect(SchemaValidator.validate(true, { anything: 1 })).toBeNull();
+    expect(SchemaValidator.validate(false, { anything: 1 })).toBeNull();
+  });
+
   /** @plan PLAN-20260826-AJVCACHE.P02 @requirement REQ-3361-01 */
   it('does not retain a compiled validator per validation of a stable schema', () => {
     // A tool declares its schema once; every invocation validates against that
@@ -78,6 +96,11 @@ describe('SchemaValidator compiled-validator retention', () => {
     expect(SchemaValidator.validate(schema, { path: '.' })).toBeNull();
     collectGarbage();
     const before = countHeapClass('SchemaEnv');
+
+    // Without this the assertion is vacuous: if Ajv is upgraded, bundled
+    // differently, or Bun reports a different class name, both samples read 0,
+    // growth computes to 0, and the test passes while validators still leak.
+    expect(before).toBeGreaterThan(0);
 
     for (let index = 0; index < VALIDATION_COUNT; index += 1) {
       expect(SchemaValidator.validate(schema, { path: `dir-${index}` })).toBe(

--- a/packages/core/src/utils/schemaValidator.compileCache.test.ts
+++ b/packages/core/src/utils/schemaValidator.compileCache.test.ts
@@ -1,0 +1,145 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ * @plan PLAN-20260826-AJVCACHE.P02
+ * @requirement REQ-3361-01
+ */
+
+import { generateHeapSnapshot } from 'bun';
+import { describe, expect, it } from 'bun:test';
+import { SchemaValidator } from './schemaValidator.js';
+
+const VALIDATION_COUNT = 300;
+/**
+ * Ajv allocates a small, fixed number of `SchemaEnv` objects for its own meta
+ * schemas. A correct compile cache adds none per validation, so anything at or
+ * above this bound means validators are accumulating per call.
+ */
+const SCHEMA_ENV_GROWTH_THRESHOLD = 20;
+
+/** @plan PLAN-20260826-AJVCACHE.P02 @requirement REQ-3361-01 */
+function countHeapClass(name: string): number {
+  const snapshot = generateHeapSnapshot();
+  // Validate the snapshot layout via a class every JavaScript heap has; a Bun
+  // format change must fail loudly instead of silently counting zero.
+  if (
+    !Array.isArray(snapshot.nodes) ||
+    !Array.isArray(snapshot.nodeClassNames) ||
+    snapshot.nodes.length % 4 !== 0 ||
+    snapshot.nodeClassNames.indexOf('Object') < 0
+  ) {
+    throw new Error(
+      'Unexpected heap snapshot encoding; class counts would be unreliable',
+    );
+  }
+  const classCount = snapshot.nodeClassNames.length;
+  const classIndex = snapshot.nodeClassNames.indexOf(name);
+  if (classIndex < 0) {
+    return 0;
+  }
+
+  let count = 0;
+  for (let position = 2; position < snapshot.nodes.length; position += 4) {
+    const nodeClass = snapshot.nodes[position];
+    if (nodeClass >= classCount) {
+      throw new Error(
+        'Unexpected heap snapshot encoding; class index out of bounds',
+      );
+    }
+    if (nodeClass === classIndex) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/** @plan PLAN-20260826-AJVCACHE.P02 @requirement REQ-3361-01 */
+function collectGarbage(): void {
+  Bun.gc(true);
+  Bun.gc(true);
+}
+
+describe('SchemaValidator compiled-validator retention', () => {
+  /** @plan PLAN-20260826-AJVCACHE.P02 @requirement REQ-3361-01 */
+  it('does not retain a compiled validator per validation of a stable schema', () => {
+    // A tool declares its schema once; every invocation validates against that
+    // same object, which is the shape this cache has to serve.
+    const schema = {
+      type: 'object',
+      properties: {
+        path: { type: 'string' },
+        depth: { type: 'number' },
+      },
+      required: ['path'],
+    };
+
+    // Warm up so first-compile allocations are not counted as growth.
+    expect(SchemaValidator.validate(schema, { path: '.' })).toBeNull();
+    collectGarbage();
+    const before = countHeapClass('SchemaEnv');
+
+    for (let index = 0; index < VALIDATION_COUNT; index += 1) {
+      expect(SchemaValidator.validate(schema, { path: `dir-${index}` })).toBe(
+        null,
+      );
+    }
+
+    collectGarbage();
+    const growth = countHeapClass('SchemaEnv') - before;
+
+    expect(growth).toBeLessThan(SCHEMA_ENV_GROWTH_THRESHOLD);
+  });
+
+  /** @plan PLAN-20260826-AJVCACHE.P02 @requirement REQ-3361-02 */
+  it('still reports validation errors after repeated validations', () => {
+    const schema = {
+      type: 'object',
+      properties: { path: { type: 'string' } },
+      required: ['path'],
+    };
+
+    for (let index = 0; index < 5; index += 1) {
+      expect(SchemaValidator.validate(schema, { path: 'ok' })).toBeNull();
+    }
+
+    const error = SchemaValidator.validate(schema, { depth: 1 });
+    expect(error).not.toBeNull();
+    expect(error).toContain('path');
+  });
+
+  /** @plan PLAN-20260826-AJVCACHE.P02 @requirement REQ-3361-02 */
+  it('keeps requireOne enforcement across repeated validations', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        old_string: { type: 'string' },
+        new_string: { type: 'string' },
+      },
+      requireOne: [['old_string', 'new_string']],
+    };
+
+    for (let index = 0; index < 5; index += 1) {
+      expect(SchemaValidator.validate(schema, { old_string: 'a' })).toBeNull();
+    }
+
+    const error = SchemaValidator.validate(schema, {});
+    expect(error).toContain('at least one of required properties');
+  });
+
+  /** @plan PLAN-20260826-AJVCACHE.P02 @requirement REQ-3361-02 */
+  it('keeps draft-07 dialect selection across repeated validations', () => {
+    const schema = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+    };
+
+    for (let index = 0; index < 5; index += 1) {
+      expect(SchemaValidator.validate(schema, { name: 'x' })).toBeNull();
+    }
+
+    expect(SchemaValidator.validate(schema, {})).toContain('name');
+  });
+});

--- a/packages/core/src/utils/schemaValidator.ts
+++ b/packages/core/src/utils/schemaValidator.ts
@@ -310,18 +310,39 @@ interface ExtendedSchema {
  */
 const ajvSchemaCache = new WeakMap<ExtendedSchema, ExtendedSchema>();
 
-/** Returns the Ajv-ready schema for a source schema, deriving it once. */
-function toAjvSchema(extSchema: ExtendedSchema): ExtendedSchema {
-  const cached = ajvSchemaCache.get(extSchema);
+/** Strips the internal keywords Ajv must not see. */
+function deriveAjvSchema(schema: unknown): ExtendedSchema {
+  // Spreading a primitive yields `{}`, which is what this code has always
+  // produced for a boolean schema. Preserved deliberately.
+  const ajvSchema = { ...(schema as ExtendedSchema) };
+  delete ajvSchema.requireOne;
+  delete ajvSchema.$schema;
+  return ajvSchema;
+}
+
+/**
+ * Returns the Ajv-ready schema for a source schema, deriving it once.
+ *
+ * Takes `unknown` rather than `ExtendedSchema` because the caller reaches this
+ * through a cast from `unknown`; the declared type cannot be trusted to exclude
+ * primitives at runtime.
+ */
+function toAjvSchema(schema: unknown): ExtendedSchema {
+  // `true` and `false` are valid JSON Schema, and a WeakMap key must be an
+  // object, so primitives cannot be cached. Derive without caching rather than
+  // throwing `Invalid value used as weak map key`.
+  if (typeof schema !== 'object' || schema === null) {
+    return deriveAjvSchema(schema);
+  }
+
+  const source = schema as ExtendedSchema;
+  const cached = ajvSchemaCache.get(source);
   if (cached !== undefined) {
     return cached;
   }
 
-  const ajvSchema = { ...extSchema };
-  delete ajvSchema.requireOne;
-  delete ajvSchema.$schema;
-
-  ajvSchemaCache.set(extSchema, ajvSchema);
+  const ajvSchema = deriveAjvSchema(source);
+  ajvSchemaCache.set(source, ajvSchema);
   return ajvSchema;
 }
 

--- a/packages/core/src/utils/schemaValidator.ts
+++ b/packages/core/src/utils/schemaValidator.ts
@@ -297,6 +297,35 @@ interface ExtendedSchema {
 }
 
 /**
+ * Ajv keys its compiled-validator cache on schema **object identity**. Deriving
+ * a fresh object per validation therefore misses the cache every time and
+ * retains one compiled validator, plus its generated code, for the life of the
+ * process (issue #3361). Memoising the derived schema on the source object
+ * restores the cache hit.
+ *
+ * A WeakMap keeps this bounded: entries disappear with the source schema, so a
+ * caller that legitimately builds schemas dynamically does not accumulate.
+ * Tool schemas are declared once and treated as immutable, so a later mutation
+ * of a source schema is not reflected. That matches how Ajv itself caches.
+ */
+const ajvSchemaCache = new WeakMap<ExtendedSchema, ExtendedSchema>();
+
+/** Returns the Ajv-ready schema for a source schema, deriving it once. */
+function toAjvSchema(extSchema: ExtendedSchema): ExtendedSchema {
+  const cached = ajvSchemaCache.get(extSchema);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const ajvSchema = { ...extSchema };
+  delete ajvSchema.requireOne;
+  delete ajvSchema.$schema;
+
+  ajvSchemaCache.set(extSchema, ajvSchema);
+  return ajvSchema;
+}
+
+/**
  * Simple utility to validate objects against JSON Schemas
  */
 export class SchemaValidator {
@@ -398,11 +427,7 @@ export class SchemaValidator {
     // meta-schema. The dialect decision has already been made above by
     // inspecting `declaredSchemaUri`, so dropping the field now has no
     // effect on which keyword rules are applied.
-    const ajvSchema = { ...extSchema };
-    delete ajvSchema.requireOne;
-    delete ajvSchema.$schema;
-
-    const validate = instance.compile(ajvSchema);
+    const validate = instance.compile(toAjvSchema(extSchema));
     const valid = validate(data);
 
     if (

--- a/packages/tools/src/tools/tools.schemaIdentity.test.ts
+++ b/packages/tools/src/tools/tools.schemaIdentity.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ * @plan PLAN-20260826-AJVCACHE.P03
+ * @requirement REQ-3361-03
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { BaseDeclarativeTool, Kind } from './tools.js';
+import type { ToolInvocation, ToolResult } from './tools.js';
+
+interface Params {
+  path: string;
+}
+
+const PARAMETER_SCHEMA = {
+  type: 'object',
+  properties: {
+    path: { type: 'string' },
+    old_string: { type: 'string' },
+    new_string: { type: 'string' },
+  },
+  required: ['path'],
+  requireOne: [['old_string', 'new_string']],
+};
+
+class ProbeTool extends BaseDeclarativeTool<Params, ToolResult> {
+  constructor(schema: unknown = PARAMETER_SCHEMA) {
+    super('probe', 'Probe', 'probe tool', Kind.Other, schema);
+  }
+
+  protected createInvocation(): ToolInvocation<Params, ToolResult> {
+    throw new Error('not needed for these assertions');
+  }
+}
+
+describe('BaseDeclarativeTool schema identity', () => {
+  /** @plan PLAN-20260826-AJVCACHE.P03 @requirement REQ-3361-03 */
+  it('returns the same schema object across reads', () => {
+    const tool = new ProbeTool();
+
+    const first = tool.schema;
+    const second = tool.schema;
+
+    // Ajv keys its compiled-validator cache on schema object identity, so a
+    // fresh object per read makes every tool call compile and retain a new
+    // validator (issue #3361).
+    expect(second).toBe(first);
+    expect(second.parametersJsonSchema).toBe(first.parametersJsonSchema);
+  });
+
+  /** @plan PLAN-20260826-AJVCACHE.P03 @requirement REQ-3361-03 */
+  it('still strips requireOne from the schema sent to the model', () => {
+    const tool = new ProbeTool();
+
+    const parameters = tool.schema.parametersJsonSchema as Record<
+      string,
+      unknown
+    >;
+
+    expect(parameters['requireOne']).toBeUndefined();
+    expect(parameters['required']).toEqual(['path']);
+    // The source schema must not be mutated by the derivation.
+    expect(
+      (PARAMETER_SCHEMA as Record<string, unknown>)['requireOne'],
+    ).toBeDefined();
+  });
+
+  /** @plan PLAN-20260826-AJVCACHE.P03 @requirement REQ-3361-03 */
+  it('returns identical validation outcomes across repeated reads', () => {
+    const tool = new ProbeTool();
+
+    for (let index = 0; index < 5; index += 1) {
+      expect(
+        tool.validateToolParams({ path: '.', old_string: 'a' } as Params),
+      ).toBeNull();
+    }
+
+    // `required` still applies; a missing required property is rejected the
+    // same way on the first read and every later one.
+    const missingRequired = tool.validateToolParams({} as Params);
+    expect(missingRequired).not.toBeNull();
+    expect(missingRequired).toContain('path');
+    expect(tool.validateToolParams({} as Params)).toBe(missingRequired);
+  });
+
+  /**
+   * Characterises existing behaviour rather than endorsing it: the `schema`
+   * getter strips `requireOne` before returning, and `validateToolParams`
+   * validates against that stripped schema, so `SchemaValidator`'s `requireOne`
+   * branch is unreachable through this path. Pre-existing on `main` and out of
+   * scope for issue #3361; pinned here so the memoisation cannot be blamed for
+   * it and so a future change is deliberate.
+   *
+   * @plan PLAN-20260826-AJVCACHE.P03
+   * @requirement REQ-3361-03
+   */
+  it('does not enforce requireOne through validateToolParams', () => {
+    const tool = new ProbeTool();
+
+    expect(tool.validateToolParams({ path: '.' } as Params)).toBeNull();
+  });
+
+  /** @plan PLAN-20260826-AJVCACHE.P03 @requirement REQ-3361-03 */
+  it('handles a null parameter schema without caching a stale result', () => {
+    const tool = new ProbeTool(null);
+
+    const first = tool.schema;
+    const second = tool.schema;
+
+    expect(second).toBe(first);
+    expect(first.parametersJsonSchema).toBeNull();
+  });
+});

--- a/packages/tools/src/tools/tools.ts
+++ b/packages/tools/src/tools/tools.ts
@@ -496,6 +496,10 @@ export abstract class DeclarativeTool<
 {
   protected readonly messageBus?: IToolMessageBus;
 
+  /** Memoised `schema` result and the `parameterSchema` it was derived from. */
+  private cachedSchema?: FunctionDeclaration;
+  private cachedSchemaSource?: unknown;
+
   constructor(
     readonly name: string,
     readonly displayName: string,
@@ -525,6 +529,27 @@ export abstract class DeclarativeTool<
   }
 
   get schema(): FunctionDeclaration {
+    // Memoised because this getter is read on every tool invocation (see
+    // validateToolParams) and Ajv keys its compiled-validator cache on schema
+    // object identity. Returning a fresh clone each time made every tool call
+    // compile and retain a new validator (issue #3361).
+    //
+    // Keyed on `parameterSchema` identity so a tool that swaps its schema
+    // rebuilds rather than serving a stale one.
+    if (
+      this.cachedSchema !== undefined &&
+      this.cachedSchemaSource === this.parameterSchema
+    ) {
+      return this.cachedSchema;
+    }
+
+    const schema = this.buildSchema();
+    this.cachedSchemaSource = this.parameterSchema;
+    this.cachedSchema = schema;
+    return schema;
+  }
+
+  private buildSchema(): FunctionDeclaration {
     // Strip requireOne from the schema before sending to the model
     // The requireOne property is used internally for validation but not sent to the model
     if (

--- a/packages/tools/src/utils/schemaValidator.compileCache.test.ts
+++ b/packages/tools/src/utils/schemaValidator.compileCache.test.ts
@@ -1,0 +1,145 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ * @plan PLAN-20260826-AJVCACHE.P01
+ * @requirement REQ-3361-01
+ */
+
+import { generateHeapSnapshot } from 'bun';
+import { describe, expect, it } from 'bun:test';
+import { SchemaValidator } from './schemaValidator.js';
+
+const VALIDATION_COUNT = 300;
+/**
+ * Ajv allocates a small, fixed number of `SchemaEnv` objects for its own meta
+ * schemas. A correct compile cache adds none per validation, so anything at or
+ * above this bound means validators are accumulating per call.
+ */
+const SCHEMA_ENV_GROWTH_THRESHOLD = 20;
+
+/** @plan PLAN-20260826-AJVCACHE.P01 @requirement REQ-3361-01 */
+function countHeapClass(name: string): number {
+  const snapshot = generateHeapSnapshot();
+  // Validate the snapshot layout via a class every JavaScript heap has; a Bun
+  // format change must fail loudly instead of silently counting zero.
+  if (
+    !Array.isArray(snapshot.nodes) ||
+    !Array.isArray(snapshot.nodeClassNames) ||
+    snapshot.nodes.length % 4 !== 0 ||
+    snapshot.nodeClassNames.indexOf('Object') < 0
+  ) {
+    throw new Error(
+      'Unexpected heap snapshot encoding; class counts would be unreliable',
+    );
+  }
+  const classCount = snapshot.nodeClassNames.length;
+  const classIndex = snapshot.nodeClassNames.indexOf(name);
+  if (classIndex < 0) {
+    return 0;
+  }
+
+  let count = 0;
+  for (let position = 2; position < snapshot.nodes.length; position += 4) {
+    const nodeClass = snapshot.nodes[position];
+    if (nodeClass >= classCount) {
+      throw new Error(
+        'Unexpected heap snapshot encoding; class index out of bounds',
+      );
+    }
+    if (nodeClass === classIndex) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/** @plan PLAN-20260826-AJVCACHE.P01 @requirement REQ-3361-01 */
+function collectGarbage(): void {
+  Bun.gc(true);
+  Bun.gc(true);
+}
+
+describe('SchemaValidator compiled-validator retention', () => {
+  /** @plan PLAN-20260826-AJVCACHE.P01 @requirement REQ-3361-01 */
+  it('does not retain a compiled validator per validation of a stable schema', () => {
+    // A tool declares its schema once; every invocation validates against that
+    // same object, which is the shape this cache has to serve.
+    const schema = {
+      type: 'object',
+      properties: {
+        path: { type: 'string' },
+        depth: { type: 'number' },
+      },
+      required: ['path'],
+    };
+
+    // Warm up so first-compile allocations are not counted as growth.
+    expect(SchemaValidator.validate(schema, { path: '.' })).toBeNull();
+    collectGarbage();
+    const before = countHeapClass('SchemaEnv');
+
+    for (let index = 0; index < VALIDATION_COUNT; index += 1) {
+      expect(SchemaValidator.validate(schema, { path: `dir-${index}` })).toBe(
+        null,
+      );
+    }
+
+    collectGarbage();
+    const growth = countHeapClass('SchemaEnv') - before;
+
+    expect(growth).toBeLessThan(SCHEMA_ENV_GROWTH_THRESHOLD);
+  });
+
+  /** @plan PLAN-20260826-AJVCACHE.P01 @requirement REQ-3361-02 */
+  it('still reports validation errors after repeated validations', () => {
+    const schema = {
+      type: 'object',
+      properties: { path: { type: 'string' } },
+      required: ['path'],
+    };
+
+    for (let index = 0; index < 5; index += 1) {
+      expect(SchemaValidator.validate(schema, { path: 'ok' })).toBeNull();
+    }
+
+    const error = SchemaValidator.validate(schema, { depth: 1 });
+    expect(error).not.toBeNull();
+    expect(error).toContain('path');
+  });
+
+  /** @plan PLAN-20260826-AJVCACHE.P01 @requirement REQ-3361-02 */
+  it('keeps requireOne enforcement across repeated validations', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        old_string: { type: 'string' },
+        new_string: { type: 'string' },
+      },
+      requireOne: [['old_string', 'new_string']],
+    };
+
+    for (let index = 0; index < 5; index += 1) {
+      expect(SchemaValidator.validate(schema, { old_string: 'a' })).toBeNull();
+    }
+
+    const error = SchemaValidator.validate(schema, {});
+    expect(error).toContain('at least one of required properties');
+  });
+
+  /** @plan PLAN-20260826-AJVCACHE.P01 @requirement REQ-3361-02 */
+  it('keeps draft-07 dialect selection across repeated validations', () => {
+    const schema = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+    };
+
+    for (let index = 0; index < 5; index += 1) {
+      expect(SchemaValidator.validate(schema, { name: 'x' })).toBeNull();
+    }
+
+    expect(SchemaValidator.validate(schema, {})).toContain('name');
+  });
+});

--- a/packages/tools/src/utils/schemaValidator.compileCache.test.ts
+++ b/packages/tools/src/utils/schemaValidator.compileCache.test.ts
@@ -61,6 +61,24 @@ function collectGarbage(): void {
 }
 
 describe('SchemaValidator compiled-validator retention', () => {
+  it('validates a boolean schema without throwing', () => {
+    // `true` and `false` are valid JSON Schema and reach the derivation path.
+    // A WeakMap key must be an object, so caching them would throw
+    // `Invalid value used as weak map key`; the cache must skip them.
+    //
+    // Both currently return null because the derivation spreads the primitive
+    // into `{}`, an empty schema that accepts anything. That loses `false`'s
+    // reject-everything meaning, but it is the behaviour on `main` and this
+    // change preserves it exactly. Asserted so the no-throw guarantee is
+    // pinned without silently claiming full JSON Schema boolean semantics.
+    expect(() => SchemaValidator.validate(true, { anything: 1 })).not.toThrow();
+    expect(() =>
+      SchemaValidator.validate(false, { anything: 1 }),
+    ).not.toThrow();
+    expect(SchemaValidator.validate(true, { anything: 1 })).toBeNull();
+    expect(SchemaValidator.validate(false, { anything: 1 })).toBeNull();
+  });
+
   /** @plan PLAN-20260826-AJVCACHE.P01 @requirement REQ-3361-01 */
   it('does not retain a compiled validator per validation of a stable schema', () => {
     // A tool declares its schema once; every invocation validates against that
@@ -78,6 +96,11 @@ describe('SchemaValidator compiled-validator retention', () => {
     expect(SchemaValidator.validate(schema, { path: '.' })).toBeNull();
     collectGarbage();
     const before = countHeapClass('SchemaEnv');
+
+    // Without this the assertion is vacuous: if Ajv is upgraded, bundled
+    // differently, or Bun reports a different class name, both samples read 0,
+    // growth computes to 0, and the test passes while validators still leak.
+    expect(before).toBeGreaterThan(0);
 
     for (let index = 0; index < VALIDATION_COUNT; index += 1) {
       expect(SchemaValidator.validate(schema, { path: `dir-${index}` })).toBe(

--- a/packages/tools/src/utils/schemaValidator.ts
+++ b/packages/tools/src/utils/schemaValidator.ts
@@ -260,18 +260,39 @@ interface ExtendedSchema {
  */
 const ajvSchemaCache = new WeakMap<ExtendedSchema, ExtendedSchema>();
 
-/** Returns the Ajv-ready schema for a source schema, deriving it once. */
-function toAjvSchema(extSchema: ExtendedSchema): ExtendedSchema {
-  const cached = ajvSchemaCache.get(extSchema);
+/** Strips the internal keywords Ajv must not see. */
+function deriveAjvSchema(schema: unknown): ExtendedSchema {
+  // Spreading a primitive yields `{}`, which is what this code has always
+  // produced for a boolean schema. Preserved deliberately.
+  const ajvSchema = { ...(schema as ExtendedSchema) };
+  delete ajvSchema.requireOne;
+  delete ajvSchema.$schema;
+  return ajvSchema;
+}
+
+/**
+ * Returns the Ajv-ready schema for a source schema, deriving it once.
+ *
+ * Takes `unknown` rather than `ExtendedSchema` because the caller reaches this
+ * through a cast from `unknown`; the declared type cannot be trusted to exclude
+ * primitives at runtime.
+ */
+function toAjvSchema(schema: unknown): ExtendedSchema {
+  // `true` and `false` are valid JSON Schema, and a WeakMap key must be an
+  // object, so primitives cannot be cached. Derive without caching rather than
+  // throwing `Invalid value used as weak map key`.
+  if (typeof schema !== 'object' || schema === null) {
+    return deriveAjvSchema(schema);
+  }
+
+  const source = schema as ExtendedSchema;
+  const cached = ajvSchemaCache.get(source);
   if (cached !== undefined) {
     return cached;
   }
 
-  const ajvSchema = { ...extSchema };
-  delete ajvSchema.requireOne;
-  delete ajvSchema.$schema;
-
-  ajvSchemaCache.set(extSchema, ajvSchema);
+  const ajvSchema = deriveAjvSchema(source);
+  ajvSchemaCache.set(source, ajvSchema);
   return ajvSchema;
 }
 

--- a/packages/tools/src/utils/schemaValidator.ts
+++ b/packages/tools/src/utils/schemaValidator.ts
@@ -246,6 +246,35 @@ interface ExtendedSchema {
   [key: string]: unknown;
 }
 
+/**
+ * Ajv keys its compiled-validator cache on schema **object identity**. Deriving
+ * a fresh object per validation therefore misses the cache every time and
+ * retains one compiled validator, plus its generated code, for the life of the
+ * process (issue #3361). Memoising the derived schema on the source object
+ * restores the cache hit.
+ *
+ * A WeakMap keeps this bounded: entries disappear with the source schema, so a
+ * caller that legitimately builds schemas dynamically does not accumulate.
+ * Tool schemas are declared once and treated as immutable, so a later mutation
+ * of a source schema is not reflected. That matches how Ajv itself caches.
+ */
+const ajvSchemaCache = new WeakMap<ExtendedSchema, ExtendedSchema>();
+
+/** Returns the Ajv-ready schema for a source schema, deriving it once. */
+function toAjvSchema(extSchema: ExtendedSchema): ExtendedSchema {
+  const cached = ajvSchemaCache.get(extSchema);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const ajvSchema = { ...extSchema };
+  delete ajvSchema.requireOne;
+  delete ajvSchema.$schema;
+
+  ajvSchemaCache.set(extSchema, ajvSchema);
+  return ajvSchema;
+}
+
 /** Resolves the error path from AJV instancePath or dataPath. */
 function resolveErrorPath(instancePath: unknown, dataPath: unknown): string {
   if (typeof instancePath === 'string' && instancePath !== '') {
@@ -290,11 +319,7 @@ export class SchemaValidator {
       ? ajValidator07
       : ajValidator2020;
 
-    const ajvSchema = { ...extSchema };
-    delete ajvSchema.requireOne;
-    delete ajvSchema.$schema;
-
-    const validate = instance.compile(ajvSchema);
+    const validate = instance.compile(toAjvSchema(extSchema));
     const valid = validate(data);
 
     if (


### PR DESCRIPTION
Fixes #3361

## What was wrong

Every tool call compiled a new Ajv validator and retained it for the life of the
process. Ajv keys its compiled-validator cache on schema **object identity**, and
two independent places handed it a freshly constructed object every time, so the
cache never hit.

This is the dominant retainer behind the "second finding" in #3329, which
recorded roughly 120 objects and 48 strings per call on the generic tool path
and explicitly did not isolate a cause. It affects **every tool**, not just
shell, and it **survives `/clear`**, because the Ajv instances are module-level
singletons with no relationship to conversation history.

## The two sites

**1. `BaseDeclarativeTool.get schema()`** (`packages/tools/src/tools/tools.ts`)
cloned `parameterSchema` on every access:

```ts
const schemaClone = { ...(this.parameterSchema as Record<string, unknown>) };
delete schemaClone.requireOne;
return { name, description, parametersJsonSchema: schemaClone };
```

`validateToolParams()` reads `this.schema.parametersJsonSchema` on every
invocation, and both call sites (`tools.ts`, `ripGrep.ts`) go through it. Now
memoised, keyed on `parameterSchema` identity so a tool that swaps its schema
rebuilds rather than serving a stale one.

**2. `SchemaValidator.validate()`** (both `packages/tools` and `packages/core`)
spread a fresh derived object per call to strip `requireOne` and `$schema`, so
even a caller passing a stable schema missed the cache. Now memoised through a
`WeakMap` keyed on the source schema, which stays bounded because entries die
with the schema.

Fixing only (2) changes nothing end to end, because (1) guarantees the source
object is fresh. I measured that intermediate state and the histogram was
unchanged. Both are required.

## Evidence

Model-free, using the `LLXPRT_FAKE_RESPONSES` harness from #3329 driving
`list_directory` at n=0/250/1000. Live counts after `Bun.gc(true)` at exit,
per-call slope taken from 250 to 1000 so fixed startup cost is excluded:

| class | before | after |
| --- | ---: | ---: |
| `SchemaEnv` | 1.00 | **0.00** |
| `Function` | 1.00 | **0.00** |
| `_Code` | 2.00 | **0.00** |
| `ValueScopeName` | 2.00 | **0.00** |
| `Name` | 2.00 | **0.00** |
| `Object` | 124.00 | 116.00 |

`SchemaEnv` is now flat at 38 for both n=250 and n=1000. `SchemaEnv`, `_Code`,
`ValueScopeName` and `Name` are Ajv code-generation classes.

Isolated proof that identity is the mechanism, 500 compiles of one schema shape:
fresh spread gives `SchemaEnv` 8 -> 509; one stable object gives 8 -> 10.

The residual `Object` growth is a separate accumulator and is **not** addressed
here. #3329 notes part of it is the conversation itself, expected until
compression.

## Tests

Behavioural, asserting via heap-snapshot class counts rather than wall-clock or
RSS, matching the convention already used in `boundedCollectors.lazy.test.ts`.
They fail on the pre-fix code at exactly one retained validator per call
(observed: 300 for 300 validations).

- `packages/tools/src/utils/schemaValidator.compileCache.test.ts`
- `packages/core/src/utils/schemaValidator.compileCache.test.ts`
- `packages/tools/src/tools/tools.schemaIdentity.test.ts`

Behaviour coverage alongside the retention assertion: error reporting,
`requireOne` enforcement at the validator level, draft-07 versus 2020-12 dialect
selection, source-schema non-mutation, and the null-schema path.

## Recorded, not changed

While testing I found that the `schema` getter strips `requireOne` before
`validateToolParams` validates, so `SchemaValidator`'s `requireOne` branch is
unreachable through `BaseDeclarativeTool`. I verified this is present on `main`,
so it is not a consequence of the memoisation. It is pinned with a
characterisation test and otherwise left alone as out of scope. It likely
deserves its own issue if that enforcement is meant to be live.

## Verification

`npm run format`, `lint`, `typecheck`, `build`, `test` all pass; the full suite
reports zero failures.

One note for reviewers: `typecheck` fails if run before `build` on a stale
checkout, with errors in `tokenUsageEstimateLogger.ts` and
`promptEnvelopeProjections.ts`, neither touched by this PR. Running `build`
first clears it. Confirmed by re-running rather than assumed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved repeated schema validation by reusing compiled schemas, reducing unnecessary memory growth.
  * Added schema memoization that refreshes automatically when the source schema changes.

* **Bug Fixes**
  * Preserved consistent validation errors and schema handling across repeated validations.
  * Ensured schema transformations do not mutate the original parameter definitions.

* **Tests**
  * Added coverage for memory retention, garbage collection, schema identity, and repeated validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->