### PR TITLE
Expand Interactive UI tmux coverage (Fixes #2017)

### DIFF
--- a/.github/workflows/interactive-ui.yml
+++ b/.github/workflows/interactive-ui.yml
@@ -16,13 +16,31 @@ on:
       # The interactive UI test and its Bun test preload
       - 'scripts/tests/test-setup.ts'
       - 'scripts/tests/interactive-ui.test.ts'
-      # The scenario JSON files executed by the test
+      # The eight scenario JSON files executed by the test
       - 'scripts/tmux-script.slash-autocomplete.json'
       - 'scripts/tmux-script.approval-ui.json'
       - 'scripts/tmux-script.issue2208-newlines.fake.json'
       - 'scripts/tmux-script.issue2016-composer.fake.json'
-      # Scenario config referenced by all scenarios (welcome banner +
-      # system settings env paths set in each scenario)
+      - 'scripts/tmux-script.provider-model.json'
+      - 'scripts/tmux-script.welcome.json'
+      - 'scripts/tmux-script.session-browser-resize.json'
+      - 'scripts/tmux-script.unicode-composer.json'
+      # Deterministic session seed executed by the resize scenario
+      - 'scripts/seed-session-browser-resize.ts'
+      - 'packages/core/package.json'
+      - 'packages/core/index.ts'
+      - 'packages/core/src/index.ts'
+      - 'packages/core/src/recording/index.ts'
+      - 'packages/core/src/recording/SessionRecordingService.ts'
+      - 'packages/core/src/recording/SessionLockManager.ts'
+      - 'packages/core/src/recording/SessionLockManager.internals.ts'
+      - 'packages/core/src/utils/paths.ts'
+      - 'packages/storage/package.json'
+      - 'packages/storage/index.ts'
+      - 'packages/storage/src/index.ts'
+      - 'packages/storage/src/config/storage.ts'
+      # Scenario config referenced by the executed scenarios (welcome banner,
+      # plus system settings env path set in each scenario)
       - 'scripts/fixtures/welcome-completed.json'
       - 'scripts/system-settings.interactive-ui.json'
       # Fixtures referenced by the executed scenarios
@@ -63,6 +81,23 @@ on:
       - 'scripts/tmux-script.approval-ui.json'
       - 'scripts/tmux-script.issue2208-newlines.fake.json'
       - 'scripts/tmux-script.issue2016-composer.fake.json'
+      - 'scripts/tmux-script.provider-model.json'
+      - 'scripts/tmux-script.welcome.json'
+      - 'scripts/tmux-script.session-browser-resize.json'
+      - 'scripts/tmux-script.unicode-composer.json'
+      - 'scripts/seed-session-browser-resize.ts'
+      - 'packages/core/package.json'
+      - 'packages/core/index.ts'
+      - 'packages/core/src/index.ts'
+      - 'packages/core/src/recording/index.ts'
+      - 'packages/core/src/recording/SessionRecordingService.ts'
+      - 'packages/core/src/recording/SessionLockManager.ts'
+      - 'packages/core/src/recording/SessionLockManager.internals.ts'
+      - 'packages/core/src/utils/paths.ts'
+      - 'packages/storage/package.json'
+      - 'packages/storage/index.ts'
+      - 'packages/storage/src/index.ts'
+      - 'packages/storage/src/config/storage.ts'
       - 'scripts/fixtures/welcome-completed.json'
       - 'scripts/system-settings.interactive-ui.json'
       - 'scripts/fixtures/approval-ui.responses.jsonl'

--- a/dev-docs/ci-relevance-guide.md
+++ b/dev-docs/ci-relevance-guide.md
@@ -173,11 +173,27 @@ consumed by the test:
 - The tmux harness entry and its split helper modules.
 - The Bun test preload (`scripts/tests/test-setup.ts`).
 - The test file itself (`scripts/tests/interactive-ui.test.ts`).
-- The three executed scenario JSON files.
-- The scenario config referenced by all three scenarios
+- The seven executed scenario JSON files.
+- The deterministic session seed invoked by the resize scenario
+  (`scripts/seed-session-browser-resize.ts`).
+- The scenario config referenced by the executed scenarios
   (`scripts/fixtures/welcome-completed.json`,
   `scripts/system-settings.interactive-ui.json`).
 - The response fixture files referenced by those scenarios.
+
+The seven executed scenarios are:
+`scripts/tmux-script.slash-autocomplete.json`,
+`scripts/tmux-script.approval-ui.json`,
+`scripts/tmux-script.issue2208-newlines.fake.json`,
+`scripts/tmux-script.provider-model.json`,
+`scripts/tmux-script.welcome.json`,
+`scripts/tmux-script.session-browser-resize.json`, and
+`scripts/tmux-script.unicode-composer.json`.
+
+The provider/model, welcome, resize, and Unicode scenarios are added by issue #2017.
+Tool-approval deny/Escape and session-browser open/navigation/search journeys are
+owned by PRs #3308 and #3310 and are executed and listed by those PRs, not by
+this lane.
 
 Broad package/runtime paths remain because the job runs `npm ci`, a
 workspace-wide build, the real CLI launcher, and the real tmux UI tests.

--- a/dev-docs/tmux-harness.md
+++ b/dev-docs/tmux-harness.md
@@ -64,6 +64,7 @@ Macros are the recommended place to encode **UI-specific behavior**, so scripts 
 - `line`: `{ "type": "line", "text": "...", "submitKeys": ["Escape","Enter"], "postTypeMs": 600 }`
 - `key`: `{ "type": "key", "key": "Enter" }`
 - `keys`: `{ "type": "keys", "keys": ["Down","Enter"] }`
+- `resize`: `{ "type": "resize", "cols": 58, "rows": 24, "settleMs": 600 }`
 - `waitFor`: `{ "type": "waitFor", "scope": "screen"|"scrollback", "contains": "..." | "regex": "...", "timeoutMs": 15000, "pollMs": 250 }`
 - `waitForNot`: like `waitFor`, but asserts absence until timeout.
 - `expect`: like `waitFor`, but checks immediately (no polling).
@@ -75,6 +76,23 @@ Macros are the recommended place to encode **UI-specific behavior**, so scripts 
 - `waitForExit`: `{ "type": "waitForExit", "timeoutMs": 15000 }`
 
 Keys are tmux key names (examples: `Enter`, `Escape`, `Up`, `Down`, `C-s`, `C-c`).
+
+### Resize step
+
+The `resize` step changes the real tmux terminal size so Ink receives a genuine
+resize event and reflows (standard terminal, not a mocked React width).
+
+- `cols` and `rows` must be positive integers. Non-integer, zero, negative,
+  or non-finite values fail the step before any tmux command runs.
+- `settleMs` is optional and defaults to `600`; it must be a finite
+  nonnegative number. The default covers the current resize debounce and deferred
+  refresh in the Ink UI.
+- The step targets the active window in the harness's isolated tmux session via
+  the session-only target (`<session>`), so a resize never touches other sessions.
+- Use `waitFor`/`waitForNot` after a resize to assert that the UI reflowed
+  into the new dimensions, with `capture` recording the before and after screens.
+  This is how real-terminal reflow behavior (for example the session browser
+  hiding its standard-width sort bar at narrow widths) is asserted.
 
 ## UI convenience steps
 

--- a/project-plans/issue2017/PLAN.md
+++ b/project-plans/issue2017/PLAN.md
@@ -1,0 +1,323 @@
+# PLAN-20260827-ISSUE2017: Core Ink UI terminal journeys
+
+Issue: #2017, Add tmux and PTY coverage for core Ink UI journeys
+
+## Accepted behavior
+
+The issue expands the existing Ubuntu-only `interactive-ui` lane. It does not
+change end-user UI behavior. Real-terminal tests are accepted only where tmux is
+needed to prove terminal rendering, key routing, or resize propagation. Existing
+Bun component and buffer tests remain responsible for non-terminal logic.
+
+Two journey families from the original plan were removed from this branch because the work
+is already being delivered by two open PRs:
+- Tool approval deny/Escape journeys are owned by PR #3308.
+- Session-browser open/navigation/search/exit coverage is owned by PR #3310.
+
+### REQ-2017-001: Provider and model selection smoke flow
+
+- **GIVEN** the fake provider and its `fake-model`, without external credentials
+- **WHEN** the user invokes the provider and model commands and opens their
+  selection dialogs
+- **THEN** the CLI renders deterministic provider/model feedback; provider Tab
+  changes modes; typed search input filters each one-item fake list to zero;
+  Backspace restores each list; Escape dismisses each dialog; and the composer
+  remains usable
+- **AND** each keyboard action is followed by an observable wait/expect that
+  fails if the key is ignored
+- **AND** no provider-switch failure or `[API Error:` output appears.
+
+Boundary: FakeProvider exposes one provider/model pair, so search/filter state
+provides falsifiable keyboard interaction without claiming directional movement
+or a credentialed cross-provider switch. Existing real-provider reproduction
+scripts remain manual and are not added to CI.
+
+### REQ-2017-002: Clean-runner welcome journey
+
+- **GIVEN** an isolated, nonexistent welcome-config path for each test run
+- **WHEN** the CLI starts and the user selects the skip-onboarding option
+- **THEN** the welcome heading, both choices, and keyboard help render; the skip
+  action reaches the composer; and the CLI exits normally
+- **AND** any welcome-state write is confined to the scenario artifact
+  directory.
+
+Boundary: repeated runs must not inherit a prior run's completed welcome state.
+No user or repository configuration may be modified.
+
+### REQ-2017-003: Real terminal resize and reflow
+
+- **GIVEN** clean config/data/cache/log roots beneath the scenario artifact
+  directory and an unlocked fake-provider session persisted there through the
+  existing session-recording service before `/continue`
+- **WHEN** the session browser opens at standard width and the harness resizes
+  the terminal below the UI's narrow breakpoint, then restores the original size
+- **THEN** Ink receives the real terminal resize, the browser hides its
+  standard-width sort bar when narrow, restores it when widened, remains live,
+  and exits normally
+- **AND** the scenario neither reads nor writes user, repository, or sibling
+  scenario session storage.
+
+The browser here is only an observable responsive surface; its open/navigation/search
+behavior is owned by PR #3310 and is not re-tested in this lane. The resize
+step's Ink reflow assertion is the accepted subject.
+
+The harness accepts a data-driven `resize` step with positive integer `cols` and
+`rows` and an optional nonnegative `settleMs`. Invalid dimensions fail before a
+tmux command runs. The step uses the harness's isolated tmux server and targets
+the active test window. Its default settle interval covers the current resize
+debounce and deferred refresh. Unknown step types continue to fail.
+
+Boundary dimensions for behavioral evidence: 110 columns at standard width,
+58 columns at narrow width, and restoration to 110 columns.
+
+### REQ-2017-004: Unicode and wide-character composer rendering
+
+- **GIVEN** a real tmux terminal and an unsubmitted composer value containing
+  CJK, emoji, accented text, and a combining character
+- **WHEN** the value is entered and captured at standard and narrow widths
+- **THEN** the standard-width screen contains the intact value, narrow-width
+  capture demonstrates wrapping without replacement characters or duplicated
+  input, and the composer can be cleared and exited.
+
+The tmux assertion proves terminal round-trip and visible rendering. Existing
+text-buffer and width unit tests remain responsible for exact cell-width and
+grapheme algorithms.
+
+### REQ-2017-005: Single-platform, artifact-rich lane and path contract
+
+- Every accepted journey runs from `scripts/tests/interactive-ui.test.ts` under
+  `npm run test:interactive-ui` on the existing `ubuntu-latest` job.
+- Each scenario has a distinct artifact directory and captures screen and
+  scrollback at the relevant decision points. Existing pane output, final
+  failure captures, and CLI debug logs remain available in the uploaded
+  `interactive-ui-artifacts` tree.
+- New scenario paths are listed explicitly and symmetrically under the
+  workflow's pull-request and push filters. Broad scripts globs remain
+  prohibited by the issue #2693 path contract.
+- The path-contract test describes the complete executed scenario set: the
+  three pre-existing scenarios plus the four accepted above.
+
+### REQ-2017-006: Harness resize behavior tests
+
+- A Bun test written before the resize implementation proves valid resize
+  command construction, isolated active-window targeting, invalid dimensions,
+  invalid settle intervals, and continued unknown-step rejection.
+- The test exercises the real exported step dispatcher and replaces only tmux
+  process I/O at the operating-system boundary.
+
+### REQ-2017-007: Focused documentation
+
+- `dev-docs/tmux-harness.md` documents resize fields, validation, targeting,
+  default settling, and real-terminal reflow assertions.
+- Only the Interactive UI path-contract section of
+  `dev-docs/ci-relevance-guide.md` changes. It lists seven executed scenarios
+  and their explicit direct paths.
+
+### REQ-2017-008: Candidate verification
+
+- The resize and workflow path-contract Bun tests pass.
+- Each of the four accepted scenarios passes individually with artifacts under
+  distinct repository-local `tmp/verify2017/interactive-ui/` directories.
+- The enabled seven-scenario lane passes with its configured artifact root.
+- Test-audit findings for touched tests are compared against `main` and
+  inspected.
+- The complete repository verification cycle passes on the candidate tree:
+  tests, lint, typecheck, format, build, and the user-approved `zai` smoke
+  command. The original `stepfun-37` profile was replaced after it returned an
+  account-level HTTP 400 for an inactive Step plan subscription.
+
+## Behavioral evidence required
+
+1. The provider/model scenario proves deterministic command feedback; observable
+   provider mode switching; provider/model filter-to-zero and restoration;
+   Escape dismissal; no switch/API failure; and clean exit.
+2. The welcome scenario proves clean-state rendering, skip selection, isolated
+   state persistence, composer arrival, and clean exit.
+3. The resize scenario proves clean artifact-local storage, one readable and
+   unlocked fake-provider session before `/continue`, and
+   standard-to-narrow-to-standard reflow through real tmux dimensions, not a
+   mocked React width.
+4. The Unicode scenario proves intact terminal round-trip at standard width and
+   records narrow wrapping without replacement characters.
+5. The harness test proves the resize dispatch and validation contract.
+6. The path-contract test proves seven direct scenario paths, the resize seed
+   input, prohibited broad globs, and symmetric pull-request and push filters.
+7. Local individual and enabled-lane runs preserve artifacts beneath
+   `tmp/verify2017/interactive-ui/`.
+8. All added tests use TypeScript and `bun:test`. No new JavaScript, Vitest suite,
+   dependency, public API, or multi-platform matrix is accepted.
+
+## Test-first implementation phases
+
+### Phase 0: Preflight
+
+- Verify current harness dispatch and isolated tmux I/O contracts.
+- Run the current path-contract test and record the current enabled scenario
+  list.
+- Confirm tmux availability/version and run one existing deterministic scenario
+  before changing the harness.
+
+### Phase 1: RED, resize behavior
+
+- Add `scripts/tests/tmux-harness-steps.test.ts` with Bun behavioral tests for
+  REQ-2017-006.
+- Run it and record the natural failure because `resize` is unknown. The retained
+  chronological RED is `tmp/verify2017/resize-red.log`; it begins with
+  `Unknown step.type: resize` before the resize implementation existed.
+
+### Phase 2: GREEN, resize primitive
+
+- Add only the `resize` step and its validation to
+  `scripts/tmux-harness-steps.ts`.
+- Use existing isolated `runTmux` and `sleep` dependencies. Do not add a harness
+  abstraction or change unrelated helpers.
+- Document the primitive in `dev-docs/tmux-harness.md`.
+
+### Phase 3: Deterministic journey scenarios
+
+- Add focused JSON scenarios for provider/model smoke, welcome, resize, and
+  Unicode composer rendering.
+- Persist the resize scenario's fake-provider session through the existing
+  session-recording service under artifact-local storage. Flush and unlock it
+  before starting the CLI, then require exactly one readable browser target.
+- Keep each scenario independent, polling for UI states instead of synchronizing
+  through long fixed sleeps.
+
+### Phase 4: Lane and path-contract wiring
+
+- Register the four accepted journeys in
+  `scripts/tests/interactive-ui.test.ts`, with per-run welcome state under its
+  artifact directory.
+- Add each direct scenario path symmetrically to
+  `.github/workflows/interactive-ui.yml`.
+- Update `scripts/tests/interactive-ui-paths.bun.test.ts` and the Interactive UI
+  section of `dev-docs/ci-relevance-guide.md` without changing other workflow
+  relevance policies.
+
+### Phase 5: Verification
+
+Run the four scenarios individually, the enabled lane, test audit against
+`main`, and then the repository verification cycle:
+
+```bash
+bun test scripts/tests/tmux-harness-steps.test.ts
+bun test scripts/tests/seed-session-browser-resize.test.ts
+bun test scripts/tests/interactive-ui-paths.bun.test.ts
+bun scripts/tmux-harness.ts --script scripts/tmux-script.provider-model.json --out-dir tmp/verify2017/remediation/provider-model
+bun scripts/tmux-harness.ts --script scripts/tmux-script.session-browser-resize.json --out-dir tmp/verify2017/remediation/resize
+LLXPRT_TMUX_ARTIFACT_DIR=tmp/verify2017/remediation/interactive-ui npm run test:interactive-ui
+bun scripts/test-audit/scan.ts tmp/verify2017/remediation/test-audit-branch
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load zai "write me a haiku and nothing else"
+```
+
+All commands run on the candidate working tree. Remediation artifacts use
+distinct directories below `tmp/verify2017/remediation/`. The enabled lane
+covers the unchanged welcome and Unicode scenarios after the focused provider
+and resize runs. Findings are classified before the working tree is presented
+for compliance review.
+
+## Finding classification
+
+- **Blocker-Fix:** breaks an accepted journey, safety, test validity, CI,
+  architecture, TDD, lint, typecheck, source/complexity limits, or artifact
+  availability.
+- **In-scope-Fix:** an issue in the changed harness step, journey scripts, lane
+  wiring, path contract, or issue documentation that does not expand behavior.
+- **Reject:** factually incorrect, already satisfied, or asks for weaker tests or
+  quality gates.
+- **Defer:** useful but outside accepted behavior, recorded without implementation.
+
+## Out of scope (owned by other PRs)
+
+- Tool approval deny-by-label and Escape-dismiss journeys are owned by PR #3308.
+- Session-browser open, navigation, search, and exit coverage is owned by PR
+  #3310. The retained resize scenario uses the browser only as a responsive
+  surface for Ink reflow assertions. It makes no claim of browser navigation
+  coverage and leaves the existing `tmux-script.session-browser.json` unchanged.
+
+## Explicitly rejected or deferred
+
+- Cross-provider testing that requires credentials or hosted models.
+- Multi-platform tmux/PTY matrices, lane splitting, new workflows, or changes to
+  unrelated workflow relevance rules.
+- New dependencies, agent memory, quality tools, public harness abstractions, or
+  broad harness refactors.
+- Exact Unicode cell-coordinate assertions beyond what tmux capture can observe.
+- Adjacent session-browser, provider, onboarding, approval, responsive-layout,
+  or composer production behavior changes discovered while adding coverage.
+- Deleting or reorganizing the older standalone session-browser wrapper as
+  cleanup. The dedicated lane may call the scenario directly.
+
+## Review finding disposition
+
+Two compliance-review rounds and two local OCR attempts exhausted the issue's
+review limits. All compliance Blocker-Fix and In-scope-Fix findings were
+resolved before final verification. The final local OCR completed all 11
+selected items and reported two additional findings:
+
+1. **Reject:** The reported risk that an unset
+   `LLXPRT_TMUX_ARTIFACT_DIR` could turn scenario cleanup into `rm -rf /storage`
+   does not match the harness execution path. `runMain` always resolves a
+   nonempty artifact directory, using a generated directory under the operating
+   system temporary directory when `--out-dir` is absent, before passing it to
+   `buildTmuxStartCommand`. The builder therefore always sets the environment
+   variable for a normal harness run.
+2. **Defer:** Rejecting an `extraEnv.LLXPRT_CODE_WELCOME_CONFIG_PATH` collision
+   could make future harness misuse fail earlier, but no current caller supplies
+   that key. The accepted issue behavior makes the dedicated `welcomeState`
+   parameter the sole welcome-state control and intentionally applies the
+   artifact-local path after `extraEnv` so a caller cannot defeat test isolation.
+   A new collision API and its tests are optional harness hardening outside this
+   issue's accepted behavior.
+
+## PR review disposition
+
+- **In-scope-Fix, CodeRabbit active-window target:** The resize command now uses
+  the session-only target so tmux selects the isolated session's active window.
+- **In-scope-Fix, OCR welcome JSON parsing:** The welcome scenario parses the
+  persisted JSON as `unknown` and checks the required semantic fields.
+- **Reject, OCR `import.meta.main` claim:** Bun
+  [documents `import.meta.main`](https://bun.com/docs/runtime/module-resolution#import-meta),
+  and the passing seven-scenario CI lane proves that the seeder entry point ran.
+- **Reject, OCR invalid-dimension expected-message claim:** Parameterized field
+  interpolation produces the exact implementation strings, and the tests passed
+  locally and in CI.
+- **Reject, OCR `settleMs` expected-message claim:** The test and implementation
+  strings are identical and passed.
+- **Reject, OCR unknown-step expected-message claim:** The test and implementation
+  strings are identical and passed.
+- **Reject, OCR top-level try/catch suggestion:** Bun reports a rejected top-level
+  await and exits nonzero. Adding catch, log, and exit wrapping would duplicate
+  the existing fail-fast runtime behavior.
+- **Defer, CodeRabbit docstring coverage finishing-touch warning:** CI does not
+  require it, repository style does not require docstrings for each small test
+  helper, and adding comment volume is outside accepted behavior.
+- **Reject, CodeRabbit linked-issues inconclusive check:** CodeRabbit's own JSON
+  review exclusion prevented it from reading the four scenario definitions.
+  The scenarios run in the local and CI tmux lanes, and changing review-tool
+  configuration to make that optional check conclusive would be an unplanned
+  quality-tool change outside this issue.
+
+## Candidate-head OCR review disposition
+
+- **Reject, broad-glob header claim:** The same test file explicitly rejects
+  `scripts/tests/**`, `scripts/fixtures/**`, and `scripts/tmux-script*.json`.
+  The finding considered only the separate duplicate-scenario assertions.
+- **Reject, session-browser response fixture claim:** The resize journey makes no
+  provider request. The existing response file supplies valid fake-provider
+  configuration shared by the new no-request scenarios, and the suggested
+  session-browser fixture does not exist.
+- **Reject, assertion-tracking guard claim:** The guard performs required TypeScript
+  narrowing after the length assertion. This fail-fast test pattern is established
+  throughout the repository and produces a precise failure message.
+- **Reject, duplicated seeder constants claim:** The fixed UUID, provider, model,
+  message, and unlocked state are the deterministic seeder contract. The scenario
+  depends on that stable data, so exact assertions are intentional.
+- **In-scope-Fix, model capture label:** The capture follows filter restoration,
+  not a second keyboard-focus transition. Its label now describes the observed
+  state as `model-dialog-filter-restored`.

--- a/scripts/seed-session-browser-resize.ts
+++ b/scripts/seed-session-browser-resize.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  getProjectHash,
+  SessionRecordingService,
+  type IContent,
+} from '@vybestack/llxprt-code-core';
+import { Storage } from '@vybestack/llxprt-code-storage';
+
+const SESSION_BROWSER_RESIZE_SESSION_ID =
+  '00000000-0000-4000-8000-000000002017';
+
+export interface SessionBrowserResizeSeedOptions {
+  readonly chatsDir: string;
+  readonly projectRoot: string;
+}
+
+function content(speaker: IContent['speaker'], text: string): IContent {
+  return {
+    speaker,
+    blocks: [{ type: 'text', text }],
+  };
+}
+
+/**
+ * Persists an unlocked fake-provider conversation for the resize scenario.
+ *
+ * @param options - Project and session-storage locations for the seed.
+ * @returns A promise that resolves after the session is flushed and unlocked.
+ */
+export async function seedSessionBrowserResize(
+  options: SessionBrowserResizeSeedOptions,
+): Promise<void> {
+  const recording = await SessionRecordingService.createLocked({
+    sessionId: SESSION_BROWSER_RESIZE_SESSION_ID,
+    projectHash: getProjectHash(options.projectRoot),
+    chatsDir: options.chatsDir,
+    workspaceDirs: [options.projectRoot],
+    cwd: options.projectRoot,
+    provider: 'fake',
+    model: 'fake-model',
+  });
+
+  try {
+    recording.recordContent(content('human', 'seed isolated resize session'));
+    recording.recordContent(content('ai', 'isolated resize session ready'));
+    await recording.flush();
+  } finally {
+    await recording.dispose();
+  }
+}
+
+async function main(): Promise<void> {
+  const projectRoot = process.cwd();
+  const storage = new Storage(projectRoot);
+  await seedSessionBrowserResize({
+    chatsDir: storage.getProjectChatsDir(),
+    projectRoot,
+  });
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/tests/interactive-ui-paths.bun.test.ts
+++ b/scripts/tests/interactive-ui-paths.bun.test.ts
@@ -84,20 +84,61 @@ describe('interactive-ui.yml: direct harness inputs are included', () => {
     expect(prPaths).toContain('scripts/tests/interactive-ui.test.ts');
   });
 
-  it('includes all executed scenario JSON files', () => {
-    expect(prPaths).toContain('scripts/tmux-script.slash-autocomplete.json');
-    expect(prPaths).toContain('scripts/tmux-script.approval-ui.json');
-    expect(prPaths).toContain(
-      'scripts/tmux-script.issue2208-newlines.fake.json',
-    );
+  it('includes the target-branch startup composer fake scenario', () => {
     expect(prPaths).toContain(
       'scripts/tmux-script.issue2016-composer.fake.json',
     );
   });
 
-  it('includes the scenario config fixtures referenced by all scenarios', () => {
-    // All executed scenarios set LLXPRT_CODE_WELCOME_CONFIG_PATH and
-    // LLXPRT_SYSTEM_SETTINGS_PATH to these direct inputs.
+  it('includes all executed scenario JSON files (target and issue #2017)', () => {
+    const executedScenarios = [
+      'scripts/tmux-script.slash-autocomplete.json',
+      'scripts/tmux-script.approval-ui.json',
+      'scripts/tmux-script.issue2208-newlines.fake.json',
+      'scripts/tmux-script.issue2016-composer.fake.json',
+      'scripts/tmux-script.provider-model.json',
+      'scripts/tmux-script.welcome.json',
+      'scripts/tmux-script.session-browser-resize.json',
+      'scripts/tmux-script.unicode-composer.json',
+    ];
+
+    for (const scenario of executedScenarios) {
+      expect(prPaths).toContain(scenario);
+    }
+
+    // Duplicate browser-navigation (PR #3310) and approval (PR #3308)
+    // scenarios are excluded from this lane and from the path contract.
+    expect(prPaths).not.toContain('scripts/tmux-script.session-browser.json');
+    expect(prPaths).not.toContain('scripts/tmux-script.approval-deny.json');
+    expect(prPaths).not.toContain('scripts/tmux-script.approval-escape.json');
+  });
+
+  it('includes the deterministic resize-session seed input', () => {
+    expect(prPaths).toContain('scripts/seed-session-browser-resize.ts');
+  });
+
+  it('includes the resize seeder package exports and direct implementations', () => {
+    const seederDependencies = [
+      'packages/core/package.json',
+      'packages/core/index.ts',
+      'packages/core/src/index.ts',
+      'packages/core/src/recording/index.ts',
+      'packages/core/src/recording/SessionRecordingService.ts',
+      'packages/core/src/recording/SessionLockManager.ts',
+      'packages/core/src/recording/SessionLockManager.internals.ts',
+      'packages/core/src/utils/paths.ts',
+      'packages/storage/package.json',
+      'packages/storage/index.ts',
+      'packages/storage/src/index.ts',
+      'packages/storage/src/config/storage.ts',
+    ];
+
+    for (const dependency of seederDependencies) {
+      expect(prPaths).toContain(dependency);
+    }
+  });
+
+  it('includes the scenario config fixtures referenced by the executed scenarios', () => {
     expect(prPaths).toContain('scripts/fixtures/welcome-completed.json');
     expect(prPaths).toContain('scripts/system-settings.interactive-ui.json');
   });

--- a/scripts/tests/interactive-ui.test.ts
+++ b/scripts/tests/interactive-ui.test.ts
@@ -21,10 +21,11 @@
  */
 
 import { spawnSync } from 'node:child_process';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { afterAll, describe, it } from 'bun:test';
+import { afterAll, describe, expect, it } from 'bun:test';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '../..');
@@ -38,7 +39,7 @@ const runTmuxE2E = isEnabled ? it : it.skip;
  */
 function getArtifactDir(testName: string): string {
   const base = process.env.LLXPRT_TMUX_ARTIFACT_DIR ?? os.tmpdir();
-  return path.join(base, testName);
+  return path.resolve(base, testName);
 }
 
 /**
@@ -57,6 +58,7 @@ interface HarnessResult {
 }
 
 const artifactDirs: string[] = [];
+type WelcomeState = 'completed' | 'clean';
 
 /**
  * Run the tmux harness with a given script and stable artifact dir.
@@ -66,10 +68,21 @@ function runHarness(
   testName: string,
   extraArgs: string[] = [],
   extraEnv: NodeJS.ProcessEnv = {},
+  welcomeState: WelcomeState = 'completed',
 ): HarnessResult {
   const scriptPath = path.join(projectRoot, 'scripts', scriptName);
   const harnessPath = path.join(projectRoot, 'scripts/tmux-harness.ts');
   const artifactDir = getArtifactDir(testName);
+  const welcomeConfigPath = path.join(artifactDir, 'welcome-config.json');
+  rmSync(artifactDir, { recursive: true, force: true });
+  mkdirSync(artifactDir, { recursive: true });
+  if (welcomeState === 'completed') {
+    writeFileSync(
+      welcomeConfigPath,
+      JSON.stringify({ welcomeCompleted: true, skipped: true }, null, 2),
+      'utf8',
+    );
+  }
   artifactDirs.push(artifactDir);
 
   const result = spawnSync(
@@ -86,7 +99,13 @@ function runHarness(
       encoding: 'utf8',
       cwd: projectRoot,
       timeout: 300_000,
-      env: { ...process.env, FORCE_COLOR: '0', ...extraEnv },
+      env: {
+        ...process.env,
+        FORCE_COLOR: '0',
+        NO_COLOR: '1',
+        ...extraEnv,
+        LLXPRT_CODE_WELCOME_CONFIG_PATH: welcomeConfigPath,
+      },
     },
   );
 
@@ -186,6 +205,69 @@ describe('Interactive UI (tmux harness)', () => {
       const result = runHarness(
         'tmux-script.issue2016-composer.fake.json',
         'issue2016-composer',
+      );
+      assertHarnessSuccess(result);
+    },
+    300_000,
+  );
+
+  runTmuxE2E(
+    'provider and model dialogs work with the fake provider',
+    () => {
+      const result = runHarness(
+        'tmux-script.provider-model.json',
+        'provider-model',
+      );
+      assertHarnessSuccess(result);
+    },
+    300_000,
+  );
+
+  runTmuxE2E(
+    'welcome onboarding skips from isolated clean state',
+    () => {
+      const testName = 'welcome';
+      const result = runHarness(
+        'tmux-script.welcome.json',
+        testName,
+        [],
+        {},
+        'clean',
+      );
+      assertHarnessSuccess(result);
+
+      const savedState: unknown = JSON.parse(
+        readFileSync(
+          path.join(getArtifactDir(testName), 'welcome-config.json'),
+          'utf8',
+        ),
+      );
+      expect(savedState).toMatchObject({
+        welcomeCompleted: true,
+        skipped: true,
+      });
+    },
+    300_000,
+  );
+
+  runTmuxE2E(
+    'session browser reflows across real terminal resizes',
+    () => {
+      const result = runHarness(
+        'tmux-script.session-browser-resize.json',
+        'session-browser-resize',
+      );
+      assertHarnessSuccess(result);
+    },
+    300_000,
+  );
+
+  runTmuxE2E(
+    'composer preserves Unicode and wide characters while wrapping',
+    () => {
+      const result = runHarness(
+        'tmux-script.unicode-composer.json',
+        'unicode-composer',
       );
       assertHarnessSuccess(result);
     },

--- a/scripts/tests/seed-session-browser-resize.test.ts
+++ b/scripts/tests/seed-session-browser-resize.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  getProjectHash,
+  SessionDiscovery,
+  SessionLockManager,
+} from '@vybestack/llxprt-code-core';
+import { seedSessionBrowserResize } from '../seed-session-browser-resize.ts';
+
+const EXPECTED_SESSION_ID = '00000000-0000-4000-8000-000000002017';
+
+let tempRoot: string;
+let chatsDir: string;
+let projectRoot: string;
+
+beforeEach(async () => {
+  tempRoot = await mkdtemp(path.join(os.tmpdir(), 'resize-session-seed-'));
+  chatsDir = path.join(tempRoot, 'chats');
+  projectRoot = path.join(tempRoot, 'workspace');
+});
+
+afterEach(async () => {
+  await rm(tempRoot, { recursive: true, force: true });
+});
+
+describe('session-browser resize seed', () => {
+  it('persists the fixed unlocked fake-provider session for the target project', async () => {
+    await seedSessionBrowserResize({ chatsDir, projectRoot });
+
+    const targets = await SessionDiscovery.listContinueTargets(
+      chatsDir,
+      getProjectHash(projectRoot),
+    );
+
+    expect(targets).toHaveLength(1);
+    const target = targets[0];
+    if (target === undefined || target.kind !== 'session') {
+      throw new Error('Expected one persisted session target');
+    }
+    expect(target.session).toMatchObject({
+      sessionId: EXPECTED_SESSION_ID,
+      provider: 'fake',
+      model: 'fake-model',
+    });
+    await expect(
+      SessionDiscovery.readFirstUserMessage(target.session.filePath),
+    ).resolves.toBe('seed isolated resize session');
+    await expect(
+      SessionLockManager.isLocked(chatsDir, EXPECTED_SESSION_ID),
+    ).resolves.toBe(false);
+  });
+});

--- a/scripts/tests/tmux-harness-steps.test.ts
+++ b/scripts/tests/tmux-harness-steps.test.ts
@@ -1,0 +1,166 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
+
+interface TmuxProcessResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly status: number;
+  readonly error: undefined;
+}
+
+function successfulTmuxProcess(): TmuxProcessResult {
+  return {
+    stdout: '',
+    stderr: '',
+    status: 0,
+    error: undefined,
+  };
+}
+
+const spawnSyncMock = vi.fn((..._args: readonly unknown[]) =>
+  successfulTmuxProcess(),
+);
+const actualChildProcess = { ...(await import('node:child_process')) };
+
+void vi.mock('node:child_process', () => ({
+  ...actualChildProcess,
+  spawnSync: (...args: readonly unknown[]) => spawnSyncMock(...args),
+}));
+
+const { executeStepDispatch } = await import('../tmux-harness-steps.ts');
+const { cleanupTmuxSocketDir, getTmuxSocketPath } = await import(
+  '../tmux-harness-io.ts'
+);
+
+type DispatchContext = Parameters<typeof executeStepDispatch>[2];
+
+function createContext(): DispatchContext {
+  return {
+    sessionName: 'issue2017-session',
+    outDir: 'tmp/verify2017/resize-test',
+    sendKeys: async () => undefined,
+    scriptState: { historySamples: [] },
+    defaults: {
+      postTypeMs: 0,
+      submitKeys: ['Enter'],
+      shellSubmitKeys: ['Enter'],
+      timeoutMs: 100,
+      pollMs: 10,
+      scrollbackLines: 100,
+    },
+  };
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === 'string')
+  );
+}
+
+function findTmuxArgs(command: string): string[] | undefined {
+  for (const call of spawnSyncMock.mock.calls) {
+    const args = call[1];
+    if (isStringArray(args) && args.includes(command)) {
+      return args;
+    }
+  }
+  return undefined;
+}
+
+function tmuxInvocations(): string[][] {
+  const invocations: string[][] = [];
+  for (const call of spawnSyncMock.mock.calls) {
+    const args = call[1];
+    if (isStringArray(args)) {
+      invocations.push(args);
+    }
+  }
+  return invocations;
+}
+
+beforeEach(() => {
+  spawnSyncMock.mockClear();
+  spawnSyncMock.mockImplementation((..._args: readonly unknown[]) =>
+    successfulTmuxProcess(),
+  );
+});
+
+afterEach(() => {
+  cleanupTmuxSocketDir();
+});
+
+describe('tmux harness resize step', () => {
+  it('resizes the active test window through the isolated tmux server', async () => {
+    await executeStepDispatch(
+      { type: 'resize', cols: 58, rows: 24, settleMs: 0 },
+      3,
+      createContext(),
+    );
+
+    const expectedArgs = [
+      process.platform === 'win32' ? '-L' : '-S',
+      getTmuxSocketPath(),
+      'resize-window',
+      '-t',
+      'issue2017-session',
+      '-x',
+      '58',
+      '-y',
+      '24',
+    ];
+    expect(findTmuxArgs('resize-window')).toEqual(expectedArgs);
+    expect(tmuxInvocations()).toEqual([expectedArgs]);
+  });
+
+  it.each([
+    ['cols', 0, 24],
+    ['cols', -1, 24],
+    ['cols', 58.5, 24],
+    ['cols', Number.POSITIVE_INFINITY, 24],
+    ['rows', 58, 0],
+    ['rows', 58, -1],
+    ['rows', 58, 24.5],
+    ['rows', 58, Number.NaN],
+  ] as const)(
+    'rejects invalid %s before invoking tmux',
+    async (field, cols, rows) => {
+      const result = executeStepDispatch(
+        { type: 'resize', cols, rows, settleMs: 0 },
+        3,
+        createContext(),
+      );
+
+      await expect(result).rejects.toThrow(`Invalid resize.${field}`);
+      expect(findTmuxArgs('resize-window')).toBeUndefined();
+    },
+  );
+
+  it.each([-1, Number.POSITIVE_INFINITY, Number.NaN])(
+    'rejects invalid settleMs %p before invoking tmux',
+    async (settleMs) => {
+      const result = executeStepDispatch(
+        { type: 'resize', cols: 58, rows: 24, settleMs },
+        3,
+        createContext(),
+      );
+
+      await expect(result).rejects.toThrow('Invalid resize.settleMs');
+      expect(findTmuxArgs('resize-window')).toBeUndefined();
+    },
+  );
+
+  it('continues to reject unknown step types', async () => {
+    const result = executeStepDispatch(
+      { type: 'resize-unknown' },
+      3,
+      createContext(),
+    );
+
+    await expect(result).rejects.toThrow('Unknown step.type: resize-unknown');
+  });
+});

--- a/scripts/tmux-harness-steps.ts
+++ b/scripts/tmux-harness-steps.ts
@@ -70,6 +70,9 @@ interface Step {
   key?: string;
   keys?: string[];
   ms?: number;
+  cols?: number;
+  rows?: number;
+  settleMs?: number;
   postTypeMs?: number;
   submitKeys?: string[];
   label?: string;
@@ -107,6 +110,37 @@ export async function executeWaitStep(step: Step): Promise<void> {
     throw new Error(`Invalid wait.ms`);
   }
   await sleep(ms);
+}
+
+async function executeResizeStep(
+  step: Step,
+  sessionName: string,
+): Promise<void> {
+  const cols = Number(step.cols);
+  if (!Number.isInteger(cols) || cols <= 0) {
+    throw new Error(`Invalid resize.cols`);
+  }
+
+  const rows = Number(step.rows);
+  if (!Number.isInteger(rows) || rows <= 0) {
+    throw new Error(`Invalid resize.rows`);
+  }
+
+  const settleMs = Number(step.settleMs ?? 600);
+  if (!Number.isFinite(settleMs) || settleMs < 0) {
+    throw new Error(`Invalid resize.settleMs`);
+  }
+
+  runTmux([
+    'resize-window',
+    '-t',
+    sessionName,
+    '-x',
+    String(cols),
+    '-y',
+    String(rows),
+  ]);
+  await sleep(settleMs);
 }
 
 export async function executeLineStep(
@@ -528,6 +562,8 @@ export async function executeStepDispatch(
   switch (step.type) {
     case 'wait':
       return executeWaitStep(step);
+    case 'resize':
+      return executeResizeStep(step, sessionName);
     case 'line':
       return executeLineStep(step, sessionName, sendKeys, defaults);
     case 'key':

--- a/scripts/tmux-script.provider-model.json
+++ b/scripts/tmux-script.provider-model.json
@@ -1,0 +1,128 @@
+{
+  "tmux": {
+    "cols": 110,
+    "rows": 40,
+    "historyLimit": 20000,
+    "scrollbackLines": 3000,
+    "initialWaitMs": 6000
+  },
+  "startCommand": [
+    "env CI=0 CONTINUOUS_INTEGRATION=0 NODE_OPTIONS= NO_COLOR=1 LLXPRT_CODE_NO_RELAUNCH=true LLXPRT_CODE_SKIP_TERMINAL_CAPABILITY_DETECTION=true LLXPRT_CODE_BUILTIN_COMMANDS_ONLY=true LLXPRT_CODE_SUPPRESS_STATIC_HEADER=true LLXPRT_SYSTEM_SETTINGS_PATH=scripts/system-settings.interactive-ui.json LLXPRT_FAKE_RESPONSES=scripts/fixtures/approval-ui.responses.jsonl ${bun} packages/cli/index.ts --provider fake --model fake-model"
+  ],
+  "yolo": false,
+  "steps": [
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Type your message",
+      "timeoutMs": 30000
+    },
+    { "type": "line", "text": "/provider fake" },
+    {
+      "type": "waitFor",
+      "scope": "scrollback",
+      "contains": "Already using provider: fake",
+      "timeoutMs": 15000
+    },
+    { "type": "line", "text": "/provider" },
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Select Provider (",
+      "timeoutMs": 15000
+    },
+    { "type": "waitFor", "scope": "screen", "contains": "fake" },
+    { "type": "key", "key": "Tab" },
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Search Providers",
+      "timeoutMs": 5000
+    },
+    { "type": "key", "key": "z" },
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "No providers match \"z\"",
+      "timeoutMs": 5000
+    },
+    { "type": "capture", "label": "provider-dialog-filtered" },
+    { "type": "key", "key": "BSpace" },
+    {
+      "type": "waitForNot",
+      "scope": "screen",
+      "contains": "No providers match",
+      "timeoutMs": 5000
+    },
+    { "type": "waitFor", "scope": "screen", "contains": "fake" },
+    { "type": "key", "key": "Tab" },
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Select Provider (",
+      "timeoutMs": 5000
+    },
+    { "type": "capture", "label": "provider-dialog-keyboard-transition" },
+    { "type": "key", "key": "Escape" },
+    {
+      "type": "waitForNot",
+      "scope": "screen",
+      "regex": "Search Providers|Select Provider",
+      "timeoutMs": 5000
+    },
+    { "type": "line", "text": "/model fake-model" },
+    {
+      "type": "waitFor",
+      "scope": "scrollback",
+      "contains": "in provider 'fake'",
+      "timeoutMs": 15000
+    },
+    { "type": "line", "text": "/model" },
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Models (fake)",
+      "timeoutMs": 15000
+    },
+    { "type": "waitFor", "scope": "screen", "contains": "fake-model" },
+    { "type": "key", "key": "z" },
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "No models match your search",
+      "timeoutMs": 5000
+    },
+    { "type": "capture", "label": "model-dialog-filtered" },
+    { "type": "key", "key": "BSpace" },
+    {
+      "type": "waitForNot",
+      "scope": "screen",
+      "contains": "No models match your search",
+      "timeoutMs": 5000
+    },
+    { "type": "waitFor", "scope": "screen", "contains": "fake-model" },
+    { "type": "capture", "label": "model-dialog-filter-restored" },
+    { "type": "key", "key": "Escape" },
+    {
+      "type": "waitForNot",
+      "scope": "screen",
+      "contains": "Models (fake)",
+      "timeoutMs": 5000
+    },
+    {
+      "type": "expectCount",
+      "scope": "scrollback",
+      "contains": "Failed to switch provider",
+      "equals": 0
+    },
+    {
+      "type": "expectCount",
+      "scope": "scrollback",
+      "contains": "[API Error:",
+      "equals": 0
+    },
+    { "type": "capture", "label": "provider-model-complete" },
+    { "type": "line", "text": "/quit", "submitKeys": ["Enter"] },
+    { "type": "waitForExit", "timeoutMs": 15000 }
+  ]
+}

--- a/scripts/tmux-script.session-browser-resize.json
+++ b/scripts/tmux-script.session-browser-resize.json
@@ -1,0 +1,68 @@
+{
+  "tmux": {
+    "cols": 110,
+    "rows": 40,
+    "historyLimit": 20000,
+    "scrollbackLines": 3000,
+    "initialWaitMs": 6000
+  },
+  "startCommand": [
+    "sh -c 'rm -rf \"$LLXPRT_TMUX_ARTIFACT_DIR/storage\" && mkdir -p \"$LLXPRT_TMUX_ARTIFACT_DIR/storage\" && export CI=0 CONTINUOUS_INTEGRATION=0 NODE_OPTIONS= NO_COLOR=1 LLXPRT_CODE_NO_RELAUNCH=true LLXPRT_CODE_SKIP_TERMINAL_CAPABILITY_DETECTION=true LLXPRT_CODE_BUILTIN_COMMANDS_ONLY=true LLXPRT_CODE_SUPPRESS_STATIC_HEADER=true LLXPRT_CONFIG_HOME=\"$LLXPRT_TMUX_ARTIFACT_DIR/storage/config\" LLXPRT_DATA_HOME=\"$LLXPRT_TMUX_ARTIFACT_DIR/storage/data\" LLXPRT_CACHE_HOME=\"$LLXPRT_TMUX_ARTIFACT_DIR/storage/cache\" LLXPRT_LOG_HOME=\"$LLXPRT_TMUX_ARTIFACT_DIR/storage/log\" LLXPRT_SYSTEM_SETTINGS_PATH=scripts/system-settings.interactive-ui.json LLXPRT_FAKE_RESPONSES=scripts/fixtures/approval-ui.responses.jsonl && ${bun} scripts/seed-session-browser-resize.ts && exec ${bun} packages/cli/index.ts --provider fake --model fake-model'"
+  ],
+  "yolo": false,
+  "steps": [
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Type your message",
+      "timeoutMs": 30000
+    },
+    { "type": "line", "text": "/continue", "submitKeys": ["Enter"] },
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Session Browser",
+      "timeoutMs": 15000
+    },
+    { "type": "waitFor", "scope": "screen", "contains": "1 target found" },
+    { "type": "waitFor", "scope": "screen", "contains": "Sort:" },
+    { "type": "capture", "label": "resize-standard-before" },
+    { "type": "resize", "cols": 58, "rows": 40 },
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Sessions",
+      "timeoutMs": 5000
+    },
+    {
+      "type": "waitForNot",
+      "scope": "screen",
+      "contains": "Sort:",
+      "timeoutMs": 5000
+    },
+    { "type": "capture", "label": "resize-narrow" },
+    { "type": "resize", "cols": 110, "rows": 40 },
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Session Browser",
+      "timeoutMs": 5000
+    },
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Sort:",
+      "timeoutMs": 5000
+    },
+    { "type": "capture", "label": "resize-standard-restored" },
+    { "type": "key", "key": "Escape" },
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Type your message",
+      "timeoutMs": 5000
+    },
+    { "type": "line", "text": "/quit", "submitKeys": ["Enter"] },
+    { "type": "waitForExit", "timeoutMs": 15000 }
+  ]
+}

--- a/scripts/tmux-script.unicode-composer.json
+++ b/scripts/tmux-script.unicode-composer.json
@@ -1,0 +1,100 @@
+{
+  "tmux": {
+    "cols": 110,
+    "rows": 40,
+    "historyLimit": 20000,
+    "scrollbackLines": 3000,
+    "initialWaitMs": 6000
+  },
+  "startCommand": [
+    "env CI=0 CONTINUOUS_INTEGRATION=0 NODE_OPTIONS= NO_COLOR=1 LLXPRT_CODE_NO_RELAUNCH=true LLXPRT_CODE_SKIP_TERMINAL_CAPABILITY_DETECTION=true LLXPRT_CODE_BUILTIN_COMMANDS_ONLY=true LLXPRT_CODE_SUPPRESS_STATIC_HEADER=true LLXPRT_SYSTEM_SETTINGS_PATH=scripts/system-settings.interactive-ui.json LLXPRT_FAKE_RESPONSES=scripts/fixtures/approval-ui.responses.jsonl ${bun} packages/cli/index.ts --provider fake --model fake-model"
+  ],
+  "yolo": false,
+  "steps": [
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Type your message",
+      "timeoutMs": 30000
+    },
+    {
+      "type": "line",
+      "text": "LLXPRT2017 Unicode composer 你好世界 🌍🚀 café naïve élan terminal rendering FIN",
+      "submitKeys": [],
+      "postTypeMs": 0
+    },
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "LLXPRT2017 Unicode composer 你好世界 🌍🚀 café naïve élan terminal rendering FIN",
+      "timeoutMs": 5000
+    },
+    { "type": "capture", "label": "unicode-standard" },
+    { "type": "resize", "cols": 58, "rows": 40 },
+    {
+      "type": "waitForNot",
+      "scope": "screen",
+      "contains": "LLXPRT2017 Unicode composer 你好世界 🌍🚀 café naïve élan terminal rendering FIN",
+      "timeoutMs": 5000
+    },
+    {
+      "type": "expectCount",
+      "scope": "screen",
+      "contains": "LLXPRT2017",
+      "equals": 1
+    },
+    {
+      "type": "expectCount",
+      "scope": "screen",
+      "contains": "你好世界",
+      "equals": 1
+    },
+    {
+      "type": "expectCount",
+      "scope": "screen",
+      "contains": "🌍🚀",
+      "equals": 1
+    },
+    {
+      "type": "expectCount",
+      "scope": "screen",
+      "contains": "café",
+      "equals": 1
+    },
+    {
+      "type": "expectCount",
+      "scope": "screen",
+      "contains": "naïve",
+      "equals": 1
+    },
+    {
+      "type": "expectCount",
+      "scope": "screen",
+      "contains": "élan",
+      "equals": 1
+    },
+    {
+      "type": "expectCount",
+      "scope": "screen",
+      "contains": "FIN",
+      "equals": 1
+    },
+    {
+      "type": "expectCount",
+      "scope": "screen",
+      "contains": "�",
+      "equals": 0
+    },
+    { "type": "capture", "label": "unicode-narrow" },
+    { "type": "key", "key": "C-c" },
+    {
+      "type": "waitForNot",
+      "scope": "screen",
+      "contains": "LLXPRT2017",
+      "timeoutMs": 5000
+    },
+    { "type": "resize", "cols": 110, "rows": 40 },
+    { "type": "line", "text": "/quit", "submitKeys": ["Enter"] },
+    { "type": "waitForExit", "timeoutMs": 15000 }
+  ]
+}

--- a/scripts/tmux-script.welcome.json
+++ b/scripts/tmux-script.welcome.json
@@ -1,0 +1,56 @@
+{
+  "tmux": {
+    "cols": 110,
+    "rows": 40,
+    "historyLimit": 20000,
+    "scrollbackLines": 3000,
+    "initialWaitMs": 6000
+  },
+  "startCommand": [
+    "env CI=0 CONTINUOUS_INTEGRATION=0 NODE_OPTIONS= NO_COLOR=1 LLXPRT_CODE_NO_RELAUNCH=true LLXPRT_CODE_SKIP_TERMINAL_CAPABILITY_DETECTION=true LLXPRT_CODE_BUILTIN_COMMANDS_ONLY=true LLXPRT_CODE_SUPPRESS_STATIC_HEADER=true LLXPRT_SYSTEM_SETTINGS_PATH=scripts/system-settings.interactive-ui.json LLXPRT_FAKE_RESPONSES=scripts/fixtures/approval-ui.responses.jsonl ${bun} packages/cli/index.ts"
+  ],
+  "yolo": false,
+  "steps": [
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Welcome to llxprt!",
+      "timeoutMs": 30000
+    },
+    {
+      "type": "expect",
+      "scope": "screen",
+      "contains": "Set up now (recommended)"
+    },
+    {
+      "type": "expect",
+      "scope": "screen",
+      "contains": "Skip setup (I know what I'm doing)"
+    },
+    {
+      "type": "expect",
+      "scope": "screen",
+      "contains": "Use ↑↓ to navigate, Enter to select, Esc to skip"
+    },
+    { "type": "capture", "label": "welcome-options" },
+    { "type": "key", "key": "Down" },
+    { "type": "key", "key": "Enter" },
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Setup skipped",
+      "timeoutMs": 5000
+    },
+    { "type": "capture", "label": "welcome-skipped" },
+    { "type": "key", "key": "Enter" },
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Type your message",
+      "timeoutMs": 15000
+    },
+    { "type": "capture", "label": "welcome-composer" },
+    { "type": "line", "text": "/quit", "submitKeys": ["Enter"] },
+    { "type": "waitForExit", "timeoutMs": 15000 }
+  ]
+}


### PR DESCRIPTION
## TLDR

Adds deterministic real-terminal coverage for four Ink UI journeys: provider/model dialogs, clean welcome onboarding, terminal resize/reflow, and Unicode composer rendering. With the release target's startup-composer coverage, the Ubuntu-only Interactive UI lane now runs eight scenarios and retains per-scenario screen, scrollback, pane-output, and debug artifacts.

## Dive Deeper

The tmux harness now accepts a validated `resize` step with positive integer dimensions and optional settling time. It targets the active window on the harness's isolated tmux server, which lets the resize scenario prove 110-column to 58-column to 110-column Ink reflow through real terminal events.

The new journeys isolate state and provider behavior:

- Provider/model dialogs use the fake provider and verify mode changes, zero-result filtering and restoration, Escape dismissal, and absence of switch or API failures.
- Welcome onboarding starts from an artifact-local clean state, selects skip, reaches the composer, and verifies the persisted completion state.
- Resize seeds one deterministic, unlocked fake-provider session in artifact-local storage before opening the responsive session-browser surface.
- Unicode coverage enters CJK, emoji, accented, and combining characters, verifies standard and narrow rendering, rejects replacement characters and duplication, clears the composer, and exits.

Workflow path filters explicitly list all eight scenarios, the resize seeder, and its direct package inputs for both pull requests and pushes. The lane remains single-platform and does not add dependencies or production UI behavior.

Approval deny/Escape coverage remains with #3308. Session-browser navigation and search coverage remains with #3310, avoiding duplicate scenarios.

## Reviewer Test Plan

1. Run focused behavioral tests:

   ```bash
   bun test scripts/tests/tmux-harness-steps.test.ts
   bun test scripts/tests/seed-session-browser-resize.test.ts
   bun test scripts/tests/interactive-ui-paths.bun.test.ts
   ```

2. Run the enabled real-terminal lane and inspect its artifact subdirectories:

   ```bash
   LLXPRT_TMUX_ARTIFACT_DIR=tmp/review2017/interactive-ui npm run test:interactive-ui
   ```

3. Confirm the resize captures show the standard sort bar, its removal at 58 columns, and its restoration at 110 columns. Confirm the Unicode captures contain the entered CJK, emoji, accented, and combining-character text without `�`.

4. Run repository gates:

   ```bash
   npm run test
   npm run lint
   npm run typecheck
   npm run format
   npm run build
   bun scripts/start.ts --profile-load zai "write me a haiku and nothing else"
   ```

Release-target candidate evidence: focused Bun tests passed 36/36, all eight tmux scenarios passed, full test/lint/typecheck/format/build passed, touched-test audit had no findings delta, and the user-approved ZAI startup smoke passed.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | CI  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

The tmux lane intentionally runs on Ubuntu only. Local repository and real-terminal verification ran on macOS.

## Linked issues / bugs

Fixes #2017

Related ownership: #3308, #3310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved interactive UI reliability across provider and model dialogs, onboarding, session browser resizing, and Unicode or wide-character text entry.
  * Added support for resizing interactive terminal sessions and validating layout changes.
  * Enhanced onboarding state handling and deterministic session setup for more consistent experiences.

* **Tests**
  * Expanded automated coverage for onboarding, terminal resizing, text wrapping, session setup, and scenario execution.
  * Improved workflow validation to ensure relevant interactive UI changes trigger verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->