### PR TITLE
Increase Ink composer and input-state coverage (Fixes #2018)

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.escape.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.escape.test.tsx
@@ -1,0 +1,367 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { automock } from '@vybestack/llxprt-code-test-utils';
+import { renderWithProviders } from '../../test-utils/render.js';
+import { waitFor } from '../../test-utils/async.js';
+import { act, useState } from 'react';
+import type { InputPromptProps } from './InputPrompt.js';
+import { InputPrompt } from './InputPrompt.js';
+import type { TextBuffer } from './shared/text-buffer.js';
+import type { Config } from '@vybestack/llxprt-code-core';
+import { ApprovalMode } from '@vybestack/llxprt-code-core';
+import * as path from 'node:path';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import type { CommandContext, SlashCommand } from '../commands/types.js';
+import { CommandKind } from '../commands/types.js';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  vi,
+  afterEach,
+  type Mock,
+} from 'bun:test';
+import type { UseShellHistoryReturn } from '../hooks/useShellHistory.js';
+import { useShellHistory } from '../hooks/useShellHistory.js';
+import type { UseCommandCompletionReturn } from '../hooks/useCommandCompletion.js';
+import { useCommandCompletion } from '../hooks/useCommandCompletion.js';
+import type { UseInputHistoryReturn } from '../hooks/useInputHistory.js';
+import { useInputHistory } from '../hooks/useInputHistory.js';
+import type { UseReverseSearchCompletionReturn } from '../hooks/useReverseSearchCompletion.js';
+import { useReverseSearchCompletion } from '../hooks/useReverseSearchCompletion.js';
+import { useKittyKeyboardProtocol } from '../hooks/useKittyKeyboardProtocol.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import { StreamingState } from '../types.js';
+import { terminalCapabilityManager } from '../utils/terminalCapabilityManager.js';
+
+const realUseShellHistoryModule = {
+  ...(await import('../hooks/useShellHistory.js')),
+};
+const realUseCommandCompletionModule = {
+  ...(await import('../hooks/useCommandCompletion.js')),
+};
+const realUseInputHistoryModule = {
+  ...(await import('../hooks/useInputHistory.js')),
+};
+const realUseReverseSearchCompletionModule = {
+  ...(await import('../hooks/useReverseSearchCompletion.js')),
+};
+const realClipboardUtilsModule = {
+  ...(await import('../utils/clipboardUtils.js')),
+};
+const realUseKittyKeyboardProtocolModule = {
+  ...(await import('../hooks/useKittyKeyboardProtocol.js')),
+};
+
+void vi.mock('../hooks/useShellHistory.js', () =>
+  automock(realUseShellHistoryModule),
+);
+void vi.mock('../hooks/useCommandCompletion.js', () =>
+  automock(realUseCommandCompletionModule),
+);
+void vi.mock('../hooks/useInputHistory.js', () =>
+  automock(realUseInputHistoryModule),
+);
+void vi.mock('../hooks/useReverseSearchCompletion.js', () =>
+  automock(realUseReverseSearchCompletionModule),
+);
+void vi.mock('../utils/clipboardUtils.js', () =>
+  automock(realClipboardUtilsModule),
+);
+void vi.mock('../hooks/useKittyKeyboardProtocol.js', () =>
+  automock(realUseKittyKeyboardProtocolModule),
+);
+
+const mockSlashCommands: SlashCommand[] = [
+  {
+    name: 'clear',
+    kind: CommandKind.BUILT_IN,
+    description: 'Clear screen',
+    action: vi.fn(),
+  },
+  {
+    name: 'memory',
+    kind: CommandKind.BUILT_IN,
+    description: 'Manage memory',
+    subCommands: [
+      {
+        name: 'show',
+        kind: CommandKind.BUILT_IN,
+        description: 'Show memory',
+        action: vi.fn(),
+      },
+      {
+        name: 'add',
+        kind: CommandKind.BUILT_IN,
+        description: 'Add to memory',
+        action: vi.fn(),
+      },
+      {
+        name: 'refresh',
+        kind: CommandKind.BUILT_IN,
+        description: 'Refresh memory',
+        action: vi.fn(),
+      },
+    ],
+  },
+  {
+    name: 'chat',
+    description: 'Manage chats',
+    kind: CommandKind.BUILT_IN,
+    subCommands: [
+      {
+        name: 'resume',
+        description: 'Resume a chat',
+        kind: CommandKind.BUILT_IN,
+        action: vi.fn(),
+        completion: async () => ['fix-foo', 'fix-bar'],
+      },
+    ],
+  },
+];
+
+describe('InputPrompt', () => {
+  let props: InputPromptProps;
+  let mockShellHistory: UseShellHistoryReturn;
+  let mockCommandCompletion: UseCommandCompletionReturn;
+  let mockInputHistory: UseInputHistoryReturn;
+  let mockReverseSearchCompletion: UseReverseSearchCompletionReturn;
+  let mockBuffer: TextBuffer;
+  let mockCommandContext: CommandContext;
+
+  const mockedUseShellHistory = useShellHistory as Mock<typeof useShellHistory>;
+  const mockedUseCommandCompletion = useCommandCompletion as Mock<
+    typeof useCommandCompletion
+  >;
+  const mockedUseInputHistory = useInputHistory as Mock<typeof useInputHistory>;
+  const mockedUseReverseSearchCompletion = useReverseSearchCompletion as Mock<
+    typeof useReverseSearchCompletion
+  >;
+  const mockedUseKittyKeyboardProtocol = useKittyKeyboardProtocol as Mock<
+    typeof useKittyKeyboardProtocol
+  >;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(
+      terminalCapabilityManager,
+      'isKittyProtocolEnabled',
+    ).mockReturnValue(true);
+
+    mockCommandContext = createMockCommandContext();
+
+    mockBuffer = {
+      text: '',
+      cursor: [0, 0],
+      lines: [''],
+      transformationsByLine: [[]],
+      visualToTransformedMap: [0],
+      setText: vi.fn((newText: string) => {
+        mockBuffer.text = newText;
+        mockBuffer.lines = [newText];
+        mockBuffer.transformationsByLine = [[]];
+        mockBuffer.visualToTransformedMap = [0];
+        mockBuffer.cursor = [0, newText.length];
+        mockBuffer.viewportVisualLines = [newText];
+        mockBuffer.allVisualLines = [newText];
+        mockBuffer.visualToLogicalMap = [[0, 0]];
+      }),
+      replaceRangeByOffset: vi.fn(),
+      viewportVisualLines: [''],
+      allVisualLines: [''],
+      visualCursor: [0, 0],
+      visualScrollRow: 0,
+      handleInput: vi.fn(),
+      move: vi.fn(),
+      moveToOffset: vi.fn((offset: number) => {
+        mockBuffer.cursor = [0, offset];
+      }),
+      moveToVisualPosition: vi.fn(),
+      killLineRight: vi.fn(),
+      killLineLeft: vi.fn(),
+      openInExternalEditor: vi.fn(),
+      newline: vi.fn(),
+      undo: vi.fn(),
+      redo: vi.fn(),
+      backspace: vi.fn(),
+      preferredCol: null,
+      selectionAnchor: null,
+      insert: vi.fn(),
+      del: vi.fn(),
+      replaceRange: vi.fn(),
+      deleteWordLeft: vi.fn(),
+      deleteWordRight: vi.fn(),
+      visualToLogicalMap: [[0, 0]],
+    } as unknown as TextBuffer;
+
+    mockShellHistory = {
+      history: [],
+      addCommandToHistory: vi.fn(),
+      getPreviousCommand: vi.fn().mockReturnValue(null),
+      getNextCommand: vi.fn().mockReturnValue(null),
+      resetHistoryPosition: vi.fn(),
+    };
+    mockedUseShellHistory.mockReturnValue(mockShellHistory);
+
+    mockCommandCompletion = {
+      suggestions: [],
+      activeHint: '',
+      activeSuggestionIndex: -1,
+      isLoadingSuggestions: false,
+      showSuggestions: false,
+      visibleStartIndex: 0,
+      isPerfectMatch: false,
+      navigateUp: vi.fn(),
+      navigateDown: vi.fn(),
+      resetCompletionState: vi.fn(),
+      setActiveSuggestionIndex: vi.fn(),
+      setShowSuggestions: vi.fn(),
+      handleAutocomplete: vi.fn(),
+      promptCompletion: {
+        text: '',
+        accept: vi.fn(),
+        clear: vi.fn(),
+        isLoading: false,
+        isActive: false,
+        markSelected: vi.fn(),
+      },
+      getCommandFromSuggestion: vi.fn().mockReturnValue(null),
+      isArgumentCompletion: false,
+      leafCommand: null,
+    };
+    mockedUseCommandCompletion.mockReturnValue(mockCommandCompletion);
+
+    mockInputHistory = {
+      navigateUp: vi.fn(),
+      navigateDown: vi.fn(),
+      handleSubmit: vi.fn(),
+    };
+    mockedUseInputHistory.mockReturnValue(mockInputHistory);
+
+    mockReverseSearchCompletion = {
+      suggestions: [],
+      activeSuggestionIndex: -1,
+      visibleStartIndex: 0,
+      showSuggestions: false,
+      isLoadingSuggestions: false,
+      navigateUp: vi.fn(),
+      navigateDown: vi.fn(),
+      handleAutocomplete: vi.fn(),
+      resetCompletionState: vi.fn(),
+    };
+    mockedUseReverseSearchCompletion.mockReturnValue(
+      mockReverseSearchCompletion,
+    );
+
+    mockedUseKittyKeyboardProtocol.mockReturnValue({
+      enabled: false,
+      checking: false,
+    });
+
+    props = {
+      buffer: mockBuffer,
+      onSubmit: vi.fn(),
+      userMessages: [],
+      onClearScreen: vi.fn(),
+      config: {
+        getProjectRoot: () => path.join('test', 'project'),
+        getTargetDir: () => path.join('test', 'project', 'src'),
+        getVimMode: () => false,
+        getWorkspaceContext: () => ({
+          getDirectories: () => ['/test/project/src'],
+        }),
+      } as unknown as Config,
+      slashCommands: mockSlashCommands,
+      commandContext: mockCommandContext,
+      shellModeActive: false,
+      setShellModeActive: vi.fn(),
+      approvalMode: ApprovalMode.DEFAULT,
+      inputWidth: 80,
+      suggestionsWidth: 80,
+      focus: true,
+      setQueueErrorMessage: vi.fn(),
+      streamingState: StreamingState.Idle,
+    };
+  });
+
+  describe('escape priority ordering', () => {
+    const temporaryDirs: string[] = [];
+
+    afterEach(() => {
+      for (const dir of temporaryDirs.splice(0)) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('closes shell path suggestions while leaving shell mode active', async () => {
+      // Complete against a small dedicated directory rather than the repo
+      // root: a real scan of the workspace is slow and its listing (and
+      // therefore the suggestion shown) varies with the checkout.
+      const completionRoot = mkdtempSync(
+        path.join(tmpdir(), 'issue2018-shellpath-'),
+      );
+      temporaryDirs.push(completionRoot);
+      mkdirSync(path.join(completionRoot, 'zebrafolder'));
+      const shellModeCalls: boolean[] = [];
+      props.shellModeActive = true;
+      props.buffer.setText('./zebra');
+      props.config.getTargetDir = () => completionRoot;
+      props.setShellModeActive = (active) => {
+        shellModeCalls.push(active);
+      };
+      const rendered = renderWithProviders(<InputPrompt {...props} />);
+      await waitFor(() =>
+        expect(rendered.stdout.lastFrame()).toContain('zebrafolder'),
+      );
+
+      rendered.stdin.write('\x1B');
+
+      await waitFor(() => {
+        expect(rendered.stdout.lastFrame()).not.toContain('zebrafolder');
+      });
+      expect(shellModeCalls).not.toContain(false);
+      rendered.unmount();
+    });
+
+    it('dismisses slash suggestions without changing input or arming clear', async () => {
+      const bufferText = '/cl';
+      let escapePromptVisible = false;
+      mockedUseCommandCompletion.mockImplementation(() => {
+        const [showSuggestions, setShowSuggestions] = useState(true);
+        return {
+          ...mockCommandCompletion,
+          showSuggestions,
+          suggestions: [{ label: 'clear', value: '/clear' }],
+          resetCompletionState: () => {
+            setShowSuggestions(false);
+          },
+        };
+      });
+      props.buffer.setText(bufferText);
+      props.onEscapePromptChange = (visible) => {
+        escapePromptVisible = visible;
+      };
+      const rendered = renderWithProviders(<InputPrompt {...props} />);
+      await waitFor(() => {
+        expect(rendered.stdout.lastFrame()).toContain('clear');
+      });
+
+      await act(async () => {
+        rendered.stdin.write('\x1B');
+      });
+
+      await waitFor(() => {
+        expect(rendered.stdout.lastFrame()).not.toContain('clear');
+      });
+      expect(props.buffer.text).toBe(bufferText);
+      expect(escapePromptVisible).toBe(false);
+      rendered.unmount();
+    });
+  });
+});

--- a/packages/cli/src/ui/components/InputPrompt.paste.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.paste.test.tsx
@@ -4,24 +4,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { automock } from '@vybestack/llxprt-code-test-utils';
+import {
+  advanceTimersByTimeAsync,
+  automock,
+} from '@vybestack/llxprt-code-test-utils';
 import { renderWithProviders } from '../../test-utils/render.js';
 import { waitFor } from '../../test-utils/async.js';
 import { act } from 'react';
-import type { InputPromptProps } from './InputPrompt.js';
-import { InputPrompt } from './InputPrompt.js';
-import type { TextBuffer } from './shared/text-buffer.js';
-import type { Config } from '@vybestack/llxprt-code-core';
-import { ApprovalMode } from '@vybestack/llxprt-code-core';
+import { FAST_RETURN_TIMEOUT } from '../contexts/KeypressContext.js';
+import { InputPrompt, type InputPromptProps } from './InputPrompt.js';
+import { useTextBuffer, type TextBuffer } from './shared/text-buffer.js';
+import { ApprovalMode, type Config } from '@vybestack/llxprt-code-core';
 import * as path from 'node:path';
 import type { CommandContext, SlashCommand } from '../commands/types.js';
 import { CommandKind } from '../commands/types.js';
-import { describe, it, expect, beforeEach, vi, type Mock } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
+import type { Mock } from 'bun:test';
 import type { UseShellHistoryReturn } from '../hooks/useShellHistory.js';
 import { useShellHistory } from '../hooks/useShellHistory.js';
 import type { UseCommandCompletionReturn } from '../hooks/useCommandCompletion.js';
 import { useCommandCompletion } from '../hooks/useCommandCompletion.js';
-import type { UseInputHistoryReturn } from '../hooks/useInputHistory.js';
 import { useInputHistory } from '../hooks/useInputHistory.js';
 import type { UseReverseSearchCompletionReturn } from '../hooks/useReverseSearchCompletion.js';
 import { useReverseSearchCompletion } from '../hooks/useReverseSearchCompletion.js';
@@ -68,6 +70,8 @@ void vi.mock('../utils/clipboardUtils.js', () =>
 void vi.mock('../hooks/useKittyKeyboardProtocol.js', () =>
   automock(realUseKittyKeyboardProtocolModule),
 );
+
+const KITTY_PROTOCOL_ENABLED = { enabled: true, checking: false };
 
 const mockSlashCommands: SlashCommand[] = [
   {
@@ -117,11 +121,28 @@ const mockSlashCommands: SlashCommand[] = [
   },
 ];
 
+function InputPromptWithRealBuffer({
+  props,
+  initialText = '',
+}: {
+  readonly props: InputPromptProps;
+  readonly initialText?: string;
+}) {
+  const buffer = useTextBuffer({
+    initialText,
+    initialCursorOffset: initialText.length,
+    viewport: { width: 80, height: 24 },
+    isValidPath: () => false,
+  });
+
+  return <InputPrompt {...props} buffer={buffer} />;
+}
+
 describe('InputPrompt', () => {
   let props: InputPromptProps;
   let mockShellHistory: UseShellHistoryReturn;
   let mockCommandCompletion: UseCommandCompletionReturn;
-  let mockInputHistory: UseInputHistoryReturn;
+  let mockInputHistory: ReturnType<typeof useInputHistory>;
   let mockReverseSearchCompletion: UseReverseSearchCompletionReturn;
   let mockBuffer: TextBuffer;
   let mockCommandContext: CommandContext;
@@ -281,6 +302,75 @@ describe('InputPrompt', () => {
       setQueueErrorMessage: vi.fn(),
       streamingState: StreamingState.Idle,
     };
+  });
+
+  describe('large paste submission', () => {
+    const alphaPaste = 'ALPHA_1\nALPHA_2\nALPHA_3\nALPHA_4';
+    const firstPaste = 'FIRST_1\nFIRST_2\nFIRST_3\nFIRST_4';
+    const secondPaste = 'SECOND_1\nSECOND_2\nSECOND_3\nSECOND_4';
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      mockedUseKittyKeyboardProtocol.mockReturnValue(KITTY_PROTOCOL_ENABLED);
+    });
+
+    afterEach(() => vi.useRealTimers());
+
+    it.each([
+      {
+        name: 'one large paste',
+        initialText: '',
+        inputs: [{ kind: 'paste', text: alphaPaste }],
+        expected: alphaPaste,
+      },
+      {
+        name: 'two distinct large pastes',
+        initialText: 'before:',
+        inputs: [
+          { kind: 'paste', text: firstPaste },
+          { kind: 'text', text: ':between:' },
+          { kind: 'paste', text: secondPaste },
+          { kind: 'text', text: ':after' },
+        ],
+        expected: `before:${firstPaste}:between:${secondPaste}:after`,
+      },
+    ] as const)(
+      'shows placeholders and expands $name through the submit path',
+      async ({ initialText, inputs, expected }) => {
+        const submittedValues: string[] = [];
+        props.onSubmit = (value) => submittedValues.push(value);
+        const rendered = renderWithProviders(
+          <InputPromptWithRealBuffer props={props} initialText={initialText} />,
+          { kittyProtocolEnabled: true },
+        );
+        let pasteCount = 0;
+
+        for (const input of inputs) {
+          const isPaste = input.kind === 'paste';
+          pasteCount += Number(isPaste);
+          const sequence = isPaste
+            ? `\x1b[200~${input.text}\x1b[201~`
+            : input.text;
+          const visibleText = isPaste
+            ? `[4 lines pasted #${pasteCount}]`
+            : input.text;
+          await act(async () => rendered.stdin.write(sequence));
+          await waitFor(() =>
+            expect(rendered.stdout.lastFrame()).toContain(visibleText),
+          );
+        }
+        const frame = rendered.stdout.lastFrame();
+        for (const paste of inputs.filter((input) => input.kind === 'paste')) {
+          expect(frame).not.toContain(paste.text.split('\n')[0]);
+        }
+        await act(() => advanceTimersByTimeAsync(FAST_RETURN_TIMEOUT + 1));
+
+        await act(async () => rendered.stdin.write('\r'));
+
+        await waitFor(() => expect(submittedValues).toEqual([expected]));
+        rendered.unmount();
+      },
+    );
   });
 
   describe('reverse search', () => {

--- a/packages/cli/src/ui/components/Notifications.test.tsx
+++ b/packages/cli/src/ui/components/Notifications.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from 'bun:test';
+import { render } from 'ink-testing-library';
+import type { HistoryItem } from '../types.js';
+import { StreamingState } from '../types.js';
+import { useUIState } from '../contexts/UIStateContext.js';
+import { Notifications } from './Notifications.js';
+
+const realRealInkModule = {
+  ...(await import('../../../test-utils/real-ink.js')),
+};
+
+void vi.mock('ink', () => realRealInkModule);
+
+void vi.mock('node:fs/promises', () => ({
+  access: async () => {},
+  mkdir: async () => {},
+  writeFile: async () => {},
+}));
+
+void vi.mock('./UpdateNotification.js', () => ({
+  UpdateNotification: () => null,
+}));
+
+void vi.mock('../contexts/UIStateContext.js', () => ({
+  useUIState: vi.fn(),
+}));
+
+const mockUseUIState = useUIState as Mock<typeof useUIState>;
+const activeRenders: Array<ReturnType<typeof render>> = [];
+
+interface NotificationTestOptions {
+  initError?: string | null;
+  streamingState?: StreamingState;
+  startupWarnings?: string[];
+  history?: HistoryItem[];
+}
+
+function renderNotifications(options: NotificationTestOptions = {}) {
+  mockUseUIState.mockReturnValue({
+    initError: options.initError ?? null,
+    streamingState: options.streamingState ?? StreamingState.Idle,
+  } as never);
+
+  const rendered = render(
+    <Notifications
+      startupWarnings={options.startupWarnings ?? []}
+      updateInfo={null}
+      history={options.history ?? []}
+    />,
+  );
+  activeRenders.push(rendered);
+  return rendered;
+}
+
+describe('Notifications', () => {
+  beforeEach(() => {
+    mockUseUIState.mockReset();
+  });
+
+  afterEach(() => {
+    for (const rendered of activeRenders.splice(0)) {
+      rendered.unmount();
+    }
+  });
+
+  // No live call site currently assigns a non-null initError; the plan records
+  // that observation as a follow-up.
+  it('renders an initialization error with actionable remediation', () => {
+    const { lastFrame } = renderNotifications({
+      initError: 'Missing API key',
+    });
+
+    const frame = lastFrame();
+    expect(frame).toContain('Initialization Error: Missing API key');
+    expect(frame).toContain('Please check API key and configuration.');
+  });
+
+  it('prefers the fuller matching error from history', () => {
+    const historyText = 'Provider error: Missing API key is not configured.';
+    const nonErrorDistractor =
+      'INFORMATION_DISTRACTOR mentions Missing API key for documentation.';
+    const unrelatedErrorDistractor =
+      'UNRELATED_ERROR_DISTRACTOR: provider connection timed out.';
+    const { lastFrame } = renderNotifications({
+      initError: 'Missing API key',
+      history: [
+        { id: 1, type: 'info', text: nonErrorDistractor },
+        { id: 2, type: 'error', text: unrelatedErrorDistractor },
+        { id: 3, type: 'error', text: historyText },
+      ],
+    });
+
+    const frame = lastFrame();
+    expect(frame).toContain(historyText);
+    expect(frame).not.toContain('INFORMATION_DISTRACTOR');
+    expect(frame).not.toContain('UNRELATED_ERROR_DISTRACTOR');
+    expect(frame).not.toContain('Please check API key and configuration.');
+  });
+
+  it('suppresses the initialization error while responding', () => {
+    const { lastFrame } = renderNotifications({
+      initError: 'Missing API key',
+      streamingState: StreamingState.Responding,
+    });
+
+    const frame = lastFrame();
+    expect(frame).not.toContain('Initialization Error');
+    expect(frame).not.toContain('Missing API key');
+    expect(frame).not.toContain('Please check API key and configuration.');
+  });
+
+  it('renders every startup warning', () => {
+    const { lastFrame } = renderNotifications({
+      startupWarnings: ['warning one', 'warning two'],
+    });
+
+    const frame = lastFrame();
+    expect(frame).toContain('warning one');
+    expect(frame).toContain('warning two');
+  });
+
+  it('renders startup warnings alongside an initialization error', () => {
+    const { lastFrame } = renderNotifications({
+      initError: 'Missing API key',
+      startupWarnings: ['Configuration migration is recommended.'],
+    });
+
+    const frame = lastFrame();
+    expect(frame).toContain('Configuration migration is recommended.');
+    expect(frame).toContain('Initialization Error: Missing API key');
+    expect(frame).toContain('Please check API key and configuration.');
+  });
+
+  it('renders nothing when there are no notifications', () => {
+    const { lastFrame } = renderNotifications();
+
+    expect(lastFrame()).toBe('');
+  });
+});

--- a/packages/cli/src/ui/components/inputPromptText.test.ts
+++ b/packages/cli/src/ui/components/inputPromptText.test.ts
@@ -1,0 +1,229 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { act } from 'react';
+import { renderHook } from '../../test-utils/render.js';
+import type { Key } from '../hooks/useKeypress.js';
+import {
+  expandLargePastePlaceholders,
+  handleLargePaste,
+} from './inputPromptText.js';
+import type { TextBuffer } from './shared/text-buffer.js';
+import { useTextBuffer } from './shared/text-buffer.js';
+
+const viewport = { width: 80, height: 24 } as const;
+
+function renderTextBuffer(
+  initialText = '',
+  initialCursorOffset = 0,
+): ReturnType<typeof renderHook<TextBuffer>> {
+  return renderHook(() =>
+    useTextBuffer({
+      initialText,
+      initialCursorOffset,
+      viewport,
+      isValidPath: () => false,
+    }),
+  );
+}
+
+function pasteKey(sequence: string): Key {
+  return {
+    name: 'paste',
+    ctrl: false,
+    meta: false,
+    shift: false,
+    sequence,
+  };
+}
+
+function getOnlyPlaceholder(
+  pendingPastes: ReadonlyMap<string, string>,
+): string {
+  const labels = [...pendingPastes.keys()];
+  expect(labels).toHaveLength(1);
+  return labels[0];
+}
+
+describe('handleLargePaste', () => {
+  it('replaces a four-line paste at the cursor with one tracked placeholder', () => {
+    const textBefore = 'prefix ';
+    const textAfter = ' suffix';
+    const pastedText = 'alpha\r\nbeta\r\ngamma\r\ndelta';
+    const sanitizedPaste = pastedText.replace(/\r\n?/g, '\n');
+    const nextPlaceholderIdRef = { current: 1 };
+    const pendingLargePastesRef = { current: new Map<string, string>() };
+    const { result, unmount } = renderTextBuffer(
+      textBefore + textAfter,
+      textBefore.length,
+    );
+
+    act(() => {
+      handleLargePaste(
+        pasteKey(pastedText),
+        result.current,
+        nextPlaceholderIdRef,
+        pendingLargePastesRef,
+      );
+    });
+
+    const placeholder = getOnlyPlaceholder(pendingLargePastesRef.current);
+    expect(result.current.text).toBe(textBefore + placeholder + textAfter);
+    expect(result.current.text).not.toContain(sanitizedPaste);
+    expect(result.current.getOffset()).toBe(
+      textBefore.length + placeholder.length,
+    );
+    expect(pendingLargePastesRef.current.get(placeholder)).toBe(sanitizedPaste);
+    unmount();
+  });
+
+  it('uses a placeholder for a single-line paste at the character threshold', () => {
+    const pastedText = 'x'.repeat(1000);
+    const nextPlaceholderIdRef = { current: 1 };
+    const pendingLargePastesRef = { current: new Map<string, string>() };
+    const { result, unmount } = renderTextBuffer();
+
+    act(() => {
+      handleLargePaste(
+        pasteKey(pastedText),
+        result.current,
+        nextPlaceholderIdRef,
+        pendingLargePastesRef,
+      );
+    });
+
+    const placeholder = getOnlyPlaceholder(pendingLargePastesRef.current);
+    expect(result.current.text).toBe(placeholder);
+    expect(result.current.text).not.toContain(pastedText);
+    expect(result.current.getOffset()).toBe(placeholder.length);
+    unmount();
+  });
+
+  it('inserts exactly three short lines without creating a placeholder', () => {
+    const textBefore = 'left:';
+    const textAfter = ':right';
+    const pastedText = 'one\ntwo\nthree';
+    const nextPlaceholderIdRef = { current: 1 };
+    const pendingLargePastesRef = { current: new Map<string, string>() };
+    const { result, unmount } = renderTextBuffer(
+      textBefore + textAfter,
+      textBefore.length,
+    );
+
+    act(() => {
+      handleLargePaste(
+        pasteKey(pastedText),
+        result.current,
+        nextPlaceholderIdRef,
+        pendingLargePastesRef,
+      );
+    });
+
+    expect(result.current.text).toBe(textBefore + pastedText + textAfter);
+    expect(pendingLargePastesRef.current.size).toBe(0);
+    unmount();
+  });
+
+  it('expands distinct placeholders back to both pasted bodies in order', () => {
+    const textBefore = 'before:';
+    const textAfter = ':after';
+    const firstPaste = 'first\nlarge\npaste\nbody';
+    const secondPaste = 'z'.repeat(1001);
+    const nextPlaceholderIdRef = { current: 1 };
+    const pendingLargePastesRef = { current: new Map<string, string>() };
+    const { result, unmount } = renderTextBuffer(
+      textBefore + textAfter,
+      textBefore.length,
+    );
+
+    act(() => {
+      handleLargePaste(
+        pasteKey(firstPaste),
+        result.current,
+        nextPlaceholderIdRef,
+        pendingLargePastesRef,
+      );
+    });
+
+    const firstPlaceholder = getOnlyPlaceholder(pendingLargePastesRef.current);
+    expect(
+      expandLargePastePlaceholders(
+        result.current.text,
+        pendingLargePastesRef.current,
+      ),
+    ).toBe(textBefore + firstPaste + textAfter);
+
+    act(() => {
+      handleLargePaste(
+        pasteKey(secondPaste),
+        result.current,
+        nextPlaceholderIdRef,
+        pendingLargePastesRef,
+      );
+    });
+
+    const placeholders = [...pendingLargePastesRef.current.keys()];
+    expect(placeholders).toHaveLength(2);
+    const secondPlaceholder = placeholders.find(
+      (placeholder) => placeholder !== firstPlaceholder,
+    );
+    if (secondPlaceholder === undefined) {
+      throw new Error('Expected a distinct second large-paste placeholder');
+    }
+    expect(secondPlaceholder).not.toBe(firstPlaceholder);
+    expect(result.current.text).toBe(
+      textBefore + firstPlaceholder + secondPlaceholder + textAfter,
+    );
+    expect(
+      expandLargePastePlaceholders(
+        result.current.text,
+        pendingLargePastesRef.current,
+      ),
+    ).toBe(textBefore + firstPaste + secondPaste + textAfter);
+    unmount();
+  });
+
+  it('normalizes CRLF and bare carriage returns in a short paste', () => {
+    const textBefore = 'left:';
+    const textAfter = ':right';
+    const pastedText = 'first\r\nsecond\rthird';
+    const normalizedPaste = pastedText.replace(/\r\n?/g, '\n');
+    const nextPlaceholderIdRef = { current: 1 };
+    const pendingLargePastesRef = { current: new Map<string, string>() };
+    const { result, unmount } = renderTextBuffer(
+      textBefore + textAfter,
+      textBefore.length,
+    );
+
+    act(() => {
+      handleLargePaste(
+        pasteKey(pastedText),
+        result.current,
+        nextPlaceholderIdRef,
+        pendingLargePastesRef,
+      );
+    });
+
+    expect(result.current.text).toBe(textBefore + normalizedPaste + textAfter);
+    expect(result.current.text).not.toContain('\r');
+    unmount();
+  });
+});
+
+describe('expandLargePastePlaceholders', () => {
+  it('leaves ordinary placeholder-like text unchanged without pending pastes', () => {
+    const placeholderLikeText =
+      'Keep [4 lines pasted #42] and [1000 characters pasted #9] as written.';
+
+    const expanded = expandLargePastePlaceholders(
+      placeholderLikeText,
+      new Map(),
+    );
+
+    expect(expanded).toBe(placeholderLikeText);
+  });
+});

--- a/packages/cli/src/ui/containers/AppContainer/hooks/useAppInput.predicate.test.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useAppInput.predicate.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { CommandKind, type SlashCommand } from '../../../commands/types.js';
+import { StreamingState } from '../../../types.js';
+import {
+  computeIsInputActive,
+  type IsInputActiveInputs,
+} from './useAppInput.js';
+
+const POPULATED_SLASH_COMMANDS = [
+  {
+    name: 'clear',
+    kind: CommandKind.BUILT_IN,
+    description: 'Clear the screen',
+  },
+] satisfies readonly SlashCommand[];
+
+function readyInputs(): IsInputActiveInputs {
+  return {
+    streamingState: StreamingState.Idle,
+    initError: null,
+    isProcessing: false,
+    slashCommands: [],
+  };
+}
+
+describe('computeIsInputActive', () => {
+  it('returns true when every input is ready', () => {
+    expect(computeIsInputActive(readyInputs())).toBe(true);
+  });
+
+  describe('streaming state gating', () => {
+    it.each(Object.values(StreamingState))(
+      'uses the visibility rule for %s',
+      (streamingState) => {
+        const expected =
+          streamingState === StreamingState.Idle ||
+          streamingState === StreamingState.Responding;
+
+        expect(computeIsInputActive({ ...readyInputs(), streamingState })).toBe(
+          expected,
+        );
+      },
+    );
+  });
+
+  it('returns false while slash commands are still loading', () => {
+    expect(
+      computeIsInputActive({ ...readyInputs(), slashCommands: undefined }),
+    ).toBe(false);
+  });
+
+  it('returns true when slash commands load as an empty array', () => {
+    expect(computeIsInputActive({ ...readyInputs(), slashCommands: [] })).toBe(
+      true,
+    );
+  });
+
+  it('returns true when slash commands load as a populated array', () => {
+    expect(
+      computeIsInputActive({
+        ...readyInputs(),
+        slashCommands: POPULATED_SLASH_COMMANDS,
+      }),
+    ).toBe(true);
+  });
+
+  it('becomes active when only slash-command readiness changes', () => {
+    const loadingInputs = { ...readyInputs(), slashCommands: undefined };
+    const loadedInputs = { ...loadingInputs, slashCommands: [] };
+
+    expect(computeIsInputActive(loadingInputs)).toBe(false);
+    expect(computeIsInputActive(loadedInputs)).toBe(true);
+  });
+
+  it('returns false when initialization has failed', () => {
+    expect(
+      computeIsInputActive({ ...readyInputs(), initError: 'Missing API key' }),
+    ).toBe(false);
+  });
+
+  it('returns false while slash-command processing is in flight', () => {
+    expect(computeIsInputActive({ ...readyInputs(), isProcessing: true })).toBe(
+      false,
+    );
+  });
+});

--- a/packages/cli/src/ui/containers/AppContainer/hooks/useAppInput.ts
+++ b/packages/cli/src/ui/containers/AppContainer/hooks/useAppInput.ts
@@ -38,6 +38,31 @@ import type {
   UiSubagentManager,
 } from '../../../cliUiRuntime.js';
 
+export interface IsInputActiveInputs {
+  streamingState: StreamingState;
+  initError: ReturnType<typeof useAgentStream>['initError'];
+  isProcessing: boolean;
+  slashCommands: ReturnType<typeof useSlashCommandProcessor>['slashCommands'];
+}
+
+/**
+ * The composer is visible only while the stream is idle or responding, there is
+ * no initialization error, no slash-command processing is in flight, and slash
+ * commands have finished loading.
+ */
+export function computeIsInputActive(inputs: IsInputActiveInputs): boolean {
+  const isStreamingIdleOrResponding =
+    inputs.streamingState === StreamingState.Idle ||
+    inputs.streamingState === StreamingState.Responding;
+
+  return (
+    isStreamingIdleOrResponding &&
+    !inputs.initError &&
+    !inputs.isProcessing &&
+    !!inputs.slashCommands
+  );
+}
+
 export interface AppInputParams {
   // From bootstrap
   streamRuntime: AppBootstrapResult['streamRuntime'];
@@ -496,14 +521,12 @@ function useInputFinish(
   const handleSettingsRestart = useCallback(() => {
     void handleSlashCommand('/quit');
   }, [handleSlashCommand]);
-  const isStreamingIdleOrResponding =
-    streamingState === StreamingState.Idle ||
-    streamingState === StreamingState.Responding;
-  const isInputActive =
-    isStreamingIdleOrResponding &&
-    !initError &&
-    !isProcessing &&
-    !!slashCommands;
+  const isInputActive = computeIsInputActive({
+    streamingState,
+    initError,
+    isProcessing,
+    slashCommands,
+  });
   return {
     handleIdePromptComplete,
     vimHandleInput,

--- a/packages/cli/src/ui/layouts/DefaultAppLayout.test.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayout.test.tsx
@@ -6,14 +6,19 @@
 
 import { render } from 'ink-testing-library';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'bun:test';
+import { Text } from '../../../test-utils/real-ink.js';
 
 // Unmock ink to use real Ink with ink-testing-library
 // The global mock in test-setup.ts conflicts with renderer behavior here.
 // Under Bun, ink is redirected to a stub by a resolution plugin rather than a
 // module mock, so there is nothing to unmock.
+const realInkModule = await import('../../../test-utils/real-ink.js');
+
+void vi.mock('ink', () => realInkModule);
 
 import { DefaultAppLayout } from './DefaultAppLayout.js';
-import { useUIState } from '../contexts/UIStateContext.js';
+import { hasActiveDialog } from './DefaultAppLayoutHelpers.js';
+import { useUIState, type UIState } from '../contexts/UIStateContext.js';
 import { useUIActions } from '../contexts/UIActionsContext.js';
 import { StreamingState } from '../types.js';
 import { ApprovalMode } from '@vybestack/llxprt-code-core';
@@ -22,10 +27,13 @@ import {
   buildUiRuntimeFromSource,
 } from '../cliUiRuntime.js';
 
-const { dialogManagerRenderSpy, composerRenderSpy } = {
-  dialogManagerRenderSpy: vi.fn(() => null),
-  composerRenderSpy: vi.fn(() => null),
-};
+const DIALOG_MANAGER_SENTINEL = 'DIALOG_MANAGER_RENDERED';
+const COMPOSER_SENTINEL = 'COMPOSER_RENDERED';
+
+const DialogManagerSentinel = () => (
+  <Text color="white">{DIALOG_MANAGER_SENTINEL}</Text>
+);
+const ComposerSentinel = () => <Text color="white">{COMPOSER_SENTINEL}</Text>;
 
 void vi.mock('../contexts/UIStateContext.js', () => ({
   useUIState: vi.fn(),
@@ -36,11 +44,11 @@ void vi.mock('../contexts/UIActionsContext.js', () => ({
 }));
 
 void vi.mock('../components/DialogManager.js', () => ({
-  DialogManager: dialogManagerRenderSpy,
+  DialogManager: DialogManagerSentinel,
 }));
 
 void vi.mock('../components/Composer.js', () => ({
-  Composer: composerRenderSpy,
+  Composer: ComposerSentinel,
 }));
 
 // Mock all other child components as null so this test only verifies
@@ -241,11 +249,76 @@ function createBaseUIState() {
     isModelsDialogOpen: false,
     isSessionBrowserDialogOpen: false,
     isModelConfigDialogOpen: false,
+    isPoliciesDialogOpen: false,
     showPrivacyNotice: false,
 
     rootUiRef: { current: null },
     pendingHistoryItemRef: { current: null },
-  };
+  } as never;
+}
+
+const ACTIVE_DIALOG_FLAGS = [
+  'showWorkspaceMigrationDialog',
+  'shouldShowIdePrompt',
+  'isFolderTrustDialogOpen',
+  'isWelcomeDialogOpen',
+  'isPermissionsDialogOpen',
+  'confirmationRequest',
+  'isThemeDialogOpen',
+  'isSettingsDialogOpen',
+  'isAuthDialogOpen',
+  'isOAuthCodeDialogOpen',
+  'isEditorDialogOpen',
+  'isProviderDialogOpen',
+  'isLoadProfileDialogOpen',
+  'isCreateProfileDialogOpen',
+  'isProfileListDialogOpen',
+  'isProfileDetailDialogOpen',
+  'isProfileEditorDialogOpen',
+  'isToolsDialogOpen',
+  'isLoggingDialogOpen',
+  'isSubagentDialogOpen',
+  'isModelsDialogOpen',
+  'isSessionBrowserDialogOpen',
+  'isModelConfigDialogOpen',
+  'isPoliciesDialogOpen',
+  'showPrivacyNotice',
+] as const satisfies ReadonlyArray<keyof UIState>;
+
+type ActiveDialogFlag = (typeof ACTIVE_DIALOG_FLAGS)[number];
+
+function createUIStateWithActiveDialog(flag: ActiveDialogFlag): UIState {
+  const baseState: UIState = createBaseUIState();
+  if (flag === 'confirmationRequest') {
+    return {
+      ...baseState,
+      confirmationRequest: {
+        prompt: null,
+        onConfirm: () => {},
+      },
+    };
+  }
+  return { ...baseState, [flag]: true };
+}
+
+function renderDefaultAppLayout(uiState: UIState): ReturnType<typeof render> {
+  mockUseUIState.mockReturnValue(uiState);
+  const config = createConfigStub() as never;
+
+  return render(
+    <DefaultAppLayout
+      uiRuntime={buildUiRuntimeFromSource(config)}
+      slashCommandRuntime={buildSlashCommandRuntime(config)}
+      settings={createSettingsStub() as never}
+      startupWarnings={[]}
+      version={'0.0.0-test'}
+      nightly={false}
+      mainControlsRef={{ current: null }}
+      availableTerminalHeight={40}
+      contextFileNames={[]}
+      updateInfo={null}
+    />,
+  );
 }
 
 describe('DefaultAppLayout', () => {
@@ -254,81 +327,42 @@ describe('DefaultAppLayout', () => {
     mockUseUIActions.mockReturnValue(createActionsStub() as never);
   });
 
-  it('renders DialogManager when session browser dialog is open', () => {
-    mockUseUIState.mockReturnValue({
-      ...createBaseUIState(),
-      isSessionBrowserDialogOpen: true,
-    } as never);
+  it('keeps the dialog test table aligned with every property read by the real predicate', () => {
+    const readKeys = new Set<string>();
+    const uiState = new Proxy(createBaseUIState(), {
+      get(target, property, receiver) {
+        if (typeof property === 'string') {
+          readKeys.add(property);
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
 
-    render(
-      <DefaultAppLayout
-        uiRuntime={buildUiRuntimeFromSource(createConfigStub() as never)}
-        slashCommandRuntime={buildSlashCommandRuntime(
-          createConfigStub() as never,
-        )}
-        settings={createSettingsStub() as never}
-        startupWarnings={[]}
-        version={'0.0.0-test'}
-        nightly={false}
-        mainControlsRef={{ current: null }}
-        availableTerminalHeight={40}
-        contextFileNames={[]}
-        updateInfo={null}
-      />,
-    );
+    hasActiveDialog(uiState);
 
-    expect(dialogManagerRenderSpy).toHaveBeenCalledTimes(1);
-    expect(composerRenderSpy).not.toHaveBeenCalled();
+    expect([...readKeys].sort()).toEqual([...ACTIVE_DIALOG_FLAGS].sort());
   });
 
-  it('renders DialogManager when model config dialog is the only active dialog', () => {
-    mockUseUIState.mockReturnValue({
-      ...createBaseUIState(),
-      isModelConfigDialogOpen: true,
-    } as never);
+  it.each(ACTIVE_DIALOG_FLAGS.map((flag) => [flag] as const))(
+    'renders DialogManager instead of Composer when %s is active',
+    (flag) => {
+      const rendered = renderDefaultAppLayout(
+        createUIStateWithActiveDialog(flag),
+      );
+      const frame = rendered.lastFrame();
 
-    render(
-      <DefaultAppLayout
-        uiRuntime={buildUiRuntimeFromSource(createConfigStub() as never)}
-        slashCommandRuntime={buildSlashCommandRuntime(
-          createConfigStub() as never,
-        )}
-        settings={createSettingsStub() as never}
-        startupWarnings={[]}
-        version={'0.0.0-test'}
-        nightly={false}
-        mainControlsRef={{ current: null }}
-        availableTerminalHeight={40}
-        contextFileNames={[]}
-        updateInfo={null}
-      />,
-    );
-
-    expect(dialogManagerRenderSpy).toHaveBeenCalledTimes(1);
-    expect(composerRenderSpy).not.toHaveBeenCalled();
-  });
+      expect(frame).toContain(DIALOG_MANAGER_SENTINEL);
+      expect(frame).not.toContain(COMPOSER_SENTINEL);
+      rendered.unmount();
+    },
+  );
 
   it('renders Composer when no dialog is open', () => {
-    mockUseUIState.mockReturnValue(createBaseUIState() as never);
+    const rendered = renderDefaultAppLayout(createBaseUIState());
+    const frame = rendered.lastFrame();
 
-    render(
-      <DefaultAppLayout
-        uiRuntime={buildUiRuntimeFromSource(createConfigStub() as never)}
-        slashCommandRuntime={buildSlashCommandRuntime(
-          createConfigStub() as never,
-        )}
-        settings={createSettingsStub() as never}
-        startupWarnings={[]}
-        version={'0.0.0-test'}
-        nightly={false}
-        mainControlsRef={{ current: null }}
-        availableTerminalHeight={40}
-        contextFileNames={[]}
-        updateInfo={null}
-      />,
-    );
-
-    expect(composerRenderSpy).toHaveBeenCalledTimes(1);
-    expect(dialogManagerRenderSpy).not.toHaveBeenCalled();
+    expect(frame).toContain(COMPOSER_SENTINEL);
+    expect(frame).not.toContain(DIALOG_MANAGER_SENTINEL);
+    rendered.unmount();
   });
 });

--- a/packages/cli/src/ui/layouts/DefaultAppLayout.test.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayout.test.tsx
@@ -329,13 +329,39 @@ describe('DefaultAppLayout', () => {
 
   it('keeps the dialog test table aligned with every property read by the real predicate', () => {
     const readKeys = new Set<string>();
+    const recordKey = (property: string | symbol): void => {
+      if (typeof property !== 'string') {
+        throw new Error(
+          `hasActiveDialog read the symbol key ${String(property)}. The drift ` +
+            'guard can only account for string keys; update the guard and ' +
+            'ACTIVE_DIALOG_FLAGS together.',
+        );
+      }
+      readKeys.add(property);
+    };
+    // Enumeration would let the predicate reach every flag at once, which
+    // would make the recorded read-set meaningless. Fail loudly instead of
+    // silently passing.
+    const rejectEnumeration = (trap: string): never => {
+      throw new Error(
+        `hasActiveDialog enumerated the UI state via ${trap}. The drift guard ` +
+          'observes discrete property accesses and cannot verify an ' +
+          'enumeration-based predicate; update the guard and ' +
+          'ACTIVE_DIALOG_FLAGS together.',
+      );
+    };
     const uiState = new Proxy(createBaseUIState(), {
       get(target, property, receiver) {
-        if (typeof property === 'string') {
-          readKeys.add(property);
-        }
+        recordKey(property);
         return Reflect.get(target, property, receiver);
       },
+      has(target, property) {
+        recordKey(property);
+        return Reflect.has(target, property);
+      },
+      ownKeys: () => rejectEnumeration('ownKeys'),
+      getOwnPropertyDescriptor: () =>
+        rejectEnumeration('getOwnPropertyDescriptor'),
     });
 
     hasActiveDialog(uiState);

--- a/packages/cli/src/ui/layouts/InlineContent.test.tsx
+++ b/packages/cli/src/ui/layouts/InlineContent.test.tsx
@@ -10,9 +10,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
 import { ApprovalMode, Config } from '@vybestack/llxprt-code-core';
 import { render } from 'ink-testing-library';
 import { LoadedSettings } from '../../config/settings.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import { renderWithProviders } from '../../test-utils/render.js';
 import { buildSlashCommandRuntime } from '../cliUiRuntime.js';
 import { StreamingState } from '../types.js';
 import { StreamingContext } from '../contexts/StreamingContext.js';
+import type { UIState } from '../contexts/UIStateContext.js';
+import {
+  UIActionsContext,
+  type UIActions,
+} from '../contexts/UIActionsContext.js';
 import { InlineContent, type InlineContentProps } from './InlineContent.js';
 
 const activeRenders: Array<ReturnType<typeof render>> = [];
@@ -93,6 +100,102 @@ function createProps(): InlineContentProps {
   };
 }
 
+function createComposerUIState(overrides: Partial<UIState> = {}): UIState {
+  return {
+    buffer: {
+      text: '',
+      lines: [''],
+      cursor: [0, 0],
+      transformationsByLine: [[]],
+      visualToTransformedMap: [0],
+      viewportVisualLines: [''],
+      allVisualLines: [''],
+      visualCursor: [0, 0],
+      visualScrollRow: 0,
+      visualToLogicalMap: [[0, 0]],
+      setText: vi.fn(),
+      replaceRangeByOffset: vi.fn(),
+      moveToVisualPosition: vi.fn(),
+    },
+    inputWidth: 80,
+    suggestionsWidth: 80,
+    shellModeActive: false,
+    isFocused: true,
+    vimModeEnabled: false,
+    showAutoAcceptIndicator: ApprovalMode.DEFAULT,
+    placeholder: '',
+    slashCommands: [],
+    commandContext: createMockCommandContext(),
+    inputHistory: [],
+    streamingState: StreamingState.Idle,
+    queueErrorMessage: null,
+    embeddedShellFocused: false,
+    queuedSubmissions: [],
+    ...overrides,
+  } as never;
+}
+
+function createUIActions(): UIActions {
+  return {
+    handleUserInputSubmit: vi.fn(),
+    handleClearScreen: vi.fn(),
+    handleSteer: vi.fn(),
+    setShellModeActive: vi.fn(),
+    vimHandleInput: vi.fn(),
+    handleEscapePromptChange: vi.fn(),
+    setQueueErrorMessage: vi.fn(),
+    sendAllQueuedSubmissions: vi.fn(),
+    steerAllQueuedSubmissions: vi.fn(),
+    clearQueuedSubmissions: vi.fn(),
+  } as never;
+}
+
+function renderComposer(
+  uiStateOverrides: Partial<UIState> = {},
+  isInputActive = true,
+): ReturnType<typeof render> {
+  const props = {
+    ...createProps(),
+    isInputActive,
+    shellModeActive: uiStateOverrides.shellModeActive ?? false,
+  };
+  const rendered = renderWithProviders(
+    <UIActionsContext.Provider value={createUIActions()}>
+      <StreamingContext.Provider value={props.streamingState}>
+        <InlineContent {...props} />
+      </StreamingContext.Provider>
+    </UIActionsContext.Provider>,
+    {
+      settings: props.settings,
+      uiState: createComposerUIState(uiStateOverrides),
+    },
+  );
+  activeRenders.push(rendered);
+  return rendered;
+}
+
+const COMPOSER_MODES = [
+  {
+    mode: 'default',
+    uiState: {},
+    placeholder: 'Type your message or @path/to/file',
+  },
+  {
+    mode: 'vim',
+    uiState: { vimModeEnabled: true },
+    placeholder: "Press 'i' for INSERT mode",
+  },
+  {
+    mode: 'shell',
+    uiState: { shellModeActive: true },
+    placeholder: 'Type your shell command',
+  },
+] satisfies Array<{
+  mode: string;
+  uiState: Partial<UIState>;
+  placeholder: string;
+}>;
+
 describe('InlineContent', () => {
   beforeEach(() => {
     setEnv('GEMINI_SYSTEM_MD', '');
@@ -148,6 +251,24 @@ describe('InlineContent', () => {
 
     expect(lastFrame()).toContain('context-summary-mock');
   });
+
+  it.each(COMPOSER_MODES)(
+    'renders the $mode placeholder through the composer input surface when input is active',
+    ({ uiState, placeholder }) => {
+      const { lastFrame } = renderComposer(uiState);
+
+      expect(lastFrame()).toContain(placeholder);
+    },
+  );
+
+  it.each(COMPOSER_MODES)(
+    'does not render the $mode placeholder when input is inactive',
+    ({ uiState, placeholder }) => {
+      const { lastFrame } = renderComposer(uiState, false);
+
+      expect(lastFrame()).not.toContain(placeholder);
+    },
+  );
 
   it('renders the system-md indicator when GEMINI_SYSTEM_MD is set', () => {
     setEnv('GEMINI_SYSTEM_MD', 'true');

--- a/project-plans/issue2018-ink-composer-input-state-coverage.md
+++ b/project-plans/issue2018-ink-composer-input-state-coverage.md
@@ -1,0 +1,184 @@
+# Issue 2018 — Increase Ink composer and input-state coverage
+
+## Problem
+
+The Ink UI surfaces that decide whether the user can type have no direct tests:
+
+- `isInputActive` is computed inline inside the unexported `useInputFinish` in
+  `packages/cli/src/ui/containers/AppContainer/hooks/useAppInput.ts`. Nothing
+  exercises the predicate.
+- `packages/cli/src/ui/components/Composer.tsx` has no test file at all. Nothing
+  proves it forwards UI state into `InputPrompt`, nor that the placeholder
+  degrades correctly for vim/shell modes.
+- `packages/cli/src/ui/components/Notifications.tsx` has no test file. The
+  startup-error surface (`InitErrorBox`) is entirely unverified.
+- `packages/cli/src/ui/layouts/InlineContent.test.tsx` always passes
+  `isInputActive: false`, so the "composer is rendered when input is active"
+  branch of `ComposerSection` is never taken.
+- `DefaultAppLayout.test.tsx` covers only two of the twenty-five dialog flags in
+  `hasActiveDialog`.
+- The large-paste placeholder path in `inputPromptText.ts`
+  (`handleLargePaste` / `expandLargePastePlaceholders`) has no test. Only the
+  below-threshold branch is covered (`InputPrompt.completion.test.tsx:524`).
+- Escape priority ordering in `inputPromptKeyHandlers.ts` is covered for single
+  states but not for the combinations where one state must win over another.
+- There is no tmux smoke asserting the first meaningful startup frame contains
+  the composer.
+
+## Scope
+
+Test coverage only, plus one behaviour-preserving extraction needed to make the
+gating predicate reachable from a test. No other production changes.
+
+Explicitly out of scope (do not do these):
+
+- Changing when `initError` is set, or fixing the observation that no live call
+  site currently assigns it a non-null value. If that gap is confirmed, note it
+  in this plan as a follow-up; do not touch production behaviour.
+- Refactoring `useAppInput`, `InputPrompt`, or the layout beyond the single
+  predicate extraction.
+- Adding new CI workflows or harness abstractions.
+
+## Acceptance criteria
+
+### AC1 — Composer is visible when command initialization completes
+
+- **AC1.1** `computeIsInputActive` returns `false` while `slashCommands` is
+  `undefined` and `true` once `slashCommands` is a loaded array, with all other
+  inputs held at their ready values (`streamingState: Idle`, `initError: null`,
+  `isProcessing: false`). An empty array counts as loaded.
+- **AC1.2** `InlineContent` renders the composer's input prompt when
+  `isInputActive` is `true` (the current suite only exercises `false`).
+
+### AC2 — Composer is hidden only for intentional blocking states
+
+- **AC2.1** `computeIsInputActive` is `true` for `StreamingState.Idle` and
+  `StreamingState.Responding`, and `false` for
+  `StreamingState.WaitingForConfirmation` (a table-driven case per enum member,
+  so a newly added streaming state cannot silently default to visible).
+- **AC2.2** `computeIsInputActive` is `false` when `initError` is a non-empty
+  string, and `false` when `isProcessing` is `true`, each with every other input
+  held at its ready value, so each blocker is proven independently sufficient.
+- **AC2.3** `InlineContent` renders nothing for the composer slot when
+  `isInputActive` is `false`.
+- **AC2.4** `DefaultAppLayout` renders `DialogManager` instead of `Composer` for
+  each flag in `hasActiveDialog` — driven off the flag list rather than a
+  hand-picked subset, so a newly added dialog flag that is not wired into the
+  layout fails the test.
+
+### AC3 — Startup errors render actionable UI, not a blank or partial screen
+
+- **AC3.1** With `initError` set and `streamingState` not `Responding`,
+  `Notifications` renders the error text and the actionable remediation line
+  ("Please check API key and configuration.").
+- **AC3.2** When the history contains an error item whose text includes the
+  `initError` string, `Notifications` renders that fuller history text instead
+  of the generic box.
+- **AC3.3** With `initError` set and `streamingState === Responding`, the init
+  error box is suppressed.
+- **AC3.4** Startup warnings render alongside/independently of `initError`, and
+  with no warnings, no init error, and no update info the component renders
+  nothing.
+
+### AC4 — Escape and Ctrl-C behaviour while suggestions or shell mode is active
+
+Only the uncovered combinations. Existing single-state cases in
+`InputPrompt.completion.test.tsx` and `InputPrompt.editing.test.tsx` are not to
+be duplicated.
+
+- **AC4.1** With shell mode active *and* shell path suggestions showing, Escape
+  closes the suggestions and leaves shell mode active (suggestion dismissal wins
+  over shell-mode exit).
+- **AC4.2** WITHDRAWN. This criterion originally asked for a case where shell
+  mode is active *and* slash-completion suggestions are showing, to prove the
+  shell-mode branch of `handleEscapeKey` wins over the completion branch. That
+  state is unreachable: `useCommandCompletion` passes
+  `reverseSearchActive || shellModeActive` as the disable flag to
+  `useSlashCompletion`, so slash suggestions are suppressed entirely while shell
+  mode is active, and `inputPromptRender.tsx` does not render them either.
+  Covering it would require mocking `useCommandCompletion` into a state the real
+  UI cannot produce, which is mock theater. Dropped rather than faked.
+- **AC4.3** With suggestions showing and a non-empty buffer, Escape closes the
+  suggestions without clearing the buffer and without arming the double-escape
+  prompt.
+
+### AC5 — Multiline paste and queued input behaviour
+
+- **AC5.1** A paste at or above the large-paste threshold (line count or char
+  count) replaces the pasted content in the buffer with a single placeholder
+  label, preserves text before and after the cursor, and leaves the cursor after
+  the placeholder.
+- **AC5.2** Submitting a buffer containing a large-paste placeholder expands it
+  back to the original pasted content; a second, distinct large paste gets a
+  distinct placeholder and both expand correctly. The expansion must be proven
+  through the real submit path (`InputPrompt` submit -> `onSubmit` payload), not
+  only by calling `expandLargePastePlaceholders` directly, so that removing the
+  call site in `inputPromptHooks.ts` fails a test.
+- **AC5.3** A paste below the threshold is inserted verbatim with CRLF and CR
+  normalised to LF (assert the boundary just below the threshold, complementing
+  the existing case).
+
+### AC6 — tmux startup smoke asserts the first meaningful frame contains the composer
+
+- **AC6.1** A dedicated tmux script waits for the composer placeholder as the
+  first-meaningful-frame gate, captures that frame, then quits cleanly, and is
+  registered in `scripts/tests/interactive-ui.test.ts` behind the existing
+  `LLXPRT_E2E_TMUX=1` gate following the surrounding `runTmuxE2E` /
+  `runHarness` / `assertHarnessSuccess` pattern.
+
+## Production change (the only one)
+
+Extract the inline predicate in
+`packages/cli/src/ui/containers/AppContainer/hooks/useAppInput.ts`:
+
+```ts
+const isInputActive =
+  isStreamingIdleOrResponding && !initError && !isProcessing && !!slashCommands;
+```
+
+into an exported pure function taking `streamingState`, `initError`,
+`isProcessing`, and `slashCommands`, and have `useInputFinish` delegate to it.
+Behaviour must be identical; the existing Agent-migration TODO note in that file
+must be preserved.
+
+## Test plan
+
+| AC | File | Kind |
+| --- | --- | --- |
+| AC1.1, AC2.1, AC2.2 | `packages/cli/src/ui/containers/AppContainer/hooks/useAppInput.predicate.test.ts` (new) | pure unit |
+| AC1.2, AC2.3 | `packages/cli/src/ui/layouts/InlineContent.test.tsx` (extend) | component |
+| AC2.4 | `packages/cli/src/ui/layouts/DefaultAppLayout.test.tsx` (extend) | component |
+| AC3.* | `packages/cli/src/ui/components/Notifications.test.tsx` (new) | component |
+| AC4.* | `packages/cli/src/ui/components/InputPrompt.completion.test.tsx` (extend) | component |
+| AC5.* | `packages/cli/src/ui/components/inputPromptText.test.ts` (new) | unit |
+| AC6.1 | `scripts/tmux-script.issue2018-composer-visibility-smoke.json` (new) + `scripts/tests/interactive-ui.test.ts` (extend) | e2e |
+
+## Test-quality constraints
+
+- Bun + `bun:test` only. TypeScript, strict, no `any`, no new `.js` files.
+- New files carry a 2026 copyright header.
+- `Composer` coverage is delivered through `InlineContent` (AC1.2/AC2.3) so the
+  real `Composer` and real `InputPrompt` render — a standalone `Composer.test`
+  that mocks `InputPrompt` and asserts the props it received would be pure mock
+  verification and is prohibited by dev-docs/RULES.md. Assert rendered output
+  (placeholder text, prompt chrome), not forwarded props.
+- No mock-mirror assertions: never assert back a literal that a stub was
+  configured with. Drive AC2.4 from the real `hasActiveDialog` flag list.
+- `bun scripts/test-audit/scan.ts` must not report new MOCK_MIRROR, ALWAYS_TRUE,
+  SELF_CONFIRMING, or NO_ASSERT findings on touched files.
+
+## Verification
+
+```bash
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```
+
+## Follow-ups (not in this issue)
+
+- Confirm whether any live code path sets `initError` to a non-null value. If it
+  is effectively dead, raise a separate issue.

--- a/scripts/fixtures/issue2018-composer-visibility.responses.jsonl
+++ b/scripts/fixtures/issue2018-composer-visibility.responses.jsonl
@@ -1,0 +1,1 @@
+{"chunks":[{"speaker":"ai","blocks":[{"type":"text","text":"OK"}]}]}

--- a/scripts/tests/interactive-ui.test.ts
+++ b/scripts/tests/interactive-ui.test.ts
@@ -21,10 +21,11 @@
  */
 
 import { spawnSync } from 'node:child_process';
+import { readFileSync, readdirSync, rmSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { afterAll, describe, it } from 'bun:test';
+import { afterAll, describe, expect, it } from 'bun:test';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '../..');
@@ -176,6 +177,38 @@ describe('Interactive UI (tmux harness)', () => {
         },
       );
       assertHarnessSuccess(result);
+    },
+    300_000,
+  );
+
+  runTmuxE2E(
+    'shows the composer in the first meaningful startup frame',
+    () => {
+      const testName = 'issue2018-composer-visibility';
+      const artifactDir = getArtifactDir(testName);
+      rmSync(artifactDir, { recursive: true, force: true });
+      const result = runHarness(
+        'tmux-script.issue2018-composer-visibility-smoke.json',
+        testName,
+      );
+      assertHarnessSuccess(result);
+
+      const startupFrameArtifacts = readdirSync(artifactDir).filter((entry) =>
+        entry.endsWith('-00-composer-visible-screen.txt'),
+      );
+      expect(startupFrameArtifacts).toHaveLength(1);
+      const startupFrameArtifact = startupFrameArtifacts[0];
+      if (startupFrameArtifact === undefined) {
+        throw new Error('Composer startup frame artifact was not created');
+      }
+
+      const startupFrame = readFileSync(
+        path.join(artifactDir, startupFrameArtifact),
+        'utf8',
+      );
+      expect(startupFrame).toContain('Type your message');
+      expect(startupFrame.trim().length).toBeGreaterThan(20);
+      expect(startupFrame).not.toContain('Initialization Error');
     },
     300_000,
   );

--- a/scripts/tmux-script.issue2018-composer-visibility-smoke.json
+++ b/scripts/tmux-script.issue2018-composer-visibility-smoke.json
@@ -1,0 +1,28 @@
+{
+  "tmux": {
+    "cols": 100,
+    "rows": 40,
+    "historyLimit": 20000,
+    "scrollbackLines": 2000,
+    "initialWaitMs": 6000
+  },
+  "startCommand": [
+    "env CI=0 CONTINUOUS_INTEGRATION=0 NODE_OPTIONS= LLXPRT_CODE_NO_RELAUNCH=true LLXPRT_CODE_SKIP_TERMINAL_CAPABILITY_DETECTION=true LLXPRT_CODE_BUILTIN_COMMANDS_ONLY=true LLXPRT_CODE_SUPPRESS_STATIC_HEADER=true LLXPRT_CODE_WELCOME_CONFIG_PATH=scripts/fixtures/welcome-completed.json LLXPRT_SYSTEM_SETTINGS_PATH=scripts/system-settings.interactive-ui.json LLXPRT_FAKE_RESPONSES=scripts/fixtures/issue2018-composer-visibility.responses.jsonl ${bun} packages/cli/index.ts --provider fake --model fake-model"
+  ],
+  "yolo": false,
+  "steps": [
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Type your message",
+      "timeoutMs": 60000
+    },
+    {
+      "type": "capture",
+      "label": "00-composer-visible",
+      "scope": "screen"
+    },
+    { "type": "line", "text": "/quit", "submitKeys": ["Enter"] },
+    { "type": "waitForExit", "timeoutMs": 15000 }
+  ]
+}


### PR DESCRIPTION
## TLDR

Test coverage for the Ink surfaces that decide whether the user can type: composer visibility, input active-state gating, startup readiness, escape priority, and large-paste handling.

The only production change is a behaviour-preserving extraction: the `isInputActive` expression inside the unexported `useInputFinish` becomes an exported pure `computeIsInputActive`. Same expression, same short-circuit order, same truthiness semantics, real hook return types rather than widened ones. Everything else in the diff is tests, one tmux script, and one fixture.

Reviewers should look hardest at two things. First, the `hasActiveDialog` drift guard in `DefaultAppLayout.test.tsx`, which uses a Proxy to record every property the real predicate reads and asserts that set equals the test table. Second, whether the new tests actually have teeth; I broke the corresponding production code for each one and recorded the failures below.

## Dive Deeper

### What had no coverage

- `isInputActive` was computed inline inside an unexported hook, so nothing exercised the predicate.
- `Composer.tsx` and `Notifications.tsx` had no test file at all.
- `InlineContent.test.tsx` always passed `isInputActive: false`, so the branch that actually renders the composer was never taken.
- `DefaultAppLayout.test.tsx` covered 2 of the 25 flags read by `hasActiveDialog`.
- `handleLargePaste` and `expandLargePastePlaceholders` had no tests; only the below-threshold branch was touched, indirectly.

### What the tests now prove

**Composer visible when command initialization completes.** The predicate flips false to true when `slashCommands` goes from `undefined` to loaded, with an empty array counting as loaded. `InlineContent` renders the real `Composer` and real `InputPrompt` and shows the default, vim and shell placeholders.

**Composer hidden only for intentional blocking states.** The streaming-state case is table-driven over `Object.values(StreamingState)` rather than a hand-listed set, so a newly added state is automatically covered and defaults to hidden. `initError` and `isProcessing` are each proven independently sufficient with every other input held at its ready value.

**Dialogs suppress the composer.** Every flag, not a hand-picked subset. The guard test wraps the base UI state in a `Proxy`, calls the real `hasActiveDialog`, and asserts the recorded read-set equals the test table, which catches drift in both directions. This also surfaced that `createBaseUIState` was missing `isPoliciesDialogOpen`.

**Startup errors render actionable UI.** `Notifications` renders the composed `Initialization Error: ...` line plus the remediation line; prefers a fuller matching history error, proven with a non-error distractor and an unrelated error distractor ahead of the match so that "render the first error item" would fail; suppresses all of it while `Responding`; and renders warnings alongside an init error.

**Escape priority ordering,** limited to the combinations the existing suites did not already cover: shell-path suggestions close while shell mode stays active, and dismissing slash suggestions leaves the buffer intact without arming the double-escape prompt.

**Large-paste placeholders:** line threshold, character threshold, the three-line boundary, cursor position derived from placeholder length, distinct labels for successive pastes, and round-trip expansion through the real `InputPrompt` submit path.

**One tmux startup smoke** asserting the first meaningful frame contains the composer, using a dedicated offline fake-provider fixture so it needs no credentials.

### Teeth checks

Each new test was verified by breaking the production code it covers and observing the failure, then restoring the code:

| Production code broken | Test that failed |
| --- | --- |
| `expandLargePastePlaceholders` call removed from `inputPromptHooks.ts` | paste submit tests, receiving `[4 lines pasted #1]` instead of the body |
| dialog ternary in `MainControls` forced to the Composer branch | all 25 dialog cases, `DIALOG_MANAGER_RENDERED` absent |
| `completion.resetCompletionState()` removed from `handleEscapeKey` | escape test, `clear` still present in the frame |
| `uiState.isNarrow` added to `hasActiveDialog` | the drift guard, reporting the extra key |

### Decisions worth flagging

**AC4.2 withdrawn.** The plan originally asked for a case proving the shell-mode branch of `handleEscapeKey` beats the completion branch. That state cannot occur: `useCommandCompletion` passes `reverseSearchActive || shellModeActive` as the disable flag to `useSlashCompletion`, and `inputPromptRender.tsx` will not render slash suggestions in shell mode. A first draft covered it by mocking `useCommandCompletion` into that impossible state; it was removed rather than kept. The reasoning is recorded in the plan document.

**New file instead of appending.** The escape tests are in a new `InputPrompt.escape.test.tsx`. Appending them to `InputPrompt.completion.test.tsx` pushed that file past the 800-line lint budget. The new file is not on the legacy typecheck-exclusion list in `packages/cli/tsconfig.json`, so unlike its five siblings it is fully typechecked.

**Assertions are on rendered output, not spies.** The `DialogManager` and `Composer` doubles in `DefaultAppLayout.test.tsx` now render text sentinels instead of being asserted via `toHaveBeenCalledTimes`, since mock-call verification is not evidence under `dev-docs/RULES.md`.

**A flaky draft was fixed.** An earlier version of the shell-path test completed against the repository root. It was slow and its assertion depended on the checkout's directory listing, and it failed under full-suite load. It now completes against a dedicated temporary directory.

### Known unrelated flake

One full-suite run showed a failure in `packages/agents/src/core/turn.watchdog.test.ts`, "whole-stream liveness ... => NO timeout". That test is byte-identical to `main`, this PR touches no file in `packages/agents`, and the test uses real timers with a 30ms idle threshold against eight 10ms sleeps, so heavy parallel load can erase the margin. It passes 5/5 in isolation on this branch and 3/3 under synthetic CPU load on a clean `main` worktree. Flagging it rather than hiding it; CI is the arbiter.

### Follow-up, not changed here

No live call site currently assigns a non-null `initError`. The `InitErrorBox` path may be dead. Noted in the plan document; changing production behaviour was out of scope for a coverage issue.

## Reviewer Test Plan

```bash
git fetch origin issue2018 && git checkout issue2018

# The new and modified suites
bun test packages/cli/src/ui/containers/AppContainer/hooks/useAppInput.predicate.test.ts
bun test packages/cli/src/ui/components/Notifications.test.tsx
bun test packages/cli/src/ui/components/inputPromptText.test.ts
bun test packages/cli/src/ui/components/InputPrompt.escape.test.tsx
bun test packages/cli/src/ui/components/InputPrompt.paste.test.tsx
bun test packages/cli/src/ui/layouts/InlineContent.test.tsx
bun test packages/cli/src/ui/layouts/DefaultAppLayout.test.tsx
```

To confirm the tests are not decorative, break the production code and watch them fail:

```bash
# 1. Drift guard: add `uiState.isNarrow,` to the dialogFlags array in
#    packages/cli/src/ui/layouts/DefaultAppLayoutHelpers.tsx
bun test packages/cli/src/ui/layouts/DefaultAppLayout.test.tsx   # guard fails

# 2. Escape: comment out `completion.resetCompletionState();` in the
#    `completion.showSuggestions` branch of handleEscapeKey in
#    packages/cli/src/ui/components/inputPromptKeyHandlers.ts
bun test packages/cli/src/ui/components/InputPrompt.escape.test.tsx   # fails

# 3. Paste: stop calling expandLargePastePlaceholders in
#    packages/cli/src/ui/components/inputPromptHooks.ts
bun test packages/cli/src/ui/components/InputPrompt.paste.test.tsx   # fails

git checkout -- packages/cli/src/ui
```

The tmux smoke is gated and does not run by default:

```bash
LLXPRT_E2E_TMUX=1 bun test scripts/tests/interactive-ui.test.ts
```

Interactively, the behaviour under test is the composer itself: start the CLI and confirm the `Type your message or @path/to/file` prompt appears, then check that opening a dialog (`/theme`, `/settings`) replaces it, that Escape closes an open suggestion list without clearing what you typed, and that pasting more than four lines collapses to a `[N lines pasted #1]` placeholder which expands back to the full text on submit.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: `npm run format`, `npm run lint`, `npm run typecheck` and `npm run build` all exit 0. The full `npm run test` run had the single unrelated `packages/agents` watchdog flake described above and no failures in any file this PR touches. The tmux lane is gated behind `LLXPRT_E2E_TMUX=1` and was validated for JSON shape and registration rather than executed locally.

## Linked issues / bugs

Fixes #2018


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of composer visibility and mode-specific placeholders across default, Vim, and shell input modes.
  - Large pasted content is represented compactly while typing and expands correctly on submission.
  - Escape handling now consistently dismisses suggestions without unexpectedly changing input state.
  - Notifications and startup states provide more dependable behavior across error and loading scenarios.

- **Tests**
  - Expanded automated coverage for input handling, dialogs, notifications, paste behavior, and interactive startup rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->