### PR TITLE
fix(sandbox): forward the capability descriptor through the bin shim (Fixes #3389)

### DIFF
--- a/packages/cli/bin/llxprt.mjs
+++ b/packages/cli/bin/llxprt.mjs
@@ -495,10 +495,12 @@ function run() {
   try {
     child = spawn(bunExe, [entry, ...process.argv.slice(2)], { stdio });
   } catch (error) {
-    // A marked but unopened fd 3 makes spawn throw EBADF synchronously. Name
-    // the capability transport rather than blaming the Bun binary.
-    if (forwardsCapability) {
-      failCapabilityForward(error?.message ?? String(error));
+    // A marked but unopened fd 3 makes spawn throw EBADF synchronously, and
+    // that is the only failure the capability transport is responsible for.
+    // Every other spawn failure keeps its original error so it is not
+    // misattributed to fd 3.
+    if (forwardsCapability && error?.code === 'EBADF') {
+      failCapabilityForward(error.message ?? String(error));
       return;
     }
     throw error;

--- a/packages/cli/bin/llxprt.mjs
+++ b/packages/cli/bin/llxprt.mjs
@@ -22,11 +22,19 @@
  * `@oven/bun-<variant>` optionalDependencies declared in packages/cli, resolves
  * the entry point, and execs Bun with stdio inherited. It deliberately does not
  * depend on the os-gated launcher packages, which may be retired independently.
+ *
+ * Unlike the `#!/bin/sh` launcher it replaced, this shim SPAWNS Bun instead of
+ * exec'ing it, so file descriptors are not inherited automatically. The sandbox
+ * credential transport hands the capability token to the CLI on fd 3 and names
+ * it with LLXPRT_CAPABILITY_FD, so that descriptor must be forwarded explicitly
+ * (issue #3389): a bare `stdio: 'inherit'` passes only fds 0-2, leaving the CLI
+ * with the marker set and fd 3 either closed or reused by the runtime for an
+ * unrelated file.
  */
 
 import { spawn, spawnSync } from 'node:child_process';
 import { createRequire } from 'node:module';
-import { existsSync, readFileSync, statSync } from 'node:fs';
+import { closeSync, existsSync, readFileSync, statSync } from 'node:fs';
 import { dirname, join, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -34,6 +42,19 @@ import { fileURLToPath } from 'node:url';
 // asserted by the launcher suites. Used for both missing-runtime and
 // missing-entry failure modes.
 const LAUNCHER_FAILURE_EXIT = 43;
+
+// Marker naming the inherited capability descriptor. The sandbox entrypoint
+// opens the credential-proxy capability token on fd 3 and exports this before
+// exec'ing the CLI; the descriptor is the ONLY channel that carries the token
+// (it is never in the child environment). See sandbox-entrypoint.ts and
+// credential-store-factory.ts.
+const CAPABILITY_FD_ENV = 'LLXPRT_CAPABILITY_FD';
+
+// The only descriptor number the transport ever uses, and the only one
+// consumeFd3Capability() accepts. Anything else is a corrupted or forged
+// marker and must fail fast rather than cause an unrelated descriptor to be
+// read and closed.
+const CAPABILITY_FD_NUMBER = 3;
 
 // import.meta.url is the real path of this module (the published bin), so the
 // package root is exactly one directory above the bin/ directory. Node's module
@@ -392,6 +413,63 @@ function failLaunch(message) {
   process.exit(LAUNCHER_FAILURE_EXIT);
 }
 
+function failCapabilityMarker(marker) {
+  console.error(
+    `LLxprt Code: invalid ${CAPABILITY_FD_ENV} marker "${marker}".`,
+  );
+  console.error(
+    `The sandbox capability transport only uses descriptor ${CAPABILITY_FD_NUMBER}.`,
+  );
+  console.error(
+    'Unset the variable if you set it manually; otherwise the sandbox',
+  );
+  console.error('entrypoint is corrupt and the container should be rebuilt.');
+  process.exit(LAUNCHER_FAILURE_EXIT);
+}
+
+function failCapabilityForward(message) {
+  console.error(
+    'LLxprt Code: the sandbox capability descriptor could not be forwarded.',
+  );
+  console.error(`Descriptor ${CAPABILITY_FD_NUMBER} is unusable: ${message}`);
+  process.exit(LAUNCHER_FAILURE_EXIT);
+}
+
+/**
+ * Builds the child stdio layout. Without a capability marker this is a plain
+ * inherit of fds 0-2. With one, fd 3 is added so the descriptor carrying the
+ * credential-proxy capability token survives the hop into Bun; the marker in
+ * the child environment then names a descriptor that is genuinely there.
+ */
+function buildStdio() {
+  const marker = process.env[CAPABILITY_FD_ENV];
+  if (marker === undefined || marker === '') {
+    return { stdio: 'inherit', forwardsCapability: false };
+  }
+  if (marker !== String(CAPABILITY_FD_NUMBER)) {
+    failCapabilityMarker(marker);
+  }
+  return {
+    stdio: ['inherit', 'inherit', 'inherit', CAPABILITY_FD_NUMBER],
+    forwardsCapability: true,
+  };
+}
+
+/**
+ * Drops this supervisor's copy of the capability descriptor once the child has
+ * inherited it, so the token is readable in exactly one live process. EBADF
+ * means it is already gone, which is the desired end state.
+ */
+function closeCapabilityFd() {
+  try {
+    closeSync(CAPABILITY_FD_NUMBER);
+  } catch (error) {
+    if (error?.code !== 'EBADF') {
+      throw error;
+    }
+  }
+}
+
 // Signals forwarded from this Node process to the Bun child. Because the child
 // shares the foreground process group (spawn is not detached), a terminal
 // Ctrl+C already reaches Bun directly; the explicit forwarding covers signals
@@ -411,9 +489,27 @@ function run() {
     return;
   }
 
-  const child = spawn(bunExe, [entry, ...process.argv.slice(2)], {
-    stdio: 'inherit',
-  });
+  const { stdio, forwardsCapability } = buildStdio();
+
+  let child;
+  try {
+    child = spawn(bunExe, [entry, ...process.argv.slice(2)], { stdio });
+  } catch (error) {
+    // A marked but unopened fd 3 makes spawn throw EBADF synchronously. Name
+    // the capability transport rather than blaming the Bun binary.
+    if (forwardsCapability) {
+      failCapabilityForward(error?.message ?? String(error));
+      return;
+    }
+    throw error;
+  }
+
+  if (forwardsCapability) {
+    closeCapabilityFd();
+    // The child already holds its own copy of the environment; deleting the
+    // marker here only narrows what this supervisor can observe.
+    delete process.env[CAPABILITY_FD_ENV];
+  }
 
   const forward = (signal) => {
     try {

--- a/scripts/tests/issue-2978-node-shim.bun.test.ts
+++ b/scripts/tests/issue-2978-node-shim.bun.test.ts
@@ -30,6 +30,7 @@ import {
   copyFileSync,
   rmSync,
   readFileSync,
+  statSync,
 } from 'node:fs';
 import * as path from 'node:path';
 import { tmpdir } from 'node:os';
@@ -323,12 +324,19 @@ describe('packages/cli/bin/llxprt.mjs node-shebang shim (issue #2978)', () => {
 const CAPABILITY_TOKEN = 'a'.repeat(64);
 
 /**
- * Entry body that reports the capability marker it was given and the bytes it
- * can read from descriptor 3, mirroring what credential-store-factory does.
+ * Entry body that reports the capability marker it was given, the identity of
+ * whatever descriptor 3 is in this process, and the bytes it can read from it.
+ *
+ * The inode is what makes the leak assertion decisive. A closed descriptor 3 is
+ * not observably closed from the child: the runtime reuses the number for its
+ * own file opens, so probing content alone cannot distinguish "the host's
+ * capability file was withheld" from "the host's file was passed but happened
+ * to read oddly". Comparing inodes answers the identity question directly.
  */
 const capabilityEntryBody = [
   'import fs from "node:fs";',
-  'const out = { marker: process.env.LLXPRT_CAPABILITY_FD ?? null, raw: "", err: "" };',
+  'const out = { marker: process.env.LLXPRT_CAPABILITY_FD ?? null, ino: null, raw: "", err: "" };',
+  'try { out.ino = String(fs.fstatSync(3).ino); } catch { out.ino = null; }',
   'try {',
   '  const buf = Buffer.alloc(128);',
   '  const read = fs.readSync(3, buf, 0, 128, null);',
@@ -341,6 +349,7 @@ const capabilityEntryBody = [
 
 interface CapabilityEntryOutput {
   readonly marker: string | null;
+  readonly ino: string | null;
   readonly raw: string;
   readonly err: string;
 }
@@ -366,7 +375,7 @@ function parseCapabilityOutput(stdout: string): CapabilityEntryOutput | null {
 function runShimWithOpenFd3(
   layout: Layout,
   extraEnv: Record<string, string> = {},
-): RunResult {
+): RunResult & { readonly tokenIno: string } {
   const tokenFile = path.join(layout.root, 'capability-token');
   writeFileSync(tokenFile, `${CAPABILITY_TOKEN}\n`);
   const script = `exec 3<${JSON.stringify(tokenFile)}\nexec node ${JSON.stringify(layout.shim)}`;
@@ -380,6 +389,7 @@ function runShimWithOpenFd3(
     status: result.status,
     stdout: result.stdout ?? '',
     stderr: result.stderr ?? '',
+    tokenIno: String(statSync(tokenFile).ino),
   };
 }
 
@@ -408,6 +418,8 @@ describe('packages/cli/bin/llxprt.mjs capability descriptor transport (issue #33
       expect(out, `stdout: ${res.stdout}`).not.toBeNull();
       expect(out?.marker).toBe('3');
       expect(out?.err).toBe('');
+      // The child holds the very descriptor the host opened, not a lookalike.
+      expect(out?.ino).toBe(res.tokenIno);
       expect(out?.raw).toBe(`${CAPABILITY_TOKEN}\n`);
     },
   );
@@ -425,8 +437,10 @@ describe('packages/cli/bin/llxprt.mjs capability descriptor transport (issue #33
       const out = parseCapabilityOutput(res.stdout);
       expect(out, `stdout: ${res.stdout}`).not.toBeNull();
       expect(out?.marker).toBeNull();
-      // Whatever descriptor 3 happens to be in the child, it must not be the
-      // host's capability file.
+      // The runtime reuses descriptor 3 for its own opens, so the child cannot
+      // observe it as closed. Identity settles it: whatever fd 3 is here, it is
+      // not the host's capability file, and its bytes are not the token.
+      expect(out?.ino).not.toBe(res.tokenIno);
       expect(out?.raw).not.toContain(CAPABILITY_TOKEN);
     },
   );

--- a/scripts/tests/issue-2978-node-shim.bun.test.ts
+++ b/scripts/tests/issue-2978-node-shim.bun.test.ts
@@ -308,3 +308,141 @@ describe('packages/cli/bin/llxprt.mjs node-shebang shim (issue #2978)', () => {
     expect(out?.argv).toEqual(['--oven']);
   });
 });
+
+/**
+ * Issue #3389: the shim SPAWNS Bun rather than exec'ing it, so descriptors are
+ * not inherited automatically the way they were under the `#!/bin/sh` launcher
+ * it replaced. The sandbox credential transport hands the capability token to
+ * the CLI on fd 3 (named by LLXPRT_CAPABILITY_FD) and never puts it in the
+ * environment, so dropping that descriptor made every container sandbox abort
+ * at startup.
+ *
+ * These tests open a REAL descriptor 3 through `bash` and run the REAL shim, so
+ * they observe what the CLI process actually receives.
+ */
+const CAPABILITY_TOKEN = 'a'.repeat(64);
+
+/**
+ * Entry body that reports the capability marker it was given and the bytes it
+ * can read from descriptor 3, mirroring what credential-store-factory does.
+ */
+const capabilityEntryBody = [
+  'import fs from "node:fs";',
+  'const out = { marker: process.env.LLXPRT_CAPABILITY_FD ?? null, raw: "", err: "" };',
+  'try {',
+  '  const buf = Buffer.alloc(128);',
+  '  const read = fs.readSync(3, buf, 0, 128, null);',
+  '  out.raw = buf.subarray(0, read).toString("utf8");',
+  '} catch (error) {',
+  '  out.err = error.code ?? String(error);',
+  '}',
+  'console.log(JSON.stringify(out));',
+].join('\n');
+
+interface CapabilityEntryOutput {
+  readonly marker: string | null;
+  readonly raw: string;
+  readonly err: string;
+}
+
+function parseCapabilityOutput(stdout: string): CapabilityEntryOutput | null {
+  const line = stdout
+    .split(/\r?\n/)
+    .find((candidate) => candidate.trim().startsWith('{'));
+  if (line === undefined) {
+    return null;
+  }
+  try {
+    return JSON.parse(line) as CapabilityEntryOutput;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Runs the shim with descriptor 3 already open on a file holding the token,
+ * exactly as the sandbox entrypoint arranges it before exec'ing the CLI.
+ */
+function runShimWithOpenFd3(
+  layout: Layout,
+  extraEnv: Record<string, string> = {},
+): RunResult {
+  const tokenFile = path.join(layout.root, 'capability-token');
+  writeFileSync(tokenFile, `${CAPABILITY_TOKEN}\n`);
+  const script = `exec 3<${JSON.stringify(tokenFile)}\nexec node ${JSON.stringify(layout.shim)}`;
+  const result = spawnSync('bash', ['--noprofile', '--norc', '-c', script], {
+    cwd: layout.root,
+    encoding: 'utf8',
+    timeout: LAUNCH_TIMEOUT_MS,
+    env: { ...process.env, ...extraEnv },
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+describe('packages/cli/bin/llxprt.mjs capability descriptor transport (issue #3389)', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'llxprt-shim-cap-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it.skipIf(isWin)(
+    'forwards descriptor 3 to the Bun child when LLXPRT_CAPABILITY_FD names it',
+    () => {
+      const layout = makeLayout(tempDir);
+      placeBundledBun(layout.nodeModules);
+      writeSourceEntry(layout.pkgRoot, capabilityEntryBody);
+
+      const res = runShimWithOpenFd3(layout, { LLXPRT_CAPABILITY_FD: '3' });
+
+      expect(res.status, `stderr: ${res.stderr}`).toBe(0);
+      const out = parseCapabilityOutput(res.stdout);
+      expect(out, `stdout: ${res.stdout}`).not.toBeNull();
+      expect(out?.marker).toBe('3');
+      expect(out?.err).toBe('');
+      expect(out?.raw).toBe(`${CAPABILITY_TOKEN}\n`);
+    },
+  );
+
+  it.skipIf(isWin)(
+    'does not leak an open descriptor 3 to the child when no marker is set',
+    () => {
+      const layout = makeLayout(tempDir);
+      placeBundledBun(layout.nodeModules);
+      writeSourceEntry(layout.pkgRoot, capabilityEntryBody);
+
+      const res = runShimWithOpenFd3(layout);
+
+      expect(res.status, `stderr: ${res.stderr}`).toBe(0);
+      const out = parseCapabilityOutput(res.stdout);
+      expect(out, `stdout: ${res.stdout}`).not.toBeNull();
+      expect(out?.marker).toBeNull();
+      // Whatever descriptor 3 happens to be in the child, it must not be the
+      // host's capability file.
+      expect(out?.raw).not.toContain(CAPABILITY_TOKEN);
+    },
+  );
+
+  it.skipIf(isWin)(
+    'exits 43 without running the CLI when the marker names any descriptor but 3',
+    () => {
+      const layout = makeLayout(tempDir);
+      placeBundledBun(layout.nodeModules);
+      writeSourceEntry(layout.pkgRoot, 'console.log("CLI_RAN");');
+
+      const res = runShimWithOpenFd3(layout, { LLXPRT_CAPABILITY_FD: '4' });
+
+      expect(res.status).toBe(LAUNCHER_FAILURE_EXIT);
+      expect(res.stderr).toContain('LLXPRT_CAPABILITY_FD');
+      expect(res.stdout).not.toContain('CLI_RAN');
+    },
+  );
+});


### PR DESCRIPTION
## TLDR

Container sandboxes have not started since 2026-08-08. `packages/cli/bin/llxprt.mjs` spawns Bun with `stdio: 'inherit'`, which passes only fds 0-2, so the sandbox capability token on fd 3 never reaches the CLI and the process dies in `main()` before rendering anything. The shim now forwards fd 3 when `LLXPRT_CAPABILITY_FD` names it.

One production file changed (`packages/cli/bin/llxprt.mjs`) plus three regression tests.

## Dive Deeper

The sandbox credential transport hands the credential-proxy capability token to the CLI on **file descriptor 3** and names it with `LLXPRT_CAPABILITY_FD=3`. The token is never in the environment; the descriptor is the only channel. `sandbox-entrypoint.ts` ends with:

```sh
exec 3<<<"${__llxprt_cap}"
LLXPRT_CAPABILITY_FD=3 exec llxprt "$@"
```

`llxprt` resolved to the `#!/bin/sh` launcher until #3086 (commit 0c81141) moved `bin.llxprt` to the Node shim so npm's cmd-shim would emit a working Windows `.cmd`. The sh launcher ended in `exec "$_llxprt_bun" "$_llxprt_entry" "$@"`, and `exec` preserves every descriptor. The Node shim ends in `spawn(bunExe, ..., { stdio: 'inherit' })`, which passes only fds 0-2.

So the Bun child starts with the marker set and fd 3 closed. Bun then reuses descriptor 3 for one of its own file opens, and `consumeFd3Capability()` reads unrelated bytes:

```
Error: Capability descriptor does not contain a valid 64-character lowercase hex token with the transport delimiter
    at consumeFd3Capability (.../bundle/llxprt.js)
    at createTokenStore (.../bundle/llxprt.js)
    at prepareSandboxCredentialStartup (.../bundle/llxprt.js)
    at main (.../bundle/llxprt.js)
```

Measured inside the published release image:

```
== direct node with fd3 inherited ==
FD3PROBE {"bytes":65,"content":"\"aaaa…aaaa\\n\""}
== via node shim spawning bun with stdio:inherit ==
FD3PROBE {"bytes":128,"content":"\"?\\t?\\u0013?5???5?u\\u001d?Р\\u000f??.O…\""}
```

The change mirrors what `packages/cli/src/launcher/bun-launcher.ts` already does for its own relaunch:

- with a marker present, spawn with `stdio: ['inherit', 'inherit', 'inherit', 3]`;
- accept only the literal marker `3` — the only value the transport uses and the only one `consumeFd3Capability()` accepts — and exit 43 with a diagnostic otherwise, rather than reading and closing some unintended descriptor;
- close the supervisor's own copy of fd 3 once the child holds it, keeping the #1954 invariant that the token is readable in exactly one live process;
- leave the no-marker path on plain `stdio: 'inherit'`, so an unrelated open fd 3 is never handed to the CLI.

Why CI missed it: the release workflow's sandbox smoke gate runs `docker run --rm "$IMAGE" llxprt --version`, which returns before any credential wiring, and `test:integration:sandbox:docker` is commented out as flaky. Worth a follow-up so this class of regression cannot ship again.

## Reviewer Test Plan

The three new tests in `scripts/tests/issue-2978-node-shim.bun.test.ts` drive the real shim with a real Bun and a real descriptor 3 opened through `bash`. Two of them fail on `main` and pass here:

```
bun test scripts/tests/issue-2978-node-shim.bun.test.ts
```

For an end-to-end check, build a nightly and its sandbox image from this branch and run the CLI inside it:

```sh
RV=$(IS_NIGHTLY=true bun scripts/get-release-version.ts | tail -1 | jq -r .releaseVersion)
npm run release:version "$RV" && bun scripts/bind-release-deps.ts
rm -rf packages/*/dist && npm run build:packages && npm run prepare:package
for p in tools storage auth settings telemetry policy mcp ide-integration core providers agents; do
  npm pack -w @vybestack/llxprt-code-$p --pack-destination ./packages/$p/dist
done
npm pack -w @vybestack/llxprt-code --pack-destination ./packages/cli/dist
podman build -t ghcr.io/vybestack/llxprt-code/sandbox:$RV --build-arg CLI_VERSION_ARG=$RV .
# install the packed tarballs somewhere, then, from a scratch workspace:
LLXPRT_SANDBOX=podman llxprt --profile-load <profile> -p "Reply with exactly: SANDBOX_OK"
```

That was run here on macOS arm64 with podman 5.7.1. Results, same host CLI in both rows, only the in-image shim differing:

| image | outcome |
| --- | --- |
| `sandbox:0.11.0-nightly.260827.354957220` (published, unpatched shim) | `Error: Capability descriptor does not contain a valid 64-character lowercase hex token…`, exit 1 |
| `sandbox:0.11.0-nightly.260827.b834d59294` (this branch) | `SANDBOX_OK`, exit 0 |

The patched image also completed a `read_file` tool call against the mounted workspace and rendered the interactive UI under a pty, so the credential proxy, tool execution and the Ink startup path all work.

Note that the fix lives inside the container image, so verifying it needs an image built from this branch; a host-only install still fails against a published image.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ✅  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Podman on macOS arm64 verified end to end as above. Seatbelt is unaffected: `sandbox-seatbelt.ts` deletes `LLXPRT_CAPABILITY_FD` from the child environment and never uses the descriptor transport. Windows has no container sandbox path, and its `.cmd`/`.ps1` launchers are untouched.

## Linked issues / bugs

Fixes #3389


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox capability handling when launching the command-line application.
  * Prevented unintended file descriptor leakage when no capability is configured.
  * Added clear failure handling for invalid or unsupported capability descriptors.

* **Tests**
  * Added coverage for capability forwarding, descriptor cleanup, and invalid configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->