### PR TITLE
Align Codex WebSocket metadata and add stream idle timeout (Fixes #2772)

### DIFF
--- a/docs/providers/quick-reference.md
+++ b/docs/providers/quick-reference.md
@@ -245,7 +245,7 @@ hyphenated forms used by the current Codex client.
 
 The WebSocket handshake times out after 15 seconds. After the connection is
 established, the stream has a five-minute idle timeout that resets on each
-incoming frame. If it expires, LLxprt closes the socket. When no output has been
+valid text frame. If it expires, LLxprt closes the socket. When no output has been
 streamed, LLxprt serves that request over HTTP/SSE instead; after repeated
 consecutive pre-output WebSocket failures it stays on HTTP for the session.
 When output has already been streamed, LLxprt reports a stream interruption

--- a/docs/providers/quick-reference.md
+++ b/docs/providers/quick-reference.md
@@ -226,6 +226,31 @@ for models that support it; when forced to `chat`, Chat Completions is used
 unless the model requires Responses on the official OpenAI endpoint (GPT-5.6+),
 where Chat is unavailable and the override is ignored.
 
+### OpenAI Codex (ChatGPT Plus/Pro)
+
+```bash
+/auth codex enable
+/provider codex
+/model gpt-5.6-sol
+```
+
+#### WebSocket transport
+
+The Codex provider sends `Authorization`, `ChatGPT-Account-ID`,
+`originator: codex_cli_rs`, and any configured custom headers during the
+WebSocket handshake. It also sends `session-id`, `thread-id`, and
+`x-client-request-id`, each set to the session's runtime ID, plus
+`OpenAI-Beta: responses_websockets=2026-02-06`. The identity headers use the
+hyphenated forms used by the current Codex client.
+
+The WebSocket handshake times out after 15 seconds. After the connection is
+established, the stream has a five-minute idle timeout that resets on each
+incoming frame. If it expires, LLxprt closes the socket. When no output has been
+streamed, LLxprt serves that request over HTTP/SSE instead; after repeated
+consecutive pre-output WebSocket failures it stays on HTTP for the session.
+When output has already been streamed, LLxprt reports a stream interruption
+without replaying partial output.
+
 ### Qwen
 
 ```bash

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
@@ -1018,7 +1018,9 @@ async function buildWebSocketHandshakeHeaders(
       ? invocationSessionId
       : params.normalizedOptions.runtime?.runtimeId;
   if (typeof sessionId === 'string' && sessionId.trim() !== '') {
-    headers['session_id'] = sessionId;
+    headers['session-id'] = sessionId;
+    headers['thread-id'] = sessionId;
+    headers['x-client-request-id'] = sessionId;
   }
   headers['OpenAI-Beta'] = CODEX_WEBSOCKET_BETA_HEADER;
   return headers;

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.websocket.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.websocket.test.ts
@@ -17,7 +17,10 @@ import { createProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtim
 import { createRuntimeInvocationContext } from '@vybestack/llxprt-code-core/runtime/RuntimeInvocationContext.js';
 import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
 import type { WebSocketTransport } from './openAIResponsesWebSocketTransport.js';
-import { createCodexResponsesWebSocketTransport } from './openAIResponsesWebSocketTransport.js';
+import {
+  CODEX_WEBSOCKET_BETA_HEADER,
+  createCodexResponsesWebSocketTransport,
+} from './openAIResponsesWebSocketTransport.js';
 import {
   SocketHarness,
   completingScript,
@@ -389,5 +392,66 @@ describe('executeOpenAIResponsesRequest WebSocket reconnect keeps the conversati
     expect(userTexts).toEqual(['second question']);
 
     transport.close();
+  });
+});
+
+describe('executeOpenAIResponsesRequest WebSocket handshake identity @issue:2772', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCoreSystemPromptAsyncSpy.mockResolvedValue('system prompt');
+  });
+
+  afterEach(() => {
+    restoreGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('sends the current Codex handshake headers with the runtime identity', async () => {
+    const harness = new SocketHarness([completingScript()]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+    });
+
+    await drainHarness(
+      executeOpenAIResponsesRequest(
+        buildNormalizedOptions(),
+        buildDeps({ getWebSocketTransport: () => transport }),
+      ),
+    );
+
+    expect(harness.headers[0]).toStrictEqual({
+      Authorization: 'Bearer codex-token',
+      'X-Provider': 'p',
+      'ChatGPT-Account-ID': 'codex-account',
+      originator: 'codex_cli_rs',
+      'session-id': 'test-runtime',
+      'thread-id': 'test-runtime',
+      'x-client-request-id': 'test-runtime',
+      'OpenAI-Beta': CODEX_WEBSOCKET_BETA_HEADER,
+    });
+  });
+
+  it('omits every identity header when no runtime identity resolves', async () => {
+    const harness = new SocketHarness([completingScript()]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+    });
+    const defaults = buildNormalizedOptions();
+    const optionsWithoutIdentity = buildNormalizedOptions({
+      invocation: { ...defaults.invocation, runtimeId: '' },
+      runtime: undefined,
+    });
+
+    await drainHarness(
+      executeOpenAIResponsesRequest(
+        optionsWithoutIdentity,
+        buildDeps({ getWebSocketTransport: () => transport }),
+      ),
+    );
+
+    const headers = harness.headers[0];
+    expect(headers['session-id']).toBeUndefined();
+    expect(headers['thread-id']).toBeUndefined();
+    expect(headers['x-client-request-id']).toBeUndefined();
   });
 });

--- a/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.handshakeHeaders.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.handshakeHeaders.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { createCodexResponsesWebSocketTransport } from './openAIResponsesWebSocketTransport.js';
+import {
+  SocketHarness,
+  completingScript,
+  drain,
+  options,
+  request,
+} from './openAIResponsesWebSocketTransport.test-helpers.js';
+
+describe('Codex Responses WebSocket handshake headers', () => {
+  it('passes every current handshake header to the connector', async () => {
+    const harness = new SocketHarness([completingScript()]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+    });
+    const headers = {
+      Authorization: 'Bearer secret',
+      'ChatGPT-Account-ID': 'account',
+      originator: 'codex_cli_rs',
+      'session-id': 'session',
+      'thread-id': 'session',
+      'x-client-request-id': 'session',
+      'X-Custom': 'custom',
+      'OpenAI-Beta': 'responses_websockets=2026-02-06',
+    };
+
+    await drain(transport.streamResponse(request(), options({ headers })));
+
+    expect(harness.headers).toStrictEqual([headers]);
+  });
+
+  it('reconnects when a handshake identity header changes', async () => {
+    const harness = new SocketHarness([completingScript(), completingScript()]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+    });
+
+    await drain(
+      transport.streamResponse(
+        request(),
+        options({ headers: { 'thread-id': 'thread-one' } }),
+      ),
+    );
+    await drain(
+      transport.streamResponse(
+        request(),
+        options({ headers: { 'thread-id': 'thread-two' } }),
+      ),
+    );
+
+    expect(harness.sockets).toHaveLength(2);
+    expect(harness.sockets[0].closedByClient).toBe(true);
+  });
+});

--- a/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.idleTimeout.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.idleTimeout.test.ts
@@ -1,0 +1,221 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  createCodexResponsesWebSocketTransport,
+  streamOverWebSocketOrFallback,
+} from './openAIResponsesWebSocketTransport.js';
+import {
+  SocketHarness,
+  completingScript,
+  complete,
+  drain,
+  fallbackStream,
+  frame,
+  options,
+  request,
+  textContent,
+} from './openAIResponsesWebSocketTransport.test-helpers.js';
+
+describe('Codex Responses WebSocket stream idle timeout', () => {
+  it('interrupts a silent stream, closes its socket, and reconnects for the next request', async () => {
+    const harness = new SocketHarness([
+      (socket) => {
+        socket.open();
+        socket.onSend = () => undefined;
+      },
+      completingScript('second'),
+    ]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+      streamIdleTimeoutMs: 50,
+    });
+
+    await expect(
+      drain(transport.streamResponse(request(), options())),
+    ).rejects.toMatchObject({
+      name: 'StreamInterruptionError',
+      message: expect.stringMatching(/idle timeout/),
+    });
+    expect(harness.sockets[0].closedByClient).toBe(true);
+
+    const messages = await drain(
+      transport.streamResponse(request(), options()),
+    );
+    expect(messages).toContainEqual(textContent('second'));
+    expect(harness.sockets).toHaveLength(2);
+  });
+
+  it('resets the timeout when valid frames keep arriving', async () => {
+    const harness = new SocketHarness([
+      (socket) => {
+        socket.open();
+        socket.onSend = () => {
+          setTimeout(
+            () =>
+              socket.message(
+                frame({
+                  type: 'response.output_text.delta',
+                  delta: 'tick',
+                }),
+              ),
+            80,
+          );
+          setTimeout(
+            () =>
+              socket.message(
+                frame({
+                  type: 'response.output_text.delta',
+                  delta: 'tick',
+                }),
+              ),
+            160,
+          );
+          setTimeout(
+            () =>
+              socket.message(
+                frame({
+                  type: 'response.output_text.delta',
+                  delta: 'tick',
+                }),
+              ),
+            240,
+          );
+          setTimeout(() => complete(socket), 320);
+        };
+      },
+    ]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+      streamIdleTimeoutMs: 200,
+    });
+
+    const messages = await drain(
+      transport.streamResponse(request(), options()),
+    );
+    const text = messages
+      .flatMap((message) => message.blocks)
+      .map((block) => (block.type === 'text' ? block.text : ''))
+      .join('');
+
+    expect(text).toBe('tickticktick');
+  });
+
+  it('preserves AbortError after an abort during the idle window', async () => {
+    const controller = new AbortController();
+    const harness = new SocketHarness([
+      (socket) => {
+        socket.open();
+        socket.onSend = () => undefined;
+      },
+    ]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+      streamIdleTimeoutMs: 50,
+    });
+    const settled = drain(
+      transport.streamResponse(
+        request(),
+        options({ abortSignal: controller.signal }),
+      ),
+    ).then(
+      () => 'completed',
+      (error: unknown) => (error instanceof Error ? error.name : 'unknown'),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    controller.abort();
+
+    const initialOutcome = await settled;
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect([initialOutcome, await settled]).toStrictEqual([
+      'AbortError',
+      'AbortError',
+    ]);
+  });
+
+  it('clears the timeout after a terminal frame and reuses the socket', async () => {
+    const harness = new SocketHarness([completingScript()]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+      streamIdleTimeoutMs: 50,
+    });
+
+    await drain(transport.streamResponse(request(), options()));
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    await drain(transport.streamResponse(request(), options()));
+
+    expect(harness.sockets).toHaveLength(1);
+  });
+
+  it('does not fall back after the idle timeout interrupts partial output', async () => {
+    const fallback = { calls: 0 };
+    const harness = new SocketHarness([
+      (socket) => {
+        socket.open();
+        socket.onSend = () => {
+          socket.message(
+            frame({ type: 'response.output_text.delta', delta: 'partial' }),
+          );
+        };
+      },
+    ]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+      streamIdleTimeoutMs: 50,
+    });
+    const iterator = streamOverWebSocketOrFallback(
+      transport,
+      request(),
+      options(),
+      fallbackStream('HTTP', fallback),
+      undefined,
+      undefined,
+    );
+
+    const first = await iterator.next();
+    expect(first.value).toStrictEqual(textContent('partial'));
+
+    await expect(iterator.next()).rejects.toThrow(/idle timeout/);
+    expect(fallback.calls).toBe(0);
+  });
+
+  it('falls back to HTTP once after a pre-event idle timeout', async () => {
+    const fallback = { calls: 0 };
+    let stickyCalls = 0;
+    const harness = new SocketHarness([
+      (socket) => {
+        socket.open();
+        socket.onSend = () => undefined;
+      },
+    ]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+      streamIdleTimeoutMs: 50,
+    });
+
+    const messages = await drain(
+      streamOverWebSocketOrFallback(
+        transport,
+        request(),
+        options(),
+        fallbackStream('HTTP', fallback),
+        () => {
+          stickyCalls += 1;
+        },
+        undefined,
+      ),
+    );
+
+    expect(messages).toStrictEqual([textContent('HTTP')]);
+    expect(fallback.calls).toBe(1);
+    // One pre-output fallback reports the failure to the provider; it does not
+    // by itself demote the session to HTTP (that needs the provider's
+    // consecutive-failure threshold).
+    expect(stickyCalls).toBe(1);
+  });
+});

--- a/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.idleTimeout.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.idleTimeout.test.ts
@@ -184,6 +184,37 @@ describe('Codex Responses WebSocket stream idle timeout', () => {
     expect(fallback.calls).toBe(0);
   });
 
+  it('closes the socket on idle expiry while the consumer is paused after partial output', async () => {
+    const harness = new SocketHarness([
+      (socket) => {
+        socket.open();
+        socket.onSend = () => {
+          socket.message(
+            frame({ type: 'response.output_text.delta', delta: 'partial' }),
+          );
+        };
+      },
+    ]);
+    const transport = createCodexResponsesWebSocketTransport({
+      openSocket: harness.openSocket,
+      streamIdleTimeoutMs: 50,
+    });
+    const iterator = transport.streamResponse(request(), options());
+
+    // The generator stays suspended at this yield until the final next() call,
+    // so only the transport's eager invalidation can close the socket.
+    const first = await iterator.next();
+    expect(first.value).toStrictEqual(textContent('partial'));
+
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(harness.sockets[0].closedByClient).toBe(true);
+
+    await expect(iterator.next()).rejects.toMatchObject({
+      name: 'StreamInterruptionError',
+      message: expect.stringMatching(/idle timeout/),
+    });
+  });
+
   it('falls back to HTTP once after a pre-event idle timeout', async () => {
     const fallback = { calls: 0 };
     let stickyCalls = 0;

--- a/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.test.ts
@@ -46,25 +46,6 @@ describe('Codex Responses WebSocket transport', () => {
     ]);
   });
 
-  it('passes every current handshake header to the connector', async () => {
-    const harness = new SocketHarness([completingScript()]);
-    const transport = createCodexResponsesWebSocketTransport({
-      openSocket: harness.openSocket,
-    });
-    const headers = {
-      Authorization: 'Bearer secret',
-      'ChatGPT-Account-ID': 'account',
-      originator: 'codex_cli_rs',
-      session_id: 'session',
-      'X-Custom': 'custom',
-      'OpenAI-Beta': 'responses_websockets=2026-02-06',
-    };
-
-    await drain(transport.streamResponse(request(), options({ headers })));
-
-    expect(harness.headers).toStrictEqual([headers]);
-  });
-
   it('feeds text frames through the existing Responses parser', async () => {
     const harness = new SocketHarness([completingScript('Hello')]);
     const transport = createCodexResponsesWebSocketTransport({

--- a/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.ts
@@ -72,11 +72,21 @@ interface WebSocketTransportConfig {
    * path without waiting the full production duration.
    */
   readonly handshakeTimeoutMs?: number;
+  /**
+   * Established-stream idle timeout. Defaults to
+   * {@link STREAM_IDLE_TIMEOUT_MS}. Exposed so tests can exercise the timeout
+   * path without waiting the full production duration. Values <= 0 disable it.
+   */
+  readonly streamIdleTimeoutMs?: number;
 }
 
 // Matches the Codex client's default WebSocket connect timeout
 // (websocket_connect_timeout_ms in codex-rs/model-provider-info/src/lib.rs).
 const HANDSHAKE_TIMEOUT_MS = 15_000;
+
+// Matches the Codex client's default established-stream idle timeout
+// (stream_idle_timeout_ms in codex-rs/model-provider-info/src/lib.rs).
+export const STREAM_IDLE_TIMEOUT_MS = 300_000;
 
 function eventType(value: unknown): string | undefined {
   if (typeof value !== 'object' || value === null) return undefined;
@@ -234,51 +244,21 @@ class RequestFrameSource {
   private readonly detachListeners: () => void;
   private readonly detachAbort: () => void;
   private readonly logger: TransportLogger | undefined;
+  private readonly streamIdleTimeoutMs: number;
+  private idleTimer: ReturnType<typeof setTimeout> | undefined;
 
   constructor(
     socket: TransportSocket,
     abortSignal: AbortSignal | undefined,
     onResponseEvent: (() => void) | undefined,
     logger: TransportLogger | undefined,
+    streamIdleTimeoutMs: number,
   ) {
     this.logger = logger;
-    const detachMessage = socket.onMessage((data) => {
-      if (this.ended) return;
-      if (typeof data !== 'string') {
-        this.fail(
-          createStreamInterruptionError(
-            'Codex Responses WebSocket received a non-text frame',
-          ),
-        );
-        return;
-      }
-      let frame: { type: string | undefined; data: string };
-      try {
-        frame = parseFrame(data);
-      } catch (error) {
-        this.fail(
-          error instanceof Error
-            ? error
-            : createStreamInterruptionError(
-                'Codex Responses WebSocket received an invalid frame',
-              ),
-        );
-        return;
-      }
-      this.queue.push(frame.data);
-      if (isTerminalEventType(frame.type)) {
-        this.receivedTerminal = true;
-        if (
-          frame.type !== undefined &&
-          ACCEPTED_TERMINAL_EVENT_TYPES.has(frame.type)
-        ) {
-          this.acceptedTerminal = true;
-        }
-        this.ended = true;
-      }
-      this.drain();
-      this.notifyResponseEvent(onResponseEvent);
-    });
+    this.streamIdleTimeoutMs = streamIdleTimeoutMs;
+    const detachMessage = socket.onMessage((data) =>
+      this.handleMessage(data, onResponseEvent),
+    );
     const detachClose = socket.onClose((info) => {
       this.logger?.debug(
         () =>
@@ -313,6 +293,50 @@ class RequestFrameSource {
     } else {
       this.detachAbort = () => undefined;
     }
+    this.resetIdleTimer();
+  }
+  private handleMessage(
+    data: unknown,
+    onResponseEvent: (() => void) | undefined,
+  ): void {
+    if (this.ended) return;
+    if (typeof data !== 'string') {
+      this.fail(
+        createStreamInterruptionError(
+          'Codex Responses WebSocket received a non-text frame',
+        ),
+      );
+      return;
+    }
+    let frame: { type: string | undefined; data: string };
+    try {
+      frame = parseFrame(data);
+    } catch (error) {
+      this.fail(
+        error instanceof Error
+          ? error
+          : createStreamInterruptionError(
+              'Codex Responses WebSocket received an invalid frame',
+            ),
+      );
+      return;
+    }
+    const isTerminal = isTerminalEventType(frame.type);
+    this.queue.push(frame.data);
+    if (isTerminal) {
+      this.receivedTerminal = true;
+      if (
+        frame.type !== undefined &&
+        ACCEPTED_TERMINAL_EVENT_TYPES.has(frame.type)
+      ) {
+        this.acceptedTerminal = true;
+      }
+      this.ended = true;
+    }
+    if (isTerminal) this.clearIdleTimer();
+    else this.resetIdleTimer();
+    this.drain();
+    this.notifyResponseEvent(onResponseEvent);
   }
 
   didReceiveAcceptedTerminal(): boolean {
@@ -353,6 +377,7 @@ class RequestFrameSource {
   }
 
   detach(): void {
+    this.clearIdleTimer();
     this.detachListeners();
     this.detachAbort();
     this.ended = true;
@@ -360,12 +385,30 @@ class RequestFrameSource {
   }
 
   private fail(error: Error): void {
+    this.clearIdleTimer();
     // First outcome wins: a terminal frame or recorded failure cannot be
     // replaced by a later close/error/abort.
     if (this.receivedTerminal || this.failure !== undefined) return;
     this.failure = error;
     this.ended = true;
     this.drain();
+  }
+
+  private resetIdleTimer(): void {
+    this.clearIdleTimer();
+    if (this.ended || this.streamIdleTimeoutMs <= 0) return;
+    this.idleTimer = setTimeout(() => {
+      this.idleTimer = undefined;
+      this.fail(
+        createStreamInterruptionError('Codex Responses WebSocket idle timeout'),
+      );
+    }, this.streamIdleTimeoutMs);
+  }
+
+  private clearIdleTimer(): void {
+    if (this.idleTimer === undefined) return;
+    clearTimeout(this.idleTimer);
+    this.idleTimer = undefined;
   }
 
   private drain(): void {
@@ -414,10 +457,13 @@ class CodexResponsesWebSocketTransport implements WebSocketTransport {
 
   private readonly openSocket: OpenTransportSocket;
   private readonly handshakeTimeoutMs: number;
+  private readonly streamIdleTimeoutMs: number;
 
   constructor(private readonly config: WebSocketTransportConfig) {
     this.openSocket = config.openSocket ?? openUndiciSocket;
     this.handshakeTimeoutMs = config.handshakeTimeoutMs ?? HANDSHAKE_TIMEOUT_MS;
+    this.streamIdleTimeoutMs =
+      config.streamIdleTimeoutMs ?? STREAM_IDLE_TIMEOUT_MS;
   }
 
   async *streamResponse(
@@ -436,6 +482,7 @@ class CodexResponsesWebSocketTransport implements WebSocketTransport {
         options.abortSignal,
         options.onResponseEvent,
         this.config.logger,
+        this.streamIdleTimeoutMs,
       );
       try {
         throwIfAborted(options.abortSignal);

--- a/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.ts
@@ -245,6 +245,7 @@ class RequestFrameSource {
   private readonly detachAbort: () => void;
   private readonly logger: TransportLogger | undefined;
   private readonly streamIdleTimeoutMs: number;
+  private readonly onIdleTimeout: () => void;
   private idleTimer: ReturnType<typeof setTimeout> | undefined;
 
   constructor(
@@ -253,9 +254,11 @@ class RequestFrameSource {
     onResponseEvent: (() => void) | undefined,
     logger: TransportLogger | undefined,
     streamIdleTimeoutMs: number,
+    onIdleTimeout: () => void,
   ) {
     this.logger = logger;
     this.streamIdleTimeoutMs = streamIdleTimeoutMs;
+    this.onIdleTimeout = onIdleTimeout;
     const detachMessage = socket.onMessage((data) =>
       this.handleMessage(data, onResponseEvent),
     );
@@ -399,9 +402,15 @@ class RequestFrameSource {
     if (this.ended || this.streamIdleTimeoutMs <= 0) return;
     this.idleTimer = setTimeout(() => {
       this.idleTimer = undefined;
+      // A terminal frame or earlier failure clears the timer, so an armed
+      // timer only fires on a genuinely idle stream; the predicate keeps a
+      // late firing from invalidating a socket that already settled.
+      const settled =
+        this.ended || this.receivedTerminal || this.failure !== undefined;
       this.fail(
         createStreamInterruptionError('Codex Responses WebSocket idle timeout'),
       );
+      if (!settled) this.onIdleTimeout();
     }, this.streamIdleTimeoutMs);
   }
 
@@ -477,12 +486,18 @@ class CodexResponsesWebSocketTransport implements WebSocketTransport {
       throwIfAborted(options.abortSignal);
       socket = await this.acquireConnection(options);
       throwIfAborted(options.abortSignal);
+      // A const alias keeps the narrowed socket type inside the closures below.
+      const liveSocket = socket;
       const source = new RequestFrameSource(
-        socket,
+        liveSocket,
         options.abortSignal,
         options.onResponseEvent,
         this.config.logger,
         this.streamIdleTimeoutMs,
+        // The consumer may be suspended at a yield when the idle timer fires,
+        // so the source's failure alone never closes the socket; invalidate
+        // eagerly so a stalled stream cannot hold the connection open.
+        () => this.invalidate(liveSocket),
       );
       try {
         throwIfAborted(options.abortSignal);

--- a/project-plans/issue2772/PLAN.md
+++ b/project-plans/issue2772/PLAN.md
@@ -1,0 +1,133 @@
+# Issue #2772 — Codex Responses WebSocket connection metadata and idle timeout
+
+Follow-up to #2041 / PR #2750 / PR #3047. Goal: parity with the open-source
+OpenAI Codex client (pinned reference `openai/codex@f21dc4638803f40046c9e294b0349782928f6b36`)
+for (a) WebSocket handshake connection metadata and (b) an established-stream
+idle timeout.
+
+## Upstream evidence (pinned commit f21dc46)
+
+Handshake headers (`codex-rs/core/src/client.rs` `build_websocket_headers` +
+`build_session_headers` in `codex-api/src/requests/headers.rs` + auth in
+`model-provider/src/auth.rs` + `codex-login` `default_headers`):
+
+- `session-id` and `thread-id` are **hyphenated only**. History: underscore
+  forms were introduced (a9862351, 2026-05-06), both forms sent temporarily
+  (bd8fc9ad / #21757, 2026-05-08), then underscore forms were dropped
+  (7c7b4861 / #22193, 2026-05-13) because `_` is rejected by some proxies.
+- `x-client-request-id` = `thread_id` verbatim (thread-scoped, NOT a fresh
+  per-request UUID).
+- `originator: codex_cli_rs`, `OpenAI-Beta: responses_websockets=2026-02-06`.
+- Auth: `Authorization`, `ChatGPT-Account-ID` (optional `X-OpenAI-Fedramp`).
+- Upstream always sends a Codex `User-Agent` via vacant-only default headers.
+
+Idle timeout (`codex-rs/codex-api/src/endpoint/responses_websocket.rs`):
+
+- Default 300000 ms (`stream_idle_timeout_ms` in
+  `codex-rs/model-provider-info/src/lib.rs`).
+- Applied around the request send ("idle timeout sending websocket request")
+  and around every wait for the next frame ("idle timeout waiting for
+  websocket"). Expiry yields `ApiError::Stream` → the socket is dropped and
+  the ordinary stream-retry path runs.
+- No proactive client ping; the idle timeout is the sole stall detector.
+
+## Decisions
+
+1. **Identity mapping.** The provider layer receives exactly one stable
+   conversation identity: `invocation.runtimeId` (fallback
+   `options.runtime?.runtimeId`), the value already sent today as
+   `session_id`. LLxprt has no separate thread branching at the provider
+   layer (`AgentRuntimeState.sessionId` is not plumbed to providers;
+   per-turn `prompt_id` changes every turn and would defeat socket reuse,
+   since `connectionIdentity` hashes the header map). Therefore:
+   - `session-id` = resolved runtimeId
+   - `thread-id` = resolved runtimeId
+   - `x-client-request-id` = resolved runtimeId (mirrors upstream setting it
+     equal to the thread id)
+   All three are guarded: only set when the resolved value is a non-empty
+   string, and dropped together otherwise. The identity value set is
+   unchanged, so socket reuse across turns is preserved.
+2. **Header forms.** Hyphenated only. The underscore `session_id` the WS
+   handshake sends today is replaced (AC #4: no duplicate legacy/current
+   forms without evidence both are required; current upstream sends
+   hyphenated only). The HTTP/SSE path (`openAIResponsesHttpStream.ts`) and
+   the codex image backend keep their existing underscore `session_id` for
+   now — changing their wire behavior is outside this issue's scope and is
+   noted as a follow-up.
+3. **User-Agent.** Preserve current behavior: no synthesized Codex UA. No
+   evidence the live service requires one (both LLxprt transports work
+   without it); users can set one via custom headers, which already flow
+   into the handshake through `getCustomHeaders`.
+4. **Idle timeout placement.** A single timer inside `RequestFrameSource`,
+   sibling to the existing handshake timeout lifecycle:
+   - Armed when the frame source is constructed (immediately before the
+     request send), which covers upstream's send-side wrap (undici `send`
+     is synchronous, so only the first-frame wait can actually stall) and
+     the wait for the first frame.
+   - Reset on every valid inbound text frame (the same point that queues
+     the frame). Ping/pong never surface as message events in undici, so
+     they cannot reset the timer — matching upstream semantics where the
+     idle timeout is the sole stall detector. Binary/malformed frames fail
+     the stream outright rather than resetting.
+   - Cleared on: terminal frame intake, `fail()` (abort/close/error/
+     malformed/idle itself), and `detach()` (normal completion, consumer
+     cancellation).
+   - Expiry: `fail(createStreamInterruptionError('Codex Responses WebSocket
+     idle timeout'))` — a non-AbortError retry-transient error. The
+     existing `streamResponse` finally-block invalidates the socket, so the
+     next request reconnects; `streamOverWebSocketOrFallback` rethrows once
+     any `IContent` was yielded (no partial-output replay) and takes the
+     one-shot HTTP fallback otherwise, reporting it via `onWebSocketFallback`
+     (the provider's existing threshold-based sticky demotion — three
+     consecutive pre-output failures — is unchanged) (AC #5–#7).
+5. **Configuration.** `STREAM_IDLE_TIMEOUT_MS = 300_000` module constant,
+   matching upstream's default; injectable as `streamIdleTimeoutMs` on the
+   transport config (same pattern as the injectable `handshakeTimeoutMs`
+   from #3047) so tests exercise the path quickly. `<= 0` disables the
+   timer. No user-facing setting is added (non-goal: the separately tracked
+   configurable WS selection #2756).
+
+## Behavioral tests (RED first)
+
+Transport-level (`openAIResponsesWebSocketTransport.*.test.ts`, real transport
++ `SocketHarness`/`FakeSocket`, real timers with small injected timeouts —
+the repo is bun-test based, no fake-timer API):
+
+1. Handshake header passthrough covers the new identity header forms, and a
+   changed identity header forces a reconnect (split into
+   `openAIResponsesWebSocketTransport.handshakeHeaders.test.ts`; the main
+   transport test file sits at the 800-effective-line lint ceiling, so the
+   header concern moved to its own file rather than growing it).
+2. A silent established stream rejects with `StreamInterruptionError`
+   (idle), closes the socket, and the next request opens a fresh socket.
+3. Frames arriving within the idle window reset the timer: a stream whose
+   total duration exceeds the idle timeout completes successfully.
+4. Abort while idle-waiting rejects `AbortError`; waiting past the idle
+   window afterwards does not change the settled outcome.
+5. After a completed response, waiting past the idle window leaves the
+   socket reusable (terminal cleanup).
+6. Pre-first-frame idle takes the one-shot HTTP fallback for the request
+   (and reports the fallback event to the provider); idle after yielded
+   content rethrows without fallback (partial-output safety).
+
+Executor-level (`openAIResponsesExecutor.websocket.test.ts`, end-to-end
+through `executeOpenAIResponsesRequest` + `SocketHarness`):
+
+7. Exact handshake header set on the recorded connector headers:
+   `Authorization`, `ChatGPT-Account-ID`, `originator`, `session-id`,
+   `thread-id`, `x-client-request-id` (all = the invocation runtimeId),
+   `OpenAI-Beta`, plus merged custom headers.
+8. When no runtime identity resolves, none of the three identity headers
+   are sent.
+
+Docs: new `### OpenAI Codex (ChatGPT Plus/Pro)` section with a WebSocket
+transport subsection in `docs/providers/quick-reference.md` documenting the
+header contract, identity mapping, handshake timeout, and idle-timeout
+behavior.
+
+## Non-goals (per issue)
+
+- Sixty-minute `websocket_connection_limit_reached` recovery.
+- Configurable regular OpenAI Responses WebSocket selection (#2756).
+- Multiplexing / connection pools / realtime audio.
+- Changing the HTTP/SSE or image-backend `session_id` header forms.


### PR DESCRIPTION
## TLDR

Completes the #2772 follow-up to #2041/#2750: the Codex Responses WebSocket handshake now carries upstream's request-identity headers (hyphenated `session-id`, `thread-id`, `x-client-request-id`) in place of the underscore `session_id`, and the established stream gains a 300 s activity-resetting idle timeout that closes silent sockets and follows the existing partial-output-safe fallback boundary. All behavior validated against `openai/codex@f21dc46`.

## Dive Deeper

**Handshake metadata (AC 1–4).** Upstream dropped the underscore header forms in openai/codex pull request 22193 ("`_` is rejected by some proxies"), and sets `x-client-request-id` = thread id verbatim. LLxprt has no thread identity plumbed to the provider layer, so all three headers resolve to the same `runtimeId` that previously filled `session_id` (identity fallback chain unchanged: `invocation.runtimeId` → `options.runtime?.runtimeId`). Because the value is unchanged, connection reuse and identity-based reconnection behave exactly as before; only the wire names change. Authorization, `ChatGPT-Account-ID`, `originator`, custom, and `OpenAI-Beta` headers are preserved untouched. No User-Agent is synthesized: upstream sends one via vacant-only defaults, but nothing indicates the service requires it, and users can already set one through custom headers. The HTTP/SSE and image-backend paths keep their underscore `session_id`; aligning those is a separate follow-up.

**Stream liveness (AC 5–7).** The transport previously had no post-handshake stall detector, so a half-open socket could hang a turn indefinitely. `RequestFrameSource` now arms a 300 000 ms idle timer (upstream `stream_idle_timeout_ms` default, exported as `STREAM_IDLE_TIMEOUT_MS`, injectable via `streamIdleTimeoutMs`, disabled at `<= 0`) that resets on every valid text frame and is cleared on terminal intake, failure, and detachment. Expiry fails the request with a `StreamInterruptionError`; the existing `finally` invalidates the socket so the next request reconnects, and `streamOverWebSocketOrFallback` falls back to HTTP only before the first yielded `IContent` — never replaying partial output. Undici does not surface ping/pong as message events, so control frames alone cannot reset the timer, matching upstream's pump semantics.

**Tests (AC 8).** Behavioral over the existing `FakeSocket`/`SocketHarness` conventions with real timers and small injected timeouts:
- exact handshake headers at executor level (strict equality proves `session_id` is gone) and transport level, plus identity-absence when `runtimeId` does not resolve
- idle expiry: `StreamInterruptionError`, socket closed by client, next request reconnects
- reset-on-activity across an interval longer than the timeout
- abort during the idle window preserves `AbortError`
- terminal frame clears the timer and the socket stays reusable
- pre-event idle takes the one-shot HTTP fallback (reported via `onWebSocketFallback`; the provider's existing 3-consecutive-failure sticky demotion is unchanged)
- post-output idle rethrows without fallback (anti-replay)

Handshake-header transport tests live in their own file because the main transport test file sits at the 800-line lint ceiling.

**Docs (AC 9).** `docs/providers/quick-reference.md` gains a Codex section documenting the header contract, the 15 s handshake timeout, and the idle-timeout semantics. Decisions and upstream evidence are recorded in `project-plans/issue2772/PLAN.md`.

**Non-goals respected:** no sixty-minute recovery, no configurable WS selection (#2756), no multiplexing/pooling, no public connection-management abstraction, no realtime audio.

## Reviewer Test Plan

- `bun test packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.idleTimeout.test.ts packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.handshakeHeaders.test.ts packages/providers/src/openai-responses/openAIResponsesExecutor.websocket.test.ts`
- Full providers suite: `cd packages/providers && bun ../../scripts/run_bun_tests.ts --workspace providers`
- Optional live check with a Codex OAuth profile: run a turn and confirm the handshake carries the hyphenated headers (visible in debug logging); kill the network mid-stream and confirm the turn fails with a stream interruption rather than hanging.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

macOS (`npm run test`, `lint`, `typecheck`, `format`, `build` all green; the startup smoke test reaches the provider but the stepfun-37 account currently returns "no active step plan subscription", external to this change).

## Linked issues / bugs

Fixes #2772
Follow-up to #2041 and PR #2750. Related: #2756, #3047.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable WebSocket idle timeouts, including automatic interruption and reconnection for stalled streams.
  * Added Codex WebSocket handshake identity headers and documented the connection, timeout, and fallback behavior.
  * WebSocket connections now refresh when identity headers change.

* **Bug Fixes**
  * Improved handling of silent streams, partial output, terminal events, and HTTP fallback after connection timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->