### PR TITLE
Remove stale tarballs in build_sandbox via enumerated cleanup (Fixes #3334)

### DIFF
--- a/project-plans/issue3334/PLAN.md
+++ b/project-plans/issue3334/PLAN.md
@@ -1,0 +1,125 @@
+# Plan: #3334: build_sandbox.ts glob rmSync leaves stale tarballs
+
+Branch `issue3334`. Issue: `scripts/build_sandbox.ts` clears the previous
+tarball before each `npm pack` with `rmSync(join(pkgDir, 'dist', '<prefix>-*.tgz'), { force: true })`.
+`node:fs` does no glob expansion: the wildcard is looked up as a literal
+filename, matches nothing, and `force: true` swallows the ENOENT. The cleanup
+is a silent no-op.
+
+## Root cause and impact
+
+Twelve call sites, one per packed workspace (tools, storage, auth, settings,
+telemetry, ide-integration, policy, mcp, core, providers, agents, cli).
+
+Within one version `npm pack` overwrites the same version-stamped filename, so
+nothing looks wrong. Across a version bump the old tarball stays in
+`packages/<pkg>/dist/`; the Dockerfile copies by glob
+(`COPY --chown=node:node packages/core/dist/vybestack-llxprt-code-core-*.tgz /tmp/`),
+so both versions land in `/tmp` and are handed to the single `npm install -g`
+transaction, the winner is left to npm's resolution instead of being
+determined by the build. `git clean` or a fresh clone hides it.
+
+Note: the issue's Origin section mentions `packages/zed-acp` as the twelfth
+site (from #3332). zed-acp does not exist on current main; the twelve sites
+present are the ones listed above. The fix covers the sites that exist.
+
+## Acceptance criteria
+
+1. **AC1, cleanup actually deletes.** Before each of the 12 `npm pack`
+   invocations, every `<prefix>-<version>.tgz` entry in
+   `packages/<pkg>/dist` is removed by enumerating the directory
+   (`readdirSync` + prefix/suffix filter + `rmSync` of each concrete path),
+   through one shared helper used at all twelve sites.
+2. **AC2, scope of deletion.** Unrelated entries in the same dist directory
+   survive: other packages' tarballs, non-`.tgz` files (e.g. `.last_build`,
+   `README.txt`), and names that only share a longer prefix boundary
+   (`vybestack-llxprt-code-corex-…` is not `core`).
+3. **AC3, missing/empty dist tolerated.** A dist directory that does not
+   exist (fresh checkout + `--skip-npm-install-build`, before any build) or is
+   empty is a no-op, not a crash, parity with the old `force: true` behavior.
+   Any non-ENOENT error propagates (fail fast).
+4. **AC4, regression test.** A behavioral test creates a dist dir holding a
+   stale `<pkg>-0.0.1.tgz`, runs the cleanup, asserts the file is gone. It
+   fails against HEAD (the helper does not exist there; the old code deletes
+   nothing).
+5. **AC5, reversion guard.** `scripts/tests/release-process.test.ts` (which
+   already reads build_sandbox.ts as text under
+   `describe('scripts/build_sandbox.ts')`) asserts the shared helper is used
+   and no literal `-*.tgz` rmSync glob remains in the source.
+6. **AC6, no collateral change.** Pack order, chmod flow, bind-release-deps
+   backup/restore, `buildImage` (podman authfile, `CLI_VERSION_ARG`,
+   `BUILD_SANDBOX_FLAGS`, image tag, temp authfile cleanup), and the final
+   `image prune` are byte-identical to HEAD.
+
+## Design decision: helper lives in `scripts/utils/tarball-cleanup.ts`
+
+The issue asks for "one shared helper rather than twelve repetitions". Two
+placements were considered:
+
+- **Export from `build_sandbox.ts`** (suggested by the auto-generated issue
+  plan): importing that module executes its top-level CLI, yargs parse,
+  `execSync('bun scripts/sandbox_command.ts')`, and `process.exit(0)` when the
+  probe reports `sandbox-exec` (the case on macOS). A test import cannot load
+  it safely. Wrapping the ~300 executable top-level lines in a `main()`
+  function would violate the `max-lines-per-function: 80` rule on the
+  `scripts/` TS block in eslint.config.js, or force splitting the script flow
+  into multiple functions, a rewrite far beyond this issue's scope.
+- **Leaf module `scripts/utils/tarball-cleanup.ts`** (chosen): importable with
+  zero side effects, no restructuring of build_sandbox.ts, and direct repo
+  precedent, `scripts/utils/release-packages.ts` exists precisely so two
+  scripts share one definition ("the exclusion set cannot drift"), and
+  `scripts/utils/error-guards.ts` provides the `isErrnoException` type guard
+  this helper reuses.
+
+`build_sandbox.ts` therefore changes by exactly one import line plus the
+twelve call-site swaps. The Dockerfile `COPY` globs stay: Docker expands them;
+`node:fs` does not.
+
+## Tests (bun:test, behavioral, no mocks, real tmp-dir fixtures)
+
+New `scripts/tests/build-sandbox-tarball-cleanup.test.ts`, importing
+`removeTarballs` from `../utils/tarball-cleanup.ts`:
+
+1. removes every tarball sharing the package prefix (0.0.1, 0.11.0) →
+   `readdirSync(dist)` is empty afterwards.
+2. preserves other-package tarball, prefix-boundary name
+   (`vybestack-llxprt-code-corex-9.9.9.tgz`), `README.txt`, `.last_build` →
+   directory contents equal exactly the preserved set.
+3. empty dist dir → no throw, still empty (idempotent).
+4. nonexistent dist dir → no throw, directory still absent (AC3).
+
+`release-process.test.ts`: build_sandbox.ts uses `removeTarballs(` and
+contains no `-*.tgz` literal (AC5).
+
+## Red → green
+
+- RED: with production changes stashed, the new test file fails (module
+  import unresolved at HEAD).
+- GREEN: with the helper module + call-site swaps, all cases pass.
+
+## Verification
+
+- `bun test` on the new/changed files with the scripts-tests preloads
+  (`storage-isolation-guard.ts`, `test-setup.ts`); logs under `tmp/verify3334/`.
+- `bun scripts/run_bun_tests.ts --root scripts-tests` (full local run has
+  historically exceeded the 900 s local command ceiling, pre-existing; CI is
+  the authoritative full-suite gate).
+- `npm run typecheck` (includes `tsc -p tsconfig.scripts.json`), scoped lint
+  on touched files, `prettier --check`, `npm run build`, smoke:
+  `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.
+- `git diff` audit: build_sandbox.ts delta is exactly import + 12 call sites.
+
+## Out of scope (noted for follow-up, not fixed here)
+
+- `.github/workflows/build-sandbox.yml` has its own "Pack npm packages" step
+  (9× `npm pack`) with no stale-tarball cleanup at all, same defect class,
+  different file; deserves its own issue.
+- No glob library introduced; no change to the packed workspace set.
+
+## Implementation incident (recorded for review context)
+
+An earlier working-tree state had (a) a duplicated helper export, (b) an
+orphan `if (import.meta.main) { main(); }` referencing an undefined `main()`,
+and (c) placeholder test assertions comparing strings to `false`. That state
+was reverted to HEAD and re-applied surgically; the final diff is audited
+against AC6.

--- a/scripts/build_sandbox.ts
+++ b/scripts/build_sandbox.ts
@@ -30,6 +30,7 @@ import os from 'node:os';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import cliPkgJson from '../packages/cli/package.json' with { type: 'json' };
+import { removeTarballs } from './utils/tarball-cleanup.ts';
 
 const argv = yargs(hideBin(process.argv))
   .option('s', {
@@ -139,18 +140,16 @@ try {
   releaseDepsBound = true;
 
   console.log('packing @vybestack/llxprt-code-tools ...');
-  rmSync(join(toolsPackageDir, 'dist', 'vybestack-llxprt-code-tools-*.tgz'), {
-    force: true,
-  });
+  removeTarballs(join(toolsPackageDir, 'dist'), 'vybestack-llxprt-code-tools');
   execSync(
     `npm pack -w @vybestack/llxprt-code-tools --pack-destination ./packages/tools/dist`,
     { stdio: 'ignore' },
   );
 
   console.log('packing @vybestack/llxprt-code-storage ...');
-  rmSync(
-    join(storagePackageDir, 'dist', 'vybestack-llxprt-code-storage-*.tgz'),
-    { force: true },
+  removeTarballs(
+    join(storagePackageDir, 'dist'),
+    'vybestack-llxprt-code-storage',
   );
   execSync(
     `npm pack -w @vybestack/llxprt-code-storage --pack-destination ./packages/storage/dist`,
@@ -158,18 +157,16 @@ try {
   );
 
   console.log('packing @vybestack/llxprt-code-auth ...');
-  rmSync(join(authPackageDir, 'dist', 'vybestack-llxprt-code-auth-*.tgz'), {
-    force: true,
-  });
+  removeTarballs(join(authPackageDir, 'dist'), 'vybestack-llxprt-code-auth');
   execSync(
     `npm pack -w @vybestack/llxprt-code-auth --pack-destination ./packages/auth/dist`,
     { stdio: 'ignore' },
   );
 
   console.log('packing @vybestack/llxprt-code-settings ...');
-  rmSync(
-    join(settingsPackageDir, 'dist', 'vybestack-llxprt-code-settings-*.tgz'),
-    { force: true },
+  removeTarballs(
+    join(settingsPackageDir, 'dist'),
+    'vybestack-llxprt-code-settings',
   );
   execSync(
     `npm pack -w @vybestack/llxprt-code-settings --pack-destination ./packages/settings/dist`,
@@ -177,9 +174,9 @@ try {
   );
 
   console.log('packing @vybestack/llxprt-code-telemetry ...');
-  rmSync(
-    join(telemetryPackageDir, 'dist', 'vybestack-llxprt-code-telemetry-*.tgz'),
-    { force: true },
+  removeTarballs(
+    join(telemetryPackageDir, 'dist'),
+    'vybestack-llxprt-code-telemetry',
   );
   execSync(
     `npm pack -w @vybestack/llxprt-code-telemetry --pack-destination ./packages/telemetry/dist`,
@@ -187,15 +184,9 @@ try {
   );
 
   console.log('packing @vybestack/llxprt-code-ide-integration ...');
-  rmSync(
-    join(
-      ideIntegrationPackageDir,
-      'dist',
-      'vybestack-llxprt-code-ide-integration-*.tgz',
-    ),
-    {
-      force: true,
-    },
+  removeTarballs(
+    join(ideIntegrationPackageDir, 'dist'),
+    'vybestack-llxprt-code-ide-integration',
   );
   execSync(
     `npm pack -w @vybestack/llxprt-code-ide-integration --pack-destination ./packages/ide-integration/dist`,
@@ -203,36 +194,33 @@ try {
   );
 
   console.log('packing @vybestack/llxprt-code-policy ...');
-  rmSync(join(policyPackageDir, 'dist', 'vybestack-llxprt-code-policy-*.tgz'), {
-    force: true,
-  });
+  removeTarballs(
+    join(policyPackageDir, 'dist'),
+    'vybestack-llxprt-code-policy',
+  );
   execSync(
     `npm pack -w @vybestack/llxprt-code-policy --pack-destination ./packages/policy/dist`,
     { stdio: 'ignore' },
   );
 
   console.log('packing @vybestack/llxprt-code-mcp ...');
-  rmSync(join(mcpPackageDir, 'dist', 'vybestack-llxprt-code-mcp-*.tgz'), {
-    force: true,
-  });
+  removeTarballs(join(mcpPackageDir, 'dist'), 'vybestack-llxprt-code-mcp');
   execSync(
     `npm pack -w @vybestack/llxprt-code-mcp --pack-destination ./packages/mcp/dist`,
     { stdio: 'ignore' },
   );
 
   console.log('packing @vybestack/llxprt-code-core ...');
-  rmSync(join(corePackageDir, 'dist', 'vybestack-llxprt-code-core-*.tgz'), {
-    force: true,
-  });
+  removeTarballs(join(corePackageDir, 'dist'), 'vybestack-llxprt-code-core');
   execSync(
     `npm pack -w @vybestack/llxprt-code-core --pack-destination ./packages/core/dist`,
     { stdio: 'ignore' },
   );
 
   console.log('packing @vybestack/llxprt-code-providers ...');
-  rmSync(
-    join(providersPackageDir, 'dist', 'vybestack-llxprt-code-providers-*.tgz'),
-    { force: true },
+  removeTarballs(
+    join(providersPackageDir, 'dist'),
+    'vybestack-llxprt-code-providers',
   );
   execSync(
     `npm pack -w @vybestack/llxprt-code-providers --pack-destination ./packages/providers/dist`,
@@ -240,17 +228,16 @@ try {
   );
 
   console.log('packing @vybestack/llxprt-code-agents ...');
-  rmSync(join(agentsPackageDir, 'dist', 'vybestack-llxprt-code-agents-*.tgz'), {
-    force: true,
-  });
+  removeTarballs(
+    join(agentsPackageDir, 'dist'),
+    'vybestack-llxprt-code-agents',
+  );
   execSync(
     `npm pack -w @vybestack/llxprt-code-agents --pack-destination ./packages/agents/dist`,
     { stdio: 'ignore' },
   );
   console.log('packing @vybestack/llxprt-code ...');
-  rmSync(join(cliPackageDir, 'dist', 'vybestack-llxprt-code-*.tgz'), {
-    force: true,
-  });
+  removeTarballs(join(cliPackageDir, 'dist'), 'vybestack-llxprt-code');
   execSync(
     `npm pack -w @vybestack/llxprt-code --pack-destination ./packages/cli/dist`,
     {

--- a/scripts/tests/build-sandbox-tarball-cleanup.test.ts
+++ b/scripts/tests/build-sandbox-tarball-cleanup.test.ts
@@ -15,6 +15,7 @@
 
 import { afterEach, describe, expect, it } from 'bun:test';
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -105,5 +106,18 @@ describe('removeTarballs', () => {
     writeFileSync(distDir, 'not a directory');
 
     expect(() => removeTarballs(distDir, CORE_PREFIX)).toThrow();
+  });
+
+  it('propagates removal failures instead of silently keeping stale tarballs', () => {
+    // A read-only dist directory makes unlink of a matched entry fail with
+    // EACCES/EPERM. The old `force: true` swallowed this, which is the same
+    // silent-stale-tarball failure mode #3334 exists to eliminate.
+    const distDir = createDistDir([`${CORE_PREFIX}-0.11.0.tgz`]);
+    chmodSync(distDir, 0o555);
+    try {
+      expect(() => removeTarballs(distDir, CORE_PREFIX)).toThrow();
+    } finally {
+      chmodSync(distDir, 0o755);
+    }
   });
 });

--- a/scripts/tests/build-sandbox-tarball-cleanup.test.ts
+++ b/scripts/tests/build-sandbox-tarball-cleanup.test.ts
@@ -15,7 +15,6 @@
 
 import { afterEach, describe, expect, it } from 'bun:test';
 import {
-  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -109,15 +108,15 @@ describe('removeTarballs', () => {
   });
 
   it('propagates removal failures instead of silently keeping stale tarballs', () => {
-    // A read-only dist directory makes unlink of a matched entry fail with
-    // EACCES/EPERM. The old `force: true` swallowed this, which is the same
-    // silent-stale-tarball failure mode #3334 exists to eliminate.
-    const distDir = createDistDir([`${CORE_PREFIX}-0.11.0.tgz`]);
-    chmodSync(distDir, 0o555);
-    try {
-      expect(() => removeTarballs(distDir, CORE_PREFIX)).toThrow();
-    } finally {
-      chmodSync(distDir, 0o755);
-    }
+    // A directory masquerading as a tarball makes the non-recursive rmSync
+    // fail with EISDIR on every platform and for any uid, so the error
+    // propagation is exercised deterministically. The old `force: true`
+    // swallowed such failures, the same silent-stale-tarball failure mode
+    // #3334 exists to eliminate.
+    const distDir = join(createTempRoot(), 'dist');
+    mkdirSync(distDir);
+    mkdirSync(join(distDir, `${CORE_PREFIX}-0.11.0.tgz`));
+
+    expect(() => removeTarballs(distDir, CORE_PREFIX)).toThrow();
   });
 });

--- a/scripts/tests/build-sandbox-tarball-cleanup.test.ts
+++ b/scripts/tests/build-sandbox-tarball-cleanup.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Regression tests for #3334: the sandbox build must clear stale packed
+ * tarballs by enumerating the dist directory, not by passing a glob to
+ * `rmSync`. `node:fs` does no glob expansion, so the old cleanup was a silent
+ * no-op and a version bump left the previous tarball behind, where the
+ * Dockerfile `COPY ... *.tgz` glob handed both versions to a single
+ * `npm install -g`.
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { removeTarballs } from '../utils/tarball-cleanup.ts';
+
+const CORE_PREFIX = 'vybestack-llxprt-code-core';
+
+const fixtureRoots: string[] = [];
+
+function createTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'tarball-cleanup-'));
+  fixtureRoots.push(root);
+  return root;
+}
+
+function createDistDir(files: readonly string[]): string {
+  const distDir = join(createTempRoot(), 'dist');
+  mkdirSync(distDir);
+  for (const name of files) {
+    writeFileSync(join(distDir, name), 'packed');
+  }
+  return distDir;
+}
+
+afterEach(() => {
+  for (const root of fixtureRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('removeTarballs', () => {
+  it('removes every tarball sharing the package prefix, including stale versions', () => {
+    const distDir = createDistDir([
+      'vybestack-llxprt-code-core-0.0.1.tgz',
+      'vybestack-llxprt-code-core-0.11.0.tgz',
+    ]);
+
+    removeTarballs(distDir, CORE_PREFIX);
+
+    expect(readdirSync(distDir)).toEqual([]);
+  });
+
+  it('preserves other packages tarballs, prefix-boundary names, and non-tarball files', () => {
+    const preserved = [
+      '.last_build',
+      'README.txt',
+      'vybestack-llxprt-code-corex-9.9.9.tgz',
+      'vybestack-llxprt-code-tools-0.5.0.tgz',
+    ];
+    const distDir = createDistDir([
+      'vybestack-llxprt-code-core-0.0.1.tgz',
+      ...preserved,
+    ]);
+
+    removeTarballs(distDir, CORE_PREFIX);
+
+    expect([...readdirSync(distDir)].sort()).toEqual(preserved);
+  });
+
+  it('is a no-op for an empty dist directory', () => {
+    const distDir = createDistDir([]);
+
+    expect(() => removeTarballs(distDir, CORE_PREFIX)).not.toThrow();
+
+    expect(readdirSync(distDir)).toEqual([]);
+  });
+
+  it('is a no-op when the dist directory does not exist', () => {
+    // Fresh checkout with --skip-npm-install-build: no build has created
+    // packages/<pkg>/dist yet. The old force:true cleanup never threw here.
+    const distDir = join(createTempRoot(), 'packages', 'core', 'dist');
+
+    expect(() => removeTarballs(distDir, CORE_PREFIX)).not.toThrow();
+
+    expect(existsSync(distDir)).toBe(false);
+  });
+
+  it('propagates errors other than a missing dist directory', () => {
+    // ENOTDIR: a file sits where the dist directory is expected. Silently
+    // swallowing this would hide a broken workspace layout.
+    const distDir = join(createTempRoot(), 'dist');
+    writeFileSync(distDir, 'not a directory');
+
+    expect(() => removeTarballs(distDir, CORE_PREFIX)).toThrow();
+  });
+});

--- a/scripts/tests/release-process.test.ts
+++ b/scripts/tests/release-process.test.ts
@@ -388,6 +388,13 @@ describe('scripts/build_sandbox.ts', () => {
     expect(buildSandbox).toContain('bind-release-deps.ts --backup');
     expect(buildSandbox).toContain('bind-release-deps.ts --restore');
   });
+
+  it('clears stale dist tarballs by enumerating dist entries instead of a glob rmSync (#3334)', () => {
+    // rmSync does not expand globs, so any literal `-*.tgz` path is a silent
+    // no-op that leaves stale tarballs for the Dockerfile COPY glob.
+    expect(buildSandbox).toMatch(/removeTarballs\(/);
+    expect(buildSandbox).not.toMatch(/-\*\.tgz/);
+  });
 });
 
 describe('.github/workflows/build-sandbox.yml', () => {

--- a/scripts/utils/tarball-cleanup.ts
+++ b/scripts/utils/tarball-cleanup.ts
@@ -22,6 +22,19 @@ import { isErrnoException } from './error-guards.ts';
  * `build_sandbox.ts --skip-npm-install-build` can run on a fresh checkout
  * before any build has created `dist/`. Any other error propagates.
  */
+function rmToleratingRace(path: string): void {
+  try {
+    rmSync(path);
+  } catch (error) {
+    // Tolerate only the enumerate/remove race; a stale tarball that
+    // cannot be removed (EPERM/EBUSY/...) must fail the build loudly
+    // rather than silently reach the Dockerfile COPY glob (#3334).
+    if (!isErrnoException(error, 'ENOENT')) {
+      throw error;
+    }
+  }
+}
+
 export function removeTarballs(distDir: string, prefix: string): void {
   let entries: readonly string[];
   try {
@@ -34,7 +47,7 @@ export function removeTarballs(distDir: string, prefix: string): void {
   }
   for (const entry of entries) {
     if (entry.startsWith(`${prefix}-`) && entry.endsWith('.tgz')) {
-      rmSync(join(distDir, entry), { force: true });
+      rmToleratingRace(join(distDir, entry));
     }
   }
 }

--- a/scripts/utils/tarball-cleanup.ts
+++ b/scripts/utils/tarball-cleanup.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { isErrnoException } from './error-guards.ts';
+
+/**
+ * Removes every tarball for `prefix` in `distDir` (#3334).
+ *
+ * `node:fs` performs no glob expansion: `rmSync(join(dir, '<prefix>-*.tgz'))`
+ * looks up that literal filename, finds nothing, and `force: true` swallows
+ * the ENOENT. The cleanup was a silent no-op, so a version bump left the
+ * previous tarball in `dist/`, where the Dockerfile `COPY ... *.tgz` glob
+ * handed both versions to a single `npm install -g`. Enumerate the directory
+ * and remove each concrete `<prefix>-<version>.tgz` path instead.
+ *
+ * A missing `distDir` is tolerated to match the old `force: true` no-op:
+ * `build_sandbox.ts --skip-npm-install-build` can run on a fresh checkout
+ * before any build has created `dist/`. Any other error propagates.
+ */
+export function removeTarballs(distDir: string, prefix: string): void {
+  let entries: readonly string[];
+  try {
+    entries = readdirSync(distDir);
+  } catch (error) {
+    if (isErrnoException(error, 'ENOENT')) {
+      return;
+    }
+    throw error;
+  }
+  for (const entry of entries) {
+    if (entry.startsWith(`${prefix}-`) && entry.endsWith('.tgz')) {
+      rmSync(join(distDir, entry), { force: true });
+    }
+  }
+}


### PR DESCRIPTION
## TLDR

`scripts/build_sandbox.ts` cleared the previous tarball before each `npm pack` with `rmSync(join(pkgDir, 'dist', '<prefix>-*.tgz'), { force: true })`. node:fs does no glob expansion, so the wildcard was looked up as a literal filename, matched nothing, and `force: true` swallowed the ENOENT. Cleanup was a silent no-op at all 12 call sites. After a version bump the stale tarball stayed in `packages/<pkg>/dist/`, the Dockerfile `COPY ... *.tgz` glob picked up both versions, and the single `npm install -g` transaction resolved between them.

This PR adds `scripts/utils/tarball-cleanup.ts`, exporting `removeTarballs(distDir, prefix)`: it enumerates the dist directory, removes every entry matching `<prefix>-*.tgz` by concrete path, tolerates a missing dist dir (parity with the old `force: true` no-op on fresh checkouts, `--skip-npm-install-build`), and rethrows any other read error. All 12 call sites now use it. Reviewers: the `scripts/build_sandbox.ts` diff is exactly one import plus the 12 cleanup expressions; pack order, chmod flow, bind-release-deps backup/restore, and `buildImage` are untouched.

fixes #3334

## Dive Deeper

- Prefix matching is `startsWith(`${prefix}-`) && endsWith('.tgz')`, so `vybestack-llxprt-code-core` cannot match a hypothetical `vybestack-llxprt-code-corex-...` tarball. Each package cleans only its own `dist` directory.
- The helper reuses `isErrnoException` from `scripts/utils/error-guards.ts`; only `ENOENT` is tolerated, so a broken workspace layout (e.g. ENOTDIR) fails the build instead of hiding.
- Out of scope, noted for follow-up: `.github/workflows/build-sandbox.yml` "Pack npm packages" runs 9 `npm pack` commands with no stale-tarball cleanup at all, same defect class. The issue text also mentions zed-acp; no such path exists on main (it originated from #3332). The Dockerfile `COPY` globs themselves are correct because Docker expands them; the bug was only the fs-level glob.
- Regression coverage: behavioral test with real temp dirs (stale `core-0.0.1.tgz` removed alongside a newer version, other-package tarballs / `corex` prefix boundary / non-tarball files preserved, empty dist no-op, missing dist no-op, ENOTDIR propagation), plus a source guard in `release-process.test.ts` asserting `build_sandbox.ts` uses `removeTarballs(` and contains no `-*.tgz` literal. Both fail against pre-fix code (verified: HEAD has 12 glob literals, 0 helper references).

## Reviewer Test Plan

```
bun test --preload ./scripts/tests/storage-isolation-guard.ts --preload ./scripts/tests/test-setup.ts \
  scripts/tests/build-sandbox-tarball-cleanup.test.ts scripts/tests/release-process.test.ts
```

25 pass / 0 fail. For an end-to-end check on a machine with podman: build a package, bump its version, run `bun scripts/build_sandbox.ts --skip-npm-install-build` twice and confirm only the current-version tarball remains in each `packages/<pkg>/dist/`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

macOS verification: targeted tests above, full scripts-tests root (270/270 files), `npm run build`, `npm run typecheck`, scoped eslint + prettier + guard scripts on the touched files, test-audit scan (0 findings). CLI smoke test was blocked by an account-level API error (`400 you have no active step plan subscription`, stepfun-37 profile, twice); the CLI startup path itself worked up to the API call and the change touches no runtime code. Windows/Linux and container runs are left to CI.

## Linked issues / bugs

Fixes #3334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup of stale package archives during sandbox builds.
  - Ensured cleanup covers all sandbox packages, including the CLI package.
  - Preserved unrelated files and handled missing output directories safely.
  - Improved handling of archive removal during filesystem changes.

- **Tests**
  - Added coverage for archive removal, boundary cases, empty or missing directories, and filesystem errors.
  - Added regression checks to prevent stale archives from affecting release builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->