### PR TITLE
Register the skill activation tool in every composition root, and on extension changes (Fixes #3382, Fixes #3383)

### DIFF
--- a/packages/agents/src/api/__tests__/expected-root-surface.json
+++ b/packages/agents/src/api/__tests__/expected-root-surface.json
@@ -186,6 +186,7 @@
   "mapLoopStream",
   "mapStreamEvent",
   "preflightAgentActivation",
+  "registerActivateSkillTool",
   "splitPartsByRole",
   "toConfigParameters"
 ]

--- a/packages/agents/src/api/__tests__/fromConfigSkills.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/fromConfigSkills.behavior.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3382, second composition root.
+ *
+ * `Config` cannot construct the skill activation tool itself (issue #2417), so
+ * it takes a registrar hook and silently registers nothing when none is
+ * supplied. `fromConfig` adopts a Config the caller built, and a caller has no
+ * reason to know that hook exists, so an adopted Config with skills enabled
+ * would produce an agent whose model was never told any skill exists.
+ *
+ * `buildCliStyleConfig` deliberately builds and initializes a Config the way an
+ * embedder would, without a registrar, which is exactly the case under test.
+ * Nothing here installs one.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fromConfig } from '@vybestack/llxprt-code-agents';
+import { ACTIVATE_SKILL_TOOL_NAME } from '@vybestack/llxprt-code-tools';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { buildCliStyleConfig } from './helpers/buildCliStyleConfig.js';
+import { internalConfig } from './helpers/agentHarness.js';
+
+interface ProviderToolDeclaration {
+  readonly name: string;
+  readonly parametersJsonSchema?: unknown;
+}
+
+/**
+ * The skill names the model may pass to `activate_skill`, read from the
+ * declarations ChatSession will send with the next provider request. Throws
+ * rather than returning empty if the shape moves, so a refactor of
+ * `ChatSession.setTools` cannot turn this green by accident.
+ */
+function modelVisibleSkillNames(config: Config): string[] {
+  const chat = config.getAgentClient().getChat() as unknown as {
+    generationConfig?: {
+      tools?: Array<{ functionDeclarations?: ProviderToolDeclaration[] }>;
+    };
+  };
+  const toolGroups = chat.generationConfig?.tools;
+  if (!Array.isArray(toolGroups) || toolGroups.length === 0) {
+    throw new Error(
+      'ChatSession carries no tool groups; ChatSession.setTools may have changed shape',
+    );
+  }
+  const declarations = toolGroups[0]?.functionDeclarations;
+  if (!Array.isArray(declarations)) {
+    throw new Error(
+      'ChatSession tool group has no functionDeclarations; ChatSession.setTools may have changed shape',
+    );
+  }
+  const declaration = declarations.find(
+    (candidate) => candidate.name === ACTIVATE_SKILL_TOOL_NAME,
+  );
+  if (!declaration) {
+    return [];
+  }
+  const schema = declaration.parametersJsonSchema as {
+    properties?: { name?: { enum?: string[] } };
+  };
+  return schema.properties?.name?.enum ?? [];
+}
+
+function writeSkill(workspace: string, name: string): void {
+  const skillDir = join(workspace, '.llxprt', 'skills', name);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: The ${name} skill\n---\n\n${name} instructions\n`,
+    'utf-8',
+  );
+}
+
+describe('fromConfig gives the model the skills the config discovered @issue:3382', () => {
+  it('offers a skill from an adopted config that supplied no registrar', async () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'llxprt-fromconfig-skills-'));
+    writeSkill(workspace, 'alpha');
+    const built = await buildCliStyleConfig('plain-text.jsonl', {
+      skillsSupport: true,
+      workingDir: workspace,
+    });
+    let agent;
+    try {
+      agent = await fromConfig({ config: built.config });
+      for await (const _event of agent.stream('hello')) {
+        // Drain the turn so the chat session and its tool list exist.
+      }
+
+      expect(agent.skills.list().map((skill) => skill.name)).toContain('alpha');
+      expect(modelVisibleSkillNames(internalConfig(agent))).toContain('alpha');
+    } finally {
+      await agent?.dispose().catch(() => {
+        /* disposed via cleanup regardless of impl state */
+      });
+      await built.cleanup();
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/agents/src/api/__tests__/fromConfigSkills.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/fromConfigSkills.behavior.test.ts
@@ -22,7 +22,7 @@ import { describe, it, expect } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { fromConfig } from '@vybestack/llxprt-code-agents';
+import { fromConfig, type Agent } from '@vybestack/llxprt-code-agents';
 import { ACTIVATE_SKILL_TOOL_NAME } from '@vybestack/llxprt-code-tools';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import { buildCliStyleConfig } from './helpers/buildCliStyleConfig.js';
@@ -87,7 +87,7 @@ describe('fromConfig gives the model the skills the config discovered @issue:338
       skillsSupport: true,
       workingDir: workspace,
     });
-    let agent;
+    let agent: Agent | undefined;
     try {
       agent = await fromConfig({ config: built.config });
       for await (const _event of agent.stream('hello')) {

--- a/packages/agents/src/api/__tests__/helpers/buildCliStyleConfig.ts
+++ b/packages/agents/src/api/__tests__/helpers/buildCliStyleConfig.ts
@@ -167,6 +167,7 @@ function createDefaultToolSchedulerFactory(): ToolSchedulerFactory {
  */
 export async function buildCliStyleConfig(
   fixtureRelPath: string,
+  overrides: Readonly<Partial<AgentConfig>> = {},
 ): Promise<BuiltCliConfig> {
   const prev = process.env.LLXPRT_FAKE_RESPONSES;
   const fixturePath = resolve(FIXTURES_DIR, fixtureRelPath);
@@ -176,6 +177,7 @@ export async function buildCliStyleConfig(
     provider: 'fake',
     model: 'fake-model',
     workingDir: resolve(HARNESS_DIR, '..'),
+    ...overrides,
   };
   const runtimeId = `cli-config-${randomUUID()}`;
 

--- a/packages/agents/src/api/__tests__/skillReloadDeclaration.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/skillReloadDeclaration.behavior.test.ts
@@ -14,20 +14,20 @@
  * therefore assert on that declaration rather than on which functions were
  * called.
  *
- * The whole production chain runs for real: skill files on disk, the real
- * SkillManager, the real ActivateSkillTool, a real ToolRegistry, the real
- * AgentClient.setTools(), and the real ChatSession. Only the registrar hook is
- * supplied by the test, because wiring it is the composition root's job and the
- * standalone `createAgent` composition does not currently do it (issue #3382).
- * When #3382 is fixed this test should drop `setPostSkillDiscoveryToolRegistrar`
- * and rely on production wiring instead.
+ * The whole production chain runs for real, with nothing supplied by the test:
+ * skill files on disk, the real SkillManager, the registrar `createAgent`
+ * installs, the real ActivateSkillTool, a real ToolRegistry, the real
+ * AgentClient.setTools(), and the real ChatSession.
+ *
+ * This file used to install the registrar itself, because `createAgent` did not
+ * (issue #3382). Now that it does, these cases also cover that wiring: removing
+ * it from `createAgent` fails every test here.
  */
 
 import { describe, it, expect } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { ActivateSkillTool } from '@vybestack/llxprt-code-tools/tools/activate-skill.js';
 import { ACTIVATE_SKILL_TOOL_NAME } from '@vybestack/llxprt-code-tools';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
 import {
@@ -112,27 +112,15 @@ function removeSkill(workspace: string, name: string): void {
 }
 
 /**
- * Installs the composition-root registrar, drives one turn so a live chat
- * session exists to be refreshed, then performs the first reload, which stands
- * in for the startup registration a real CLI session gets.
+ * Drives one turn so a live chat session exists with a tool list, which is the
+ * state a reload has to update. The registrar is already installed by
+ * `createAgent`; nothing here supplies it.
  */
-async function installRegistrarAndSettle(agent: Agent): Promise<Config> {
-  const config = internalConfig(agent);
-  config.setPostSkillDiscoveryToolRegistrar(
-    (toolRegistry, skillService, messageBus) => {
-      toolRegistry.unregisterTool(ActivateSkillTool.Name);
-      if (skillService.listSkills().length > 0) {
-        toolRegistry.registerTool(
-          new ActivateSkillTool(skillService, messageBus),
-        );
-      }
-    },
-  );
+async function settle(agent: Agent): Promise<Config> {
   for await (const _event of agent.stream('hello')) {
     // Drain the turn so the chat session and its tool list exist.
   }
-  await agent.skills.reload();
-  return config;
+  return internalConfig(agent);
 }
 
 async function withWorkspace(
@@ -152,7 +140,7 @@ async function withWorkspace(
     workingDir: workspace,
   });
   try {
-    const config = await installRegistrarAndSettle(agent);
+    const config = await settle(agent);
     await run({ agent, config, workspace });
   } finally {
     await cleanup();
@@ -161,7 +149,14 @@ async function withWorkspace(
 }
 
 describe('skill reload reaches the model @issue:3379', () => {
-  it('offers a skill that existed before the reload', async () => {
+  /**
+   * No reload happens here. This is the startup path: `createAgent` installs
+   * the registrar, `Config.initialize` discovers the skill and rebuilds the
+   * tool, and the first turn hands the declaration to the chat session. Before
+   * issue #3382 the public Agent API supplied no registrar, so this produced no
+   * activate_skill tool at all.
+   */
+  it('offers a skill discovered at startup, with no reload @issue:3382', async () => {
     await withWorkspace(['alpha'], async ({ config }) => {
       expect(modelVisibleSkillNames(config)).toEqual(['alpha']);
     });

--- a/packages/agents/src/api/createAgent.ts
+++ b/packages/agents/src/api/createAgent.ts
@@ -47,6 +47,7 @@ import {
   toConfigParameters,
   applyRuntimeEphemerals,
 } from './agentConfig.adapter.js';
+import { registerActivateSkillTool } from '../skill-tool-registrar.js';
 import { AgenticLoop } from '../core/agenticLoop/AgenticLoop.js';
 import type { DisplayCallbacks } from '../core/agenticLoop/types.js';
 import { CoreToolScheduler } from '../core/coreToolScheduler.js';
@@ -104,6 +105,12 @@ export async function createAgent(rawConfig: AgentConfig): Promise<Agent> {
   // to inject the agentClientFactory and optional toolSchedulerFactory.
   const params = { ...frozenParams };
   params.agentClientFactory = agentClientFactory;
+  // Without this the model never learns which skills exist: Config cannot
+  // construct ActivateSkillTool itself (issue #2417), so a composition root
+  // that omits the hook silently produces an agent with no skill activation
+  // tool at all (issue #3382). Unconditional because syncSkillActivationTool
+  // already gates on skillsSupport.
+  params.postSkillDiscoveryToolRegistrar = registerActivateSkillTool;
   // @plan:PLAN-20260617-COREAPI.P23 @requirement:REQ-006 @requirement:REQ-016
   const forceConfirmations = applyHarnessGates(parsed, params);
   // Registry of scheduler handles created via a caller-injected factory. The

--- a/packages/agents/src/api/fromConfig.ts
+++ b/packages/agents/src/api/fromConfig.ts
@@ -27,6 +27,7 @@ import {
 import { executeProviderActivation } from './providerActivationExecutor.js';
 import { consumeCompletedActivationPreflight } from './activationPreflightState.js';
 import { finalizeAgent, registerProvidersOntoManager } from './createAgent.js';
+import { registerActivateSkillTool } from '../skill-tool-registrar.js';
 
 /**
  * Adopts an existing caller-supplied Config and returns a ready Agent.
@@ -113,8 +114,28 @@ export async function fromConfig(options: FromConfigOptions): Promise<Agent> {
       metadata: { source: 'fromConfig' },
     });
 
+    // The caller built this Config, so it may not have wired the hook that
+    // lets core build the skill activation tool (issue #2417 forbids core
+    // constructing it directly). Without a hook the tool is never registered
+    // and the model is told nothing about skills, which is the same
+    // composition failure #3382 fixed in createAgent. A registrar the caller
+    // supplied deliberately is left alone.
+    const installedRegistrar =
+      config.getPostSkillDiscoveryToolRegistrar() === undefined;
+    if (installedRegistrar) {
+      config.setPostSkillDiscoveryToolRegistrar(registerActivateSkillTool);
+    }
+
     // @pseudocode lines 31-35: initialize once or adopt the original result.
     await config.ensureInitialized({ messageBus });
+
+    // ensureInitialized is a no-op for a Config the caller already
+    // initialized, so a registrar installed above would never run. Reconcile
+    // whenever we installed one. On a fresh Config this repeats one discovery,
+    // which is a better trade than leaving the model with no skill tool.
+    if (installedRegistrar) {
+      await config.refreshSkills();
+    }
 
     // @plan:PLAN-20270104-ISSUE2374.P03 @requirement:REQ-001
     await resolveActivation(config, options);

--- a/packages/agents/src/api/fromConfig.ts
+++ b/packages/agents/src/api/fromConfig.ts
@@ -120,9 +120,9 @@ export async function fromConfig(options: FromConfigOptions): Promise<Agent> {
     // and the model is told nothing about skills, which is the same
     // composition failure #3382 fixed in createAgent. A registrar the caller
     // supplied deliberately is left alone.
-    const installedRegistrar =
-      config.getPostSkillDiscoveryToolRegistrar() === undefined;
-    if (installedRegistrar) {
+    const callerSuppliedRegistrar =
+      config.getPostSkillDiscoveryToolRegistrar() !== undefined;
+    if (!callerSuppliedRegistrar) {
       config.setPostSkillDiscoveryToolRegistrar(registerActivateSkillTool);
     }
 
@@ -133,7 +133,7 @@ export async function fromConfig(options: FromConfigOptions): Promise<Agent> {
     // initialized, so a registrar installed above would never run. Reconcile
     // whenever we installed one. On a fresh Config this repeats one discovery,
     // which is a better trade than leaving the model with no skill tool.
-    if (installedRegistrar) {
+    if (!callerSuppliedRegistrar) {
       await config.refreshSkills();
     }
 

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -17,6 +17,12 @@ export * from './api/index.js';
 // type identity (with newHistory and metadata) that main shipped.
 export type { CompressionResult } from '@vybestack/llxprt-code-core/core/compression/types.js';
 
+// The skill activation tool cannot be constructed from core (issue #2417), so
+// every composition root needs this hook. Exported from the root barrel rather
+// than a subpath because the CLI boundary guard permits the agents package root
+// and no deep paths (scripts/cli-boundary/config.ts).
+export { registerActivateSkillTool } from './skill-tool-registrar.js';
+
 /**
  * @plan PLAN-20260610-ISSUE1592.P03
  * @requirement REQ-INV-003

--- a/packages/agents/src/skill-tool-registrar.test.ts
+++ b/packages/agents/src/skill-tool-registrar.test.ts
@@ -22,7 +22,7 @@ import {
   type SkillManager,
 } from '@vybestack/llxprt-code-tools';
 import type { MessageBus } from '@vybestack/llxprt-code-core';
-import { registerActivateSkillTool } from './activateSkillToolRegistrar.js';
+import { registerActivateSkillTool } from './skill-tool-registrar.js';
 
 /**
  * The registry and the registrar hook describe the same bus through different
@@ -115,7 +115,7 @@ function enumeratedSkillNames(registry: ToolRegistry): string[] {
   return schema.properties?.name?.enum ?? [];
 }
 
-describe('registerActivateSkillTool @issue:3379', () => {
+describe('registerActivateSkillTool @issue:3379 @issue:3382', () => {
   it('registers the activation tool enumerating every available skill', () => {
     const registry = createRegistry();
     const skillService = new FakeSkillService([

--- a/packages/agents/src/skill-tool-registrar.ts
+++ b/packages/agents/src/skill-tool-registrar.ts
@@ -19,8 +19,15 @@ import type { PostSkillDiscoveryToolRegistrar } from '@vybestack/llxprt-code-cor
  * registered with an empty enum, so a session that starts with no skills can
  * still gain the tool on a later reload.
  *
- * Lives in the CLI because `ActivateSkillTool` may not be referenced from core
- * (issue #2417).
+ * Lives outside core because `ActivateSkillTool` may not be referenced from
+ * there (issue #2417), and in `agents` rather than in the CLI so that both
+ * composition roots share one implementation. They had already drifted once:
+ * the CLI wired a registrar and `createAgent` did not, which left the public
+ * Agent API with no skill activation tool at all (issue #3382).
+ *
+ * The import of `ActivateSkillTool` must stay a deep path. The tools barrel
+ * reaches `tools/structural-analysis/`, which loads `@ast-grep/napi`;
+ * `activate-skill.js` on its own does not.
  */
 export const registerActivateSkillTool: PostSkillDiscoveryToolRegistrar = (
   toolRegistry,

--- a/packages/cli/src/config/configBuilder.ts
+++ b/packages/cli/src/config/configBuilder.ts
@@ -14,9 +14,11 @@ import {
   type PolicyEngineConfig,
   type MCPServerConfig,
 } from '@vybestack/llxprt-code-core';
-import { createAgentRuntimeFactoryBindings } from '@vybestack/llxprt-code-agents';
+import {
+  createAgentRuntimeFactoryBindings,
+  registerActivateSkillTool,
+} from '@vybestack/llxprt-code-agents';
 import { registerAgentRuntimeFactories } from '@vybestack/llxprt-code-providers/runtime.js';
-import { registerActivateSkillTool } from './activateSkillToolRegistrar.js';
 import { getEnableHooks, getEnableHooksUI } from './settingsSchema.js';
 import { loadSettings } from './settings.js';
 import { appEvents } from '../utils/events.js';

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -460,17 +460,16 @@ export class Config extends ConfigBase {
     await this.mcpClientManager?.reconcileConfiguredMcpServers();
   }
 
-  async reloadSkills(): Promise<void> {
-    if (this._onReload) {
-      const result = await this._onReload();
-      if (result.disabledSkills) {
-        this.disabledSkills = result.disabledSkills;
-      }
-      if (result.adminSkillsEnabled !== undefined) {
-        this.adminSkillsEnabled = result.adminSkillsEnabled;
-        this.skillManager.setAdminSettings(this.adminSkillsEnabled);
-      }
-    }
+  /**
+   * Rediscovers skills and carries the result through to the model, without
+   * re-reading settings.
+   *
+   * Use this when the set of skill *sources* changes underneath the session,
+   * for example when an extension that contributes skills is loaded or
+   * unloaded (issue #3383). `reloadSkills` is the variant to use when the user
+   * asked for a reload and settings should be re-read too.
+   */
+  async refreshSkills(): Promise<void> {
     await this.skillManager.discoverSkills(this.storage, this.getExtensions());
     this.skillManager.setDisabledSkills(this.disabledSkills);
 
@@ -482,6 +481,20 @@ export class Config extends ConfigBase {
     if (client) {
       await client.setTools();
     }
+  }
+
+  async reloadSkills(): Promise<void> {
+    if (this._onReload) {
+      const result = await this._onReload();
+      if (result.disabledSkills) {
+        this.disabledSkills = result.disabledSkills;
+      }
+      if (result.adminSkillsEnabled !== undefined) {
+        this.adminSkillsEnabled = result.adminSkillsEnabled;
+        this.skillManager.setAdminSettings(this.adminSkillsEnabled);
+      }
+    }
+    await this.refreshSkills();
   }
 
   /**

--- a/packages/core/src/config/extensionSkillRefresh.test.ts
+++ b/packages/core/src/config/extensionSkillRefresh.test.ts
@@ -1,0 +1,259 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3383: extension-contributed skills are one of the sources
+ * SkillManager reads, but ExtensionLoader reconciled MCP servers, subagents and
+ * memory on load/unload without ever rediscovering skills. So an extension that
+ * ships skills left both the discovered set and the model-facing activation
+ * tool stale until someone ran `/skills reload`.
+ *
+ * These tests assert on the discovered skill set and on what the activation
+ * tool was rebuilt from. That the rebuilt tool then reaches the provider
+ * request is covered end to end in the agents package, in
+ * skillReloadDeclaration.behavior.test.ts.
+ *
+ * The mock harness mirrors config.d.test.ts so Config.initialize() can run
+ * without touching the filesystem, git, telemetry or a real provider.
+ */
+
+import { describe, it, expect, vi } from 'bun:test';
+import { Config } from './config.js';
+import type { SkillDefinition } from '../skills/skillLoader.js';
+import type { LlxprtExtension } from './configTypes.js';
+import { SimpleExtensionLoader } from '../utils/extensionLoader.js';
+import { MCPDiscoveryState } from '@vybestack/llxprt-code-mcp';
+import { initializeTestConfig } from '../test-utils/config.js';
+import {
+  buildFsMockBody,
+  buildToolsMockBody,
+  buildContentGeneratorMockBody,
+  buildTelemetryMockBody,
+  buildGitServiceMockBody,
+  buildSettingsMockBody,
+  buildIdeIntegrationMockBody,
+  buildMemoryDiscoveryMockBody,
+  buildEventsMockBody,
+  buildFetchMockBody,
+  type HoistedConfigMocks,
+} from './configTestHarness.js';
+
+// Hoisted mocks referenced by the mock factories below.
+const hoistedConfigMocks = {
+  loadJitSubdirectoryMemory: vi.fn(),
+  coreEvents: {
+    emitFeedback: vi.fn(),
+    emitModelChanged: vi.fn(),
+    emitConsoleLog: vi.fn(),
+  },
+  setGlobalProxy: vi.fn(),
+} as HoistedConfigMocks;
+const __actual = { ...(await import('@vybestack/llxprt-code-mcp')) };
+void vi.mock('@vybestack/llxprt-code-mcp', () => {
+  const actual = __actual as Record<string, unknown>;
+  return {
+    ...actual,
+    McpClientManager: vi.fn().mockImplementation(() => ({
+      getMcpServers: vi.fn().mockReturnValue({}),
+      getDiscoveryFailures: vi.fn().mockReturnValue(new Map<string, string>()),
+      getDiscoveryState: vi.fn().mockReturnValue(MCPDiscoveryState.NOT_STARTED),
+      whenDiscoverySettled: vi.fn().mockResolvedValue(undefined),
+      restart: vi.fn().mockResolvedValue(undefined),
+      restartServer: vi.fn().mockResolvedValue(undefined),
+      reconcileConfiguredMcpServers: vi.fn().mockResolvedValue(undefined),
+      getMcpInstructions: vi.fn().mockReturnValue(''),
+      startConfiguredMcpServers: vi.fn().mockResolvedValue(undefined),
+      // ExtensionLoader drives these on every load/unload.
+      startExtension: vi.fn().mockResolvedValue(undefined),
+      stopExtension: vi.fn().mockResolvedValue(undefined),
+      onFolderTrustGained: vi.fn().mockResolvedValue(undefined),
+      onFolderTrustRevoked: vi.fn().mockResolvedValue(undefined),
+      quarantineForTrustRevocation: vi.fn(),
+      stop: vi.fn().mockResolvedValue(undefined),
+    })),
+  };
+});
+
+const __actual2 = { ...(await import('fs')) };
+void vi.mock('fs', () => buildFsMockBody(__actual2));
+
+const __actual3 = { ...(await import('@vybestack/llxprt-code-tools')) };
+void vi.mock('@vybestack/llxprt-code-tools', () =>
+  buildToolsMockBody(__actual3),
+);
+
+const __actual4 = { ...(await import('../core/contentGenerator.js')) };
+void vi.mock('../core/contentGenerator.js', () =>
+  buildContentGeneratorMockBody(__actual4),
+);
+
+void vi.mock('../telemetry/index.js', () => buildTelemetryMockBody());
+
+void vi.mock('../services/gitService.js', () => buildGitServiceMockBody());
+
+void vi.mock('@vybestack/llxprt-code-settings', () => buildSettingsMockBody());
+
+const __actual5 = {
+  ...(await import('@vybestack/llxprt-code-ide-integration')),
+};
+void vi.mock('@vybestack/llxprt-code-ide-integration', () =>
+  buildIdeIntegrationMockBody(__actual5),
+);
+
+void vi.mock('../utils/memoryDiscovery.js', () =>
+  buildMemoryDiscoveryMockBody(hoistedConfigMocks),
+);
+
+const __actual6 = { ...(await import('../utils/events.js')) };
+void vi.mock('../utils/events.js', () =>
+  buildEventsMockBody(__actual6, hoistedConfigMocks),
+);
+
+void vi.mock('../utils/fetch.js', () => buildFetchMockBody(hoistedConfigMocks));
+
+interface RegistrarObservation {
+  readonly skills: string[];
+}
+
+function extensionSkill(name: string): SkillDefinition {
+  return {
+    name,
+    description: `The ${name} skill`,
+    location: `memory://${name}/SKILL.md`,
+    body: `${name} instructions`,
+    source: 'extension',
+  };
+}
+
+function skillExtension(
+  name: string,
+  skills: SkillDefinition[],
+): LlxprtExtension {
+  return {
+    name,
+    version: '1.0.0',
+    isActive: true,
+    path: `memory://${name}`,
+    contextFiles: [],
+    skills,
+  };
+}
+
+interface Harness {
+  readonly config: Config;
+  readonly loader: SimpleExtensionLoader;
+  readonly observations: RegistrarObservation[];
+}
+
+async function buildHarness(
+  extensions: LlxprtExtension[] = [],
+): Promise<Harness> {
+  const observations: RegistrarObservation[] = [];
+  const loader = new SimpleExtensionLoader(extensions);
+  const config = new Config({
+    sessionId: 'test-session',
+    targetDir: '/tmp/test',
+    debugMode: false,
+    model: 'test-model',
+    cwd: '/tmp/test',
+    skillsSupport: true,
+    enableExtensionReloading: true,
+    extensionLoader: loader,
+    postSkillDiscoveryToolRegistrar: (_registry, skillService) => {
+      observations.push({
+        skills: skillService.listSkills().map((skill) => skill.name),
+      });
+    },
+  });
+  await initializeTestConfig(config);
+  // Real discovery would walk the filesystem for builtin/user/project skills;
+  // the extension tier is the one under test, so only that is left live.
+  vi.spyOn(config.getSkillManager(), 'discoverBuiltinSkills').mockResolvedValue(
+    [],
+  );
+  observations.length = 0;
+  return { config, loader, observations };
+}
+
+/** The most recent skill list the activation tool was rebuilt from. */
+function lastRebuiltFrom(observations: RegistrarObservation[]): string[] {
+  if (observations.length === 0) {
+    throw new Error('the activation tool was never rebuilt');
+  }
+  return observations[observations.length - 1].skills;
+}
+
+function discoveredSkillNames(config: Config): string[] {
+  return config
+    .getSkillManager()
+    .getSkills()
+    .map((skill) => skill.name)
+    .sort();
+}
+
+describe('extension load and unload refresh the skill surface @issue:3383', () => {
+  it('discovers the skills an extension brings when it is loaded', async () => {
+    const { config, loader, observations } = await buildHarness();
+
+    await loader.loadExtension(
+      skillExtension('pack', [extensionSkill('alpha')]),
+    );
+
+    expect(discoveredSkillNames(config)).toContain('alpha');
+    expect(lastRebuiltFrom(observations)).toContain('alpha');
+  });
+
+  it('drops the skills an extension brought when it is unloaded', async () => {
+    const extension = skillExtension('pack', [extensionSkill('alpha')]);
+    const { config, loader, observations } = await buildHarness([extension]);
+    expect(discoveredSkillNames(config)).toContain('alpha');
+
+    await loader.unloadExtension(extension);
+
+    expect(discoveredSkillNames(config)).not.toContain('alpha');
+    expect(lastRebuiltFrom(observations)).not.toContain('alpha');
+  });
+
+  it('leaves the skill surface alone for an extension that ships no skills', async () => {
+    const { loader, observations } = await buildHarness();
+
+    await loader.loadExtension(skillExtension('no-skills', []));
+
+    // Rediscovery is not free, so an extension with nothing to contribute must
+    // not trigger one.
+    expect(observations).toEqual([]);
+  });
+
+  it('leaves the skill available after a restart', async () => {
+    const extension = skillExtension('pack', [extensionSkill('alpha')]);
+    const { config, observations } = await buildHarness([extension]);
+
+    await config.getExtensionLoader().restartExtension(extension);
+
+    expect(discoveredSkillNames(config)).toContain('alpha');
+    // restartExtension awaits the stop before the start, so each transition
+    // settles on its own and rediscovery runs twice; batching collapses
+    // concurrent transitions, not sequential ones. The skill stays available
+    // throughout, because a restart leaves the extension in the loader's list
+    // and still active. Only unloadExtension removes it.
+    expect(observations).toHaveLength(2);
+    for (const observation of observations) {
+      expect(observation.skills).toContain('alpha');
+    }
+  });
+
+  it('rediscovers once for a batch of concurrent loads', async () => {
+    const { config, loader, observations } = await buildHarness();
+
+    await Promise.all([
+      loader.loadExtension(skillExtension('one', [extensionSkill('alpha')])),
+      loader.loadExtension(skillExtension('two', [extensionSkill('beta')])),
+    ]);
+
+    expect(discoveredSkillNames(config)).toEqual(['alpha', 'beta']);
+    expect(observations).toHaveLength(1);
+  });
+});

--- a/packages/core/src/config/extensionSkillRefresh.test.ts
+++ b/packages/core/src/config/extensionSkillRefresh.test.ts
@@ -20,7 +20,7 @@
  * without touching the filesystem, git, telemetry or a real provider.
  */
 
-import { describe, it, expect, vi } from 'bun:test';
+import { describe, it, expect, vi, type Mock } from 'bun:test';
 import { Config } from './config.js';
 import type { SkillDefinition } from '../skills/skillLoader.js';
 import type { LlxprtExtension } from './configTypes.js';
@@ -243,6 +243,43 @@ describe('extension load and unload refresh the skill surface @issue:3383', () =
     for (const observation of observations) {
       expect(observation.skills).toContain('alpha');
     }
+  });
+
+  it('still reconciles after a failed load, on the next transition', async () => {
+    const { config, loader, observations } = await buildHarness();
+    const manager = config.getMcpClientManager() as unknown as {
+      startExtension: Mock<(extension: LlxprtExtension) => Promise<void>>;
+    };
+    manager.startExtension.mockRejectedValueOnce(new Error('mcp exploded'));
+
+    // loadExtension adds to the collection before starting, so the skill is
+    // already discoverable even though the transition failed.
+    await expect(
+      loader.loadExtension(skillExtension('pack', [extensionSkill('alpha')])),
+    ).rejects.toThrow('mcp exploded');
+
+    await loader.loadExtension(skillExtension('other', []));
+
+    expect(discoveredSkillNames(config)).toContain('alpha');
+    expect(lastRebuiltFrom(observations)).toContain('alpha');
+  });
+
+  it('retries on the next transition when the refresh itself fails', async () => {
+    const { config, loader, observations } = await buildHarness();
+    vi.spyOn(config, 'refreshSkills').mockRejectedValueOnce(
+      new Error('discovery exploded'),
+    );
+
+    await expect(
+      loader.loadExtension(skillExtension('pack', [extensionSkill('alpha')])),
+    ).rejects.toThrow('discovery exploded');
+    expect(observations).toEqual([]);
+
+    await loader.loadExtension(skillExtension('other', []));
+
+    // The second extension ships no skills, so only the retained marker from
+    // the failed refresh can explain a rebuild happening here.
+    expect(lastRebuiltFrom(observations)).toContain('alpha');
   });
 
   it('rediscovers once for a batch of concurrent loads', async () => {

--- a/packages/core/src/utils/extensionLoader.ts
+++ b/packages/core/src/utils/extensionLoader.ts
@@ -77,9 +77,12 @@ export abstract class ExtensionLoader {
       completed: this.startCompletedCount,
     });
     try {
-      // Before the await: loadExtension/unloadExtension have already mutated
-      // the collection discoverSkills reads, so if the MCP transition rejects
-      // the skill surface is stale and still needs reconciling.
+      // Mark before the await, not after. By the time we get here the caller
+      // has already changed what getExtensions() returns: SimpleExtensionLoader
+      // pushes in loadExtension and splices in unloadExtension, both before
+      // this runs. So if the MCP transition below rejects, the skill surface is
+      // already stale and still needs reconciling. Moving this after the await
+      // reintroduces issue #3383 for the failure path.
       this.markSkillsDirty(extension);
       await this.config.getMcpClientManager()!.startExtension(extension);
       await this.maybeRefreshAgentTools(extension);
@@ -249,8 +252,9 @@ export abstract class ExtensionLoader {
     });
 
     try {
-      // See startExtension: mark before the await so a rejected transition
-      // does not leave the skill surface stale.
+      // See startExtension: the caller has already removed the extension from
+      // the collection getExtensions() reads, so mark before the await or a
+      // rejected transition leaves the skill surface stale.
       this.markSkillsDirty(extension);
       await this.config.getMcpClientManager()!.stopExtension(extension);
       await this.maybeRefreshAgentTools(extension);

--- a/packages/core/src/utils/extensionLoader.ts
+++ b/packages/core/src/utils/extensionLoader.ts
@@ -77,8 +77,11 @@ export abstract class ExtensionLoader {
       completed: this.startCompletedCount,
     });
     try {
-      await this.config.getMcpClientManager()!.startExtension(extension);
+      // Before the await: loadExtension/unloadExtension have already mutated
+      // the collection discoverSkills reads, so if the MCP transition rejects
+      // the skill surface is stale and still needs reconciling.
       this.markSkillsDirty(extension);
+      await this.config.getMcpClientManager()!.startExtension(extension);
       await this.maybeRefreshAgentTools(extension);
       // Register extension subagents
       if (
@@ -108,8 +111,8 @@ export abstract class ExtensionLoader {
         this.startingCount = 0;
         this.startCompletedCount = 0;
       }
-      await this.maybeRefreshSkills();
       await this.maybeRefreshMemory();
+      await this.maybeRefreshSkills();
     }
   }
 
@@ -159,9 +162,12 @@ export abstract class ExtensionLoader {
   /**
    * Rediscovers skills once every extension transition has settled.
    *
-   * Batched on the same counters as {@link maybeRefreshMemory}, so a
-   * `restartExtension` (a stop followed by a start) rediscovers once rather
-   * than twice, and a parallel batch rediscovers once at the end.
+   * Batched on the same counters as {@link maybeRefreshMemory}, so a batch of
+   * concurrent transitions rediscovers once at the end rather than once each.
+   * Sequential transitions are not collapsed: `restartExtension` awaits its
+   * stop before its start, so each settles on its own and this runs twice. That
+   * is harmless, because a restart leaves the extension listed and active, so
+   * its skills stay available throughout.
    *
    * Skipped during the initial `start()`: `Config.initialize` runs
    * `discoverSkills` immediately after `start()` returns, so anything done here
@@ -184,7 +190,15 @@ export abstract class ExtensionLoader {
       return;
     }
     this.skillsNeedRefresh = false;
-    await this.config.refreshSkills();
+    try {
+      await this.config.refreshSkills();
+    } catch (error) {
+      // The failure propagates; this only restores the marker so the next
+      // transition retries rather than inheriting a skill surface that was
+      // never reconciled.
+      this.skillsNeedRefresh = true;
+      throw error;
+    }
   }
 
   /**
@@ -227,8 +241,10 @@ export abstract class ExtensionLoader {
     });
 
     try {
-      await this.config.getMcpClientManager()!.stopExtension(extension);
+      // See startExtension: mark before the await so a rejected transition
+      // does not leave the skill surface stale.
       this.markSkillsDirty(extension);
+      await this.config.getMcpClientManager()!.stopExtension(extension);
       await this.maybeRefreshAgentTools(extension);
       // Remove extension subagents
       const subagentMgr = this.config.getSubagentManager();
@@ -250,8 +266,8 @@ export abstract class ExtensionLoader {
         this.stoppingCount = 0;
         this.stopCompletedCount = 0;
       }
-      await this.maybeRefreshSkills();
       await this.maybeRefreshMemory();
+      await this.maybeRefreshSkills();
     }
   }
 

--- a/packages/core/src/utils/extensionLoader.ts
+++ b/packages/core/src/utils/extensionLoader.ts
@@ -23,6 +23,10 @@ export abstract class ExtensionLoader {
   // Whether or not we are currently executing `start`
   private isStarting: boolean = false;
 
+  // Set when an extension that contributes skills starts or stops, so the
+  // rediscovery happens once per settled batch instead of once per extension.
+  private skillsNeedRefresh: boolean = false;
+
   constructor(private readonly eventEmitter?: EventEmitter<ExtensionEvents>) {}
 
   /**
@@ -74,6 +78,7 @@ export abstract class ExtensionLoader {
     });
     try {
       await this.config.getMcpClientManager()!.startExtension(extension);
+      this.markSkillsDirty(extension);
       await this.maybeRefreshAgentTools(extension);
       // Register extension subagents
       if (
@@ -103,6 +108,7 @@ export abstract class ExtensionLoader {
         this.startingCount = 0;
         this.startCompletedCount = 0;
       }
+      await this.maybeRefreshSkills();
       await this.maybeRefreshMemory();
     }
   }
@@ -134,6 +140,51 @@ export abstract class ExtensionLoader {
         await agentClient.setTools();
       }
     }
+  }
+
+  /**
+   * Records that an extension transition changed the available skills.
+   *
+   * Extension-contributed skills are one of the sources SkillManager reads, so
+   * loading or unloading an extension that ships skills makes the discovered
+   * set, and therefore the model-facing skill activation tool, stale
+   * (issue #3383). Extensions that ship no skills cost nothing here.
+   */
+  private markSkillsDirty(extension: LlxprtExtension): void {
+    if (Array.isArray(extension.skills) && extension.skills.length > 0) {
+      this.skillsNeedRefresh = true;
+    }
+  }
+
+  /**
+   * Rediscovers skills once every extension transition has settled.
+   *
+   * Batched on the same counters as {@link maybeRefreshMemory}, so a
+   * `restartExtension` (a stop followed by a start) rediscovers once rather
+   * than twice, and a parallel batch rediscovers once at the end.
+   *
+   * Skipped during the initial `start()`: `Config.initialize` runs
+   * `discoverSkills` immediately after `start()` returns, so anything done here
+   * would be thrown away. The flag is cleared on that path so the first real
+   * transition is not misattributed to startup.
+   */
+  private async maybeRefreshSkills(): Promise<void> {
+    if (!this.config) {
+      throw new Error('Cannot refresh skills prior to calling `start`.');
+    }
+    if (this.isStarting) {
+      this.skillsNeedRefresh = false;
+      return;
+    }
+    if (
+      !this.skillsNeedRefresh ||
+      this.startingCount !== this.startCompletedCount ||
+      this.stoppingCount !== this.stopCompletedCount
+    ) {
+      return;
+    }
+    this.skillsNeedRefresh = false;
+    await this.config.refreshSkills();
   }
 
   /**
@@ -177,6 +228,7 @@ export abstract class ExtensionLoader {
 
     try {
       await this.config.getMcpClientManager()!.stopExtension(extension);
+      this.markSkillsDirty(extension);
       await this.maybeRefreshAgentTools(extension);
       // Remove extension subagents
       const subagentMgr = this.config.getSubagentManager();
@@ -198,6 +250,7 @@ export abstract class ExtensionLoader {
         this.stoppingCount = 0;
         this.stopCompletedCount = 0;
       }
+      await this.maybeRefreshSkills();
       await this.maybeRefreshMemory();
     }
   }

--- a/packages/core/src/utils/extensionLoader.ts
+++ b/packages/core/src/utils/extensionLoader.ts
@@ -182,11 +182,7 @@ export abstract class ExtensionLoader {
       this.skillsNeedRefresh = false;
       return;
     }
-    if (
-      !this.skillsNeedRefresh ||
-      this.startingCount !== this.startCompletedCount ||
-      this.stoppingCount !== this.stopCompletedCount
-    ) {
+    if (!this.skillsNeedRefresh || !this.transitionsSettled()) {
       return;
     }
     this.skillsNeedRefresh = false;
@@ -202,6 +198,19 @@ export abstract class ExtensionLoader {
   }
 
   /**
+   * Whether every in-flight extension start and stop has completed.
+   *
+   * Shared by the memory and skill reconciliation steps so the two cannot
+   * drift apart on what "settled" means.
+   */
+  private transitionsSettled(): boolean {
+    return (
+      this.startingCount === this.startCompletedCount &&
+      this.stoppingCount === this.stopCompletedCount
+    );
+  }
+
+  /**
    * Refreshes memory only after all extensions are done loading/unloading.
    */
   private async maybeRefreshMemory(): Promise<void> {
@@ -210,8 +219,7 @@ export abstract class ExtensionLoader {
     }
     if (
       !this.isStarting && // Don't refresh memories on the first call to `start`.
-      this.startingCount === this.startCompletedCount &&
-      this.stoppingCount === this.stopCompletedCount
+      this.transitionsSettled()
     ) {
       // Wait until all extensions are done starting and stopping before we
       // reload memory, this is somewhat expensive and also busts the context

--- a/project-plans/skills-composition-3382-3383/plan.md
+++ b/project-plans/skills-composition-3382-3383/plan.md
@@ -1,0 +1,172 @@
+# Issues #3382 and #3383: the two remaining ways the model's skill list goes stale
+
+Branch: `issue3382-3383`
+
+Both defects were found while fixing #3379 and share its mechanism: the model
+learns which skills exist only from the `activate_skill` tool declaration, which
+`ActivateSkillTool` bakes in at construction. #3379 fixed the explicit
+`/skills reload` path. These are the two remaining ways that declaration can be
+wrong, and they are fixed together because the second one depends on a seam the
+first one moves.
+
+## #3382: the public Agent API never registers the tool
+
+`Config` cannot reference `ActivateSkillTool` (#2417), so it receives the tool
+through the injected `postSkillDiscoveryToolRegistrar` hook, and
+`syncSkillActivationTool` returns early when no hook is present.
+
+The CLI supplies one. `packages/agents/src/api/createAgent.ts` does not. So
+`createAgent({ skillsSupport: true })` discovers skills, lists them happily
+through `agent.skills.list()`, and never gives the model an `activate_skill`
+tool at all. Reloading cannot help, because there is nothing to rebuild.
+
+### Fix
+
+Move `registerActivateSkillTool` from `packages/cli/src/config/` to
+`packages/agents/src/skill-tool-registrar.ts` and export it from the agents root
+barrel. Both composition roots then share one implementation, which is the point:
+the two roots have already drifted once.
+
+- `createAgent` sets `params.postSkillDiscoveryToolRegistrar = registerActivateSkillTool`
+  next to the existing `params.agentClientFactory` assignment.
+- `packages/cli/src/config/configBuilder.ts` imports it from
+  `@vybestack/llxprt-code-agents` instead of its local module, which is deleted.
+
+The agents **root barrel**, not a subpath: `scripts/cli-boundary/config.ts` lists
+`'@vybestack/llxprt-code-agents': []`, meaning the CLI may import the bare root
+and no deep paths. Using the root also avoids editing the curated exports map.
+
+The registrar keeps importing `@vybestack/llxprt-code-tools/tools/activate-skill.js`
+by deep path. `activate-skill.ts` itself does not pull `@ast-grep/napi`; the
+tools *barrel* does, via `tools/structural-analysis/`. The deep path is what
+keeps the native module out of the graph, so it must stay a deep path.
+
+No `skillsSupport` gate at the call site: `syncSkillActivationTool` already
+returns early when skills support is off, so wiring the hook unconditionally is
+correct and keeps one gate rather than two.
+
+## #3383: extension load and unload do not rediscover skills
+
+`SkillManager.discoverSkills` reads extension-contributed skills:
+
+```ts
+for (const extension of extensions) {
+  if (extension.isActive && extension.skills) { ... }
+}
+```
+
+`ExtensionLoader.startExtension` / `stopExtension` reconcile MCP servers,
+subagents and memory, and call `maybeRefreshAgentTools`, which only does anything
+when the extension declares `excludeTools`. Skills are never rediscovered. So
+loading an extension that ships skills leaves them invisible, and unloading one
+leaves its skills listed and still in the enum, until an explicit `/skills reload`.
+
+### Fix
+
+**Split `Config.reloadSkills()` into settings-refresh plus a reusable refresh.**
+
+```ts
+async refreshSkills(): Promise<void> {
+  await this.skillManager.discoverSkills(this.storage, this.getExtensions());
+  this.skillManager.setDisabledSkills(this.disabledSkills);
+  syncSkillActivationTool(this);
+  const client = this.getAgentClientIfReady();
+  if (client) {
+    await client.setTools();
+  }
+}
+
+async reloadSkills(): Promise<void> {
+  if (this._onReload) { /* unchanged settings refresh */ }
+  await this.refreshSkills();
+}
+```
+
+This is a pure extraction: `refreshSkills` is exactly the current tail of
+`reloadSkills`, so `/skills reload` behaviour does not change. No `skillsSupport`
+guard is added to `refreshSkills`, because `reloadSkills` does not have one today
+and adding one would silently change when discovery runs.
+
+The extension path calls `refreshSkills`, not `reloadSkills`: an extension
+transition should not re-read `disabledSkills` and `adminSkillsEnabled` from
+settings, because the user did not ask for a settings reload and an unrelated
+half-finished settings edit should not take effect as a side effect of an
+extension loading.
+
+**Make `ExtensionLoader` refresh when a skill-contributing extension settles.**
+
+Mirror the existing `maybeRefreshMemory` shape:
+
+- `startExtension` and `stopExtension` mark skills dirty when the extension
+  actually contributes skills, so an extension with none costs nothing.
+- Refresh only once every in-flight start and stop has settled, using the same
+  counter comparison `maybeRefreshMemory` uses, so a batch of concurrent loads
+  rediscovers once rather than once each. This does not collapse *sequential*
+  transitions: `restartExtension` awaits its stop before its start, so each half
+  settles on its own and rediscovery runs twice. That is left alone. A restart
+  keeps the extension in the loader's list and active, so its skills stay
+  available throughout and the second pass is redundant rather than wrong.
+- Skip during the initial `start()`, guarded by the existing `isStarting` flag.
+  `Config.initialize` runs `discoverSkills` immediately after
+  `getExtensionLoader().start(this)` returns, so refreshing per-extension there
+  would be redundant work whose result is immediately overwritten. The dirty
+  flag is cleared on that path so the first real transition is not misattributed.
+
+## Tests
+
+Behavioral, per dev-docs/RULES.md. Assert on the registry and on the declaration
+the chat session will send, not on call counts.
+
+### #3382
+
+- Move `packages/cli/src/config/activateSkillToolRegistrar.test.ts` to
+  `packages/agents/src/skill-tool-registrar.test.ts` alongside the implementation.
+  Its eight cases carry over unchanged.
+- `packages/agents/src/api/__tests__/skillReloadDeclaration.behavior.test.ts`
+  drops its manual `setPostSkillDiscoveryToolRegistrar` call and relies on
+  production wiring, which is what its header comment promised would happen when
+  #3382 was fixed. If the wiring regresses, all five cases fail.
+- The first case in that file becomes the explicit startup assertion: an agent
+  built through `createAgent` with a skill on disk exposes `activate_skill` in
+  its provider-facing declarations after one turn and no reload at all.
+
+### #3383
+
+New `packages/core/src/config/extensionSkillRefresh.test.ts`, using the same
+mock harness as `config.skillReload.test.ts` with a real `SimpleExtensionLoader`
+and `enableExtensionReloading: true`:
+
+- Loading an extension that contributes a skill puts that skill in the
+  discovered set and in what the activation tool was rebuilt from, with no
+  explicit reload.
+- Unloading it removes the skill from both.
+- An extension contributing no skills triggers no rediscovery at all.
+- A restart leaves the skill available throughout.
+- A batch of concurrent loads rediscovers once.
+
+Four of the five fail on pre-fix code. The remaining link, that the rebuilt tool
+reaches the provider request, is already covered end to end by
+`skillReloadDeclaration.behavior.test.ts` in the agents package, so it is not
+duplicated here.
+
+### Regression
+
+`packages/core/src/config/config.skillReload.test.ts` and
+`packages/core/src/config/config.d.test.ts` must pass unchanged, since
+`reloadSkills` is only being decomposed, not altered.
+
+## Verification
+
+```bash
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```
+
+Plus the boundary guards that constrain this change:
+`packages/core/src/config/__tests__/import-boundary.test.ts`,
+`packages/providers/src/auth/__tests__/auth-import-isolation.test.ts`,
+`scripts/tests/cli-import-boundary.test.ts`.

--- a/project-plans/skills-composition-3382-3383/plan.md
+++ b/project-plans/skills-composition-3382-3383/plan.md
@@ -29,6 +29,13 @@ the two roots have already drifted once.
 
 - `createAgent` sets `params.postSkillDiscoveryToolRegistrar = registerActivateSkillTool`
   next to the existing `params.agentClientFactory` assignment.
+- `fromConfig` is the other public entry, and it adopts a `Config` the caller
+  built. A caller has no reason to know the hook exists, so `fromConfig`
+  installs the shared registrar when the adopted config has none, leaving a
+  deliberately supplied one alone. `ensureInitialized` is a no-op for a config
+  the caller already initialized, so when `fromConfig` installs the hook it also
+  calls `refreshSkills()` to reconcile. On a fresh config that repeats one
+  discovery, which is a better trade than leaving the model with no skill tool.
 - `packages/cli/src/config/configBuilder.ts` imports it from
   `@vybestack/llxprt-code-agents` instead of its local module, which is deleted.
 
@@ -98,7 +105,11 @@ extension loading.
 Mirror the existing `maybeRefreshMemory` shape:
 
 - `startExtension` and `stopExtension` mark skills dirty when the extension
-  actually contributes skills, so an extension with none costs nothing.
+  actually contributes skills, so an extension with none costs nothing. The mark
+  happens *before* the awaited MCP transition: `loadExtension` and
+  `unloadExtension` mutate the collection `discoverSkills` reads before starting
+  or stopping anything, so a rejected transition still leaves a stale skill
+  surface that needs reconciling.
 - Refresh only once every in-flight start and stop has settled, using the same
   counter comparison `maybeRefreshMemory` uses, so a batch of concurrent loads
   rediscovers once rather than once each. This does not collapse *sequential*
@@ -111,6 +122,12 @@ Mirror the existing `maybeRefreshMemory` shape:
   `getExtensionLoader().start(this)` returns, so refreshing per-extension there
   would be redundant work whose result is immediately overwritten. The dirty
   flag is cleared on that path so the first real transition is not misattributed.
+- Run after `maybeRefreshMemory`, not before. Memory and hook reconciliation
+  predate this change, and a `refreshSkills` rejection must not stop them from
+  happening.
+- Restore the dirty flag if `refreshSkills` rejects, then rethrow. The failure
+  still propagates; the marker only ensures the next transition retries instead
+  of inheriting a surface that was never reconciled.
 
 ## Tests
 
@@ -143,11 +160,30 @@ and `enableExtensionReloading: true`:
 - An extension contributing no skills triggers no rediscovery at all.
 - A restart leaves the skill available throughout.
 - A batch of concurrent loads rediscovers once.
+- A failed MCP transition still leaves the surface reconciled on the next one.
+- A failed `refreshSkills` retries on the next transition.
 
-Four of the five fail on pre-fix code. The remaining link, that the rebuilt tool
+Four of these fail on pre-fix code. The remaining link, that the rebuilt tool
 reaches the provider request, is already covered end to end by
 `skillReloadDeclaration.behavior.test.ts` in the agents package, so it is not
 duplicated here.
+
+New `packages/agents/src/api/__tests__/fromConfigSkills.behavior.test.ts`: an
+agent built with `fromConfig` from a caller-built config that supplied no
+registrar offers a discovered skill in its provider-facing declarations. Fails
+on pre-fix code. `buildCliStyleConfig` gains an overrides parameter so the
+config can enable skills and point at a workspace; existing callers are
+unaffected.
+
+### Known limitation, not fixed here
+
+`refreshSkills` updates the foreground `AgentClient` only. A subagent already
+running when an extension is loaded or unloaded keeps the declarations its
+`ChatSession` was assembled with, so a later turn in that subagent can advertise
+a stale enum. This is not specific to skills: the same is true of any registry
+change during a subagent's lifetime, including MCP tool changes today. Fixing it
+means propagating tool-surface changes into live subagent sessions, which is a
+change to subagent runtime setup rather than to skill discovery.
 
 ### Regression
 


### PR DESCRIPTION
## TLDR

The two remaining ways the model's skill list goes stale, found while fixing #3379 and fixed together because the second depends on a seam the first moves.

`ActivateSkillTool` bakes its description hint and `name` enum in at construction, and that declaration is the only thing that tells the model a skill exists. Core cannot construct the tool (#2417), so `Config` takes an injected registrar hook and `syncSkillActivationTool` returns early when none is present.

**#3382**: neither `createAgent` nor `fromConfig` supplied the hook. An agent from the public API with `skillsSupport: true` discovered skills, listed them happily through `agent.skills.list()`, and gave the model no `activate_skill` tool at all. Reloading could not help, because there was nothing to rebuild.

**#3383**: `ExtensionLoader` reconciled MCP servers, subagents and memory on extension load and unload, but never rediscovered extension-contributed skills.

Reviewers should look hardest at the extension reconciliation in `packages/core/src/utils/extensionLoader.ts`: where the dirty mark sits relative to the awaited MCP transition, the ordering against `maybeRefreshMemory`, and whether the dirty flag can be lost.

## Dive Deeper

### #3382: one registrar, both composition roots

`registerActivateSkillTool` moves from `packages/cli/src/config/activateSkillToolRegistrar.ts` to `packages/agents/src/skill-tool-registrar.ts` and is exported from the agents root barrel. Both roots now share one implementation, which is the point: they had already drifted once, and that drift is this bug.

- `createAgent` assigns it next to `params.agentClientFactory`.
- `fromConfig` adopts a `Config` the caller built. A caller has no reason to know the hook exists, so `fromConfig` installs the shared registrar when the adopted config has none and leaves a deliberately supplied one alone. `ensureInitialized` is a no-op for a config the caller already initialized, so when `fromConfig` installs the hook it also calls `refreshSkills()` to reconcile. On a fresh config that repeats one discovery, which beats leaving the model with no skill tool.
- `packages/cli/src/config/configBuilder.ts` imports it instead of owning a copy.

The agents **root barrel**, not a subpath: `scripts/cli-boundary/config.ts` lists `'@vybestack/llxprt-code-agents': []`, so the CLI may import the bare package root and no deep paths.

The `ActivateSkillTool` import inside the registrar stays a deep path. The tools barrel reaches `tools/structural-analysis/`, which loads `@ast-grep/napi`; `activate-skill.js` on its own does not. Verified independently during review via Bun bundle metafiles, which also confirmed the agents root already pulled ast-grep before this change, so the new export adds nothing to agents-root consumers.

No `skillsSupport` check at either call site, because `syncSkillActivationTool` already carries that gate and one gate beats two.

### #3383: rediscover when the skill sources change

`Config.reloadSkills` is split. `refreshSkills` is the discover, apply-disabled, rebuild-tool, push-to-session tail; `reloadSkills` is the settings refresh followed by it. Pure extraction, so `/skills reload` is unchanged.

The extension path calls `refreshSkills`, not `reloadSkills`, deliberately. An extension transition should not re-read `disabledSkills` and `adminSkillsEnabled` from settings: the user did not ask for that, and a half-finished settings edit should not take effect as a side effect of an extension loading.

`ExtensionLoader`:

- Marks skills dirty only when the extension actually contributes skills, so an extension with none costs nothing.
- Marks **before** the awaited MCP transition. `loadExtension` and `unloadExtension` mutate the collection `discoverSkills` reads before starting or stopping anything, so a rejected transition still leaves a stale surface that needs reconciling.
- Rediscovers once every in-flight transition has settled, batched on the same counters `maybeRefreshMemory` uses, now shared through `transitionsSettled()` so the two cannot drift.
- Runs **after** `maybeRefreshMemory`. Memory and hook reconciliation predate this change and a skill-refresh failure must not stop them.
- Restores the dirty flag before rethrowing, so a failure still propagates but the next transition retries instead of inheriting a surface that was never reconciled.
- Skips the initial `start()` entirely, guarded by the existing `isStarting` flag, because `Config.initialize` discovers skills immediately after `start()` returns.

Sequential transitions are not collapsed: `restartExtension` awaits its stop before its start, so it rediscovers twice. Left alone. A restart keeps the extension listed and active, so its skills stay available throughout and the second pass is redundant rather than wrong.

### Fail-fast

No try/catch swallows anything. The one `catch` in `maybeRefreshSkills` restores a retry marker and rethrows; the failure still propagates.

### Known limitation, documented not fixed

`refreshSkills` updates the foreground `AgentClient` only. A subagent already running when an extension loads or unloads keeps the declarations its `ChatSession` was assembled with, so a later turn in that subagent can advertise a stale enum. This is not specific to skills: any registry change during a subagent's lifetime behaves the same way today, including MCP tool changes. Fixing it means propagating tool-surface changes into live subagent sessions, which is a change to subagent runtime setup rather than to skill discovery. Recorded in the plan.

### Tests

`packages/agents/src/api/__tests__/skillReloadDeclaration.behavior.test.ts` drops the registrar it used to install and now runs entirely on production wiring, which is what its header comment promised would happen once #3382 was fixed. Removing the `createAgent` assignment fails all five cases; its first case is now the explicit startup assertion with no reload at all.

`packages/agents/src/api/__tests__/fromConfigSkills.behavior.test.ts` builds a config the way an embedder would, with no registrar, adopts it through `fromConfig`, and asserts the skill reaches the provider-facing declarations. Fails without the `fromConfig` change.

`packages/core/src/config/extensionSkillRefresh.test.ts` covers load, unload, an extension with no skills triggering nothing, restart, a concurrent batch collapsing to one rediscovery, reconciliation after a failed MCP transition, and retry after a failed refresh.

`packages/agents/src/skill-tool-registrar.test.ts` moves with the implementation, eight cases unchanged.

`buildCliStyleConfig` gains an optional overrides parameter so an adopted config can enable skills and point at a workspace. Existing callers are unaffected.

## Reviewer Test Plan

**#3382**, both entry points:

```ts
// Put a skill at <workspace>/.llxprt/skills/alpha/SKILL.md first.
const agent = await createAgent({ provider: 'openai', model: '...', skillsSupport: true, workingDir: workspace });
// On main: agent.skills.list() shows alpha, but the model is never offered activate_skill.
// On this branch: the model can activate it.
```

Same for `fromConfig` with a `Config` you built yourself and did not give a registrar.

**#3383**, in the CLI with extension reloading enabled: load an extension that ships skills and confirm the model can use them without running `/skills reload`; unload it and confirm they go away.

Automated:

```bash
cd packages/agents && bun test src/api/__tests__/skillReloadDeclaration.behavior.test.ts src/api/__tests__/fromConfigSkills.behavior.test.ts src/skill-tool-registrar.test.ts
cd packages/core   && bun test src/config/extensionSkillRefresh.test.ts src/config/config.skillReload.test.ts src/config/__tests__/import-boundary.test.ts
bun scripts/check-cli-import-boundary.ts
```

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: typecheck, build and format all exit 0. Lint passes on every changed file and across `packages/agents/src` and `packages/core/src/config`; the repo-wide lint run exhausts its 12 GB V8 heap on this machine regardless of the change, which is #3387. Boundary guards pass: core's #2417 import guard, the providers auth isolation guard, and `check-cli-import-boundary.ts` across 744 production files. Startup smoke test passes.

One failure in the full local suite, `packages/providers/src/runtime/explicitRuntimeId.behavior.test.ts`, was a stale `packages/mcp/dist` artifact from running tests before the build in the same pass; it passes once the build has run. An earlier pass also flaked `SessionLockManager.safety`'s subprocess race under load, which passes in isolation. Neither touches anything in this change.

## Linked issues / bugs

Fixes #3382
Fixes #3383


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Agents now consistently expose the skill activation tool, including when created from an existing configuration.
  - Skills discovered from configuration and extensions are automatically made available to the model.
  - Added support for refreshing skills and synchronizing available tools without reloading all settings.
  - Skill lists and activation tools now update when extensions are loaded, unloaded, restarted, or retried after an error.

- **Bug Fixes**
  - Resolved cases where configured or extension-provided skills were not visible to agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->