### PR TITLE
fix(cli): let at-completion recover from a failed crawl or search (Fixes #3373)

### DIFF
--- a/packages/cli/src/ui/hooks/useAtCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.test.ts
@@ -423,6 +423,203 @@ describe('useAtCompletion', () => {
     });
   });
 
+  describe('ERROR recovery', () => {
+    it('re-initializes and searches when a failed crawl retries on a pattern change (AC1)', async () => {
+      testRootDir = await createTmpDir({ 'alpha.txt': '' });
+
+      const realFileSearch = FileSearchFactory.create({
+        projectRoot: testRootDir,
+        ignoreDirs: [],
+        useGitignore: true,
+        useExtensionIgnore: true,
+        cache: false,
+        cacheTtl: 0,
+        enableRecursiveFileSearch: true,
+        enableFuzzySearch: true,
+      });
+      await realFileSearch.initialize();
+
+      const failingSearcher: FileSearch = {
+        initialize: vi.fn().mockRejectedValue(new Error('crawl failed')),
+        search: vi.fn().mockResolvedValue([]),
+      };
+
+      let createCall = 0;
+      vi.spyOn(FileSearchFactory, 'create').mockImplementation(() => {
+        createCall += 1;
+        return createCall === 1 ? failingSearcher : realFileSearch;
+      });
+
+      const { result, rerender } = renderHook(
+        ({ pattern }: { pattern: string }) =>
+          useTestHarnessForAtCompletion(true, pattern, mockConfig, testRootDir),
+        { initialProps: { pattern: 'alp' } },
+      );
+
+      // The first crawl fails; the hook settles in ERROR.
+      await waitFor(() => {
+        expect(result.current.isLoadingSuggestions).toBe(false);
+        expect(result.current.suggestions).toStrictEqual([]);
+      });
+
+      // A new pattern re-initializes against the same cwd and searches.
+      rerender({ pattern: 'alph' });
+
+      await waitFor(() => {
+        expect(result.current.suggestions.map((s) => s.value)).toStrictEqual([
+          'alpha.txt',
+        ]);
+      });
+      expect(result.current.isLoadingSuggestions).toBe(false);
+    });
+
+    it('re-searches when a failed search retries on a pattern change (AC2)', async () => {
+      testRootDir = await createTmpDir({ 'alpha.txt': '', 'beta.txt': '' });
+
+      const realFileSearch = FileSearchFactory.create({
+        projectRoot: testRootDir,
+        ignoreDirs: [],
+        useGitignore: true,
+        useExtensionIgnore: true,
+        cache: false,
+        cacheTtl: 0,
+        enableRecursiveFileSearch: true,
+        enableFuzzySearch: true,
+      });
+      await realFileSearch.initialize();
+
+      let rejectAlpSearch = (_error: Error): void => {
+        throw new Error('Expected the alp search promise to be initialized');
+      };
+      const alpSearch = new Promise<string[]>((_resolve, reject) => {
+        rejectAlpSearch = reject;
+      });
+      const stubFileSearch: FileSearch = {
+        initialize: vi.fn().mockResolvedValue(undefined),
+        search: vi.fn((searchPattern: string, options) => {
+          if (searchPattern === 'alp') {
+            return alpSearch;
+          }
+          return realFileSearch.search(searchPattern, options);
+        }),
+      };
+      vi.spyOn(FileSearchFactory, 'create').mockReturnValue(stubFileSearch);
+
+      const { result, rerender } = renderHook(
+        ({ pattern }: { pattern: string }) =>
+          useTestHarnessForAtCompletion(true, pattern, mockConfig, testRootDir),
+        { initialProps: { pattern: 'alp' } },
+      );
+
+      // Drive the initial search to failure and let it settle in ERROR.
+      await waitFor(() => {
+        expect(stubFileSearch.search).toHaveBeenCalledWith(
+          'alp',
+          expect.any(Object),
+        );
+      });
+      await act(async () => {
+        rejectAlpSearch(new Error('search failed'));
+        await Promise.resolve();
+      });
+      expect(result.current.isLoadingSuggestions).toBe(false);
+      expect(result.current.suggestions).toStrictEqual([]);
+
+      rerender({ pattern: 'bet' });
+
+      await waitFor(() => {
+        expect(result.current.suggestions.map((s) => s.value)).toStrictEqual([
+          'beta.txt',
+        ]);
+      });
+      expect(result.current.isLoadingSuggestions).toBe(false);
+    });
+
+    it('retries at most once per distinct normalized pattern (AC3)', async () => {
+      testRootDir = await createTmpDir({});
+
+      const failingSearcher: FileSearch = {
+        initialize: vi.fn().mockRejectedValue(new Error('crawl failed')),
+        search: vi.fn().mockResolvedValue([]),
+      };
+      const createSpy = vi
+        .spyOn(FileSearchFactory, 'create')
+        .mockReturnValue(failingSearcher);
+
+      const { result, rerender } = renderHook(
+        ({ pattern }: { pattern: string }) =>
+          useTestHarnessForAtCompletion(true, pattern, mockConfig, testRootDir),
+        { initialProps: { pattern: 'alp' } },
+      );
+
+      // The crawl fails; the hook settles in ERROR.
+      await waitFor(() => {
+        expect(result.current.isLoadingSuggestions).toBe(false);
+        expect(result.current.suggestions).toStrictEqual([]);
+      });
+
+      expect(createSpy).toHaveBeenCalledTimes(1);
+
+      // Same pattern and a case-variant of it normalize to the same value, so
+      // no retry is scheduled. Drive the clock well past the 150ms retry
+      // debounce to prove nothing fires late.
+      vi.useFakeTimers();
+      act(() => {
+        rerender({ pattern: 'alp' });
+        rerender({ pattern: 'ALP' });
+        vi.advanceTimersByTime(1000);
+      });
+
+      expect(createSpy).toHaveBeenCalledTimes(1);
+      expect(result.current.isLoadingSuggestions).toBe(false);
+      expect(result.current.suggestions).toStrictEqual([]);
+    });
+
+    it('does not loop when a retry fails again (AC4)', async () => {
+      testRootDir = await createTmpDir({});
+
+      const failingSearcher: FileSearch = {
+        initialize: vi.fn().mockRejectedValue(new Error('crawl failed')),
+        search: vi.fn().mockResolvedValue([]),
+      };
+      const createSpy = vi
+        .spyOn(FileSearchFactory, 'create')
+        .mockReturnValue(failingSearcher);
+
+      const { result, rerender } = renderHook(
+        ({ pattern }: { pattern: string }) =>
+          useTestHarnessForAtCompletion(true, pattern, mockConfig, testRootDir),
+        { initialProps: { pattern: 'alp' } },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoadingSuggestions).toBe(false);
+        expect(result.current.suggestions).toStrictEqual([]);
+      });
+
+      // One retry fires on the new pattern... wait for it to actually attempt
+      // (the retry is debounced, and ERROR already looks "settled").
+      rerender({ pattern: 'alph' });
+      await waitFor(() => {
+        expect(createSpy).toHaveBeenCalledTimes(2);
+      });
+
+      // ...fails again, and settles in ERROR without spinning.
+      await waitFor(() => {
+        expect(result.current.isLoadingSuggestions).toBe(false);
+        expect(result.current.suggestions).toStrictEqual([]);
+      });
+
+      // The failed retry recorded 'alph', so the unchanged pattern schedules
+      // nothing more even once the retry debounce window has long passed.
+      vi.useFakeTimers();
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(createSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('Filtering and Configuration', () => {
     it('should respect .gitignore files', async () => {
       const gitignoreContent = ['dist/', '*.log'].join('\n');

--- a/packages/cli/src/ui/hooks/useAtCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.test.ts
@@ -533,6 +533,60 @@ describe('useAtCompletion', () => {
         ]);
       });
       expect(result.current.isLoadingSuggestions).toBe(false);
+      // Exactly the two searches the user asked for: the retry must not replay
+      // the pattern that already failed.
+      expect(stubFileSearch.search).toHaveBeenCalledTimes(2);
+    });
+
+    it('still retries when a case-only edit cancels the pending retry (AC1)', async () => {
+      testRootDir = await createTmpDir({ 'alpha.txt': '' });
+
+      const realFileSearch = FileSearchFactory.create({
+        projectRoot: testRootDir,
+        ignoreDirs: [],
+        useGitignore: true,
+        useExtensionIgnore: true,
+        cache: false,
+        cacheTtl: 0,
+        enableRecursiveFileSearch: true,
+        enableFuzzySearch: true,
+      });
+      await realFileSearch.initialize();
+
+      const failingSearcher: FileSearch = {
+        initialize: vi.fn().mockRejectedValue(new Error('crawl failed')),
+        search: vi.fn().mockResolvedValue([]),
+      };
+
+      let createCall = 0;
+      vi.spyOn(FileSearchFactory, 'create').mockImplementation(() => {
+        createCall += 1;
+        return createCall === 1 ? failingSearcher : realFileSearch;
+      });
+
+      const { result, rerender } = renderHook(
+        ({ pattern }: { pattern: string }) =>
+          useTestHarnessForAtCompletion(true, pattern, mockConfig, testRootDir),
+        { initialProps: { pattern: 'alp' } },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoadingSuggestions).toBe(false);
+        expect(result.current.suggestions).toStrictEqual([]);
+      });
+
+      // The second edit lands inside the retry debounce and normalizes to the
+      // same pattern, so it cancels the pending retry. Recovery must still
+      // happen: that retry was never actually made.
+      rerender({ pattern: 'alph' });
+      rerender({ pattern: 'ALPH' });
+
+      await waitFor(() => {
+        expect(result.current.suggestions.map((s) => s.value)).toStrictEqual([
+          'alpha.txt',
+        ]);
+      });
+      expect(result.current.isLoadingSuggestions).toBe(false);
     });
 
     it('retries at most once per distinct normalized pattern (AC3)', async () => {
@@ -573,6 +627,8 @@ describe('useAtCompletion', () => {
       expect(createSpy).toHaveBeenCalledTimes(1);
       expect(result.current.isLoadingSuggestions).toBe(false);
       expect(result.current.suggestions).toStrictEqual([]);
+
+      vi.useRealTimers();
     });
 
     it('does not loop when a retry fails again (AC4)', async () => {
@@ -617,6 +673,69 @@ describe('useAtCompletion', () => {
         vi.advanceTimersByTime(1000);
       });
       expect(createSpy).toHaveBeenCalledTimes(2);
+
+      vi.useRealTimers();
+    });
+
+    it('keeps recovering when the retry runs its own failing search (AC2/AC3)', async () => {
+      testRootDir = await createTmpDir({ 'alphabet.txt': '' });
+
+      const realFileSearch = FileSearchFactory.create({
+        projectRoot: testRootDir,
+        ignoreDirs: [],
+        useGitignore: true,
+        useExtensionIgnore: true,
+        cache: false,
+        cacheTtl: 0,
+        enableRecursiveFileSearch: true,
+        enableFuzzySearch: true,
+      });
+      await realFileSearch.initialize();
+
+      // Every search fails until the user has typed 'alphab'.
+      const stubFileSearch: FileSearch = {
+        initialize: vi.fn().mockResolvedValue(undefined),
+        search: vi.fn((searchPattern: string, options) => {
+          if (searchPattern !== 'alphab') {
+            return Promise.reject(new Error('search failed'));
+          }
+          return realFileSearch.search(searchPattern, options);
+        }),
+      };
+      vi.spyOn(FileSearchFactory, 'create').mockReturnValue(stubFileSearch);
+
+      const { result, rerender } = renderHook(
+        ({ pattern }: { pattern: string }) =>
+          useTestHarnessForAtCompletion(true, pattern, mockConfig, testRootDir),
+        { initialProps: { pattern: 'alp' } },
+      );
+
+      await waitFor(() => {
+        expect(stubFileSearch.search).toHaveBeenCalledWith(
+          'alp',
+          expect.any(Object),
+        );
+      });
+
+      // The retry for 'alpha' runs a search that fails too, so the hook lands
+      // back in ERROR rather than getting stuck against the first failure.
+      rerender({ pattern: 'alpha' });
+      await waitFor(() => {
+        expect(stubFileSearch.search).toHaveBeenCalledWith(
+          'alpha',
+          expect.any(Object),
+        );
+      });
+
+      // A third pattern still recovers, which it could not do if a failing
+      // retry stranded the hook.
+      rerender({ pattern: 'alphab' });
+      await waitFor(() => {
+        expect(result.current.suggestions.map((s) => s.value)).toStrictEqual([
+          'alphabet.txt',
+        ]);
+      });
+      expect(result.current.isLoadingSuggestions).toBe(false);
     });
   });
 

--- a/packages/cli/src/ui/hooks/useAtCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.test.ts
@@ -456,7 +456,10 @@ describe('useAtCompletion', () => {
         { initialProps: { pattern: 'alp' } },
       );
 
-      // The first crawl fails; the hook settles in ERROR.
+      // The crawl is in flight, so the wait below cannot pass on the value the
+      // hook started with; only the ERROR dispatch clears the loading flag
+      // while leaving suggestions empty.
+      expect(result.current.isLoadingSuggestions).toBe(true);
       await waitFor(() => {
         expect(result.current.isLoadingSuggestions).toBe(false);
         expect(result.current.suggestions).toStrictEqual([]);
@@ -570,6 +573,7 @@ describe('useAtCompletion', () => {
         { initialProps: { pattern: 'alp' } },
       );
 
+      expect(result.current.isLoadingSuggestions).toBe(true);
       await waitFor(() => {
         expect(result.current.isLoadingSuggestions).toBe(false);
         expect(result.current.suggestions).toStrictEqual([]);
@@ -607,6 +611,7 @@ describe('useAtCompletion', () => {
       );
 
       // The crawl fails; the hook settles in ERROR.
+      expect(result.current.isLoadingSuggestions).toBe(true);
       await waitFor(() => {
         expect(result.current.isLoadingSuggestions).toBe(false);
         expect(result.current.suggestions).toStrictEqual([]);
@@ -648,6 +653,7 @@ describe('useAtCompletion', () => {
         { initialProps: { pattern: 'alp' } },
       );
 
+      expect(result.current.isLoadingSuggestions).toBe(true);
       await waitFor(() => {
         expect(result.current.isLoadingSuggestions).toBe(false);
         expect(result.current.suggestions).toStrictEqual([]);

--- a/packages/cli/src/ui/hooks/useAtCompletion.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.ts
@@ -517,6 +517,48 @@ function useResetOnCwdChange(
   ]);
 }
 
+type DebounceTimerRef = React.MutableRefObject<ReturnType<
+  typeof setTimeout
+> | null>;
+
+function clearDebounceTimer(debounceTimer: DebounceTimerRef): void {
+  if (debounceTimer.current !== null) {
+    clearTimeout(debounceTimer.current);
+    debounceTimer.current = null;
+  }
+}
+
+/**
+ * Invalidates any in-flight completion work and dispatches `action` for
+ * `normalizedPattern`.
+ *
+ * An empty pattern dispatches immediately, because the user is waiting on the
+ * full listing and has typed nothing to debounce. Anything else waits out
+ * SEARCH_DEBOUNCE_MS, so a burst of keystrokes costs one unit of work rather
+ * than one per character.
+ */
+function startPatternWork(
+  normalizedPattern: string,
+  action: AtCompletionAction,
+  attemptedPattern: React.MutableRefObject<PatternInput>,
+  lifecycleGeneration: React.MutableRefObject<number>,
+  debounceTimer: DebounceTimerRef,
+  abortCurrentSearch: () => void,
+  dispatch: React.Dispatch<AtCompletionAction>,
+): void {
+  attemptedPattern.current = normalizedPattern;
+  lifecycleGeneration.current += 1;
+  abortCurrentSearch();
+  clearDebounceTimer(debounceTimer);
+  if (normalizedPattern === '') {
+    dispatch(action);
+    return;
+  }
+  debounceTimer.current = setTimeout(() => {
+    dispatch(action);
+  }, SEARCH_DEBOUNCE_MS);
+}
+
 function usePatternChangeHandler(
   enabled: boolean,
   pattern: PatternInput,
@@ -526,17 +568,17 @@ function usePatternChangeHandler(
   abortCurrentSearch: () => void,
   dispatch: React.Dispatch<AtCompletionAction>,
 ): void {
-  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const debounceTimerRef: DebounceTimerRef = useRef(null);
+  // The normalized pattern that work was last started for.
+  const attemptedPatternRef = useRef<PatternInput>(null);
 
   useEffect(() => {
     if (!enabled) {
+      attemptedPatternRef.current = null;
       lifecycleGeneration.current += 1;
       latestRequestedPattern.current = null;
       abortCurrentSearch();
-      if (debounceTimerRef.current !== null) {
-        clearTimeout(debounceTimerRef.current);
-        debounceTimerRef.current = null;
-      }
+      clearDebounceTimer(debounceTimerRef);
       if (state.status !== AtCompletionStatus.IDLE) {
         dispatch({ type: 'RESET' });
       }
@@ -545,13 +587,11 @@ function usePatternChangeHandler(
     }
 
     if (pattern === null) {
+      attemptedPatternRef.current = null;
       lifecycleGeneration.current += 1;
       latestRequestedPattern.current = null;
       abortCurrentSearch();
-      if (debounceTimerRef.current !== null) {
-        clearTimeout(debounceTimerRef.current);
-        debounceTimerRef.current = null;
-      }
+      clearDebounceTimer(debounceTimerRef);
       dispatch({ type: 'RESET' });
       return undefined;
     }
@@ -559,35 +599,44 @@ function usePatternChangeHandler(
     const normalizedPattern = pattern.toLowerCase();
     latestRequestedPattern.current = normalizedPattern;
     if (state.status === AtCompletionStatus.IDLE) {
+      attemptedPatternRef.current = normalizedPattern;
       dispatch({ type: 'INITIALIZE' });
     } else if (
       (state.status === AtCompletionStatus.READY ||
         state.status === AtCompletionStatus.SEARCHING) &&
       normalizedPattern !== state.pattern
     ) {
-      lifecycleGeneration.current += 1;
-      abortCurrentSearch();
-      if (normalizedPattern === '') {
-        if (debounceTimerRef.current !== null) {
-          clearTimeout(debounceTimerRef.current);
-          debounceTimerRef.current = null;
-        }
-        dispatch({ type: 'SEARCH', payload: normalizedPattern });
-      } else {
-        if (debounceTimerRef.current !== null) {
-          clearTimeout(debounceTimerRef.current);
-        }
-        debounceTimerRef.current = setTimeout(() => {
-          dispatch({ type: 'SEARCH', payload: normalizedPattern });
-        }, SEARCH_DEBOUNCE_MS);
-      }
+      startPatternWork(
+        normalizedPattern,
+        { type: 'SEARCH', payload: normalizedPattern },
+        attemptedPatternRef,
+        lifecycleGeneration,
+        debounceTimerRef,
+        abortCurrentSearch,
+        dispatch,
+      );
+    } else if (
+      state.status === AtCompletionStatus.ERROR &&
+      normalizedPattern !== attemptedPatternRef.current
+    ) {
+      // A failed crawl or search leaves the hook in ERROR with no way back, so
+      // typing another character would otherwise never retry. The recorded
+      // attempted pattern is the bound: one retry per distinct normalized
+      // pattern, which keeps a genuinely broken directory from re-crawling on
+      // every render and keeps a failing retry from looping.
+      startPatternWork(
+        normalizedPattern,
+        { type: 'INITIALIZE' },
+        attemptedPatternRef,
+        lifecycleGeneration,
+        debounceTimerRef,
+        abortCurrentSearch,
+        dispatch,
+      );
     }
 
     return (): void => {
-      if (debounceTimerRef.current !== null) {
-        clearTimeout(debounceTimerRef.current);
-        debounceTimerRef.current = null;
-      }
+      clearDebounceTimer(debounceTimerRef);
     };
   }, [
     enabled,

--- a/packages/cli/src/ui/hooks/useAtCompletion.ts
+++ b/packages/cli/src/ui/hooks/useAtCompletion.ts
@@ -536,6 +536,11 @@ function clearDebounceTimer(debounceTimer: DebounceTimerRef): void {
  * full listing and has typed nothing to debounce. Anything else waits out
  * SEARCH_DEBOUNCE_MS, so a burst of keystrokes costs one unit of work rather
  * than one per character.
+ *
+ * The attempted pattern is recorded when the action dispatches, not when it is
+ * scheduled. A debounced action can still be cancelled by the effect cleanup,
+ * and recording it early would tell the ERROR branch that a retry had already
+ * been made for a pattern that never got one.
  */
 function startPatternWork(
   normalizedPattern: string,
@@ -546,17 +551,18 @@ function startPatternWork(
   abortCurrentSearch: () => void,
   dispatch: React.Dispatch<AtCompletionAction>,
 ): void {
-  attemptedPattern.current = normalizedPattern;
   lifecycleGeneration.current += 1;
   abortCurrentSearch();
   clearDebounceTimer(debounceTimer);
-  if (normalizedPattern === '') {
+  const startWork = (): void => {
+    attemptedPattern.current = normalizedPattern;
     dispatch(action);
+  };
+  if (normalizedPattern === '') {
+    startWork();
     return;
   }
-  debounceTimer.current = setTimeout(() => {
-    dispatch(action);
-  }, SEARCH_DEBOUNCE_MS);
+  debounceTimer.current = setTimeout(startWork, SEARCH_DEBOUNCE_MS);
 }
 
 function usePatternChangeHandler(
@@ -620,13 +626,17 @@ function usePatternChangeHandler(
       normalizedPattern !== attemptedPatternRef.current
     ) {
       // A failed crawl or search leaves the hook in ERROR with no way back, so
-      // typing another character would otherwise never retry. The recorded
-      // attempted pattern is the bound: one retry per distinct normalized
-      // pattern, which keeps a genuinely broken directory from re-crawling on
-      // every render and keeps a failing retry from looping.
+      // typing another character would otherwise never retry. Reset instead of
+      // initializing directly: that drops the pattern the failure was recorded
+      // against, so the IDLE branch above re-enters the normal
+      // initialize-then-search path for the pattern the user actually typed.
+      //
+      // The recorded attempted pattern is the bound: one retry per distinct
+      // normalized pattern, which keeps a genuinely broken directory from
+      // re-crawling on every render and keeps a failing retry from looping.
       startPatternWork(
         normalizedPattern,
-        { type: 'INITIALIZE' },
+        { type: 'RESET' },
         attemptedPatternRef,
         lifecycleGeneration,
         debounceTimerRef,

--- a/project-plans/issue3373-at-completion-error-recovery.md
+++ b/project-plans/issue3373-at-completion-error-recovery.md
@@ -1,0 +1,114 @@
+# Issue #3373 — At-completion cannot recover from a transient search error
+
+## Problem
+
+`usePatternChangeHandler` in `packages/cli/src/ui/hooks/useAtCompletion.ts`
+starts work only from `IDLE`, `READY`, and `SEARCHING`. `ERROR` has no
+transition on a pattern change, so once a crawl or a search fails, every
+subsequent keystroke dispatches nothing. The suggestion list stays empty for
+the rest of the session in that directory unless the hook is disabled, the
+pattern goes null, or `cwd`/`config` changes (all of which reach `RESET`).
+
+Two paths reach `ERROR`:
+
+1. `useInitializationHandler` catch — `createFileSearcher` rejected. In this
+   case `state.pattern` is still `null`, because only `SEARCH` writes it.
+2. `performSearch` catch — a search rejected for a non-abort reason. Here
+   `state.pattern` holds the pattern that failed.
+
+Both must recover.
+
+## Accepted behavior
+
+**AC1 — Recovery from an initialization failure.** With the hook enabled and
+`cwd`/`config` unchanged, if the hook is in `ERROR` after a failed
+initialization and the user changes the pattern, the hook re-enters
+initialization, performs the search for the new pattern, and populates
+suggestions. `isLoadingSuggestions` settles to `false`.
+
+**AC2 — Recovery from a search failure.** Same as AC1 when `ERROR` was
+reached from a failed `FileSearch.search` rather than a failed
+`initialize`.
+
+**AC3 — Retry is bounded to one attempt per distinct normalized pattern.**
+While in `ERROR`, re-rendering with a pattern that normalizes (lowercases) to
+the pattern already attempted does not start another initialization. Only a
+genuinely new normalized pattern triggers a retry. This keeps a permanently
+broken directory from crawling on every render, and it prevents a retry loop
+when the retry itself fails: a second failure returns to `ERROR` with the same
+attempted pattern recorded, so no further work is dispatched until the user
+types something different.
+
+**AC4 — The retry is debounced like a search.** For a non-empty pattern the
+retry initialization is scheduled through the existing
+`SEARCH_DEBOUNCE_MS` (150 ms) timer, so fast typing in a broken directory
+produces one crawl after the user pauses rather than one per character. An
+empty pattern retries immediately, matching how `SEARCH` is dispatched today.
+
+**AC5 — No regression in the other transitions.** `IDLE` still initializes,
+`READY`/`SEARCHING` still debounce-search on pattern change, and disable /
+null-pattern / `cwd`-change still `RESET`.
+
+### Boundary cases
+
+- `ERROR` with `state.pattern === null` (initialization failure) — the retry
+  gate cannot use `state.pattern`, so a separate record of the attempted
+  pattern is required.
+- Pattern that differs only by case (`"ALP"` after `"alp"`) — normalizes to the
+  same value, so it is not a retry trigger.
+- Empty pattern in `ERROR` — retries without debounce.
+- Retry that fails again — lands back in `ERROR`, dispatches nothing further.
+- Stale in-flight work — the lifecycle generation is bumped and any current
+  search aborted before the retry, so a late result from the failed lifecycle
+  cannot dispatch into the new one.
+
+### Out of scope
+
+- Surfacing the error to the user (no error UI exists today).
+- Automatic time-based retry, retry counters, or backoff.
+- Any change to `FileSearch`, the reducer's other actions, or the other hooks
+  in this file.
+
+## Implementation
+
+In `usePatternChangeHandler` only:
+
+1. Add a ref recording the normalized pattern for which work was last started
+   (`INITIALIZE` or `SEARCH`). Clear it on the disable and null-pattern
+   branches, which both `RESET`.
+2. Add an `ERROR` branch to the status dispatch chain: when
+   `state.status === ERROR` and the normalized pattern differs from the
+   recorded attempted pattern, record the new pattern, bump the lifecycle
+   generation, abort any current search, and dispatch `INITIALIZE` —
+   immediately for an empty pattern, otherwise through the existing debounce
+   timer.
+
+The reducer, `useInitializationHandler`, `useSearchHandler`, and
+`useResetOnCwdChange` are untouched. After a successful retry the hook lands in
+`READY` and the existing `READY` branch issues the search for the current
+pattern, which is how the first search is issued today.
+
+## Tests (behavioral, `packages/cli/src/ui/hooks/useAtCompletion.test.ts`)
+
+All tests use a real temp directory and the real `FileSearch` for the success
+path, with `FileSearchFactory.create` stubbed only to inject the failure.
+
+1. **AC1** — first `create` returns a searcher whose `initialize` rejects;
+   later calls return a real searcher. Render with pattern `"alp"`, wait for the
+   error settle (`isLoadingSuggestions === false`, no suggestions), then
+   rerender with `"alph"` and the same `cwd`. Assert suggestions become
+   `["alpha.txt"]` and `isLoadingSuggestions` is `false`. Fails on `main`.
+2. **AC2** — `initialize` resolves; `search` rejects for the first pattern and
+   delegates to a real searcher otherwise. Drive to `ERROR`, change the
+   pattern, assert suggestions populate.
+3. **AC3** — `initialize` always rejects. Drive to `ERROR`, then rerender with
+   the same pattern and with a case variant of it. Assert
+   `FileSearchFactory.create` was called exactly once.
+4. **AC4/AC3** — `initialize` always rejects. Drive to `ERROR`, change the
+   pattern once, wait for the second failure to settle, and assert
+   `FileSearchFactory.create` was called exactly twice — the retry happened and
+   did not loop.
+
+The existing suite must continue to pass unchanged, in particular
+`should reset the state when disabled after being in an ERROR state` and
+`should reset and re-initialize when the cwd changes`.

--- a/project-plans/issue3373-at-completion-error-recovery.md
+++ b/project-plans/issue3373-at-completion-error-recovery.md
@@ -55,7 +55,11 @@ null-pattern / `cwd`-change still `RESET`.
   gate cannot use `state.pattern`, so a separate record of the attempted
   pattern is required.
 - Pattern that differs only by case (`"ALP"` after `"alp"`) — normalizes to the
-  same value, so it is not a retry trigger.
+  same value, so it is not a retry trigger. If it arrives while a retry is
+  still waiting on the debounce it cancels that retry through the effect
+  cleanup, so the attempted pattern must be recorded when the retry dispatches
+  rather than when it is scheduled; otherwise the cancelled retry would count
+  as made and recovery would never happen.
 - Empty pattern in `ERROR` — retries without debounce.
 - Retry that fails again — lands back in `ERROR`, dispatches nothing further.
 - Stale in-flight work — the lifecycle generation is bumped and any current
@@ -79,14 +83,26 @@ In `usePatternChangeHandler` only:
 2. Add an `ERROR` branch to the status dispatch chain: when
    `state.status === ERROR` and the normalized pattern differs from the
    recorded attempted pattern, record the new pattern, bump the lifecycle
-   generation, abort any current search, and dispatch `INITIALIZE` —
-   immediately for an empty pattern, otherwise through the existing debounce
-   timer.
+   generation, abort any current search, and dispatch `RESET` — immediately for
+   an empty pattern, otherwise through the existing debounce timer.
+
+`RESET` rather than `INITIALIZE` because `INITIALIZE` leaves `state.pattern`
+alone. On the search-failure path that pattern is the one that just failed, and
+`useInitializationHandler` would then dispatch a `SEARCH` for it as soon as the
+retry crawl succeeded: a wasted search of the pattern the user has already
+typed past. `RESET` clears it and hands control to the `IDLE` branch, which is
+the state machine's existing entry point, so the retry runs the normal
+initialize-then-search path for the pattern the user actually typed.
 
 The reducer, `useInitializationHandler`, `useSearchHandler`, and
-`useResetOnCwdChange` are untouched. After a successful retry the hook lands in
-`READY` and the existing `READY` branch issues the search for the current
-pattern, which is how the first search is issued today.
+`useResetOnCwdChange` are untouched.
+
+Getting under the repository's `max-lines-per-function` (80) and
+`sonarjs/cognitive-complexity` (30) limits required extracting the
+debounce-and-dispatch body, which the search path and the retry path now share,
+into `startPatternWork`, and the three copies of the timer teardown into
+`clearDebounceTimer`. Both are behavior-preserving extractions of code that
+already existed.
 
 ## Tests (behavioral, `packages/cli/src/ui/hooks/useAtCompletion.test.ts`)
 
@@ -108,6 +124,17 @@ path, with `FileSearchFactory.create` stubbed only to inject the failure.
    pattern once, wait for the second failure to settle, and assert
    `FileSearchFactory.create` was called exactly twice — the retry happened and
    did not loop.
+5. **AC1 boundary** — drive to `ERROR`, then rerender twice back to back with
+   `"alph"` and `"ALPH"`. The second edit cancels the pending retry and
+   normalizes to the same pattern; suggestions must still populate.
+6. **AC2/AC3** — every search fails until the third pattern. Drive to `ERROR`,
+   change the pattern into a retry whose own search also fails, then change it
+   once more and assert suggestions populate. A failing retry must not strand
+   the hook.
+
+Test 2 also asserts `FileSearch.search` was called exactly twice, which is the
+evidence for the `RESET`-over-`INITIALIZE` decision: dispatching `INITIALIZE`
+there replays the failed pattern and makes that count three.
 
 The existing suite must continue to pass unchanged, in particular
 `should reset the state when disabled after being in an ERROR state` and


### PR DESCRIPTION
## TLDR

`useAtCompletion` had no transition out of `AtCompletionStatus.ERROR` on a pattern change. One failed file-system crawl or search left `@` completion silently empty for the rest of the session in that working directory: typing more characters looked like it should retry and dispatched nothing. The only escapes were deleting the `@`, disabling the hook, or changing `cwd`.

A pattern change from `ERROR` now dispatches `RESET`, which returns the machine to `IDLE`, whose existing branch re-enters initialization and then search. The retry is bounded to one attempt per distinct normalized pattern, so a genuinely broken directory does not re-crawl on every render and a retry that fails again does not loop.

Reviewers should look at two decisions in `usePatternChangeHandler`: why the retry dispatches `RESET` instead of `INITIALIZE`, and why the attempted pattern is recorded when the action dispatches rather than when it is scheduled. Each has a test that fails without it.

## Dive Deeper

`ERROR` is reachable two ways, and they leave the state differently:

- `useInitializationHandler` catches a rejected `createFileSearcher`. `state.pattern` is still `null` here, because only the `SEARCH` action writes it.
- `performSearch` catches a rejected `FileSearch.search`. `state.pattern` holds the pattern that failed.

Both now recover.

**Why `RESET` and not `INITIALIZE`.** `INITIALIZE` leaves `state.pattern` alone. On the search-failure path that value is the pattern that just failed, so as soon as the retry crawl succeeded `useInitializationHandler` would dispatch a `SEARCH` for it: a wasted search of a pattern the user has already typed past. Its result is discarded by the `shouldDispatchResult` guard, so nothing wrong reaches the screen, but the work is pointless. `RESET` clears the pattern and hands control to the `IDLE` branch, which is the state machine's existing entry point. The search-failure test asserts `FileSearch.search` was called exactly twice; dispatching `INITIALIZE` there makes it three.

**Why the retry bound is a ref and not `state.pattern`.** On the initialization-failure path `state.pattern` is `null`, so a `normalizedPattern !== state.pattern` guard would be true forever and the hook would re-crawl on every render, spinning without end on a directory that is genuinely broken. `attemptedPatternRef` records the normalized pattern that work was last started for, and the `ERROR` branch fires only when the current pattern differs from it.

**Why the bound is written at dispatch time.** The retry is debounced by the existing `SEARCH_DEBOUNCE_MS` (150 ms), and a debounced action can still be cancelled by the effect cleanup. A case-only edit arriving inside that window (`alph` then `ALPH`) cancels the pending retry and normalizes to the same value, so a bound written at schedule time would record a retry that never happened and leave completion stuck in `ERROR`. Writing it inside the dispatch closure fixes that.

**Refactor.** The debounce-and-dispatch body is now shared by the search path and the retry path, so it was extracted into `startPatternWork`, and the three copies of the timer teardown into `clearDebounceTimer`. This is a behavior-preserving extraction of code that already existed; it was required because adding the `ERROR` branch pushed `usePatternChangeHandler` past the repository's `max-lines-per-function` (80) and `sonarjs/cognitive-complexity` (30) limits.

Out of scope and deliberately not done: surfacing the error in the UI (there is no error affordance today), time-based retry, backoff, and retry counters.

Acceptance criteria and the reasoning behind each are recorded in `project-plans/issue3373-at-completion-error-recovery.md`.

## Reviewer Test Plan

Six behavioral tests were added to `packages/cli/src/ui/hooks/useAtCompletion.test.ts`, all driving the real hook against a real temp directory with `FileSearchFactory.create` stubbed only to inject the failure:

1. Recovery after a rejected `initialize`, `cwd` unchanged.
2. Recovery after a rejected `search`, plus the assertion that the failed pattern is not replayed.
3. A case-only edit inside the retry debounce still recovers.
4. The retry is bounded to one attempt per distinct normalized pattern (`FileSearchFactory.create` called once across `alp`, `alp`, `ALP`, with the clock driven past the debounce).
5. A retry that fails again settles in `ERROR` without spinning (`create` called exactly twice).
6. A retry whose own search also fails does not strand the hook; a third pattern still recovers.

To confirm they bite, each was run against the unfixed code:

- On `main`, tests 1, 2, 5, and 6 fail.
- Reverting only the `RESET` decision to `INITIALIZE` fails test 2.
- Reverting only the dispatch-time bound to a schedule-time bound fails test 3.
- Replacing the ref bound with `normalizedPattern !== state.pattern` fails test 4.

Manual check: point the CLI at a directory whose crawl can be made to fail, type `@`, then keep typing. Before this change the list stays empty forever; after it, the next character retries and suggestions appear.

Full local cycle on the candidate head: `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`, and the `stepfun-37` startup smoke all pass.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3373

Related to #2019, whose `ERROR`-path coverage was limited to `cwd`-change recovery precisely because same-directory recovery did not work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery after failed file crawls and searches.
  * Prevented duplicate retries and retry loops when patterns change or searches fail repeatedly.
  * Ensured case-only pattern edits trigger the correct recovery behavior.
  * Improved handling when completion is disabled or no pattern is available.
  * Corrected loading-state reporting while suggestions are being fetched before an error is shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->