### PR TITLE
Increase slash, at-command, and path completion coverage (Fixes #2019)

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.completion.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.completion.test.tsx
@@ -12,7 +12,10 @@ import {
 import { renderWithProviders } from '../../test-utils/render.js';
 import { waitFor } from '../../test-utils/async.js';
 import { act } from 'react';
-import { ESC_TIMEOUT } from '../contexts/KeypressContext.js';
+import {
+  ESC_TIMEOUT,
+  FAST_RETURN_TIMEOUT,
+} from '../contexts/KeypressContext.js';
 import type { InputPromptProps } from './InputPrompt.js';
 import { InputPrompt } from './InputPrompt.js';
 import type { TextBuffer } from './shared/text-buffer.js';
@@ -129,6 +132,13 @@ const mockSlashCommands: SlashCommand[] = [
     ],
   },
 ];
+
+const pressEnter = async (stdin: { write: (data: string) => void }) => {
+  await new Promise((resolve) => setTimeout(resolve, FAST_RETURN_TIMEOUT + 10));
+  await act(async () => {
+    stdin.write('\r');
+  });
+};
 
 describe('InputPrompt', () => {
   let props: InputPromptProps;
@@ -291,6 +301,58 @@ describe('InputPrompt', () => {
       setQueueErrorMessage: vi.fn(),
       streamingState: StreamingState.Idle,
     };
+  });
+
+  describe('completion acceptance and dismissal', () => {
+    it.each(['Tab', 'Enter'])(
+      '%s accepts the first suggestion when no suggestion is actively selected',
+      async (keyName) => {
+        const { handleAutocomplete } = mockCommandCompletion;
+        mockedUseCommandCompletion.mockReturnValue({
+          ...mockCommandCompletion,
+          showSuggestions: true,
+          suggestions: [{ label: 'memory', value: 'memory' }],
+          activeSuggestionIndex: -1,
+        });
+
+        const { stdin, unmount } = renderWithProviders(
+          <InputPrompt {...props} />,
+          { kittyProtocolEnabled: false },
+        );
+
+        await (keyName === 'Tab'
+          ? act(async () => stdin.write('\t'))
+          : pressEnter(stdin));
+
+        expect(handleAutocomplete).toHaveBeenCalledWith(0);
+        expect(props.onSubmit).not.toHaveBeenCalled();
+        unmount();
+      },
+    );
+
+    it('Escape dismisses the suggestions without accepting one', async () => {
+      props.buffer.setText('/mem');
+      mockedUseCommandCompletion.mockReturnValue({
+        ...mockCommandCompletion,
+        showSuggestions: true,
+        suggestions: [{ label: 'memory', value: 'memory' }],
+      });
+
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+        { kittyProtocolEnabled: false },
+      );
+
+      await act(async () => stdin.write('\x1B'));
+
+      await waitFor(() =>
+        expect(mockCommandCompletion.resetCompletionState).toHaveBeenCalled(),
+      );
+      expect(mockCommandCompletion.handleAutocomplete).not.toHaveBeenCalled();
+      expect(props.onSubmit).not.toHaveBeenCalled();
+      expect(props.buffer.text).toBe('/mem');
+      unmount();
+    });
   });
 
   describe('Highlighting and Cursor Display', () => {

--- a/packages/cli/src/ui/components/SuggestionsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.test.tsx
@@ -318,8 +318,13 @@ describe('<SuggestionsDisplay /> rendering contract', () => {
         />,
       );
       const rows = frameOf(lastFrame).split('\n');
-      const inactiveRow = rows.find((row) => row.includes('idle')) ?? '';
-      const activeRow = rows.find((row) => row.includes('selected')) ?? '';
+      const inactiveRow = rows.find((row) => row.includes('idle'));
+      const activeRow = rows.find((row) => row.includes('selected'));
+
+      // Both rows must actually render, otherwise the negative assertion
+      // below would hold vacuously for a missing row.
+      expect(inactiveRow).toBeDefined();
+      expect(activeRow).toBeDefined();
       const activeColorSample = chalk.hex('#00ff00')('sample');
       const sampleIndex = activeColorSample.indexOf('sample');
 

--- a/packages/cli/src/ui/components/SuggestionsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/SuggestionsDisplay.test.tsx
@@ -5,6 +5,7 @@
  */
 
 import { render } from 'ink-testing-library';
+import chalk from 'chalk';
 import { describe, it, expect } from 'bun:test';
 import { SuggestionsDisplay, type Suggestion } from './SuggestionsDisplay.js';
 import { CommandKind } from '../commands/types.js';
@@ -16,6 +17,15 @@ const baseProps = {
   scrollOffset: 0,
   userInput: '',
 };
+
+function frameOf(lastFrame: () => string | undefined): string {
+  const frame = lastFrame();
+  if (frame === undefined) {
+    throw new Error('expected a rendered frame');
+  }
+
+  return frame;
+}
 
 describe('<SuggestionsDisplay /> subagent badge', () => {
   it('renders the [Subagent] badge for subagent-kind suggestions', () => {
@@ -70,5 +80,255 @@ describe('<SuggestionsDisplay /> subagent badge', () => {
     const output = lastFrame();
     expect(output).not.toContain('[Subagent]');
     expect(output).toContain('plain.txt');
+  });
+});
+
+describe('<SuggestionsDisplay /> rendering contract', () => {
+  const makeSuggestions = (count: number): Suggestion[] =>
+    Array.from({ length: count }, (_, i) => ({
+      label: `label${i}`,
+      value: `value${i}`,
+    }));
+
+  it('renders "Loading suggestions..." and no suggestion labels while isLoading', () => {
+    const { lastFrame } = render(
+      <SuggestionsDisplay
+        {...baseProps}
+        isLoading={true}
+        suggestions={makeSuggestions(3)}
+      />,
+    );
+
+    const output = frameOf(lastFrame);
+    expect(output).toContain('Loading suggestions...');
+    for (let i = 0; i < 3; i++) {
+      expect(output).not.toContain(`label${i}`);
+    }
+  });
+
+  it('renders nothing when there are no suggestions', () => {
+    const { lastFrame, rerender } = render(
+      <SuggestionsDisplay
+        {...baseProps}
+        suggestions={[{ label: 'memory', value: 'memory' }]}
+      />,
+    );
+
+    expect(frameOf(lastFrame)).toContain('memory');
+    rerender(<SuggestionsDisplay {...baseProps} suggestions={[]} />);
+    expect(frameOf(lastFrame).trim()).toBe('');
+  });
+
+  it('renders no scroll markers when the list fits in the visible window', () => {
+    const { lastFrame } = render(
+      <SuggestionsDisplay {...baseProps} suggestions={makeSuggestions(4)} />,
+    );
+
+    const output = frameOf(lastFrame);
+    for (let i = 0; i < 4; i++) {
+      expect(output).toContain(`label${i}`);
+    }
+    expect(output).not.toContain('▲');
+    expect(output).not.toContain('▼');
+  });
+
+  it('renders a down marker for a list longer than the visible window', () => {
+    const { lastFrame } = render(
+      <SuggestionsDisplay {...baseProps} suggestions={makeSuggestions(12)} />,
+    );
+
+    const output = frameOf(lastFrame);
+    expect(output).toContain('▼');
+    expect(output).not.toContain('▲');
+  });
+
+  it('renders an up marker and no down marker at the last scroll window', () => {
+    const { lastFrame } = render(
+      <SuggestionsDisplay
+        {...baseProps}
+        suggestions={makeSuggestions(12)}
+        scrollOffset={4}
+      />,
+    );
+
+    const output = frameOf(lastFrame);
+    expect(output).toContain('▲');
+    expect(output).not.toContain('▼');
+  });
+
+  it('renders only the 8 visible suggestions from scrollOffset 0', () => {
+    const { lastFrame } = render(
+      <SuggestionsDisplay {...baseProps} suggestions={makeSuggestions(12)} />,
+    );
+
+    const output = frameOf(lastFrame);
+    for (let i = 0; i < 8; i++) {
+      expect(output).toContain(`label${i}`);
+    }
+    for (let i = 8; i < 12; i++) {
+      expect(output).not.toContain(`label${i}`);
+    }
+  });
+
+  it('renders suggestions starting from the scroll offset', () => {
+    const { lastFrame } = render(
+      <SuggestionsDisplay
+        {...baseProps}
+        suggestions={makeSuggestions(12)}
+        scrollOffset={4}
+      />,
+    );
+
+    const output = frameOf(lastFrame);
+    expect(output).toContain('label4');
+    expect(output).not.toContain('label3');
+  });
+
+  it('does not render the counter at exactly 8 suggestions', () => {
+    const { lastFrame } = render(
+      <SuggestionsDisplay {...baseProps} suggestions={makeSuggestions(8)} />,
+    );
+
+    const output = frameOf(lastFrame);
+    for (let i = 0; i < 8; i++) {
+      expect(output).toContain(`label${i}`);
+    }
+    expect(output).not.toContain('(');
+    expect(output).not.toContain('▼');
+  });
+
+  it('renders the (activeIndex+1/total) counter when suggestions exceed the window', () => {
+    const { lastFrame } = render(
+      <SuggestionsDisplay
+        {...baseProps}
+        suggestions={makeSuggestions(9)}
+        activeIndex={2}
+      />,
+    );
+
+    expect(frameOf(lastFrame)).toContain('(3/9)');
+  });
+
+  it('renders the description next to each label', () => {
+    const suggestions: Suggestion[] = [
+      { label: 'memory', value: 'memory', description: 'manage memory' },
+      { label: 'chat', value: 'chat', description: 'manage chats' },
+    ];
+    const { lastFrame } = render(
+      <SuggestionsDisplay {...baseProps} suggestions={suggestions} />,
+    );
+
+    const rows = frameOf(lastFrame).split('\n');
+    const memoryRow = rows.find((row) => row.includes('memory'));
+    const chatRow = rows.find((row) => row.includes('chat'));
+    expect(memoryRow).toContain('manage memory');
+    expect(chatRow).toContain('manage chats');
+  });
+
+  it('aligns descriptions in a single column in slash mode', () => {
+    const suggestions: Suggestion[] = [
+      { label: 'm', value: 'm', description: 'DDD-short' },
+      { label: 'longlonglonglong', value: 'long', description: 'DDD-long' },
+    ];
+    const { lastFrame } = render(
+      <SuggestionsDisplay
+        {...baseProps}
+        userInput="/"
+        suggestions={suggestions}
+      />,
+    );
+
+    const rows = frameOf(lastFrame).split('\n');
+    const shortRow = rows.find((row) => row.includes('DDD-short')) ?? '';
+    const longRow = rows.find((row) => row.includes('DDD-long')) ?? '';
+    const shortDescriptionIndex = shortRow.indexOf('DDD-short');
+    const longDescriptionIndex = longRow.indexOf('DDD-long');
+
+    expect(shortDescriptionIndex).toBeGreaterThanOrEqual(0);
+    expect(longDescriptionIndex).toBeGreaterThanOrEqual(0);
+    expect(shortDescriptionIndex).toBe(longDescriptionIndex);
+  });
+
+  it('does not column-align descriptions outside slash mode', () => {
+    const suggestions: Suggestion[] = [
+      { label: 'm', value: 'm', description: 'DESC-short' },
+      { label: 'longlonglonglong', value: 'long', description: 'DESC-long' },
+    ];
+    const { lastFrame } = render(
+      <SuggestionsDisplay
+        {...baseProps}
+        userInput="@"
+        suggestions={suggestions}
+      />,
+    );
+
+    const rows = frameOf(lastFrame).split('\n');
+    const shortRow = rows.find((row) => row.includes('DESC-short')) ?? '';
+    const longRow = rows.find((row) => row.includes('DESC-long')) ?? '';
+    const shortDescriptionIndex = shortRow.indexOf('DESC-short');
+    const longDescriptionIndex = longRow.indexOf('DESC-long');
+
+    expect(shortDescriptionIndex).toBeGreaterThanOrEqual(0);
+    expect(longDescriptionIndex).toBeGreaterThanOrEqual(0);
+    expect(shortDescriptionIndex).toBeLessThan(longDescriptionIndex);
+  });
+
+  it('renders the active hint above the list when provided', () => {
+    const { lastFrame } = render(
+      <SuggestionsDisplay
+        {...baseProps}
+        suggestions={[{ label: 'memory', value: 'memory' }]}
+        activeHint="tab to accept"
+      />,
+    );
+
+    const lines = frameOf(lastFrame).split('\n');
+    const suggestionLineIndex = lines.findIndex(
+      (line) => line.trim() === 'memory',
+    );
+    expect(lines[0]?.trim()).toBe('tab to accept');
+    expect(suggestionLineIndex).toBeGreaterThan(0);
+  });
+
+  it('omits the active hint when the prop is not provided', () => {
+    const { lastFrame } = render(
+      <SuggestionsDisplay
+        {...baseProps}
+        suggestions={[{ label: 'memory', value: 'memory' }]}
+      />,
+    );
+
+    const lines = frameOf(lastFrame).split('\n');
+    expect(lines[0]?.trim()).toBe('memory');
+  });
+
+  it('renders the active row with the active colour only', () => {
+    const previousChalkLevel = chalk.level;
+    chalk.level = 3;
+
+    try {
+      const { lastFrame } = render(
+        <SuggestionsDisplay
+          {...baseProps}
+          suggestions={[
+            { label: 'idle', value: 'idle' },
+            { label: 'selected', value: 'selected' },
+          ]}
+          activeIndex={1}
+        />,
+      );
+      const rows = frameOf(lastFrame).split('\n');
+      const inactiveRow = rows.find((row) => row.includes('idle')) ?? '';
+      const activeRow = rows.find((row) => row.includes('selected')) ?? '';
+      const activeColorSample = chalk.hex('#00ff00')('sample');
+      const sampleIndex = activeColorSample.indexOf('sample');
+
+      expect(sampleIndex).toBeGreaterThan(0);
+      const activeColorSequence = activeColorSample.slice(0, sampleIndex);
+      expect(activeRow).toContain(activeColorSequence);
+      expect(inactiveRow).not.toContain(activeColorSequence);
+    } finally {
+      chalk.level = previousChalkLevel;
+    }
   });
 });

--- a/packages/cli/src/ui/hooks/atCompletionUtils.test.ts
+++ b/packages/cli/src/ui/hooks/atCompletionUtils.test.ts
@@ -1,0 +1,192 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'fs/promises';
+import type { Dirent } from 'fs';
+import { escapePath, unescapePath } from '@vybestack/llxprt-code-core';
+import type { FileSystemStructure } from '@vybestack/llxprt-code-test-utils';
+import { cleanupTmpDir, createTmpDir } from '@vybestack/llxprt-code-test-utils';
+import type { Suggestion } from '../components/SuggestionsDisplay.js';
+import {
+  filterEntriesByPrefix,
+  findFilesRecursively,
+} from './atCompletionUtils.js';
+
+function names(entries: readonly Dirent[]): string[] {
+  return entries.map((entry) => entry.name).sort();
+}
+
+function labels(suggestions: readonly Suggestion[]): string[] {
+  return suggestions.map((suggestion) => suggestion.label).sort();
+}
+
+function requireSuggestion(
+  suggestions: readonly Suggestion[],
+  label: string,
+): Suggestion {
+  const suggestion = suggestions.find((candidate) => candidate.label === label);
+  if (suggestion === undefined) {
+    throw new Error(`Expected suggestion for ${label}`);
+  }
+  return suggestion;
+}
+
+describe('atCompletionUtils', () => {
+  let testRootDir: string;
+
+  beforeEach(async () => {
+    const structure: FileSystemStructure = {
+      '.env': '',
+      '.hidden': '',
+      'visible.txt': '',
+      'hidden-ish.txt': '',
+      'MixedCase.TXT': '',
+      "single'quote.txt": '',
+      'double"quote.txt': '',
+      'café.txt': '',
+      'emoji-😀.txt': '',
+      nested: {
+        '.nested-env': '',
+        'nested-visible.txt': '',
+      },
+    };
+    testRootDir = await createTmpDir(structure);
+  });
+
+  afterEach(async () => {
+    await cleanupTmpDir(testRootDir);
+  });
+
+  describe('filterEntriesByPrefix', () => {
+    it('excludes dotfiles for an empty prefix while retaining visible entries', async () => {
+      const entries = await fs.readdir(testRootDir, { withFileTypes: true });
+
+      const filteredNames = names(filterEntriesByPrefix(entries, ''));
+
+      expect(
+        filteredNames.filter((name) => name.startsWith('.')),
+      ).toStrictEqual([]);
+      expect(filteredNames).toEqual(
+        expect.arrayContaining(['hidden-ish.txt', 'visible.txt']),
+      );
+    });
+
+    it('excludes dotfiles when the non-dot prefix matches a visible filename', async () => {
+      const entries = await fs.readdir(testRootDir, { withFileTypes: true });
+
+      const filteredNames = names(filterEntriesByPrefix(entries, 'h'));
+
+      expect(filteredNames).toStrictEqual(['hidden-ish.txt']);
+    });
+
+    it('includes only matching dotfiles when the prefix starts with a dot', async () => {
+      const entries = await fs.readdir(testRootDir, { withFileTypes: true });
+
+      const dotfileNames = names(filterEntriesByPrefix(entries, '.'));
+      const envNames = names(filterEntriesByPrefix(entries, '.e'));
+
+      expect(dotfileNames).toStrictEqual(['.env', '.hidden']);
+      expect(envNames).toStrictEqual(['.env']);
+    });
+
+    it('matches prefixes case-insensitively', async () => {
+      const entries = await fs.readdir(testRootDir, { withFileTypes: true });
+
+      const filteredNames = names(filterEntriesByPrefix(entries, 'mIxEdCaSe'));
+
+      expect(filteredNames).toStrictEqual(['MixedCase.TXT']);
+    });
+  });
+
+  describe('findFilesRecursively', () => {
+    it('excludes nested dotfiles when the search prefix does not start with a dot', async () => {
+      const suggestions = await findFilesRecursively(testRootDir, '', null, {});
+      const suggestionLabels = labels(suggestions);
+
+      expect(
+        suggestionLabels.filter((label) =>
+          label.split('/').some((segment) => segment.startsWith('.')),
+        ),
+      ).toStrictEqual([]);
+      expect(suggestionLabels).toEqual(
+        expect.arrayContaining([
+          'hidden-ish.txt',
+          'nested/',
+          'nested/nested-visible.txt',
+          'visible.txt',
+        ]),
+      );
+    });
+
+    it('includes matching dotfiles through nested visible directories for a dot prefix', async () => {
+      const dotSuggestions = await findFilesRecursively(
+        testRootDir,
+        '.',
+        null,
+        {},
+      );
+      const envSuggestions = await findFilesRecursively(
+        testRootDir,
+        '.e',
+        null,
+        {},
+      );
+
+      expect(labels(dotSuggestions)).toStrictEqual([
+        '.env',
+        '.hidden',
+        'nested/.nested-env',
+      ]);
+      expect(labels(envSuggestions)).toStrictEqual(['.env']);
+    });
+
+    it('surfaces single-quoted and double-quoted filenames with escaped values', async () => {
+      const singleQuoteLabel = "single'quote.txt";
+      const doubleQuoteLabel = 'double"quote.txt';
+      const singleQuoteSuggestions = await findFilesRecursively(
+        testRootDir,
+        'single',
+        null,
+        {},
+      );
+      const doubleQuoteSuggestions = await findFilesRecursively(
+        testRootDir,
+        'double',
+        null,
+        {},
+      );
+
+      const singleQuoteSuggestion = requireSuggestion(
+        singleQuoteSuggestions,
+        singleQuoteLabel,
+      );
+      const doubleQuoteSuggestion = requireSuggestion(
+        doubleQuoteSuggestions,
+        doubleQuoteLabel,
+      );
+
+      expect(singleQuoteSuggestion.value).toBe(escapePath(singleQuoteLabel));
+      expect(singleQuoteSuggestion.value).not.toBe(singleQuoteSuggestion.label);
+      expect(unescapePath(singleQuoteSuggestion.value)).toBe(singleQuoteLabel);
+      expect(doubleQuoteSuggestion.value).toBe(escapePath(doubleQuoteLabel));
+      expect(doubleQuoteSuggestion.value).not.toBe(doubleQuoteSuggestion.label);
+      expect(unescapePath(doubleQuoteSuggestion.value)).toBe(doubleQuoteLabel);
+    });
+
+    it('surfaces unicode filenames without changing labels or round-tripped values', async () => {
+      const unicodeLabels = ['café.txt', 'emoji-😀.txt'];
+      const suggestions = await findFilesRecursively(testRootDir, '', null, {});
+
+      for (const label of unicodeLabels) {
+        const suggestion = requireSuggestion(suggestions, label);
+        expect(suggestion.label).toBe(label);
+        expect(suggestion.value).toBe(escapePath(label));
+        expect(unescapePath(suggestion.value)).toBe(label);
+      }
+    });
+  });
+});

--- a/packages/cli/src/ui/hooks/useAtCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.test.ts
@@ -367,27 +367,28 @@ describe('useAtCompletion', () => {
       const failedCwd = path.join(testRootDir, 'failed');
       const recoveredCwd = path.join(testRootDir, 'recovered');
 
-      const realFileSearch = FileSearchFactory.create({
-        projectRoot: recoveredCwd,
-        ignoreDirs: [],
-        useGitignore: false,
-        useExtensionIgnore: false,
-        cache: false,
-        enableRecursiveFileSearch: true,
-        enableFuzzySearch: true,
-      });
-      const mockFileSearch: FileSearch = {
-        initialize: vi
-          .fn()
-          .mockRejectedValueOnce(new Error('Initialization failed'))
-          .mockImplementation(async () => realFileSearch.initialize()),
-        search: vi
-          .fn()
-          .mockImplementation(async (...args) =>
-            realFileSearch.search(...args),
-          ),
-      };
-      vi.spyOn(FileSearchFactory, 'create').mockReturnValue(mockFileSearch);
+      // Each fake delegates to a real searcher rooted at the projectRoot the
+      // hook actually asked for, so recovery is proven by the suggestions
+      // themselves: re-initializing against the wrong cwd yields no matches.
+      const createRealFileSearch =
+        FileSearchFactory.create.bind(FileSearchFactory);
+      let initializeCalls = 0;
+      vi.spyOn(FileSearchFactory, 'create').mockImplementation(
+        (options: Parameters<typeof FileSearchFactory.create>[0]) => {
+          const realFileSearch = createRealFileSearch(options);
+          const fake: FileSearch = {
+            initialize: vi.fn(async () => {
+              initializeCalls += 1;
+              if (initializeCalls === 1) {
+                throw new Error('Initialization failed');
+              }
+              return realFileSearch.initialize();
+            }),
+            search: vi.fn(async (...args) => realFileSearch.search(...args)),
+          };
+          return fake;
+        },
+      );
 
       const { result, rerender } = renderHook(
         ({ cwd, pattern }) =>

--- a/packages/cli/src/ui/hooks/useAtCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'bun:test';
 import { renderHook, waitFor } from '../../test-utils/render.js';
 import { act } from 'react';
+import * as path from 'path';
 import type { Config, FileSearch } from '@vybestack/llxprt-code-core';
 import { FileSearchFactory } from '@vybestack/llxprt-code-core';
 import type { FileSystemStructure } from '@vybestack/llxprt-code-test-utils';
@@ -355,6 +356,66 @@ describe('useAtCompletion', () => {
       // We can't directly inspect the internal state, but we can ensure it doesn't crash
       // and the suggestions remain empty.
       expect(result.current.suggestions).toStrictEqual([]);
+    });
+
+    it('should recover from an initialization error when the cwd changes', async () => {
+      const structure: FileSystemStructure = {
+        failed: {},
+        recovered: { 'recovered.txt': '' },
+      };
+      testRootDir = await createTmpDir(structure);
+      const failedCwd = path.join(testRootDir, 'failed');
+      const recoveredCwd = path.join(testRootDir, 'recovered');
+
+      const realFileSearch = FileSearchFactory.create({
+        projectRoot: recoveredCwd,
+        ignoreDirs: [],
+        useGitignore: false,
+        useExtensionIgnore: false,
+        cache: false,
+        enableRecursiveFileSearch: true,
+        enableFuzzySearch: true,
+      });
+      const mockFileSearch: FileSearch = {
+        initialize: vi
+          .fn()
+          .mockRejectedValueOnce(new Error('Initialization failed'))
+          .mockImplementation(async () => realFileSearch.initialize()),
+        search: vi
+          .fn()
+          .mockImplementation(async (...args) =>
+            realFileSearch.search(...args),
+          ),
+      };
+      vi.spyOn(FileSearchFactory, 'create').mockReturnValue(mockFileSearch);
+
+      const { result, rerender } = renderHook(
+        ({ cwd, pattern }) =>
+          useTestHarnessForAtCompletion(true, pattern, mockConfig, cwd),
+        {
+          initialProps: {
+            cwd: failedCwd,
+            pattern: 'recovered',
+          },
+        },
+      );
+
+      expect(result.current.isLoadingSuggestions).toBe(true);
+      await waitFor(() => {
+        expect(result.current.isLoadingSuggestions).toBe(false);
+      });
+      expect(result.current.suggestions).toStrictEqual([]);
+
+      act(() => {
+        rerender({ cwd: recoveredCwd, pattern: 'recovered' });
+      });
+
+      await waitFor(() => {
+        expect(result.current.suggestions.map((s) => s.value)).toStrictEqual([
+          'recovered.txt',
+        ]);
+      });
+      expect(result.current.isLoadingSuggestions).toBe(false);
     });
 
     it('should reset when disabled during initialization', async () => {

--- a/packages/cli/src/ui/hooks/useAtCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.test.ts
@@ -370,16 +370,16 @@ describe('useAtCompletion', () => {
       // Each fake delegates to a real searcher rooted at the projectRoot the
       // hook actually asked for, so recovery is proven by the suggestions
       // themselves: re-initializing against the wrong cwd yields no matches.
+      // Failure is keyed to the directory rather than to call order, so the
+      // failed root always fails however many times the hook initializes it.
       const createRealFileSearch =
         FileSearchFactory.create.bind(FileSearchFactory);
-      let initializeCalls = 0;
       vi.spyOn(FileSearchFactory, 'create').mockImplementation(
         (options: Parameters<typeof FileSearchFactory.create>[0]) => {
           const realFileSearch = createRealFileSearch(options);
           const fake: FileSearch = {
             initialize: vi.fn(async () => {
-              initializeCalls += 1;
-              if (initializeCalls === 1) {
+              if (options.projectRoot === failedCwd) {
                 throw new Error('Initialization failed');
               }
               return realFileSearch.initialize();

--- a/project-plans/issue2019-completion-coverage.md
+++ b/project-plans/issue2019-completion-coverage.md
@@ -1,0 +1,171 @@
+# Issue #2019 — Increase slash, at-command, and path completion coverage
+
+## Nature of the work
+
+Test-only. No production behavior changes. Every new test must fail if the
+corresponding production code is broken, and must not enshrine a bug as spec.
+
+## Baseline: what is already covered (verified, do not duplicate)
+
+Audited against the real sources and test files on `main`.
+
+| Behavior | Status | Evidence |
+| --- | --- | --- |
+| Slash filtering by partial prefix | COVERED | `useSlashCompletion.part2.test.ts:114`, `:139`, `:533` |
+| Slash no-result (unknown command, invalid subcommand, fully-typed leaf) | COVERED | `part2:376`, `part2:567`, `part2:353` |
+| Enter accepts active suggestion | COVERED | `InputPrompt.test.tsx:716` |
+| Tab accepts active suggestion | COVERED | `InputPrompt.test.tsx:666-697`, `:737`, `InputPrompt.editing.test.tsx:363` |
+| `isPerfectMatch` Enter short-circuit | COVERED | `InputPrompt.test.tsx:781`, `:796`, `:819` |
+| At-command debounce (150ms) | COVERED | `useAtCompletion.subagent.test.ts:343`, `:392`, `:519` |
+| At-command cancellation / abort | COVERED | `useAtCompletion.test.ts:267`, `subagent.test.ts:464` |
+| Slow-loading indicator (200ms) | COVERED | `useAtCompletion.test.ts:181`, `:210` |
+| Entering the ERROR state | COVERED | `useAtCompletion.test.ts:327`, `:360` |
+| Path completion with spaces | COVERED | `useAtCompletion.test.ts:44`, `part4:371` |
+| gitignore / llxprtignore filtering | COVERED | `useAtCompletion.test.ts:384`, `:518`, `part3:433`, `:460`, `:495` |
+| Special chars: `()`, `[]`, `{}`, `&`, `$`, `!`, separators | COVERED | `part4:398`, `:424`, `:450`, `:480`, `:512`, `:546`, `:586` |
+| Dotfile INCLUSION when prefix starts with `.` | COVERED | `part3:310` |
+| tmux real-keyboard slash smoke (open/navigate/Escape-dismiss) | COVERED | `scripts/tmux-script.slash-autocomplete.json`, registered `interactive-ui.test.ts:133` |
+
+## Verified gaps → acceptance criteria
+
+### AC1 — `SuggestionsDisplay` rendering contract
+
+`SuggestionsDisplay.test.tsx` today asserts only the `[Subagent]` badge. The
+rest of the render contract is unasserted.
+
+Deliver, in the existing `SuggestionsDisplay.test.tsx`:
+
+1. `isLoading: true` renders `Loading suggestions...` and renders no suggestion
+   labels (even when suggestions are non-empty).
+2. Empty `suggestions` renders nothing (component returns `null`).
+3. `scrollOffset > 0` renders the up marker; a list longer than the visible
+   window renders the down marker; a list that fits renders neither.
+4. Only `MAX_SUGGESTIONS_TO_SHOW` (8) rows are rendered from `scrollOffset`;
+   items outside the window are absent.
+5. The `(activeIndex+1/total)` counter appears only when
+   `suggestions.length > MAX_SUGGESTIONS_TO_SHOW`; it is absent at exactly 8,
+   and its value tracks `activeIndex`.
+6. Descriptions render alongside labels.
+7. Slash mode (`userInput` starts with `/`) pads labels into a fixed-width
+   column so descriptions align across rows of differing label length;
+   non-slash mode does not pad.
+8. `activeHint` renders above the list when provided and is absent otherwise.
+
+Boundary cases to pin: exactly 8 suggestions (no counter, no down marker);
+9 suggestions (counter present, down marker present); `scrollOffset` at the
+last window (up marker present, down marker absent).
+
+Active-row highlighting is observable when `chalk.level` is raised to 3. A test
+now saves the prior level, renders with level 3, asserts the active-row ANSI
+colour, and restores the prior level. The default level of 0 explains why the
+first probe emitted no ANSI escapes.
+
+### AC2 — Acceptance and dismissal at the key-handler boundary
+
+In `InputPrompt.completion.test.tsx`:
+
+1. With `showSuggestions: true`, non-empty suggestions, and
+   `activeSuggestionIndex: -1`, pressing Tab accepts index 0.
+2. Same state, pressing Enter accepts index 0.
+   (This is the untested `-1 → 0` fallback in
+   `inputPromptKeyHandlers.ts` `acceptCompletionSuggestion`.)
+3. Escape dismisses without accepting: `resetCompletionState` is called,
+   `handleAutocomplete` is NOT called, and the buffer text is unchanged.
+   The existing test at `:800` asserts only the first of these three.
+
+Enter tests must use the existing `pressEnter` helper pattern
+(`InputPrompt.test.tsx:129-135`) — a bare fast `\r` is classified as pasted
+text by `KeypressContext`, not as submit.
+
+### AC3 — At-command error recovery
+
+Scope limit found during implementation: the hook can only recover from `ERROR`
+via a `cwd`/`config` change, because `usePatternChangeHandler` starts work only
+from `IDLE`, `READY`, or `SEARCHING`. A same-directory pattern change while in
+`ERROR` dispatches nothing — verified by probe (no second
+`FileSearchFactory.create`, no suggestions). That is a production bug, filed as
+issue #3373, and deliberately not fixed here. The test added covers the
+recovery path that actually exists and is named for it; no test asserts that
+same-directory retry fails, so nothing freezes the bug as specification.
+
+In `useAtCompletion.test.ts`: drive the hook into ERROR (first `initialize`
+rejects), then let a subsequent search succeed, and assert the hook recovers —
+suggestions populate and `isLoadingSuggestions` is `false`. Today only ERROR
+*entry* and ERROR-then-disable are covered; the ERROR → success transition is
+not.
+
+### AC4 — Path completion edge cases (dotfiles, quotes, unicode)
+
+1. Dotfile EXCLUSION: with a fixture containing hidden and visible entries,
+   a prefix that does not start with `.` surfaces only the visible entries.
+   Pair this with the existing inclusion case so both halves of the
+   `shouldIgnoreDotfile` rule are pinned.
+2. Quote characters in filenames (`'` and `"`) are surfaced and escaped.
+   They are in `SHELL_SPECIAL_CHARS` but appear in no test fixture.
+3. Unicode filenames are surfaced as suggestions and their values round-trip.
+   Today unicode appears only in trigger-detection assertions
+   (`InputPrompt.editing.test.tsx:674`), never as a surfaced suggestion.
+
+Prefer exercising the exported helpers in `atCompletionUtils.ts`
+(`filterEntriesByPrefix`, `findFilesRecursively`) against a real temp directory
+where that gives a direct, non-duplicative assertion of the dotfile rule.
+
+### AC5 — tmux real-keyboard smoke
+
+The existing `slash-autocomplete` script already provides real-keyboard smoke
+coverage for opening, filtering, navigating, and Escape-dismissing the slash
+menu, and it runs in the `interactive-ui` CI lane. The issue asks to *keep* one
+or two such tests, and directs that most coverage be hook and component tests.
+
+Decision: **pending user approval** — adding a second (at/path) tmux script
+requires editing `.github/workflows/interactive-ui.yml` path filters and the
+`interactive-ui-paths.bun.test.ts` contract that pins "the three executed
+scenario JSON files". That is a workflow change, so it is not taken
+unilaterally. See "Open question" below.
+
+## Known divergences found during the audit (reported, NOT fixed here)
+
+These are production-behavior observations outside the scope of a
+test-coverage issue. They are recorded so new tests do not accidentally
+contradict them, and are candidates for separate issues.
+
+1. **Cross-engine dotfile divergence.** Bare `@path` completion is served by
+   `useAtCompletion` (FileSearch engine); `@path` inside a slash-command line
+   is served by `slashCompletionEffect` (which applies `shouldIgnoreDotfile`).
+   The two disagree about whether hidden entries appear for an empty prefix:
+   `useAtCompletion.test.ts:384` expects `.gitignore` present,
+   `part3:460` expects it absent. Both currently pass. New dotfile tests must
+   target one engine explicitly and must not assert the other engine's rule.
+2. **Tautological existing test.** `part3:398` asserts
+   `length >= 0` alongside `length > 0`; the first assertion cannot fail.
+3. **Backslash separator divergence** between the `useCommandCompletion`
+   accept path and `slashCompletionEffect`'s `normalizePathSeparators`.
+4. **Orphaned scenario.** `scripts/tmux-script.github-at-completion.llxprt.json`
+   is git-tracked but referenced by no test, workflow, or doc. It also hits a
+   live GitHub broker, so registering it would need a fixture first.
+
+## Constraints
+
+- `bun:test` only. No vitest, no new `.js` files.
+- Reuse existing harnesses: `renderHook`/`waitFor` from `test-utils/render.js`,
+  `createTmpDir`/`cleanupTmpDir`/`FileSystemStructure` from
+  `@vybestack/llxprt-code-test-utils`, `vi.spyOn(FileSearchFactory, 'create')`
+  for search injection, the established `useCommandCompletion` mock shape and
+  `stdin.write` keystroke dispatch for `InputPrompt`.
+- Do not copy the `result.current.suggestions.push(...)` state-fabrication
+  smell from `part4:283/:310/:340`; drive real suggestions.
+- No production source changes.
+- New files carry a 2026 copyright year.
+
+## Verification
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+`npm run build`, plus the `stepfun-37` startup smoke, and
+`bun scripts/test-audit/scan.ts` with no new MOCK_MIRROR / ALWAYS_TRUE /
+SELF_CONFIRMING / NO_ASSERT findings on touched files.
+
+## Open question for the user
+
+Should AC5 add a second, deterministic at/path-completion tmux scenario? It
+would require workflow and workflow-contract-test edits. If not, the existing
+slash scenario stands as the "one" smoke test the issue permits.


### PR DESCRIPTION
## TLDR

Adds behavioral test coverage for the completion subsystem's untested branches. **Zero production source changes** — `git diff` against `main` touches only test files and one plan document.

Before writing anything, I audited the existing suites to establish what was already pinned on `main`, so nothing here duplicates existing coverage. Slash filtering and no-result behavior, Enter/Tab acceptance at an explicit index, the `isPerfectMatch` short-circuit, at-command debounce and cancellation, the 200ms loading indicator, gitignore/llxprtignore filtering, and most special-character escaping were already covered. This PR fills the gaps that remained.

Reviewers should look hardest at two things: the `chalk.level` manipulation in the highlight test (explained below), and the scope note about at-command error recovery.

## Dive Deeper

### `SuggestionsDisplay` render contract

The component had three tests, all for the `[Subagent]` badge. Everything else about its rendering was unasserted. Now pinned: the loading branch, the empty-to-`null` transition, scroll markers, the eight-row window, counter gating at the `MAX_SUGGESTIONS_TO_SHOW` boundary, descriptions paired with their labels, slash-mode column alignment versus non-slash inline layout, the `activeHint` line, and the active-row highlight.

The highlight test raises `chalk.level` to 3 and restores it in a `finally`. This is worth explaining because it looks odd. My first probe of `ink-testing-library` returned plain text with no ANSI, which suggested the highlight was simply unobservable and should not be tested. That was wrong: the default chalk level in the test process is 0, which strips colour. At level 3 the active row carries `38;2;0;255;0` and inactive rows carry the theme foreground. Without raising the level, active and inactive rows are textually identical and no assertion could fail, so the test would have been theatre.

The boundary cases are pinned explicitly rather than sampled: exactly 8 suggestions produces no counter and no down marker, 9 produces both, and the last scroll window produces an up marker and no down marker.

### `InputPrompt` acceptance and dismissal

`acceptCompletionSuggestion` falls back to index 0 when `activeSuggestionIndex` is `-1`. Every existing acceptance test set the index to 0 or 1, so that branch was never exercised. Both Tab and Enter now cover it.

The Enter test waits `FAST_RETURN_TIMEOUT + 10`ms before writing `\r`, because `KeypressContext` reclassifies a fast-arriving Return as pasted text rather than submit. Without the wait the test would pass through a different code path than the one it claims to test.

Escape dismissal is now distinguished from acceptance: the buffer text is unchanged, nothing was accepted, and the prompt was not submitted. The pre-existing Escape test asserted only that reset was called.

### `atCompletionUtils`

This module had no test file at all. Its dotfile rule is now pinned in both directions against a real temp directory — hidden entries are excluded unless the typed prefix itself starts with `.`, and the `h` prefix case proves the rule keys on the prefix rather than on a name match. Also covered: case-insensitive prefix matching, and the surfacing and escaping of quote and unicode filenames, which are in `SHELL_SPECIAL_CHARS` but appeared in no fixture.

### Every assertion was mutation-checked

Rather than trusting that the tests are meaningful, each was verified to fail for the right reason by temporarily breaking production code and reverting:

| Mutation | Expected to fail | Result |
| --- | --- | --- |
| `SuggestionsDisplay` always returns `null` | the 3 negative-branch render tests | failed, then passed after revert |
| active and inactive rows use the same colour | the highlight test | failed, then passed after revert |
| `activeSuggestionIndex === -1 ? 1` instead of `? 0` | the Tab and Enter fallback tests | failed, then passed after revert |
| dotfile predicate inverted | the 4 dotfile tests | failed, then passed after revert |

All production files are byte-identical to `main` in the final state.

### Scope note: at-command error recovery

The issue asks for error-recovery coverage. Recovery only works when `cwd` changes. A same-directory retry cannot recover, because `usePatternChangeHandler` transitions only from `IDLE`, `READY`, and `SEARCHING` — `ERROR` is absent, so a new pattern dispatches nothing. Verified by probe: after entering the error state, changing only the pattern produced no new `FileSearchFactory.create` and no suggestions.

That is a production bug, not a coverage gap, so it is filed as #3373 rather than fixed here or frozen into a passing test. The test added covers the recovery path that actually exists and is named for it.

### Two other pre-existing issues found and reported, not fixed

- A cross-engine divergence: bare `@path` (`useAtCompletion`) shows dotfiles for an empty prefix, while `@path` inside a slash-command line (`slashCompletionEffect`) hides them. Both behaviors are already frozen in passing tests on `main`. The new tests target the `atCompletionUtils` rule only and do not contradict or entrench either side.
- `scripts/tmux-script.github-at-completion.llxprt.json` is git-tracked but referenced by no test, workflow, or doc, and hits a live GitHub broker.

### On the tmux smoke test

The issue says to keep one or two tmux smoke tests for real keyboard behavior. `tmux-script.slash-autocomplete.json` already runs in the `interactive-ui` CI lane and covers opening, filtering, arrow navigation, the counter, and Escape dismissal through real keystrokes. Adding a second scenario would require editing the workflow's path filters plus the contract test that pins "the three executed scenario JSON files", so it was not done unilaterally. The issue also directs that most coverage be hook and component tests, which is what this PR delivers.

## Reviewer Test Plan

Confirm nothing in production changed:

```bash
git diff main...issue2019 --stat
```

Run the touched suites (from `packages/cli`, since running from the repo root suffix-matches an unrelated `research/gemini-cli` copy):

```bash
cd packages/cli && bun test \
  src/ui/components/SuggestionsDisplay.test.tsx \
  src/ui/components/InputPrompt.completion.test.tsx \
  src/ui/hooks/atCompletionUtils.test.ts \
  src/ui/hooks/useAtCompletion.test.ts
```

To confirm the tests are not theatre, reproduce any row of the mutation table. The quickest is to make `SuggestionsDisplay` return `null` immediately and watch the three negative-branch tests fail, or flip `=== -1 ? 0` to `? 1` in `inputPromptKeyHandlers.ts` and watch the Tab and Enter tests fail.

Interactively, the covered behaviors are: type `/` and check the menu, counter, and Escape dismissal; type `@` in a directory containing hidden files and confirm they stay hidden until you type a leading `.`; press Tab with the menu open but nothing arrow-selected and confirm the first suggestion is accepted rather than nothing happening.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified locally on macOS: `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, and `npm run build` all pass. The startup smoke test passes. `bun scripts/test-audit/scan.ts` reports no `MOCK_MIRROR`, `ALWAYS_TRUE`, `SELF_CONFIRMING`, or `NO_ASSERT` findings on the touched files. Open Code Review returned 0 findings across all 4 files.

This is a test-only change with no production diff, so platform-specific runtime behavior is not affected. The filename fixtures (quotes, unicode) are created on the local filesystem and all succeeded on darwin; Linux CI will confirm portability.

## Linked issues / bugs

Fixes #2019

Filed while working on this, deliberately out of scope: #3373 (at-command completion cannot recover from a transient search error while typing).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for completion acceptance, dismissal, and keyboard interactions.
  * Added rendering checks for suggestion loading, empty states, scrolling, descriptions, counters, and active-row styling.
  * Added coverage for file matching, recursive searches, hidden files, case-insensitive names, and special characters.
  * Verified completion recovery when the working directory changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->