### PR TITLE
Rebuild the skill activation tool on reload (Fixes #3379)

### DIFF
--- a/packages/agents/src/api/__tests__/skillReloadDeclaration.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/skillReloadDeclaration.behavior.test.ts
@@ -1,0 +1,205 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * End-to-end coverage for issue #3379.
+ *
+ * `/skills reload` used to refresh SkillManager and stop there, so a skill
+ * added on disk never reached the model. The model learns which skills exist
+ * from exactly one place: the `activate_skill` declaration carried in the tool
+ * list that ChatSession hands to the provider on every request. These tests
+ * therefore assert on that declaration rather than on which functions were
+ * called.
+ *
+ * The whole production chain runs for real: skill files on disk, the real
+ * SkillManager, the real ActivateSkillTool, a real ToolRegistry, the real
+ * AgentClient.setTools(), and the real ChatSession. Only the registrar hook is
+ * supplied by the test, because wiring it is the composition root's job and the
+ * standalone `createAgent` composition does not currently do it (issue #3382).
+ * When #3382 is fixed this test should drop `setPostSkillDiscoveryToolRegistrar`
+ * and rely on production wiring instead.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { ActivateSkillTool } from '@vybestack/llxprt-code-tools/tools/activate-skill.js';
+import { ACTIVATE_SKILL_TOOL_NAME } from '@vybestack/llxprt-code-tools';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import {
+  buildAgent,
+  internalConfig,
+  type Agent,
+} from './helpers/agentHarness.js';
+
+interface ProviderToolDeclaration {
+  readonly name: string;
+  readonly description?: string;
+  readonly parametersJsonSchema?: unknown;
+}
+
+/**
+ * Reads the tool declarations ChatSession will send with the next provider
+ * request. `generationConfig` is the object handed to the provider, so this is
+ * the model's actual view rather than a proxy for it.
+ */
+function providerToolDeclarations(config: Config): ProviderToolDeclaration[] {
+  const chat = config.getAgentClient().getChat() as unknown as {
+    generationConfig?: {
+      tools?: Array<{ functionDeclarations?: ProviderToolDeclaration[] }>;
+    };
+  };
+  return chat.generationConfig?.tools?.[0]?.functionDeclarations ?? [];
+}
+
+function activateSkillDeclaration(
+  config: Config,
+): ProviderToolDeclaration | undefined {
+  return providerToolDeclarations(config).find(
+    (declaration) => declaration.name === ACTIVATE_SKILL_TOOL_NAME,
+  );
+}
+
+/** The skill names the model is allowed to pass to `activate_skill`. */
+function modelVisibleSkillNames(config: Config): string[] {
+  const declaration = activateSkillDeclaration(config);
+  if (!declaration) {
+    return [];
+  }
+  const schema = declaration.parametersJsonSchema as {
+    properties?: { name?: { enum?: string[] } };
+  };
+  return schema.properties?.name?.enum ?? [];
+}
+
+function writeSkill(workspace: string, name: string): void {
+  const skillDir = join(workspace, '.llxprt', 'skills', name);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: The ${name} skill\n---\n\n${name} instructions\n`,
+    'utf-8',
+  );
+}
+
+function removeSkill(workspace: string, name: string): void {
+  rmSync(join(workspace, '.llxprt', 'skills', name), {
+    recursive: true,
+    force: true,
+  });
+}
+
+/**
+ * Installs the composition-root registrar, drives one turn so a live chat
+ * session exists to be refreshed, then performs the first reload, which stands
+ * in for the startup registration a real CLI session gets.
+ */
+async function installRegistrarAndSettle(agent: Agent): Promise<Config> {
+  const config = internalConfig(agent);
+  config.setPostSkillDiscoveryToolRegistrar(
+    (toolRegistry, skillService, messageBus) => {
+      toolRegistry.unregisterTool(ActivateSkillTool.Name);
+      if (skillService.listSkills().length > 0) {
+        toolRegistry.registerTool(
+          new ActivateSkillTool(skillService, messageBus),
+        );
+      }
+    },
+  );
+  for await (const _event of agent.stream('hello')) {
+    // Drain the turn so the chat session and its tool list exist.
+  }
+  await agent.skills.reload();
+  return config;
+}
+
+async function withWorkspace(
+  initialSkills: string[],
+  run: (ctx: {
+    agent: Agent;
+    config: Config;
+    workspace: string;
+  }) => Promise<void>,
+): Promise<void> {
+  const workspace = mkdtempSync(join(tmpdir(), 'llxprt-skill-reload-'));
+  for (const name of initialSkills) {
+    writeSkill(workspace, name);
+  }
+  const { agent, cleanup } = await buildAgent('plain-text.jsonl', {
+    skillsSupport: true,
+    workingDir: workspace,
+  });
+  try {
+    const config = await installRegistrarAndSettle(agent);
+    await run({ agent, config, workspace });
+  } finally {
+    await cleanup();
+    rmSync(workspace, { recursive: true, force: true });
+  }
+}
+
+describe('skill reload reaches the model @issue:3379', () => {
+  it('offers a skill that existed before the reload', async () => {
+    await withWorkspace(['alpha'], async ({ config }) => {
+      expect(modelVisibleSkillNames(config)).toEqual(['alpha']);
+    });
+  });
+
+  it('offers a skill added on disk after the session started', async () => {
+    await withWorkspace(['alpha'], async ({ agent, config, workspace }) => {
+      expect(modelVisibleSkillNames(config)).toEqual(['alpha']);
+
+      writeSkill(workspace, 'beta');
+      await agent.skills.reload();
+
+      expect(modelVisibleSkillNames(config).sort()).toEqual(['alpha', 'beta']);
+      expect(activateSkillDeclaration(config)?.description).toContain("'beta'");
+    });
+  });
+
+  it('stops offering a skill removed from disk', async () => {
+    await withWorkspace(
+      ['alpha', 'beta'],
+      async ({ agent, config, workspace }) => {
+        expect(modelVisibleSkillNames(config).sort()).toEqual([
+          'alpha',
+          'beta',
+        ]);
+
+        removeSkill(workspace, 'beta');
+        await agent.skills.reload();
+
+        expect(modelVisibleSkillNames(config)).toEqual(['alpha']);
+        expect(activateSkillDeclaration(config)?.description).not.toContain(
+          "'beta'",
+        );
+      },
+    );
+  });
+
+  it('offers the first skill in a session that started with none', async () => {
+    await withWorkspace([], async ({ agent, config, workspace }) => {
+      expect(activateSkillDeclaration(config)).toBeUndefined();
+
+      writeSkill(workspace, 'alpha');
+      await agent.skills.reload();
+
+      expect(modelVisibleSkillNames(config)).toEqual(['alpha']);
+    });
+  });
+
+  it('withdraws the tool once the last skill goes away', async () => {
+    await withWorkspace(['alpha'], async ({ agent, config, workspace }) => {
+      expect(activateSkillDeclaration(config)).toBeDefined();
+
+      removeSkill(workspace, 'alpha');
+      await agent.skills.reload();
+
+      expect(activateSkillDeclaration(config)).toBeUndefined();
+    });
+  });
+});

--- a/packages/agents/src/api/__tests__/skillReloadDeclaration.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/skillReloadDeclaration.behavior.test.ts
@@ -46,6 +46,12 @@ interface ProviderToolDeclaration {
  * Reads the tool declarations ChatSession will send with the next provider
  * request. `generationConfig` is the object handed to the provider, so this is
  * the model's actual view rather than a proxy for it.
+ *
+ * There is no public read seam for this, so the shape is reached directly.
+ * Every step is checked and throws on a mismatch rather than returning an
+ * empty list, because a silent `?? []` here would let a refactor of
+ * `ChatSession.setTools` turn these assertions green while the model saw
+ * nothing.
  */
 function providerToolDeclarations(config: Config): ProviderToolDeclaration[] {
   const chat = config.getAgentClient().getChat() as unknown as {
@@ -53,7 +59,19 @@ function providerToolDeclarations(config: Config): ProviderToolDeclaration[] {
       tools?: Array<{ functionDeclarations?: ProviderToolDeclaration[] }>;
     };
   };
-  return chat.generationConfig?.tools?.[0]?.functionDeclarations ?? [];
+  const toolGroups = chat.generationConfig?.tools;
+  if (!Array.isArray(toolGroups) || toolGroups.length === 0) {
+    throw new Error(
+      'ChatSession carries no tool groups; ChatSession.setTools may have changed shape',
+    );
+  }
+  const declarations = toolGroups[0]?.functionDeclarations;
+  if (!Array.isArray(declarations)) {
+    throw new Error(
+      'ChatSession tool group has no functionDeclarations; ChatSession.setTools may have changed shape',
+    );
+  }
+  return declarations;
 }
 
 function activateSkillDeclaration(

--- a/packages/agents/src/api/__tests__/skillsControl.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/skillsControl.behavior.test.ts
@@ -17,7 +17,7 @@
  */
 
 import { describe, it, expect } from 'bun:test';
-import { buildAgent, internalConfig } from './helpers/agentHarness.js';
+import { buildAgent } from './helpers/agentHarness.js';
 
 describe('agent.skills control @plan:PLAN-20260626-RUNTIMEBOUNDARY.P03', () => {
   it('list returns an array of SkillInfo (possibly empty) @scenario:list @given:an agent built normally @when:agent.skills.list() @then:the result is an array', async () => {
@@ -107,46 +107,6 @@ describe('agent.skills control @plan:PLAN-20260626-RUNTIMEBOUNDARY.P03', () => {
       expect(listed).not.toHaveProperty('body');
       expect(fetched).not.toHaveProperty('body');
       expect(JSON.stringify([listed, fetched])).not.toContain(secretBody);
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it('reload rebuilds the skill activation tool from the current skill set @issue:3379 @scenario:reload-refreshes-tool @given:an agent with an active extension skill @when:agent.skills.reload() @then:the composition-root registrar is invoked with the reloaded skills', async () => {
-    const { agent, cleanup } = await buildAgent('plain-text.jsonl', {
-      skillsSupport: true,
-      extensions: [
-        {
-          name: 'skill-extension',
-          version: '1.0.0',
-          isActive: true,
-          path: 'memory://skill-extension',
-          contextFiles: [],
-          skills: [
-            {
-              name: 'reloadable-skill',
-              description: 'A skill the model should be able to activate',
-              location: 'memory://reloadable-skill/SKILL.md',
-              body: 'instructions',
-            },
-          ],
-        },
-      ],
-    });
-    try {
-      const observedSkillNames: string[][] = [];
-      internalConfig(agent).setPostSkillDiscoveryToolRegistrar(
-        (_toolRegistry, skillService) => {
-          observedSkillNames.push(
-            skillService.listSkills().map((skill) => skill.name),
-          );
-        },
-      );
-
-      await agent.skills.reload();
-
-      expect(observedSkillNames).toHaveLength(1);
-      expect(observedSkillNames[0]).toContain('reloadable-skill');
     } finally {
       await cleanup();
     }

--- a/packages/agents/src/api/__tests__/skillsControl.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/skillsControl.behavior.test.ts
@@ -17,7 +17,7 @@
  */
 
 import { describe, it, expect } from 'bun:test';
-import { buildAgent } from './helpers/agentHarness.js';
+import { buildAgent, internalConfig } from './helpers/agentHarness.js';
 
 describe('agent.skills control @plan:PLAN-20260626-RUNTIMEBOUNDARY.P03', () => {
   it('list returns an array of SkillInfo (possibly empty) @scenario:list @given:an agent built normally @when:agent.skills.list() @then:the result is an array', async () => {
@@ -107,6 +107,46 @@ describe('agent.skills control @plan:PLAN-20260626-RUNTIMEBOUNDARY.P03', () => {
       expect(listed).not.toHaveProperty('body');
       expect(fetched).not.toHaveProperty('body');
       expect(JSON.stringify([listed, fetched])).not.toContain(secretBody);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('reload rebuilds the skill activation tool from the current skill set @issue:3379 @scenario:reload-refreshes-tool @given:an agent with an active extension skill @when:agent.skills.reload() @then:the composition-root registrar is invoked with the reloaded skills', async () => {
+    const { agent, cleanup } = await buildAgent('plain-text.jsonl', {
+      skillsSupport: true,
+      extensions: [
+        {
+          name: 'skill-extension',
+          version: '1.0.0',
+          isActive: true,
+          path: 'memory://skill-extension',
+          contextFiles: [],
+          skills: [
+            {
+              name: 'reloadable-skill',
+              description: 'A skill the model should be able to activate',
+              location: 'memory://reloadable-skill/SKILL.md',
+              body: 'instructions',
+            },
+          ],
+        },
+      ],
+    });
+    try {
+      const observedSkillNames: string[][] = [];
+      internalConfig(agent).setPostSkillDiscoveryToolRegistrar(
+        (_toolRegistry, skillService) => {
+          observedSkillNames.push(
+            skillService.listSkills().map((skill) => skill.name),
+          );
+        },
+      );
+
+      await agent.skills.reload();
+
+      expect(observedSkillNames).toHaveLength(1);
+      expect(observedSkillNames[0]).toContain('reloadable-skill');
     } finally {
       await cleanup();
     }

--- a/packages/cli/src/config/activateSkillToolRegistrar.test.ts
+++ b/packages/cli/src/config/activateSkillToolRegistrar.test.ts
@@ -1,0 +1,202 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral coverage for the composition-root skill activation registrar.
+ *
+ * Issue #3379: the registered activation tool captures the available skill
+ * names at construction time, so re-running discovery has to produce a tool
+ * whose declaration reflects the new skill set.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  ACTIVATE_SKILL_TOOL_NAME,
+  ToolRegistry,
+  type ISkillService,
+  type IToolMessageBus,
+  type SkillInfo,
+  type SkillManager,
+} from '@vybestack/llxprt-code-tools';
+import type { MessageBus } from '@vybestack/llxprt-code-core';
+import { registerActivateSkillTool } from './activateSkillToolRegistrar.js';
+
+/**
+ * The registry and the registrar hook describe the same bus through different
+ * interfaces, so the stub satisfies both.
+ */
+const messageBus = {
+  publish() {},
+  subscribe() {},
+  unsubscribe() {},
+} as unknown as IToolMessageBus & MessageBus;
+
+function skillInfo(name: string): SkillInfo {
+  return {
+    name,
+    description: `${name} description`,
+    location: `/skills/${name}/SKILL.md`,
+  };
+}
+
+/**
+ * Minimal skill service whose skill list can be swapped between registrar
+ * invocations, mirroring what re-running discovery does to the real adapter.
+ */
+class FakeSkillService implements ISkillService {
+  constructor(private skills: SkillInfo[]) {}
+
+  setSkills(skills: SkillInfo[]): void {
+    this.skills = skills;
+  }
+
+  getSkillManager(): SkillManager {
+    return {
+      getSkills: () => this.listSkills(),
+      getSkill: (name: string) => this.getSkill(name),
+    };
+  }
+
+  listSkills(): SkillInfo[] {
+    return this.skills;
+  }
+
+  getSkill(name: string): SkillInfo | null {
+    return this.skills.find((skill) => skill.name === name) ?? null;
+  }
+
+  async activateSkill(name: string) {
+    const skill = this.getSkill(name);
+    if (!skill) {
+      return {
+        success: false as const,
+        availableSkills: this.skills.map((s) => s.name),
+      };
+    }
+    return {
+      success: true as const,
+      instructions: `${name} instructions`,
+      description: skill.description,
+      location: skill.location,
+      folderStructure: '',
+      resourceDirectory: `/skills/${name}`,
+    };
+  }
+
+  async getFolderStructure(): Promise<string> {
+    return '';
+  }
+}
+
+function createRegistry(): ToolRegistry {
+  return new ToolRegistry({}, messageBus);
+}
+
+function activateSkillDeclaration(registry: ToolRegistry) {
+  return registry
+    .getFunctionDeclarations()
+    .find((declaration) => declaration.name === ACTIVATE_SKILL_TOOL_NAME);
+}
+
+function enumeratedSkillNames(registry: ToolRegistry): string[] {
+  const declaration = activateSkillDeclaration(registry);
+  if (!declaration) {
+    throw new Error(`${ACTIVATE_SKILL_TOOL_NAME} is not registered`);
+  }
+  const schema = (declaration.parametersJsonSchema ??
+    declaration.parameters) as {
+    properties?: { name?: { enum?: string[] } };
+  };
+  return schema.properties?.name?.enum ?? [];
+}
+
+describe('registerActivateSkillTool @issue:3379', () => {
+  it('registers the activation tool enumerating every available skill', () => {
+    const registry = createRegistry();
+    const skillService = new FakeSkillService([
+      skillInfo('alpha'),
+      skillInfo('beta'),
+    ]);
+
+    registerActivateSkillTool(registry, skillService, messageBus);
+
+    expect(enumeratedSkillNames(registry)).toEqual(['alpha', 'beta']);
+  });
+
+  it('names the available skills in the tool description', () => {
+    const registry = createRegistry();
+    const skillService = new FakeSkillService([skillInfo('alpha')]);
+
+    registerActivateSkillTool(registry, skillService, messageBus);
+
+    expect(activateSkillDeclaration(registry)?.description).toContain(
+      "Available: 'alpha'",
+    );
+  });
+
+  it('exposes a newly discovered skill when invoked again', () => {
+    const registry = createRegistry();
+    const skillService = new FakeSkillService([skillInfo('alpha')]);
+    registerActivateSkillTool(registry, skillService, messageBus);
+
+    skillService.setSkills([skillInfo('alpha'), skillInfo('gamma')]);
+    registerActivateSkillTool(registry, skillService, messageBus);
+
+    expect(enumeratedSkillNames(registry)).toEqual(['alpha', 'gamma']);
+    expect(activateSkillDeclaration(registry)?.description).toContain(
+      "'gamma'",
+    );
+  });
+
+  it('drops a skill that is no longer available when invoked again', () => {
+    const registry = createRegistry();
+    const skillService = new FakeSkillService([
+      skillInfo('alpha'),
+      skillInfo('gamma'),
+    ]);
+    registerActivateSkillTool(registry, skillService, messageBus);
+
+    skillService.setSkills([skillInfo('alpha')]);
+    registerActivateSkillTool(registry, skillService, messageBus);
+
+    expect(enumeratedSkillNames(registry)).toEqual(['alpha']);
+    expect(activateSkillDeclaration(registry)?.description).not.toContain(
+      "'gamma'",
+    );
+  });
+
+  it('leaves the tool unregistered when no skills are available', () => {
+    const registry = createRegistry();
+
+    registerActivateSkillTool(registry, new FakeSkillService([]), messageBus);
+
+    expect(activateSkillDeclaration(registry)).toBeUndefined();
+  });
+
+  it('unregisters the tool once the last skill goes away', () => {
+    const registry = createRegistry();
+    const skillService = new FakeSkillService([skillInfo('alpha')]);
+    registerActivateSkillTool(registry, skillService, messageBus);
+    expect(activateSkillDeclaration(registry)).toBeDefined();
+
+    skillService.setSkills([]);
+    registerActivateSkillTool(registry, skillService, messageBus);
+
+    expect(activateSkillDeclaration(registry)).toBeUndefined();
+  });
+
+  it('registers the tool for a session that started with no skills', () => {
+    const registry = createRegistry();
+    const skillService = new FakeSkillService([]);
+    registerActivateSkillTool(registry, skillService, messageBus);
+    expect(activateSkillDeclaration(registry)).toBeUndefined();
+
+    skillService.setSkills([skillInfo('alpha')]);
+    registerActivateSkillTool(registry, skillService, messageBus);
+
+    expect(enumeratedSkillNames(registry)).toEqual(['alpha']);
+  });
+});

--- a/packages/cli/src/config/activateSkillToolRegistrar.test.ts
+++ b/packages/cli/src/config/activateSkillToolRegistrar.test.ts
@@ -106,8 +106,10 @@ function enumeratedSkillNames(registry: ToolRegistry): string[] {
   if (!declaration) {
     throw new Error(`${ACTIVATE_SKILL_TOOL_NAME} is not registered`);
   }
-  const schema = (declaration.parametersJsonSchema ??
-    declaration.parameters) as {
+  // Read only parametersJsonSchema. Falling back to the legacy `parameters`
+  // field would let this pass for a declaration that does not satisfy the
+  // provider contract.
+  const schema = declaration.parametersJsonSchema as {
     properties?: { name?: { enum?: string[] } };
   };
   return schema.properties?.name?.enum ?? [];

--- a/packages/cli/src/config/activateSkillToolRegistrar.test.ts
+++ b/packages/cli/src/config/activateSkillToolRegistrar.test.ts
@@ -199,4 +199,24 @@ describe('registerActivateSkillTool @issue:3379', () => {
 
     expect(enumeratedSkillNames(registry)).toEqual(['alpha']);
   });
+
+  it('keeps the previous tool registered when building the replacement fails', () => {
+    const registry = createRegistry();
+    const skillService = new FakeSkillService([skillInfo('alpha')]);
+    registerActivateSkillTool(registry, skillService, messageBus);
+
+    const exploding = new FakeSkillService([skillInfo('beta')]);
+    exploding.listSkills = () => {
+      throw new Error('discovery blew up');
+    };
+
+    expect(() =>
+      registerActivateSkillTool(registry, exploding, messageBus),
+    ).toThrow('discovery blew up');
+
+    // Config.reloadSkills() lets this propagate and never reaches setTools(),
+    // so the live chat session still advertises activate_skill. Removing it
+    // here would leave the model calling a tool the registry no longer has.
+    expect(enumeratedSkillNames(registry)).toEqual(['alpha']);
+  });
 });

--- a/packages/cli/src/config/activateSkillToolRegistrar.ts
+++ b/packages/cli/src/config/activateSkillToolRegistrar.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ActivateSkillTool } from '@vybestack/llxprt-code-tools/tools/activate-skill.js';
+import type { PostSkillDiscoveryToolRegistrar } from '@vybestack/llxprt-code-core';
+
+/**
+ * Composition-root implementation of {@link PostSkillDiscoveryToolRegistrar}.
+ *
+ * `ActivateSkillTool` captures the available skill names in its description and
+ * its `name` parameter schema when it is constructed, so the registered
+ * instance has to be replaced whenever the skill set changes. Core invokes this
+ * after every skill discovery, including `/skills reload` (issue #3379).
+ *
+ * When no skills are available the tool is left unregistered rather than
+ * registered with an empty enum, so a session that starts with no skills can
+ * still gain the tool on a later reload.
+ *
+ * Lives in the CLI because `ActivateSkillTool` may not be referenced from core
+ * (issue #2417).
+ */
+export const registerActivateSkillTool: PostSkillDiscoveryToolRegistrar = (
+  toolRegistry,
+  skillService,
+  messageBus,
+) => {
+  toolRegistry.unregisterTool(ActivateSkillTool.Name);
+  if (skillService.listSkills().length > 0) {
+    toolRegistry.registerTool(new ActivateSkillTool(skillService, messageBus));
+  }
+};

--- a/packages/cli/src/config/activateSkillToolRegistrar.ts
+++ b/packages/cli/src/config/activateSkillToolRegistrar.ts
@@ -27,8 +27,18 @@ export const registerActivateSkillTool: PostSkillDiscoveryToolRegistrar = (
   skillService,
   messageBus,
 ) => {
+  // Build the replacement before touching the registry. Construction is the
+  // only step here that can throw, and Config.reloadSkills() lets that
+  // propagate. Unregistering first would leave the registry without a tool the
+  // live chat session is still advertising, because the setTools() that would
+  // have corrected the session never runs on the failure path.
+  const replacement =
+    skillService.listSkills().length > 0
+      ? new ActivateSkillTool(skillService, messageBus)
+      : undefined;
+
   toolRegistry.unregisterTool(ActivateSkillTool.Name);
-  if (skillService.listSkills().length > 0) {
-    toolRegistry.registerTool(new ActivateSkillTool(skillService, messageBus));
+  if (replacement) {
+    toolRegistry.registerTool(replacement);
   }
 };

--- a/packages/cli/src/config/configBuilder.ts
+++ b/packages/cli/src/config/configBuilder.ts
@@ -16,7 +16,7 @@ import {
 } from '@vybestack/llxprt-code-core';
 import { createAgentRuntimeFactoryBindings } from '@vybestack/llxprt-code-agents';
 import { registerAgentRuntimeFactories } from '@vybestack/llxprt-code-providers/runtime.js';
-import { ActivateSkillTool } from '@vybestack/llxprt-code-tools/tools/activate-skill.js';
+import { registerActivateSkillTool } from './activateSkillToolRegistrar.js';
 import { getEnableHooks, getEnableHooksUI } from './settingsSchema.js';
 import { loadSettings } from './settings.js';
 import { appEvents } from '../utils/events.js';
@@ -360,16 +360,7 @@ export function buildConfig(input: ConfigBuildInput): Config {
     agentClientFactory: agentRuntimeFactoryBindings.agentClientFactory,
     toolSchedulerFactory: agentRuntimeFactoryBindings.toolSchedulerFactory,
     taskToolRegistration: agentRuntimeFactoryBindings.taskToolRegistration(),
-    postSkillDiscoveryToolRegistrar: (
-      toolRegistry,
-      skillService,
-      messageBus,
-    ) => {
-      toolRegistry.unregisterTool(ActivateSkillTool.Name);
-      toolRegistry.registerTool(
-        new ActivateSkillTool(skillService, messageBus),
-      );
-    },
+    postSkillDiscoveryToolRegistrar: registerActivateSkillTool,
   });
 }
 

--- a/packages/core/src/config/config.skillReload.test.ts
+++ b/packages/core/src/config/config.skillReload.test.ts
@@ -226,15 +226,23 @@ describe('reloadSkills refreshes the model-facing skill surface @issue:3379', ()
     const skillManager = config.getSkillManager();
     const discovered = [skillDefinition('alpha'), skillDefinition('beta')];
     vi.spyOn(skillManager, 'discoverSkills').mockImplementation(async () => {
-      // Real discovery repopulates the manager; this stands in for that so
-      // setDisabledSkills has something to mark.
-      skillManager.getAllSkills().length = 0;
-      skillManager.getAllSkills().push(...discovered);
+      // Real discovery repopulates the manager's store; this stands in for it
+      // so the real setDisabledSkills has something to mark.
+      const store = skillManager.getAllSkills();
+      store.length = 0;
+      store.push(...discovered);
     });
     observations.length = 0;
 
     await config.reloadSkills();
 
+    // Guard: the stand-in above depends on getAllSkills exposing the live
+    // store. If that ever returns a copy, the manager stays empty and the
+    // assertion below would pass for the wrong reason.
+    expect(skillManager.getAllSkills().map((skill) => skill.name)).toEqual([
+      'alpha',
+      'beta',
+    ]);
     // The disabled list arrives via onReload and is applied before the tool is
     // rebuilt, so the registrar must never see the disabled skill.
     expect(observations).toEqual([{ skills: ['alpha'] }]);

--- a/packages/core/src/config/config.skillReload.test.ts
+++ b/packages/core/src/config/config.skillReload.test.ts
@@ -209,6 +209,42 @@ describe('reloadSkills refreshes the model-facing skill surface @issue:3379', ()
     expect(observations).toEqual([]);
   });
 
+  it('hides a skill that the reload disabled', async () => {
+    const observations: RegistrarObservation[] = [];
+    const config = new Config(
+      buildParams({
+        onReload: async () => ({ disabledSkills: ['beta'] }),
+        postSkillDiscoveryToolRegistrar: (_registry, skillService) => {
+          observations.push({
+            skills: skillService.listSkills().map((skill) => skill.name),
+          });
+        },
+      }),
+    );
+    await initializeTestConfig(config);
+
+    const skillManager = config.getSkillManager();
+    const discovered = [skillDefinition('alpha'), skillDefinition('beta')];
+    vi.spyOn(skillManager, 'discoverSkills').mockImplementation(async () => {
+      // Real discovery repopulates the manager; this stands in for that so
+      // setDisabledSkills has something to mark.
+      skillManager.getAllSkills().length = 0;
+      skillManager.getAllSkills().push(...discovered);
+    });
+    observations.length = 0;
+
+    await config.reloadSkills();
+
+    // The disabled list arrives via onReload and is applied before the tool is
+    // rebuilt, so the registrar must never see the disabled skill.
+    expect(observations).toEqual([{ skills: ['alpha'] }]);
+  });
+
+  /**
+   * Ordering only. That the refreshed registry actually reaches the model is
+   * asserted end to end against a real ChatSession in the agents package, in
+   * skillReloadDeclaration.behavior.test.ts.
+   */
   it('pushes refreshed declarations to the chat session after rebuilding the tool', async () => {
     const sequence: string[] = [];
     const config = new Config(

--- a/packages/core/src/config/config.skillReload.test.ts
+++ b/packages/core/src/config/config.skillReload.test.ts
@@ -1,0 +1,271 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3379: `/skills reload` refreshed SkillManager but left the model's
+ * view of the available skills frozen at whatever it was when the CLI started.
+ * These tests pin the two steps that carry a reload through to the model:
+ * rebuilding the skill activation tool, and pushing the refreshed tool
+ * declarations into the live chat session.
+ *
+ * The mock harness mirrors config.d.test.ts so Config.initialize() can run
+ * without touching the filesystem, git, telemetry or a real provider.
+ */
+
+import { describe, it, expect, vi } from 'bun:test';
+import type { ConfigParameters } from './config.js';
+import { Config } from './config.js';
+import type { SkillDefinition } from '../skills/skillLoader.js';
+import { MCPDiscoveryState } from '@vybestack/llxprt-code-mcp';
+import { initializeTestConfig } from '../test-utils/config.js';
+import {
+  buildFsMockBody,
+  buildToolsMockBody,
+  buildContentGeneratorMockBody,
+  buildTelemetryMockBody,
+  buildGitServiceMockBody,
+  buildSettingsMockBody,
+  buildIdeIntegrationMockBody,
+  buildMemoryDiscoveryMockBody,
+  buildEventsMockBody,
+  buildFetchMockBody,
+  type HoistedConfigMocks,
+} from './configTestHarness.js';
+
+// Hoisted mocks referenced by the mock factories below.
+const hoistedConfigMocks = {
+  loadJitSubdirectoryMemory: vi.fn(),
+  coreEvents: {
+    emitFeedback: vi.fn(),
+    emitModelChanged: vi.fn(),
+    emitConsoleLog: vi.fn(),
+  },
+  setGlobalProxy: vi.fn(),
+} as HoistedConfigMocks;
+const __actual = { ...(await import('@vybestack/llxprt-code-mcp')) };
+void vi.mock('@vybestack/llxprt-code-mcp', () => {
+  const actual = __actual as Record<string, unknown>;
+  return {
+    ...actual,
+    McpClientManager: vi.fn().mockImplementation(() => ({
+      getMcpServers: vi.fn().mockReturnValue({}),
+      getDiscoveryFailures: vi.fn().mockReturnValue(new Map<string, string>()),
+      getDiscoveryState: vi.fn().mockReturnValue(MCPDiscoveryState.NOT_STARTED),
+      whenDiscoverySettled: vi.fn().mockResolvedValue(undefined),
+      restart: vi.fn().mockResolvedValue(undefined),
+      restartServer: vi.fn().mockResolvedValue(undefined),
+      reconcileConfiguredMcpServers: vi.fn().mockResolvedValue(undefined),
+      getMcpInstructions: vi.fn().mockReturnValue(''),
+      startConfiguredMcpServers: vi.fn().mockResolvedValue(undefined),
+      onFolderTrustGained: vi.fn().mockResolvedValue(undefined),
+      onFolderTrustRevoked: vi.fn().mockResolvedValue(undefined),
+      quarantineForTrustRevocation: vi.fn(),
+      stop: vi.fn().mockResolvedValue(undefined),
+    })),
+  };
+});
+
+const __actual2 = { ...(await import('fs')) };
+void vi.mock('fs', () => buildFsMockBody(__actual2));
+
+const __actual3 = { ...(await import('@vybestack/llxprt-code-tools')) };
+void vi.mock('@vybestack/llxprt-code-tools', () =>
+  buildToolsMockBody(__actual3),
+);
+
+const __actual4 = { ...(await import('../core/contentGenerator.js')) };
+void vi.mock('../core/contentGenerator.js', () =>
+  buildContentGeneratorMockBody(__actual4),
+);
+
+void vi.mock('../telemetry/index.js', () => buildTelemetryMockBody());
+
+void vi.mock('../services/gitService.js', () => buildGitServiceMockBody());
+
+void vi.mock('@vybestack/llxprt-code-settings', () => buildSettingsMockBody());
+
+const __actual5 = {
+  ...(await import('@vybestack/llxprt-code-ide-integration')),
+};
+void vi.mock('@vybestack/llxprt-code-ide-integration', () =>
+  buildIdeIntegrationMockBody(__actual5),
+);
+
+void vi.mock('../utils/memoryDiscovery.js', () =>
+  buildMemoryDiscoveryMockBody(hoistedConfigMocks),
+);
+
+const __actual6 = { ...(await import('../utils/events.js')) };
+void vi.mock('../utils/events.js', () =>
+  buildEventsMockBody(__actual6, hoistedConfigMocks),
+);
+
+void vi.mock('../utils/fetch.js', () => buildFetchMockBody(hoistedConfigMocks));
+
+/**
+ * Issue #3379: the model only learns which skills exist from the skill
+ * activation tool's declaration. Reloading skills has to rebuild that tool
+ * and push the refreshed declarations into the live chat session, otherwise
+ * a reloaded skill stays invisible to the model until the CLI restarts.
+ */
+describe('reloadSkills refreshes the model-facing skill surface @issue:3379', () => {
+  interface RegistrarObservation {
+    readonly skills: string[];
+  }
+
+  function skillDefinition(name: string): SkillDefinition {
+    return {
+      name,
+      description: `${name} description`,
+      location: `/skills/${name}/SKILL.md`,
+      body: '',
+      source: 'project',
+    };
+  }
+
+  function buildParams(overrides: Partial<ConfigParameters>): ConfigParameters {
+    return {
+      sessionId: 'test-session',
+      targetDir: '/tmp/test',
+      debugMode: false,
+      model: 'test-model',
+      cwd: '/tmp/test',
+      skillsSupport: true,
+      ...overrides,
+    };
+  }
+
+  it('rebuilds the activation tool from the post-reload skill set', async () => {
+    const observations: RegistrarObservation[] = [];
+    const config = new Config(
+      buildParams({
+        postSkillDiscoveryToolRegistrar: (_registry, skillService) => {
+          observations.push({
+            skills: skillService.listSkills().map((skill) => skill.name),
+          });
+        },
+      }),
+    );
+    await initializeTestConfig(config);
+
+    const skillManager = config.getSkillManager();
+    vi.spyOn(skillManager, 'discoverSkills').mockResolvedValue(undefined);
+    vi.spyOn(skillManager, 'getSkills').mockReturnValue([
+      skillDefinition('alpha'),
+      skillDefinition('beta'),
+    ]);
+    observations.length = 0;
+
+    await config.reloadSkills();
+
+    expect(observations).toEqual([{ skills: ['alpha', 'beta'] }]);
+  });
+
+  it('rebuilds the activation tool even when no skills remain', async () => {
+    const observations: RegistrarObservation[] = [];
+    const config = new Config(
+      buildParams({
+        postSkillDiscoveryToolRegistrar: (_registry, skillService) => {
+          observations.push({
+            skills: skillService.listSkills().map((skill) => skill.name),
+          });
+        },
+      }),
+    );
+    await initializeTestConfig(config);
+
+    const skillManager = config.getSkillManager();
+    vi.spyOn(skillManager, 'discoverSkills').mockResolvedValue(undefined);
+    vi.spyOn(skillManager, 'getSkills').mockReturnValue([]);
+    observations.length = 0;
+
+    await config.reloadSkills();
+
+    expect(observations).toEqual([{ skills: [] }]);
+  });
+
+  it('does not rebuild the activation tool when skills support is off', async () => {
+    const observations: RegistrarObservation[] = [];
+    const config = new Config(
+      buildParams({
+        skillsSupport: false,
+        postSkillDiscoveryToolRegistrar: (_registry, skillService) => {
+          observations.push({
+            skills: skillService.listSkills().map((skill) => skill.name),
+          });
+        },
+      }),
+    );
+    await initializeTestConfig(config);
+
+    const skillManager = config.getSkillManager();
+    vi.spyOn(skillManager, 'discoverSkills').mockResolvedValue(undefined);
+
+    await config.reloadSkills();
+
+    expect(observations).toEqual([]);
+  });
+
+  it('pushes refreshed declarations to the chat session after rebuilding the tool', async () => {
+    const sequence: string[] = [];
+    const config = new Config(
+      buildParams({
+        postSkillDiscoveryToolRegistrar: () => {
+          sequence.push('registrar');
+        },
+      }),
+    );
+    await initializeTestConfig(config);
+
+    const skillManager = config.getSkillManager();
+    vi.spyOn(skillManager, 'discoverSkills').mockResolvedValue(undefined);
+    vi.spyOn(config.getAgentClient(), 'setTools').mockImplementation(
+      async () => {
+        sequence.push('setTools');
+      },
+    );
+    sequence.length = 0;
+
+    await config.reloadSkills();
+
+    expect(sequence).toEqual(['registrar', 'setTools']);
+  });
+
+  it('completes without a chat session to refresh', async () => {
+    const config = new Config(
+      buildParams({
+        postSkillDiscoveryToolRegistrar: () => {},
+      }),
+    );
+    await initializeTestConfig(config);
+
+    const skillManager = config.getSkillManager();
+    vi.spyOn(skillManager, 'discoverSkills').mockResolvedValue(undefined);
+    vi.spyOn(config.getAgentClient(), 'isInitialized').mockReturnValue(false);
+
+    await expect(config.reloadSkills()).resolves.toBeUndefined();
+  });
+
+  it('propagates a rebuild failure instead of reporting a successful reload', async () => {
+    let failOnRegister = false;
+    const config = new Config(
+      buildParams({
+        postSkillDiscoveryToolRegistrar: () => {
+          if (failOnRegister) {
+            throw new Error('registration failed');
+          }
+        },
+      }),
+    );
+    await initializeTestConfig(config);
+    failOnRegister = true;
+
+    const skillManager = config.getSkillManager();
+    vi.spyOn(skillManager, 'discoverSkills').mockResolvedValue(undefined);
+
+    await expect(config.reloadSkills()).rejects.toThrow('registration failed');
+  });
+});

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -10,7 +10,6 @@ import { PromptRegistry } from '../prompts/prompt-registry.js';
 import { ResourceRegistry } from '../resources/resource-registry.js';
 import type { ToolRegistry } from '@vybestack/llxprt-code-tools';
 import { Storage } from '@vybestack/llxprt-code-settings';
-import { CoreSkillServiceAdapter } from '../tools-adapters/CoreSkillServiceAdapter.js';
 import { DebugLogger } from '../debug/DebugLogger.js';
 import { getErrorMessage } from '../utils/errors.js';
 import { initializeParser } from '../utils/shell-parser.js';
@@ -45,6 +44,7 @@ import {
   transferHistoryToNewClient,
 } from './agentClientLifecycle.js';
 import { syncActivateMcpServerTool } from './mcp-lazy-tool-sync.js';
+import { syncSkillActivationTool } from './skill-tool-sync.js';
 import {
   getOrCreateAsyncTaskManager,
   getOrCreateAsyncTaskReminderService,
@@ -241,19 +241,7 @@ export class Config extends ConfigBase {
         this.getExtensions(),
       );
       this.getSkillManager().setDisabledSkills(this.disabledSkills);
-
-      // Re-register ActivateSkillTool via the injected registrar hook
-      // (eliminates the inverted core->tools dependency — issue #2417)
-      if (this.getSkillManager().getSkills().length > 0) {
-        const registrar = this.getPostSkillDiscoveryToolRegistrar();
-        if (registrar) {
-          registrar(
-            this.getToolRegistry(),
-            new CoreSkillServiceAdapter(this),
-            initializationMessageBus,
-          );
-        }
-      }
+      syncSkillActivationTool(this);
     }
 
     // Register subagents (after skill discovery, before AgentClient creation)
@@ -485,6 +473,15 @@ export class Config extends ConfigBase {
     }
     await this.skillManager.discoverSkills(this.storage, this.getExtensions());
     this.skillManager.setDisabledSkills(this.disabledSkills);
+
+    syncSkillActivationTool(this);
+
+    // Registry changes do not reach the model on their own: the chat session
+    // caches the declarations it was last given.
+    const client = this.getAgentClientIfReady();
+    if (client) {
+      await client.setTools();
+    }
   }
 
   /**

--- a/packages/core/src/config/configTypes.ts
+++ b/packages/core/src/config/configTypes.ts
@@ -47,10 +47,17 @@ export type { MCPOAuthConfig, AnyToolInvocation, SkillDefinition };
 
 /**
  * Registration hook for post-skill-discovery tool registration.
- * Core calls this during initialize() after skill discovery, passing
- * core-owned dependencies. The composition root (CLI) supplies a
- * callback that constructs and registers the concrete ActivateSkillTool
- * from the tools package, eliminating the inverted core->tools dependency.
+ *
+ * Core calls this after every skill discovery, during initialize() and again
+ * on reloadSkills(), passing core-owned dependencies. The composition root
+ * (CLI) supplies a callback that constructs and registers the concrete
+ * ActivateSkillTool from the tools package, eliminating the inverted
+ * core->tools dependency.
+ *
+ * The callback owns both halves of the decision: it must replace any existing
+ * registration so the tool's captured skill names stay current, and it must
+ * unregister the tool when the skill service reports no available skills
+ * (issue #3379).
  */
 export type PostSkillDiscoveryToolRegistrar = (
   toolRegistry: ToolRegistry,

--- a/packages/core/src/config/skill-tool-sync.ts
+++ b/packages/core/src/config/skill-tool-sync.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CoreSkillServiceAdapter } from '../tools-adapters/CoreSkillServiceAdapter.js';
+import type { Config } from './config.js';
+
+/**
+ * Rebuilds the skill activation tool so it reflects the current skill set.
+ *
+ * The activation tool captures the available skill names in its description
+ * and parameter schema when it is constructed, and that declaration is the
+ * only channel by which the model learns which skills exist. It therefore has
+ * to be rebuilt after every skill discovery, not just the first one, or a
+ * reloaded skill stays invisible to the model until the CLI restarts
+ * (issue #3379).
+ *
+ * The concrete tool is built by the injected registrar hook so the inverted
+ * core->tools dependency stays out of core (issue #2417). The hook also owns
+ * the decision of whether the tool should exist at all, which is why it is
+ * invoked even when no skills are available: that is how a stale registration
+ * gets removed.
+ */
+export function syncSkillActivationTool(config: Config): void {
+  if (!config.isSkillsSupportEnabled()) {
+    return;
+  }
+  const registrar = config.getPostSkillDiscoveryToolRegistrar();
+  const messageBus = config.getRuntimeMessageBus();
+  if (!registrar || !messageBus) {
+    return;
+  }
+  registrar(
+    config.getToolRegistry(),
+    new CoreSkillServiceAdapter(config),
+    messageBus,
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -698,6 +698,10 @@ export { resolvePerfSettings } from './config/configConstructor.js';
 export { TELEMETRY_OUTFILE_BOUND_DEFAULTS } from './config/configConstructor.js';
 export type { PerfTelemetrySettings } from './config/configTypes.js';
 
+// The composition root supplies this hook; it needs the type to declare its
+// implementation (issue #3379).
+export type { PostSkillDiscoveryToolRegistrar } from './config/configTypes.js';
+
 // Export MCP Client Manager — re-exported from @vybestack/llxprt-code-mcp (also available above)
 
 // Export models (legacy constants)

--- a/packages/tools/src/tools/activate-skill.test.ts
+++ b/packages/tools/src/tools/activate-skill.test.ts
@@ -124,4 +124,75 @@ describe('ActivateSkillTool', () => {
       tool.build({ name: '' } as unknown as { name: string }),
     ).toThrow(Error);
   });
+
+  /**
+   * Issue #3379: the model only learns which skills exist from this tool's
+   * declaration, and that declaration is built from the skill list captured
+   * when the instance is constructed. Rebuilding the instance is therefore the
+   * mechanism that refreshes the model-facing skill list after a reload.
+   */
+  describe('declaration reflects the skill list at construction @issue:3379', () => {
+    function serviceListing(names: string[]): ISkillService {
+      const skills: SkillInfo[] = names.map((name) => ({
+        name,
+        description: `${name} description`,
+        location: `/skills/${name}/SKILL.md`,
+      }));
+      return {
+        activateSkill: vi.fn(),
+        getSkillManager: vi.fn(),
+        listSkills: vi.fn().mockReturnValue(skills),
+        getSkill: vi
+          .fn()
+          .mockImplementation(
+            (name: string) => skills.find((s) => s.name === name) ?? null,
+          ),
+        getFolderStructure: vi.fn().mockResolvedValue(''),
+      } as unknown as ISkillService;
+    }
+
+    function enumeratedNames(instance: ActivateSkillTool): string[] {
+      const schema = instance.schema.parametersJsonSchema as {
+        properties?: { name?: { enum?: string[] } };
+      };
+      return schema.properties?.name?.enum ?? [];
+    }
+
+    it('enumerates every listed skill and names them in the description', () => {
+      const instance = new ActivateSkillTool(
+        serviceListing(['alpha', 'beta']),
+        mockMessageBus,
+      );
+
+      expect(enumeratedNames(instance)).toEqual(['alpha', 'beta']);
+      expect(instance.description).toContain("Available: 'alpha', 'beta'");
+      expect(instance.build({ name: 'beta' })).toBeDefined();
+    });
+
+    it('reflects a changed skill list when reconstructed', () => {
+      const before = new ActivateSkillTool(
+        serviceListing(['alpha']),
+        mockMessageBus,
+      );
+      expect(() => before.build({ name: 'gamma' })).toThrow(Error);
+
+      const after = new ActivateSkillTool(
+        serviceListing(['alpha', 'gamma']),
+        mockMessageBus,
+      );
+
+      expect(enumeratedNames(after)).toEqual(['alpha', 'gamma']);
+      expect(after.build({ name: 'gamma' })).toBeDefined();
+    });
+
+    it('enumerates no names when no skills are listed', () => {
+      const instance = new ActivateSkillTool(
+        serviceListing([]),
+        mockMessageBus,
+      );
+
+      expect(enumeratedNames(instance)).toEqual([]);
+      expect(instance.description).not.toContain('Available:');
+    });
+  });
 });

--- a/project-plans/skills-reload-3379/plan.md
+++ b/project-plans/skills-reload-3379/plan.md
@@ -208,6 +208,24 @@ design smell. Making the declaration lazy would remove this class of staleness
 entirely, but it is a change to `BaseDeclarativeTool`'s contract and is tracked
 separately. Steps 1 through 3 fix the reported bug without it.
 
+Two adjacent defects were found while reviewing this change. Neither is the
+reported `/skills reload` failure and neither is fixed here.
+
+1. The standalone `createAgent` composition
+   (`packages/agents/src/api/createAgent.ts`) never supplies a
+   `postSkillDiscoveryToolRegistrar`, so an agent built through the public API
+   with `skillsSupport: true` gets no `activate_skill` tool at startup and
+   cannot gain one by reloading. The CLI, and anything built from a CLI
+   `Config` including the ACP path, is unaffected because it inherits the CLI
+   registrar. The end-to-end test in
+   `packages/agents/src/api/__tests__/skillReloadDeclaration.behavior.test.ts`
+   installs the registrar itself and says so in its header comment, so it does
+   not paper over this.
+2. `packages/core/src/utils/extensionLoader.ts` starts and stops extensions
+   without rediscovering extension-contributed skills, so hot-loading an
+   extension that ships skills leaves both `SkillManager` and the declaration
+   stale until an explicit `/skills reload`.
+
 ## Verification
 
 ```bash

--- a/project-plans/skills-reload-3379/plan.md
+++ b/project-plans/skills-reload-3379/plan.md
@@ -1,0 +1,224 @@
+# Issue #3379: `/skills reload` does not make skills usable by the model
+
+Branch: `issue3379`
+
+## Problem
+
+`/skills reload` re-runs discovery on `SkillManager` but the model-facing surface
+never changes. The only channel by which the model learns about skills is the
+`activate_skill` tool declaration: its description carries an
+`(Available: 'a', 'b')` hint and its `name` parameter is a `z.enum` of the skill
+names. Both are baked into the `ActivateSkillTool` instance at construction.
+
+That instance is constructed in exactly one place, the
+`postSkillDiscoveryToolRegistrar` hook supplied by the CLI composition root
+(`packages/cli/src/config/configBuilder.ts`), and that hook is invoked in exactly
+one place, `Config.performInitialization()`.
+
+`Config.reloadSkills()` does not invoke the registrar, and does not call
+`AgentClient.setTools()` to push refreshed declarations into the live chat
+session. Three user-visible failures follow:
+
+1. A skill added on disk and picked up by `/skills reload` is absent from the
+   `activate_skill` enum, so a model call naming it fails parameter validation.
+2. `/skills enable <name>` and `/skills disable <name>` tell the user to run
+   `/skills reload` "for it to take effect", but the tool schema does not change.
+3. `performInitialization` only registers the tool when
+   `getSkillManager().getSkills().length > 0`. A session that starts with zero
+   enabled skills never registers `activate_skill` at all, and reload cannot
+   recover it.
+
+`AgentSkillsControl.reload()` (`packages/agents/src/api/control/skillsControl.ts`)
+delegates to `Config.reloadSkills()`, so ACP and API consumers share the defect.
+
+## Constraints
+
+- `packages/core/src/config/config.ts` must not gain a value import from
+  `@vybestack/llxprt-code-tools` and must not reference `ActivateSkillTool`.
+  Enforced by `packages/core/src/config/__tests__/import-boundary.test.ts`
+  (issue #2417). The zero-skill decision therefore belongs in the CLI registrar,
+  not in core.
+- Fail fast over defensive layering. Do not add try/catch swallows around the
+  new registrar or `setTools()` calls; a failure during reload should surface
+  through the existing `/skills reload` error path in `skillsCommand.ts`.
+- Bun + TypeScript. New tests are `bun:test`. No new `.js` files.
+
+## Design
+
+### 1. Core: one shared sync step, invoked from init and reload
+
+Extract the registrar invocation currently inlined in `performInitialization()`
+into `packages/core/src/config/skill-tool-sync.ts`, mirroring the existing
+`mcp-lazy-tool-sync.ts`:
+
+```ts
+export function syncSkillActivationTool(config: Config): void {
+  if (!config.isSkillsSupportEnabled()) {
+    return;
+  }
+  const registrar = config.getPostSkillDiscoveryToolRegistrar();
+  const messageBus = config.getRuntimeMessageBus();
+  if (!registrar || !messageBus) {
+    return;
+  }
+  registrar(
+    config.getToolRegistry(),
+    new CoreSkillServiceAdapter(config),
+    messageBus,
+  );
+}
+```
+
+`performInitialization()` already calls `setRuntimeMessageBus(initializationMessageBus)`
+before skill discovery, so `getRuntimeMessageBus()` returns the same bus the
+inline code used. Replace the inlined block (including the
+`getSkills().length > 0` gate) with a call to `syncSkillActivationTool(this)`.
+
+A separate module rather than a private method for two reasons: `config.ts` sits
+at the 800-line `max-lines` limit, and a method named `syncActivateSkillTool`
+would contain the substring `ActivateSkillTool`, which the issue #2417 boundary
+guard rejects anywhere in `config.ts`.
+
+### 2. Core: reload re-syncs the tool and refreshes the live session
+
+```ts
+async reloadSkills(): Promise<void> {
+  if (this._onReload) { /* unchanged */ }
+  await this.skillManager.discoverSkills(this.storage, this.getExtensions());
+  this.skillManager.setDisabledSkills(this.disabledSkills);
+
+  syncSkillActivationTool(this);
+
+  const client = this.getAgentClientIfReady();
+  if (client) {
+    await client.setTools();
+  }
+}
+```
+
+This mirrors `refreshMcpContext()`, which already re-registers its activation
+tool and then calls `client.setTools()`. `updateSystemInstruction()` is NOT
+needed: llxprt's assembled system prompt contains no skill list (the
+`<available_skills>` text in `packages/core/src/core/__snapshots__/prompts.test.js.snap`
+is inherited upstream snapshot content, not something our prompt assembly
+produces).
+
+`ToolRegistryView.listToolNames()` is backed by the live registry
+(`packages/core/src/runtime/runtimeAdapters.ts`), so a freshly registered tool is
+not filtered out of the declarations built by `buildToolDeclarationsFromView`.
+
+### 3. CLI: registrar becomes a two-way sync
+
+`packages/cli/src/config/configBuilder.ts`:
+
+```ts
+postSkillDiscoveryToolRegistrar: (toolRegistry, skillService, messageBus) => {
+  toolRegistry.unregisterTool(ActivateSkillTool.Name);
+  if (skillService.listSkills().length > 0) {
+    toolRegistry.registerTool(new ActivateSkillTool(skillService, messageBus));
+  }
+},
+```
+
+Core now calls the registrar unconditionally (when skills support is on) and the
+composition root decides whether the tool should exist. When every skill is
+disabled or removed, `activate_skill` is unregistered rather than left behind
+with a stale enum. `CoreSkillServiceAdapter.listSkills()` already filters out
+disabled skills, so the enum and the registration decision use one source.
+
+The closure is extracted to `packages/cli/src/config/activateSkillToolRegistrar.ts`
+as `registerActivateSkillTool` so it can be unit tested directly against a real
+`ToolRegistry`. `PostSkillDiscoveryToolRegistrar` is exported from the core
+barrel so the composition root can type its implementation.
+
+Update the doc comment on `PostSkillDiscoveryToolRegistrar` in
+`packages/core/src/config/configTypes.ts` to say the hook is called after every
+skill discovery (initialization and reload) and is responsible for both
+registering and unregistering.
+
+## Tests (write first)
+
+All behavioral, asserting observable outcomes rather than call counts wherever
+the observable outcome is reachable. Follow dev-docs/RULES.md.
+
+### `packages/core/src/config/config.skillReload.test.ts` (new file)
+
+A dedicated file rather than an extension of `config.d.test.ts`, because that
+file is also at the 800-line `max-lines` limit. It reuses the same mock harness
+so `Config.initialize()` runs without touching disk, git or a real provider.
+
+- After `reloadSkills()`, the injected `postSkillDiscoveryToolRegistrar` has been
+  invoked with the live tool registry and a skill service whose `listSkills()`
+  reflects the post-reload skill set. Assert on the skill service contents, not
+  merely that a function was called.
+- With `skillsSupport: false`, `reloadSkills()` does not invoke the registrar.
+- When an initialized agent client is present, `reloadSkills()` results in the
+  client's tool declarations being refreshed. When no client is ready,
+  `reloadSkills()` completes without throwing.
+- A registrar failure propagates out of `reloadSkills()` rather than being
+  swallowed into a false "reloaded successfully" report.
+- The existing assertions in `config.d.test.ts` about `discoverSkills` /
+  `setDisabledSkills` / `setAdminSettings` continue to pass unchanged.
+
+### `packages/core/src/config/__tests__/import-boundary.test.ts`
+
+No change expected; it must still pass. The new core code introduces no value
+import from the tools barrel and no `ActivateSkillTool` reference.
+
+### CLI registrar behavior
+
+New or extended test covering the registrar closure produced by
+`createConfigFromInput` (or the extracted registrar function, if the
+implementation factors it out for testability):
+
+- With a skill service reporting one or more skills, `activate_skill` is present
+  in the registry and its declaration's `name` enum contains those skill names.
+- Re-invoking the registrar after the skill service starts reporting an extra
+  skill yields a declaration whose enum contains the new name and whose
+  description mentions it.
+- Re-invoking the registrar when the skill service reports zero skills removes
+  `activate_skill` from the registry.
+
+Prefer a real `ToolRegistry` and a hand-written fake `ISkillService` over mocks
+of the registry.
+
+### `packages/tools/src/tools/activate-skill.test.ts`
+
+Add coverage pinning the contract the fix depends on: a tool constructed from a
+skill service listing skills A and B exposes both in the `name` enum and both in
+the description hint; constructed from an empty service, the schema does not
+enumerate names. This guards the assumption that rebuilding the instance is what
+refreshes the model-facing surface.
+
+### `packages/agents/src/api/__tests__/skillsControl.behavior.test.ts`
+
+`SkillsControl.reload()` drives the same refresh as the slash command: after
+reload the bound config's tool registry exposes an `activate_skill` declaration
+matching the post-reload skill set.
+
+### `packages/cli/src/ui/commands/skillsCommand.test.ts`
+
+Existing tests must keep passing. No behavioral change to the command itself; it
+already delegates to `config.reloadSkills()`.
+
+## Out of scope
+
+`ActivateSkillTool` caching its skill list in the constructor is the deeper
+design smell. Making the declaration lazy would remove this class of staleness
+entirely, but it is a change to `BaseDeclarativeTool`'s contract and is tracked
+separately. Steps 1 through 3 fix the reported bug without it.
+
+## Verification
+
+```bash
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```
+
+Manual check: start the CLI, add a skill directory under `.llxprt/skills/`, run
+`/skills reload`, and confirm the model can call `activate_skill` with the new
+name. Then `/skills disable` it, reload, and confirm the name is gone.


### PR DESCRIPTION
## TLDR

`/skills reload` said it worked, `/skills list` showed the new skill, and the model still could not use it. Only a restart picked up a skill added on disk.

The skill list reaches the model through exactly one channel: the `activate_skill` tool declaration, whose `(Available: ...)` description hint and `name` enum are both built in `ActivateSkillTool`'s constructor. That instance was constructed in one place (the registrar hook the CLI supplies) and that hook ran in one place (`Config.performInitialization`). `reloadSkills()` only re-ran discovery on `SkillManager`, so the registry kept a stale tool and the chat session kept the declarations it was last handed.

The registrar call now lives in `core/src/config/skill-tool-sync.ts` and runs on both paths, and `reloadSkills()` follows it with `client.setTools()` to push the refreshed declarations into the live session. That mirrors `refreshMcpContext()`, which already did both for its own activation tool.

Reviewers should look hardest at two things: the ordering inside the CLI registrar (construct, then unregister, then register), and whether unregistering `activate_skill` when the skill set empties is the right call versus leaving a tool with an empty enum.

## Dive Deeper

### Why the model never saw the reload

There is no `<available_skills>` block in llxprt's assembled system prompt. The one in `packages/core/src/core/__snapshots__/prompts.test.js.snap` is inherited upstream snapshot text that our prompt assembly does not produce. So the tool declaration is the whole contract, and a stale declaration means a stale model.

Three symptoms fell out of that:

1. A skill discovered by reload was absent from the enum, so a model call naming it failed parameter validation before `execute()` ran.
2. `/skills enable` and `/skills disable` both tell the user to run `/skills reload` "for it to take effect", which was not true of the model-facing surface.
3. Initialization registered the tool only when `getSkillManager().getSkills().length > 0`. A session that started with zero enabled skills never got `activate_skill` at all and could not recover by reloading.

`AgentSkillsControl.reload()` routes through `Config.reloadSkills()`, so the ACP and API paths had the same gap and are fixed by the same change.

The existing coverage at `config.d.test.ts` asserted only that `discoverSkills` and `setDisabledSkills` were called, which is why this passed CI.

### Changes

**`packages/core/src/config/skill-tool-sync.ts`** (new). Holds `syncSkillActivationTool(config)`, extracted from `performInitialization`. Returns early when skills support is off or when the composition root supplied no registrar or bus, then invokes the registrar with the live registry and a fresh `CoreSkillServiceAdapter`.

A separate module rather than a private method for two reasons. `config.ts` sits at the 800-line `max-lines` limit, and a method named `syncActivateSkillTool` would contain the substring `ActivateSkillTool`, which the #2417 boundary guard rejects anywhere in `config.ts`. It also matches the shape of the existing `mcp-lazy-tool-sync.ts`.

**`packages/core/src/config/config.ts`.** `performInitialization` and `reloadSkills` both call it. `reloadSkills` then calls `client.setTools()` when an initialized client exists. `updateSystemInstruction()` is deliberately not called, because the prompt carries no skill list.

**`packages/cli/src/config/activateSkillToolRegistrar.ts`** (new). The registrar closure moves out of `configBuilder.ts` so it can be tested directly against a real `ToolRegistry`, and becomes a two-way sync: it registers when the skill service reports at least one skill and unregisters otherwise. The zero-skill decision belongs here because core may not reference `ActivateSkillTool`.

It builds the replacement *before* touching the registry. Construction is the only step that can throw, and `reloadSkills()` lets that propagate, so the failure path never reaches `setTools()`. Unregistering first would leave the registry without a tool the live session was still advertising, and the next model call would name a tool that no longer existed.

**`packages/core/src/index.ts`.** Exports the `PostSkillDiscoveryToolRegistrar` type so the composition root can type its implementation.

### Fail-fast

No try/catch was added. A registrar or `setTools()` failure propagates and surfaces through the existing `Failed to reload skills: ...` path in `skillsCommand.ts`, rather than reporting a successful reload that silently did nothing. There is a test for that.

### Boundary

`config.ts` gains no value import from the tools barrel and no `ActivateSkillTool` reference. `packages/core/src/config/__tests__/import-boundary.test.ts` and `packages/providers/src/auth/__tests__/auth-import-isolation.test.ts` both still pass.

### Tests

Behavioral, asserting on what the registry and the model-facing declaration actually contain rather than on call counts.

`packages/agents/src/api/__tests__/skillReloadDeclaration.behavior.test.ts` is the one that matters most. It runs the whole production chain against real skill files on disk, the real `SkillManager`, the real `ActivateSkillTool`, a real `ToolRegistry`, the real `AgentClient.setTools()` and a real `ChatSession`, then asserts on the tool declarations `ChatSession` will send with the next provider request. Five cases: a skill present before the reload, one added on disk mid-session, one removed from disk, the first skill in a session that started with none, and withdrawal of the tool when the last skill goes away. All five fail on the pre-fix code.

`packages/cli/src/config/activateSkillToolRegistrar.test.ts` drives the registrar against a real registry: add, drop, unregister-at-zero, recovery from a zero-skill start, and survival of the previous registration when building the replacement throws.

`packages/core/src/config/config.skillReload.test.ts` covers the reload path itself, including that a skill disabled through the `onReload` hook never reaches the registrar (pinning the ordering of `setDisabledSkills` before the rebuild) and that a rebuild failure propagates. Four of its assertions fail on the pre-fix code. It lives in its own file because `config.d.test.ts` is also at the `max-lines` limit.

`packages/tools/src/tools/activate-skill.test.ts` pins the constructor-snapshot contract the whole fix depends on.

### Two adjacent defects found and filed, not fixed here

- **#3382**: standalone `createAgent` never supplies a registrar, so the public Agent API gets no `activate_skill` at all. The end-to-end test installs the registrar itself and its header comment says so, pointing at #3382, so it does not paper over the gap.
- **#3383**: `extensionLoader` starts and stops extensions without rediscovering the skills they ship.

### Known follow-up, out of scope

`ActivateSkillTool` caching its skill list in the constructor is the underlying design smell. A lazily built declaration would remove this class of staleness entirely, but that changes `BaseDeclarativeTool`'s contract.

## Reviewer Test Plan

Reproduce the bug on `main` first, then confirm the fix on this branch.

1. Start the CLI in a workspace that already has at least one skill under `.llxprt/skills/`.
2. Add a new skill directory, for example `.llxprt/skills/my-new-skill/SKILL.md` with `name` and `description` frontmatter.
3. Run `/skills reload`. It reports `1 newly available skill` on both branches.
4. Ask the model to use the new skill by name.
   - On `main`: the `activate_skill` description still lists only the pre-reload names and a call with the new name is rejected.
   - On this branch: the model sees the new name and can activate it.
5. Run `/skills disable <name>` then `/skills reload`, and confirm the name is gone from what the model is offered. Then `/skills enable <name>`, reload, and confirm it comes back.
6. Start a session in a workspace with no skills at all, add one, and run `/skills reload`. On `main` the tool never appears; on this branch it does.
7. Remove every skill and reload. `activate_skill` should disappear rather than linger with a stale enum.

Automated equivalents:

```bash
cd packages/agents && bun test src/api/__tests__/skillReloadDeclaration.behavior.test.ts
cd packages/cli    && bun test src/config/activateSkillToolRegistrar.test.ts
cd packages/core   && bun test src/config/config.skillReload.test.ts src/config/__tests__/import-boundary.test.ts
```

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: full test suite, typecheck and build all exit 0 with zero failures. Lint passes on every changed file; the repo-wide lint run exhausts its 12 GB V8 heap on this machine regardless of the change, so CI is the authority there. Startup smoke test passes.

## Linked issues / bugs

Fixes #3379

Filed while working on this, not fixed here: #3382, #3383


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Skill activation tools now stay synchronized when skills are added, removed, or reloaded.
  - Chat sessions receive updated tool declarations after skill changes.
  - Sessions starting without skills can gain the activation tool when skills become available.
  - The activation tool is removed when no skills remain.

- **Bug Fixes**
  - Prevented outdated skill names from remaining available after reloads.
  - Preserved the existing tool registration if a replacement cannot be created.

- **Tests**
  - Added comprehensive coverage for initialization, reloads, additions, removals, and empty skill sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->