### PR TITLE
test: cover onboarding, profile, provider, and model UI behavior (Fixes #2023)

### DIFF
--- a/.github/workflows/interactive-ui.yml
+++ b/.github/workflows/interactive-ui.yml
@@ -21,8 +21,11 @@ on:
       - 'scripts/tmux-script.approval-ui.json'
       - 'scripts/tmux-script.issue2208-newlines.fake.json'
       - 'scripts/tmux-script.issue2016-composer.fake.json'
-      # Scenario config referenced by all scenarios (welcome banner +
-      # system settings env paths set in each scenario)
+      - 'scripts/tmux-script.onboarding.json'
+      # Scenario config referenced by the scenarios (welcome banner +
+      # system settings env paths set in each scenario). The onboarding
+      # scenario deliberately points the welcome config at a per-run temp
+      # path instead, so it does not consume welcome-completed.json.
       - 'scripts/fixtures/welcome-completed.json'
       - 'scripts/system-settings.interactive-ui.json'
       # Fixtures referenced by the executed scenarios
@@ -31,6 +34,8 @@ on:
       # CLI UI layer (dialogs, autocomplete, input handling)
       - 'packages/cli/src/ui/**'
       - 'packages/cli/src/commands/**'
+      # First-run welcome detection/persistence driven by the onboarding scenario
+      - 'packages/cli/src/config/welcomeConfig.ts'
       # Core tool approval, skills, fake provider, and policy logic
       - 'packages/agents/src/scheduler/**'
       - 'packages/cli/src/providers/providerManagerInstance.ts'
@@ -63,12 +68,14 @@ on:
       - 'scripts/tmux-script.approval-ui.json'
       - 'scripts/tmux-script.issue2208-newlines.fake.json'
       - 'scripts/tmux-script.issue2016-composer.fake.json'
+      - 'scripts/tmux-script.onboarding.json'
       - 'scripts/fixtures/welcome-completed.json'
       - 'scripts/system-settings.interactive-ui.json'
       - 'scripts/fixtures/approval-ui.responses.jsonl'
       - 'scripts/fixtures/issue2208-newlines.responses.jsonl'
       - 'packages/cli/src/ui/**'
       - 'packages/cli/src/commands/**'
+      - 'packages/cli/src/config/welcomeConfig.ts'
       - 'packages/agents/src/scheduler/**'
       - 'packages/cli/src/providers/providerManagerInstance.ts'
       - 'packages/core/src/policy/**'

--- a/packages/cli/src/config/welcomeConfig.test.ts
+++ b/packages/cli/src/config/welcomeConfig.test.ts
@@ -1,0 +1,215 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  WELCOME_CONFIG_FILENAME,
+  getWelcomeConfigPath,
+  isWelcomeCompleted,
+  loadWelcomeConfig,
+  markWelcomeCompleted,
+  resetWelcomeConfigForTesting,
+  saveWelcomeConfig,
+} from './welcomeConfig.js';
+import { USER_SETTINGS_DIR } from './paths.js';
+
+const WELCOME_CONFIG_ENV = 'LLXPRT_CODE_WELCOME_CONFIG_PATH';
+
+interface PersistedWelcomeConfig {
+  welcomeCompleted: boolean;
+  completedAt?: string;
+  skipped?: boolean;
+}
+
+function isPersistedWelcomeConfig(
+  value: unknown,
+): value is PersistedWelcomeConfig {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate.welcomeCompleted !== 'boolean') return false;
+  if ('completedAt' in candidate && typeof candidate.completedAt !== 'string') {
+    return false;
+  }
+  if ('skipped' in candidate && typeof candidate.skipped !== 'boolean') {
+    return false;
+  }
+  return true;
+}
+
+function readWelcomeConfig(configPath: string): PersistedWelcomeConfig {
+  const onDisk: unknown = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  if (!isPersistedWelcomeConfig(onDisk)) {
+    throw new Error(`Malformed welcome config at ${configPath}`);
+  }
+  return onDisk;
+}
+
+/**
+ * Shared temp-config lifecycle. Registers beforeEach/afterEach that point the
+ * welcome config at a throwaway path under the OS temp dir, so no test ever
+ * touches the real user settings dir, and restores the environment afterwards.
+ * Returns a lazy accessor for the config path configured for the current test.
+ */
+function useTempWelcomeConfig(): () => string {
+  let configDir: string | undefined;
+  let originalEnv: string | undefined;
+  let configPath = '';
+
+  beforeEach(() => {
+    originalEnv = process.env[WELCOME_CONFIG_ENV];
+    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'welcome-config-'));
+    configPath = path.join(configDir, WELCOME_CONFIG_FILENAME);
+    process.env[WELCOME_CONFIG_ENV] = configPath;
+    resetWelcomeConfigForTesting();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env[WELCOME_CONFIG_ENV];
+    } else {
+      process.env[WELCOME_CONFIG_ENV] = originalEnv;
+    }
+    resetWelcomeConfigForTesting();
+    if (configDir) {
+      fs.rmSync(configDir, { recursive: true, force: true });
+      configDir = undefined;
+    }
+  });
+
+  return () => configPath;
+}
+
+describe('getWelcomeConfigPath', () => {
+  const getConfigPath = useTempWelcomeConfig();
+
+  it('returns the environment override verbatim when the override is set', () => {
+    expect(getWelcomeConfigPath()).toBe(getConfigPath());
+  });
+
+  it('falls back to the user settings dir when the override is unset', () => {
+    delete process.env[WELCOME_CONFIG_ENV];
+    resetWelcomeConfigForTesting();
+    expect(getWelcomeConfigPath()).toBe(
+      path.join(USER_SETTINGS_DIR, WELCOME_CONFIG_FILENAME),
+    );
+  });
+});
+
+describe('loadWelcomeConfig', () => {
+  const getConfigPath = useTempWelcomeConfig();
+
+  it('returns welcomeCompleted false when no file exists on disk', () => {
+    expect(loadWelcomeConfig()).toEqual({ welcomeCompleted: false });
+    expect(isWelcomeCompleted()).toBe(false);
+  });
+
+  it('reports onboarding complete when the file says welcomeCompleted true', () => {
+    fs.writeFileSync(getConfigPath(), '{"welcomeCompleted": true}', 'utf-8');
+    resetWelcomeConfigForTesting();
+    expect(isWelcomeCompleted()).toBe(true);
+  });
+
+  it('falls back to welcomeCompleted false instead of throwing on malformed JSON', () => {
+    fs.writeFileSync(getConfigPath(), '{ not json', 'utf-8');
+    resetWelcomeConfigForTesting();
+    expect(loadWelcomeConfig()).toEqual({ welcomeCompleted: false });
+    expect(isWelcomeCompleted()).toBe(false);
+  });
+});
+
+describe('saveWelcomeConfig', () => {
+  const getConfigPath = useTempWelcomeConfig();
+
+  it('creates a missing parent directory and writes the file', () => {
+    const configPath = path.join(
+      getConfigPath(),
+      'nested',
+      'dir',
+      'welcomeConfig.json',
+    );
+    process.env[WELCOME_CONFIG_ENV] = configPath;
+    resetWelcomeConfigForTesting();
+    saveWelcomeConfig({ welcomeCompleted: true });
+    expect(fs.existsSync(configPath)).toBe(true);
+    expect(loadWelcomeConfig()).toEqual({ welcomeCompleted: true });
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'writes the file with owner-only permissions',
+    () => {
+      saveWelcomeConfig({ welcomeCompleted: true });
+      const mode = fs.statSync(getConfigPath()).mode & 0o777;
+      expect(mode).toBe(0o600);
+    },
+  );
+
+  it('round-trips the exact JSON that was saved', () => {
+    saveWelcomeConfig({
+      welcomeCompleted: true,
+      skipped: true,
+      completedAt: '2026-01-02T03:04:05.000Z',
+    });
+    expect(JSON.parse(fs.readFileSync(getConfigPath(), 'utf-8'))).toEqual({
+      welcomeCompleted: true,
+      skipped: true,
+      completedAt: '2026-01-02T03:04:05.000Z',
+    });
+  });
+
+  it('does not throw when the config path is unwritable', () => {
+    const configPath = getConfigPath();
+    fs.mkdirSync(configPath);
+    expect(() => saveWelcomeConfig({ welcomeCompleted: true })).not.toThrow();
+  });
+});
+
+describe('markWelcomeCompleted', () => {
+  const getConfigPath = useTempWelcomeConfig();
+
+  it('persists welcomeCompleted and skipped true with a strict ISO completion time', () => {
+    markWelcomeCompleted(true);
+    const onDisk = readWelcomeConfig(getConfigPath());
+    expect(onDisk.welcomeCompleted).toBe(true);
+    expect(onDisk.skipped).toBe(true);
+    expect(onDisk.completedAt).toBeDefined();
+    if (onDisk.completedAt === undefined) {
+      throw new Error('completedAt must be present for a skipped completion');
+    }
+    expect(new Date(onDisk.completedAt).toISOString()).toBe(onDisk.completedAt);
+  });
+
+  it('persists skipped false with a strict ISO completion time', () => {
+    markWelcomeCompleted(false);
+    const onDisk = readWelcomeConfig(getConfigPath());
+    expect(onDisk.welcomeCompleted).toBe(true);
+    expect(onDisk.skipped).toBe(false);
+    expect(onDisk.completedAt).toBeDefined();
+    if (onDisk.completedAt === undefined) {
+      throw new Error(
+        'completedAt must be present for a non-skipped completion',
+      );
+    }
+    expect(new Date(onDisk.completedAt).toISOString()).toBe(onDisk.completedAt);
+  });
+});
+
+describe('welcome config caching', () => {
+  const getConfigPath = useTempWelcomeConfig();
+
+  it('returns the cached value until the cache is reset', () => {
+    // The first and second reads assert the same value on purpose: the second
+    // one comes AFTER an out-of-band rewrite, so an unchanged result is the
+    // evidence that the process-lifetime cache is being served.
+    expect(loadWelcomeConfig()).toEqual({ welcomeCompleted: false });
+    fs.writeFileSync(getConfigPath(), '{"welcomeCompleted": true}', 'utf-8');
+    expect(loadWelcomeConfig()).toEqual({ welcomeCompleted: false });
+    resetWelcomeConfigForTesting();
+    expect(loadWelcomeConfig()).toEqual({ welcomeCompleted: true });
+  });
+});

--- a/packages/cli/src/config/welcomeConfig.test.ts
+++ b/packages/cli/src/config/welcomeConfig.test.ts
@@ -120,6 +120,19 @@ describe('loadWelcomeConfig', () => {
     resetWelcomeConfigForTesting();
     expect(loadWelcomeConfig()).toEqual({ welcomeCompleted: false });
     expect(isWelcomeCompleted()).toBe(false);
+    // Repeated reads without a cache reset must keep returning the default
+    // rather than re-parsing (or caching) the corrupt file into something else.
+    expect(loadWelcomeConfig()).toEqual({ welcomeCompleted: false });
+    expect(isWelcomeCompleted()).toBe(false);
+  });
+
+  it('recovers once the malformed file is replaced and the cache is reset', () => {
+    fs.writeFileSync(getConfigPath(), '{ not json', 'utf-8');
+    resetWelcomeConfigForTesting();
+    expect(isWelcomeCompleted()).toBe(false);
+    fs.writeFileSync(getConfigPath(), '{"welcomeCompleted": true}', 'utf-8');
+    resetWelcomeConfigForTesting();
+    expect(isWelcomeCompleted()).toBe(true);
   });
 });
 

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -1,0 +1,311 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'bun:test';
+import { act } from 'react';
+import type { HydratedModel } from '@vybestack/llxprt-code-core';
+import { createDeferred, waitFor } from '../../test-utils/async.js';
+import { render } from '../../test-utils/render.js';
+import { KeypressProvider } from '../contexts/KeypressContext.js';
+import { ModelsDialog, type ModelsDialogProps } from './ModelDialog.js';
+
+// The kitty/CSI-u escape keycode. A lone ESC byte only becomes a decoded
+// 'escape' key after the KeypressProvider's 100ms escape timeout, so the tests
+// drive the synchronous keycode form the real terminal sends instead of
+// sleeping on a timer.
+const ESCAPE_KEY = '\u001B[27u';
+
+type MockRuntimeApi = {
+  listProviders: () => string[];
+  listAvailableModels: (providerName: string) => Promise<HydratedModel[]>;
+};
+
+// Module-scope mutable mocks. The vi.mock factory is hoisted above these
+// declarations, so the factory must return a useRuntimeApi that dereferences the
+// mutable holder at CALL time, never at factory-definition time. Reset in
+// beforeEach so each test installs its own behavior.
+const runtimeHolder: MockRuntimeApi = {
+  listProviders: () => [],
+  listAvailableModels: () => Promise.resolve([]),
+};
+
+// The api object is memoized so re-renders see a stable reference (matching how
+// the real RuntimeContext memoizes its bridge) so useModelsData's effects do not
+// re-run on every render.
+let memoizedRuntimeApi: MockRuntimeApi | undefined;
+
+void vi.mock('../contexts/RuntimeContext.js', () => ({
+  useRuntimeApi: () => {
+    memoizedRuntimeApi ??= {
+      listProviders: () => runtimeHolder.listProviders(),
+      listAvailableModels: (providerName: string) =>
+        runtimeHolder.listAvailableModels(providerName),
+    };
+    return memoizedRuntimeApi;
+  },
+}));
+
+// Pin to a wide terminal so column widths and frames are deterministic.
+void vi.mock('../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({ columns: 140, rows: 40 }),
+}));
+
+// The dialog loads models in an async effect. Flush pending microtasks inside
+// act() before polling, so the resolution-driven state update is attributed to
+// the test rather than leaking a React act() warning.
+async function waitForFrame(assertion: () => void): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+  await waitFor(assertion);
+}
+
+function makeModel(
+  provider: string,
+  id: string,
+  overrides?: Partial<HydratedModel>,
+): HydratedModel {
+  return { provider, id, name: id, ...overrides };
+}
+
+type OnSelectSpy = ReturnType<typeof vi.fn<ModelsDialogProps['onSelect']>>;
+type OnCloseSpy = ReturnType<typeof vi.fn<ModelsDialogProps['onClose']>>;
+type RenderModelsDialogResult = ReturnType<typeof render> & {
+  onSelect: OnSelectSpy;
+  onClose: OnCloseSpy;
+};
+
+function renderModelsDialog(
+  props: Partial<ModelsDialogProps> = {},
+): RenderModelsDialogResult {
+  const onSelect = vi.fn<ModelsDialogProps['onSelect']>();
+  const onClose = vi.fn<ModelsDialogProps['onClose']>();
+  const result = render(
+    <KeypressProvider>
+      <ModelsDialog onSelect={onSelect} onClose={onClose} {...props} />
+    </KeypressProvider>,
+  );
+  return { ...result, onSelect, onClose };
+}
+
+beforeEach(() => {
+  runtimeHolder.listProviders = () => [];
+  runtimeHolder.listAvailableModels = () => Promise.resolve([]);
+  memoizedRuntimeApi = undefined;
+});
+
+describe('ModelsDialog', () => {
+  it('shows a loading frame while models are in flight and lists them after they resolve', async () => {
+    // showAllProviders: true => computedInitialFilter is null, so all providers are fetched.
+    const models = [
+      makeModel('alpha', 'alpha-a'),
+      makeModel('alpha', 'alpha-b'),
+    ];
+    const deferred = createDeferred<HydratedModel[]>();
+    runtimeHolder.listProviders = () => ['alpha'];
+    runtimeHolder.listAvailableModels = () => deferred.promise;
+
+    const { lastFrame } = renderModelsDialog({ showAllProviders: true });
+
+    const loadingFrame = lastFrame() ?? '';
+    expect(loadingFrame).toContain('Loading models...');
+    // The results frame is entirely absent while loading: no table header, no
+    // search UI, no Found count, no model ids.
+    expect(loadingFrame).not.toContain('alpha-a');
+    expect(loadingFrame).not.toContain('MODEL ID');
+    expect(loadingFrame).not.toContain('Search:');
+    expect(loadingFrame).not.toContain('Found');
+
+    await act(async () => {
+      deferred.resolve(models);
+    });
+
+    await waitForFrame(() => {
+      const frame = lastFrame() ?? '';
+      expect(frame).not.toContain('Loading models...');
+      expect(frame).toContain('MODEL ID');
+      expect(frame).toContain('Search:');
+      expect(frame).toContain(`Found ${String(models.length)}`);
+      expect(frame).toContain('alpha-a');
+      expect(frame).toContain('alpha-b');
+    });
+  });
+
+  it('shows an empty results frame when listProviders throws', async () => {
+    // showAllProviders: true => providerFilter is null, so the models come from
+    // listProviders; with it throwing there are zero providers and zero models.
+    runtimeHolder.listProviders = () => {
+      throw new Error('providers unavailable');
+    };
+
+    const { lastFrame } = renderModelsDialog({ showAllProviders: true });
+
+    await waitForFrame(() => {
+      const frame = lastFrame() ?? '';
+      expect(frame).toContain('Found 0');
+      expect(frame).not.toContain('Loading models...');
+    });
+  });
+
+  it('shows an empty results frame when listAvailableModels rejects for the only provider', async () => {
+    // showAllProviders: true => providerFilter is null, so the only provider (alpha)
+    // is fetched and its rejection yields zero models.
+    runtimeHolder.listProviders = () => ['alpha'];
+    runtimeHolder.listAvailableModels = () =>
+      Promise.reject(new Error('model fetch failed'));
+
+    const { lastFrame } = renderModelsDialog({ showAllProviders: true });
+
+    await waitForFrame(() => {
+      const frame = lastFrame() ?? '';
+      expect(frame).toContain('Found 0');
+      expect(frame).not.toContain('Loading models...');
+    });
+  });
+
+  it('does not abort the rest when the first provider rejects, listing the second resolving provider', async () => {
+    // showAllProviders: true => providerFilter is null, so both alpha and beta are
+    // fetched; the FIRST provider rejects and the shared fetch continues past it to
+    // keep beta's models, so an implementation that only ever fetched the first
+    // provider would fail on beta's ids below.
+    const betaModels = [
+      makeModel('beta', 'beta-a'),
+      makeModel('beta', 'beta-b'),
+    ];
+    runtimeHolder.listProviders = () => ['alpha', 'beta'];
+    runtimeHolder.listAvailableModels = (providerName: string) => {
+      if (providerName === 'alpha') {
+        return Promise.reject(new Error('alpha outage'));
+      }
+      return Promise.resolve(betaModels);
+    };
+
+    const { lastFrame } = renderModelsDialog({ showAllProviders: true });
+
+    await waitForFrame(() => {
+      const frame = lastFrame() ?? '';
+      expect(frame).toContain('beta-a');
+      expect(frame).toContain('beta-b');
+      expect(frame).toContain(`Found ${String(betaModels.length)}`);
+      expect(frame).not.toContain('alpha-a');
+    });
+  });
+
+  it('shows Found 0 of the baseline count when the search matches nothing', async () => {
+    // showAllProviders: true => providerFilter is null, so the baseline is all
+    // loaded models; the search term matches none of them.
+    const loadedModels = [
+      makeModel('alpha', 'a-one'),
+      makeModel('alpha', 'a-two'),
+      makeModel('alpha', 'a-three'),
+    ];
+    runtimeHolder.listProviders = () => ['alpha'];
+    runtimeHolder.listAvailableModels = () => Promise.resolve(loadedModels);
+
+    const { stdin, lastFrame } = renderModelsDialog({ showAllProviders: true });
+
+    await waitForFrame(() => {
+      expect(lastFrame() ?? '').toContain(
+        `Found ${String(loadedModels.length)}`,
+      );
+    });
+
+    await act(async () => {
+      stdin.write('zzz-no-match');
+    });
+
+    expect(lastFrame() ?? '').toContain(
+      `Found 0 of ${String(loadedModels.length)}`,
+    );
+  });
+
+  it('confirms the first filtered row on Enter without closing', async () => {
+    // showAllProviders: true => providerFilter is null, so all loaded models are
+    // candidates and the first filtered row is the alphabetically first id.
+    const models = [
+      makeModel('alpha', 'alpha-c'),
+      makeModel('alpha', 'alpha-a'),
+      makeModel('alpha', 'alpha-b'),
+    ];
+    runtimeHolder.listProviders = () => ['alpha'];
+    runtimeHolder.listAvailableModels = () => Promise.resolve(models);
+
+    const { stdin, lastFrame, onSelect, onClose } = renderModelsDialog({
+      showAllProviders: true,
+    });
+
+    await waitForFrame(() => {
+      expect(lastFrame() ?? '').toContain(`Found ${String(models.length)}`);
+    });
+
+    await act(async () => {
+      stdin.write('\r');
+    });
+
+    const firstFilteredId = models.map((model) => model.id).sort()[0];
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0]?.[0]?.id).toBe(firstFilteredId);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('clears the search term on Escape instead of closing', async () => {
+    // showAllProviders: true => providerFilter is null, so the full baseline is all
+    // loaded models; once the term is cleared the of-N suffix disappears.
+    const models = [
+      makeModel('alpha', 'alpha-a'),
+      makeModel('alpha', 'alpha-b'),
+    ];
+    runtimeHolder.listProviders = () => ['alpha'];
+    runtimeHolder.listAvailableModels = () => Promise.resolve(models);
+
+    const { stdin, lastFrame, onSelect, onClose } = renderModelsDialog({
+      showAllProviders: true,
+    });
+
+    await waitForFrame(() => {
+      expect(lastFrame() ?? '').toContain(`Found ${String(models.length)}`);
+    });
+
+    await act(async () => {
+      stdin.write('alpha-a');
+    });
+
+    expect(lastFrame() ?? '').toContain(`Found 1 of ${String(models.length)}`);
+
+    await act(async () => {
+      stdin.write(ESCAPE_KEY);
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onSelect).not.toHaveBeenCalled();
+    const clearedFrame = lastFrame() ?? '';
+    expect(clearedFrame).toContain(`Found ${String(models.length)}`);
+    expect(clearedFrame).not.toContain(` of ${String(models.length)}`);
+  });
+
+  it('closes on Escape when the search is empty', async () => {
+    // showAllProviders: true => providerFilter is null, so the dialog filters over
+    // all loaded providers while the search stays empty.
+    const models = [makeModel('alpha', 'alpha-a')];
+    runtimeHolder.listProviders = () => ['alpha'];
+    runtimeHolder.listAvailableModels = () => Promise.resolve(models);
+
+    const { stdin, lastFrame, onSelect, onClose } = renderModelsDialog({
+      showAllProviders: true,
+    });
+
+    await waitForFrame(() => {
+      expect(lastFrame() ?? '').toContain('Found 1');
+    });
+
+    await act(async () => {
+      stdin.write(ESCAPE_KEY);
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/ui/components/ProfileCreateWizard/validation.test.ts
+++ b/packages/cli/src/ui/components/ProfileCreateWizard/validation.test.ts
@@ -1,0 +1,248 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
+import { tmpdir as osTmpdir } from 'node:os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// The home directory is an OS boundary, so it is the one thing redirected here.
+// Bun resolves node:os `homedir()` once at process start and never rereads
+// $HOME, so pointing the env var at a temp dir cannot move it; the module is
+// redirected instead. Every other node:os export is passed through untouched so
+// the temp-dir helper below keeps using the real tmpdir().
+const realOs = { ...(await import('node:os')) };
+let homeDirOverride: string | undefined;
+
+void vi.mock('node:os', () => {
+  const patched = {
+    ...realOs,
+    homedir: (): string => homeDirOverride ?? realOs.homedir(),
+  };
+  return { ...patched, default: patched };
+});
+
+import {
+  PARAM_VALIDATORS,
+  validateBaseUrl,
+  validateKeyFile,
+  validateProfileName,
+} from './validation.js';
+
+/**
+ * Shared temp-dir lifecycle. Registers beforeEach/afterEach that provision a
+ * throwaway directory under the OS temp dir and always remove it afterwards.
+ * Returns a lazy accessor for the directory path for the current test.
+ */
+function useTempDir(): () => string {
+  let dir: string | undefined;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(osTmpdir(), 'wizard-keyfile-'));
+  });
+
+  afterEach(() => {
+    homeDirOverride = undefined;
+    if (dir) {
+      fs.rmSync(dir, { recursive: true, force: true });
+      dir = undefined;
+    }
+  });
+
+  return () => dir as string;
+}
+
+describe('validateBaseUrl', () => {
+  it('rejects empty and whitespace-only URLs with the required message', () => {
+    for (const url of ['', '   ']) {
+      expect(validateBaseUrl(url)).toEqual({
+        valid: false,
+        error: 'Base URL is required',
+      });
+    }
+  });
+
+  it('rejects URLs whose protocol is not http or https', () => {
+    expect(validateBaseUrl('ftp://host')).toEqual({
+      valid: false,
+      error: 'URL must use http:// or https://',
+    });
+  });
+
+  it('rejects strings that are not valid URLs', () => {
+    expect(validateBaseUrl('not a url')).toEqual({
+      valid: false,
+      error: 'Invalid URL format',
+    });
+  });
+
+  it('accepts http and https URLs', () => {
+    expect(validateBaseUrl('http://localhost:1234')).toEqual({ valid: true });
+    expect(validateBaseUrl('https://api.example.com/v1')).toEqual({
+      valid: true,
+    });
+  });
+});
+
+describe('validateProfileName', () => {
+  it('rejects empty and whitespace-only names', async () => {
+    for (const name of ['', '   ']) {
+      expect(await validateProfileName(name, [])).toEqual({
+        valid: false,
+        error: 'Profile name cannot be empty',
+      });
+    }
+  });
+
+  it('rejects names containing path separators', async () => {
+    for (const name of ['a/b', 'a\\b']) {
+      expect(await validateProfileName(name, [])).toEqual({
+        valid: false,
+        error: 'Profile name cannot contain path separators',
+      });
+    }
+  });
+
+  it('rejects a name that already exists', async () => {
+    expect(await validateProfileName('dupe', ['dupe'])).toEqual({
+      valid: false,
+      error: 'Profile name already exists',
+    });
+  });
+
+  it('accepts a fresh name without mutating the existing list', async () => {
+    const existing = ['alpha', 'beta'];
+    const snapshot = [...existing];
+    await expect(validateProfileName('gamma', existing)).resolves.toEqual({
+      valid: true,
+    });
+    expect(existing).toEqual(snapshot);
+  });
+});
+
+describe('validateKeyFile', () => {
+  const keyFileDir = useTempDir();
+
+  it('accepts an existing readable key file', async () => {
+    const dir = keyFileDir();
+    const filePath = path.join(dir, 'key.json');
+    fs.writeFileSync(filePath, '{}', { mode: 0o600 });
+    await expect(validateKeyFile(filePath)).resolves.toEqual({ valid: true });
+  });
+
+  it('reports a missing file with the error echoing the original path', async () => {
+    const dir = keyFileDir();
+    const missing = path.join(dir, 'nope.json');
+    const result = await validateKeyFile(missing);
+    expect(result).toEqual({
+      valid: false,
+      error: `File not found: ${missing}`,
+    });
+  });
+
+  it('expands a tilde-prefixed path against the home directory', async () => {
+    // The key file only exists inside the redirected home, so this resolves
+    // only if expandTilde() really substitutes homedir() for the leading `~`.
+    // Without expansion, `~/tilde-key.txt` resolves relative to the cwd and
+    // reports not-found instead.
+    const dir = keyFileDir();
+    homeDirOverride = dir;
+    fs.writeFileSync(path.join(dir, 'tilde-key.txt'), '{}');
+
+    await expect(validateKeyFile('~/tilde-key.txt')).resolves.toEqual({
+      valid: true,
+    });
+  });
+
+  it('expands a bare tilde to the home directory itself', async () => {
+    const dir = keyFileDir();
+    homeDirOverride = dir;
+
+    await expect(validateKeyFile('~')).resolves.toEqual({ valid: true });
+  });
+
+  it('reports not-found for a tilde path whose target is absent from the home directory', async () => {
+    const dir = keyFileDir();
+    homeDirOverride = dir;
+
+    await expect(validateKeyFile('~/absent-key.txt')).resolves.toEqual({
+      valid: false,
+      error: 'File not found: ~/absent-key.txt',
+    });
+  });
+
+  it.skipIf(process.platform === 'win32' || process.getuid?.() === 0)(
+    'reports a permission error for a file without read access',
+    async () => {
+      const dir = keyFileDir();
+      const filePath = path.join(dir, 'locked.json');
+      fs.writeFileSync(filePath, '{}');
+      fs.chmodSync(filePath, 0o000);
+      const result = await validateKeyFile(filePath);
+      expect(result).toEqual({
+        valid: false,
+        error: `Permission denied: ${filePath}`,
+      });
+    },
+  );
+});
+
+describe('PARAM_VALIDATORS', () => {
+  describe('temperature', () => {
+    it('rejects values outside the 0.0 to 2.0 range', () => {
+      for (const value of [-0.1, 2.1]) {
+        expect(PARAM_VALIDATORS.temperature(value)).toEqual({
+          valid: false,
+          error: 'Must be between 0.0 and 2.0',
+        });
+      }
+    });
+
+    it('accepts values within the 0.0 to 2.0 range, inclusive', () => {
+      for (const value of [0, 1, 2]) {
+        expect(PARAM_VALIDATORS.temperature(value)).toEqual({ valid: true });
+      }
+    });
+  });
+
+  describe('maxTokens', () => {
+    it('rejects non-positive or non-integer token counts', () => {
+      for (const value of [0, -1, 1.5]) {
+        expect(PARAM_VALIDATORS.maxTokens(value)).toEqual({
+          valid: false,
+          error: 'Must be a positive integer',
+        });
+      }
+    });
+
+    it('rejects token counts above the maximum', () => {
+      expect(PARAM_VALIDATORS.maxTokens(1_000_001)).toEqual({
+        valid: false,
+        error: 'Maximum value is 1,000,000',
+      });
+    });
+
+    it('accepts token counts at the boundaries', () => {
+      expect(PARAM_VALIDATORS.maxTokens(1)).toEqual({ valid: true });
+      expect(PARAM_VALIDATORS.maxTokens(1_000_000)).toEqual({ valid: true });
+    });
+  });
+
+  describe('contextLimit', () => {
+    it('rejects non-positive or non-integer context limits', () => {
+      for (const value of [0, -1, 2.5]) {
+        expect(PARAM_VALIDATORS.contextLimit(value)).toEqual({
+          valid: false,
+          error: 'Must be a positive integer',
+        });
+      }
+    });
+
+    it('accepts a positive integer context limit', () => {
+      expect(PARAM_VALIDATORS.contextLimit(1)).toEqual({ valid: true });
+    });
+  });
+});

--- a/packages/cli/src/ui/components/ProfileCreateWizard/validation.test.ts
+++ b/packages/cli/src/ui/components/ProfileCreateWizard/validation.test.ts
@@ -157,11 +157,19 @@ describe('validateKeyFile', () => {
     });
   });
 
-  it('expands a bare tilde to the home directory itself', async () => {
+  it('treats a bare tilde exactly like the literal home directory path', async () => {
+    // expandTilde has a separate branch for a bare `~`. Asserting that `~` and
+    // the literal home path get the SAME verdict pins that branch without
+    // asserting anything about what the verdict for a directory ought to be —
+    // validateKeyFile currently only checks read access, so it accepts a
+    // directory, and that is a separate question (filed as #3402) that this
+    // coverage-only test must not enshrine either way.
     const dir = keyFileDir();
     homeDirOverride = dir;
 
-    await expect(validateKeyFile('~')).resolves.toEqual({ valid: true });
+    const bareTilde = await validateKeyFile('~');
+    const literalHome = await validateKeyFile(dir);
+    expect(bareTilde.valid).toBe(literalHome.valid);
   });
 
   it('reports not-found for a tilde path whose target is absent from the home directory', async () => {

--- a/packages/cli/src/ui/components/ProviderDialog.selection.test.tsx
+++ b/packages/cli/src/ui/components/ProviderDialog.selection.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { automock } from '@vybestack/llxprt-code-test-utils';
+import { renderWithProviders as render } from '../../test-utils/render.js';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'bun:test';
+import { act } from 'react';
+import { ProviderDialog } from './ProviderDialog.js';
+import { useTerminalSize } from '../hooks/useTerminalSize.js';
+
+const realUseTerminalSizeModule = {
+  ...(await import('../hooks/useTerminalSize.js')),
+};
+
+void vi.mock('../hooks/useTerminalSize.js', () =>
+  automock(realUseTerminalSizeModule),
+);
+
+const PROVIDERS = [
+  'anthropic',
+  'openai',
+  'gemini',
+  'qwen',
+  'fireworks',
+  'cerebras',
+];
+const CURRENT_PROVIDER = 'openai';
+const WIDE_COLUMNS = 180;
+
+// The kitty/CSI-u escape keycode. A lone ESC is decodable, but only after
+// an ESC_TIMEOUT (100ms) flush, so the tests drive the synchronous keycode
+// form (the same sequence the real terminal sends).
+const ESCAPE_KEY = '\u001B[27u';
+
+function renderProviderDialog(
+  overrides: {
+    providers?: string[];
+    currentProvider?: string;
+  } = {},
+) {
+  const providers = overrides.providers ?? PROVIDERS;
+  const currentProvider = overrides.currentProvider ?? CURRENT_PROVIDER;
+  const onSelect = vi.fn();
+  const onClose = vi.fn();
+  const result = render(
+    <ProviderDialog
+      providers={providers}
+      currentProvider={currentProvider}
+      onSelect={onSelect}
+      onClose={onClose}
+    />,
+  );
+  return { ...result, providers, onSelect, onClose };
+}
+
+describe('ProviderDialog selection semantics', () => {
+  let mockUseTerminalSize: Mock<typeof useTerminalSize>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseTerminalSize = useTerminalSize as Mock<typeof useTerminalSize>;
+    mockUseTerminalSize.mockReturnValue({ columns: WIDE_COLUMNS, rows: 24 });
+  });
+
+  it('shows an empty-results message when the search term matches nothing', async () => {
+    const { stdin, lastFrame, providers } = renderProviderDialog();
+
+    await act(async () => {
+      stdin.write('\t'); // enter search mode
+    });
+    for (const char of 'zzzz') {
+      await act(async () => {
+        stdin.write(char);
+      });
+    }
+
+    const output = lastFrame() ?? '';
+    expect(output).toContain('No providers match');
+    expect(output).toContain('zzzz');
+    for (const name of providers) {
+      expect(output).not.toContain(name);
+    }
+  });
+
+  it('confirms the current provider on Enter without closing', async () => {
+    const { stdin, lastFrame, onSelect, onClose, providers } =
+      renderProviderDialog();
+
+    await act(async () => {
+      stdin.write('\r');
+    });
+
+    const expected = providers[providers.indexOf(CURRENT_PROVIDER)];
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(expected);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(lastFrame() ?? '').toContain(expected);
+  });
+
+  it('confirms the provider after moving focus with Right', async () => {
+    const { stdin, onSelect, onClose, providers } = renderProviderDialog();
+
+    await act(async () => {
+      stdin.write('\u001B[C'); // right
+    });
+    await act(async () => {
+      stdin.write('\r'); // enter
+    });
+
+    const expected = providers[providers.indexOf(CURRENT_PROVIDER) + 1];
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(expected);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('closes on Escape with an empty search', async () => {
+    const { stdin, onClose, onSelect } = renderProviderDialog();
+
+    await act(async () => {
+      stdin.write(ESCAPE_KEY);
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('clears the search term on Escape before closing on a second Escape', async () => {
+    const { stdin, lastFrame, onClose, onSelect, providers } =
+      renderProviderDialog();
+
+    await act(async () => {
+      stdin.write('\t'); // enter search mode
+    });
+    for (const char of 'en') {
+      await act(async () => {
+        stdin.write(char);
+      });
+    }
+
+    const term = 'en';
+    const matching = providers.filter((name) =>
+      name.toLowerCase().includes(term),
+    );
+    expect(matching.length).toBeGreaterThan(0);
+    expect(matching.length).toBeLessThan(providers.length);
+    expect(lastFrame() ?? '').toContain(
+      `(Found ${String(matching.length)} of ${String(providers.length)} providers)`,
+    );
+
+    await act(async () => {
+      stdin.write(ESCAPE_KEY);
+    });
+
+    const frameAfterFirstEscape = lastFrame() ?? '';
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onSelect).not.toHaveBeenCalled();
+    // The found-count line only renders while a search term is present, so its
+    // disappearance is the evidence that the first Escape cleared the term.
+    expect(frameAfterFirstEscape).not.toContain('Found');
+
+    await act(async () => {
+      stdin.write(ESCAPE_KEY);
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    // Repeated deliberately: cancelling must stay side-effect free across both
+    // Escapes, not just the first one.
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('does not select or close when Enter is pressed with zero matches', async () => {
+    const { stdin, lastFrame, onSelect, onClose } = renderProviderDialog();
+
+    await act(async () => {
+      stdin.write('\t'); // enter search mode
+    });
+    for (const char of 'zzzz') {
+      await act(async () => {
+        stdin.write(char);
+      });
+    }
+    await act(async () => {
+      stdin.write('\r');
+    });
+
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(lastFrame() ?? '').toContain('No providers match');
+  });
+});

--- a/packages/cli/src/ui/hooks/useWelcomeOnboarding.bun.tsx
+++ b/packages/cli/src/ui/hooks/useWelcomeOnboarding.bun.tsx
@@ -12,13 +12,39 @@ import * as path from 'node:path';
 import { createMockSettings, renderHook } from '../../test-utils/render.js';
 import { createFakeAgent } from './agentStream/__tests__/helpers/createFakeAgent.js';
 
-const stubRuntime = {
-  getCliProviderManager: () => ({ listProviders: () => [] }),
+interface RuntimeStub {
+  getCliProviderManager: () => {
+    listProviders: () => string[];
+    getActiveProviderName: () => string | null;
+  };
+  listAvailableModels: (provider?: string) => Promise<unknown[]>;
+  setActiveModel: (modelId: string) => Promise<void>;
+  listSavedProfiles: () => Promise<string[]>;
+  saveProfileSnapshot: (name: string) => Promise<void>;
+  setDefaultProfileName: (name: string) => void;
+  loadProfileByName: (name: string) => Promise<unknown>;
+}
+
+const defaultRuntime: RuntimeStub = {
+  getCliProviderManager: () => ({
+    listProviders: () => [],
+    getActiveProviderName: () => null,
+  }),
   listAvailableModels: async () => [],
   setActiveModel: async () => {},
+  listSavedProfiles: async () => [],
+  saveProfileSnapshot: async () => {},
+  setDefaultProfileName: () => {},
+  loadProfileByName: async () => undefined,
 };
+
+// Mutable runtime stub. The mock factory dereferences `currentRuntime` lazily on
+// every useRuntimeApi() call (vi.mock factories are hoisted, so the factory must
+// not capture the value at registration time — it reads through the `let` binding),
+// letting each test plug in a different fake runtime API.
+let currentRuntime: RuntimeStub = defaultRuntime;
 void vi.mock('../contexts/RuntimeContext.js', () => ({
-  useRuntimeApi: () => stubRuntime,
+  useRuntimeApi: () => currentRuntime,
 }));
 
 import { useWelcomeOnboarding } from './useWelcomeOnboarding.js';
@@ -29,7 +55,98 @@ import {
 
 const agent = createFakeAgent([]);
 
+interface PersistedWelcomeConfig {
+  welcomeCompleted: boolean;
+  completedAt?: string;
+  skipped?: boolean;
+}
+
+function isPersistedWelcomeConfig(
+  value: unknown,
+): value is PersistedWelcomeConfig {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate.welcomeCompleted !== 'boolean') return false;
+  if ('completedAt' in candidate && typeof candidate.completedAt !== 'string') {
+    return false;
+  }
+  if ('skipped' in candidate && typeof candidate.skipped !== 'boolean') {
+    return false;
+  }
+  return true;
+}
+
+function readWelcomeConfig(configPath: string): PersistedWelcomeConfig {
+  const onDisk: unknown = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  if (!isPersistedWelcomeConfig(onDisk)) {
+    throw new Error(`Malformed welcome config at ${configPath}`);
+  }
+  return onDisk;
+}
+
+interface FakeProfileStore {
+  readonly runtime: Pick<
+    RuntimeStub,
+    | 'listSavedProfiles'
+    | 'saveProfileSnapshot'
+    | 'setDefaultProfileName'
+    | 'loadProfileByName'
+  >;
+  savedProfiles: () => string[];
+  defaultProfileName: () => string | undefined;
+  loadedProfiles: () => string[];
+  overwriteAttempts: () => number;
+}
+
+/**
+ * An in-memory stand-in for the runtime's profile storage. It enforces the
+ * invariants the real store has — a profile cannot be defaulted or loaded
+ * before it is saved — so tests can assert resulting state instead of
+ * recording which stub methods were called in which order.
+ */
+function createFakeProfileStore(initial: string[]): FakeProfileStore {
+  const saved = [...initial];
+  const loaded: string[] = [];
+  let defaultName: string | undefined;
+  let overwrites = 0;
+
+  return {
+    runtime: {
+      listSavedProfiles: async () => [...saved],
+      saveProfileSnapshot: async (name: string) => {
+        if (saved.includes(name)) {
+          overwrites += 1;
+          return;
+        }
+        saved.push(name);
+      },
+      setDefaultProfileName: (name: string) => {
+        if (!saved.includes(name)) {
+          throw new Error(
+            `Cannot default a profile that was never saved: ${name}`,
+          );
+        }
+        defaultName = name;
+      },
+      loadProfileByName: async (name: string) => {
+        if (!saved.includes(name)) {
+          throw new Error(
+            `Cannot load a profile that was never saved: ${name}`,
+          );
+        }
+        loaded.push(name);
+        return undefined;
+      },
+    },
+    savedProfiles: () => [...saved],
+    defaultProfileName: () => defaultName,
+    loadedProfiles: () => [...loaded],
+    overwriteAttempts: () => overwrites,
+  };
+}
+
 let tempConfigDir: string | undefined;
+let originalEnv: string | undefined;
 
 function isolateWelcomeConfig(): string {
   tempConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), 'welcome-suppress-'));
@@ -39,26 +156,25 @@ function isolateWelcomeConfig(): string {
   return configPath;
 }
 
+beforeEach(() => {
+  originalEnv = process.env.LLXPRT_CODE_WELCOME_CONFIG_PATH;
+  currentRuntime = defaultRuntime;
+});
+
+afterEach(() => {
+  if (originalEnv === undefined) {
+    delete process.env.LLXPRT_CODE_WELCOME_CONFIG_PATH;
+  } else {
+    process.env.LLXPRT_CODE_WELCOME_CONFIG_PATH = originalEnv;
+  }
+  resetWelcomeConfigForTesting();
+  if (tempConfigDir) {
+    fs.rmSync(tempConfigDir, { recursive: true, force: true });
+    tempConfigDir = undefined;
+  }
+});
+
 describe('useWelcomeOnboarding startup suppression', () => {
-  let originalEnv: string | undefined;
-
-  beforeEach(() => {
-    originalEnv = process.env.LLXPRT_CODE_WELCOME_CONFIG_PATH;
-  });
-
-  afterEach(() => {
-    if (originalEnv === undefined) {
-      delete process.env.LLXPRT_CODE_WELCOME_CONFIG_PATH;
-    } else {
-      process.env.LLXPRT_CODE_WELCOME_CONFIG_PATH = originalEnv;
-    }
-    resetWelcomeConfigForTesting();
-    if (tempConfigDir) {
-      fs.rmSync(tempConfigDir, { recursive: true, force: true });
-      tempConfigDir = undefined;
-    }
-  });
-
   it('shows the welcome dialog when welcome is incomplete and not suppressed after trust', () => {
     isolateWelcomeConfig();
     const { result } = renderHook(() =>
@@ -141,5 +257,162 @@ describe('useWelcomeOnboarding startup suppression', () => {
       result.current.actions.resetAndReopen();
     });
     expect(result.current.showWelcome).toBe(true);
+  });
+});
+
+describe('useWelcomeOnboarding skip and save persistence', () => {
+  it('persists skipped true to the config file when the user skips then dismisses', () => {
+    const configPath = isolateWelcomeConfig();
+    const { result } = renderHook(() =>
+      useWelcomeOnboarding({
+        settings: createMockSettings({}),
+        isFolderTrustComplete: true,
+        agent,
+      }),
+    );
+    act(() => {
+      result.current.actions.skipSetup();
+    });
+    act(() => {
+      result.current.actions.dismiss();
+    });
+    const onDisk = readWelcomeConfig(configPath);
+    expect(result.current.showWelcome).toBe(false);
+    expect(onDisk.welcomeCompleted).toBe(true);
+    expect(onDisk.skipped).toBe(true);
+    resetWelcomeConfigForTesting();
+    expect(isWelcomeCompleted()).toBe(true);
+  });
+
+  it('persists skipped false when dismissing from the completion step', async () => {
+    const configPath = isolateWelcomeConfig();
+    currentRuntime = {
+      ...defaultRuntime,
+      listAvailableModels: async () => [{ id: 'model-id', name: 'model-name' }],
+      setActiveModel: async () => {},
+    };
+    const { result } = renderHook(() =>
+      useWelcomeOnboarding({
+        settings: createMockSettings({}),
+        isFolderTrustComplete: true,
+        agent,
+      }),
+    );
+    act(() => {
+      result.current.actions.startSetup();
+    });
+    act(() => {
+      result.current.actions.selectProvider('provider-id');
+    });
+    act(() => {
+      result.current.actions.selectAuthMethod('api_key');
+    });
+    await act(async () => {
+      await result.current.actions.onAuthComplete();
+    });
+    await act(async () => {
+      await result.current.actions.selectModel('model-id');
+    });
+    expect(result.current.state.step).toBe('completion');
+    act(() => {
+      result.current.actions.dismiss();
+    });
+    const onDisk = readWelcomeConfig(configPath);
+    expect(onDisk.welcomeCompleted).toBe(true);
+    expect(onDisk.skipped).toBe(false);
+  });
+
+  it('saveProfile leaves the new profile saved, defaulted, and loaded', async () => {
+    isolateWelcomeConfig();
+    // A stateful fake profile store rather than a call recorder: defaulting or
+    // loading a profile that was never saved is rejected by the store itself,
+    // so the ordering the hook depends on is enforced by the fake's invariants
+    // and the assertions below are about the resulting state.
+    const store = createFakeProfileStore(['other']);
+    currentRuntime = { ...defaultRuntime, ...store.runtime };
+    const { result } = renderHook(() =>
+      useWelcomeOnboarding({
+        settings: createMockSettings({}),
+        isFolderTrustComplete: true,
+        agent,
+      }),
+    );
+    await act(async () => {
+      await result.current.actions.saveProfile('newprof');
+    });
+    expect(store.savedProfiles()).toContain('newprof');
+    expect(store.defaultProfileName()).toBe('newprof');
+    expect(store.loadedProfiles()).toEqual(['newprof']);
+  });
+
+  it('saveProfile rejects a duplicate name and leaves the store untouched', async () => {
+    isolateWelcomeConfig();
+    const store = createFakeProfileStore(['dupe']);
+    currentRuntime = { ...defaultRuntime, ...store.runtime };
+    const { result } = renderHook(() =>
+      useWelcomeOnboarding({
+        settings: createMockSettings({}),
+        isFolderTrustComplete: true,
+        agent,
+      }),
+    );
+    let caught: unknown;
+    await act(async () => {
+      try {
+        await result.current.actions.saveProfile('dupe');
+      } catch (error) {
+        caught = error;
+      }
+    });
+    if (!(caught instanceof Error)) {
+      throw new TypeError('expected saveProfile to reject with an Error');
+    }
+    expect(caught.message).toContain('dupe');
+    expect(caught.message).toContain('already exists');
+    // The pre-existing profile must not have been overwritten, defaulted, or
+    // loaded: rejecting has to leave the store exactly as it was.
+    expect(store.savedProfiles()).toEqual(['dupe']);
+    expect(store.overwriteAttempts()).toBe(0);
+    expect(store.defaultProfileName()).toBeUndefined();
+    expect(store.loadedProfiles()).toEqual([]);
+  });
+
+  it('selectModel advances to completion when the runtime accepts the model', async () => {
+    isolateWelcomeConfig();
+    const { result } = renderHook(() =>
+      useWelcomeOnboarding({
+        settings: createMockSettings({}),
+        isFolderTrustComplete: true,
+        agent,
+      }),
+    );
+    await act(async () => {
+      await result.current.actions.selectModel('model-id');
+    });
+    expect(result.current.state.step).toBe('completion');
+    expect(result.current.state.selectedModel).toBe('model-id');
+  });
+
+  it('selectModel keeps the welcome step and records the error when the runtime rejects', async () => {
+    isolateWelcomeConfig();
+    currentRuntime = {
+      ...defaultRuntime,
+      setActiveModel: async () => {
+        throw new Error('boom');
+      },
+    };
+    const { result } = renderHook(() =>
+      useWelcomeOnboarding({
+        settings: createMockSettings({}),
+        isFolderTrustComplete: true,
+        agent,
+      }),
+    );
+    await act(async () => {
+      await result.current.actions.selectModel('model-id');
+    });
+    expect(result.current.state.step).toBe('welcome');
+    expect(result.current.state.selectedModel).toBeUndefined();
+    expect(result.current.state.error).toContain('boom');
   });
 });

--- a/project-plans/issue2023/plan.md
+++ b/project-plans/issue2023/plan.md
@@ -1,0 +1,258 @@
+# Issue #2023 — Increase onboarding, profile, provider, and model UI coverage
+
+## 1. What the issue asks for
+
+This is a **coverage** issue. No product behavior changes. Add tests that pin
+down existing, correct behavior in four areas:
+
+1. Welcome-completed config skips onboarding.
+2. Clean config shows onboarding.
+3. Skip and save paths persist expected state.
+4. Profile create wizard validation.
+5. Provider/model loading errors and empty states.
+6. Provider/model switch cancellation and confirmation.
+7. One tmux smoke for clean-runner onboarding.
+
+## 2. Ground truth found in the repo (2026-08-27, branch `issue2023` off `main`)
+
+The CodeRabbit auto-plan on the issue is **stale**: it assumes Vitest, a
+`vitest.config.ts` exclusion of `**/ui/components/*.test.tsx`, and a
+`.spec.tsx`-under-`__tests__/` workaround. None of that exists any more.
+
+Current reality:
+
+- The CLI workspace runs on **bun test only** (`packages/cli/run-bun-tests.ts`,
+  `packages/cli/bunfig.toml`). No Vitest, no exclude list.
+- `scripts/check-cli-test-discovery.ts` discovers `\.(test|spec|bun)\.(ts|tsx)$`
+  under `src`, `test`, `test-bun`, `test-utils`. Colocated `*.test.tsx` next to
+  the component is the dominant convention and is discovered.
+- `bun-test-setup.ts` redirects `ink` to `packages/cli/test-utils/ink-stub.ts`
+  at resolution time. There is nothing to `vi.unmock`.
+- Existing helpers: `src/test-utils/render.tsx` (`render`,
+  `renderWithProviders`, `createMockSettings`, `renderHook`),
+  `src/test-utils/regex.ts` (`testRegex`), `src/test-utils/async.ts`.
+
+### Existing coverage (do NOT duplicate)
+
+- `packages/cli/src/ui/hooks/useWelcomeOnboarding.bun.tsx` already covers the
+  `showWelcome` gate: clean config + trust complete → true; completed config →
+  false; trust incomplete → false; `suppressStartup` → false and no persist;
+  `resetAndReopen` → true.
+- `packages/cli/src/ui/hooks/useProviderDialog.spec.ts` already covers
+  `openDialog` success/empty-provider/list-failure and `handleSelect`
+  success/failure.
+- `packages/cli/src/ui/components/ProviderDialog.responsive.test.tsx` covers
+  responsive **rendering** only. No keypress coverage.
+
+### Confirmed gaps (this issue's work)
+
+| Gap | Module |
+| --- | --- |
+| No unit test at all | `packages/cli/src/config/welcomeConfig.ts` |
+| Skip/save persistence never asserted end to end | `useWelcomeOnboarding.dismiss` / `saveProfile` |
+| No unit test at all | `packages/cli/src/ui/components/ProfileCreateWizard/validation.ts` |
+| No component test at all | `packages/cli/src/ui/components/ModelDialog.tsx` (`ModelsDialog`) |
+| No keypress/selection test | `packages/cli/src/ui/components/ProviderDialog.tsx` |
+| No clean-runner onboarding smoke | tmux harness |
+
+## 3. Acceptance criteria
+
+Every AC is proved by a behavioral assertion against real production code.
+Filesystem is the only thing stubbed for persistence (temp dirs via the
+`LLXPRT_CODE_WELCOME_CONFIG_PATH` env override — a real file, not a mock).
+
+### AC1 — Welcome config persistence and detection (`welcomeConfig.ts`)
+
+New file: `packages/cli/src/config/welcomeConfig.test.ts`
+
+- `getWelcomeConfigPath()` returns the `LLXPRT_CODE_WELCOME_CONFIG_PATH`
+  override when set, and the `USER_SETTINGS_DIR`-joined default when unset.
+- Missing config file → `loadWelcomeConfig()` returns
+  `{ welcomeCompleted: false }` and `isWelcomeCompleted()` is `false`.
+- Existing file with `welcomeCompleted: true` → `isWelcomeCompleted()` is
+  `true`.
+- Malformed JSON on disk → falls back to `{ welcomeCompleted: false }` rather
+  than throwing (boundary case: corrupt user file).
+- `saveWelcomeConfig()` creates the parent directory when absent and writes the
+  file with mode `0o600`; the round-tripped JSON on disk equals what was saved.
+- `markWelcomeCompleted(true)` persists `welcomeCompleted: true`,
+  `skipped: true`, and a parseable ISO `completedAt`.
+- `markWelcomeCompleted(false)` persists `skipped: false` with the same
+  invariants.
+- Caching: after `loadWelcomeConfig()`, an out-of-band file rewrite is NOT
+  observed until `resetWelcomeConfigForTesting()` is called (documents the
+  process-lifetime cache the CLI relies on).
+- `saveWelcomeConfig()` swallows write failures (unwritable path) instead of
+  throwing — the CLI must not crash on a read-only settings dir.
+
+### AC2 — Skip and save paths persist expected state (`useWelcomeOnboarding`)
+
+Extend `packages/cli/src/ui/hooks/useWelcomeOnboarding.bun.tsx` (the file that
+already owns the gating cases, so temp-config lifecycle is shared, per the DRY
+setup rule).
+
+- `skipSetup()` then `dismiss()` → the real temp config file on disk contains
+  `{ welcomeCompleted: true, skipped: true }`, and `showWelcome` flips to
+  `false`.
+- `dismiss()` from a non-skipped step (completion path) → the file contains
+  `skipped: false`, `welcomeCompleted: true`.
+- After either dismissal, a fresh `isWelcomeCompleted()` read (post
+  `resetWelcomeConfigForTesting()`) is `true` — proving the persisted state is
+  what a subsequent clean runner would observe.
+- `actions.saveProfile(name)`:
+  - happy path calls, in order, `saveProfileSnapshot(name)`,
+    `setDefaultProfileName(name)`, `loadProfileByName(name)` on the runtime;
+    asserted through a recording stub that captures the **call order** (a
+    derived property, not a mirrored literal).
+  - rejects with a message naming the profile when `listSavedProfiles()`
+    already contains the name, and does NOT call `saveProfileSnapshot`.
+- `actions.selectModel(id)` when `setActiveModel` rejects → state keeps
+  `step` unchanged and exposes an `error`; when it resolves → `step` becomes
+  `'completion'` and `selectedModel` is the chosen id.
+
+### AC3 — Profile create wizard validation
+
+New file:
+`packages/cli/src/ui/components/ProfileCreateWizard/validation.test.ts`
+
+- `validateBaseUrl`: empty/whitespace → `Base URL is required`; `ftp://host` →
+  protocol error; `not a url` → `Invalid URL format`; `http://` and `https://`
+  URLs → valid.
+- `validateProfileName`: empty/whitespace → invalid; contains `/` or `\` →
+  path-separator error; name present in `existingProfiles` → already-exists
+  error; otherwise valid. Existing-profiles array is not mutated.
+- `validateKeyFile` against a real temp dir: readable file → valid; absent path
+  → `File not found:` with the **original** (unexpanded) path echoed; `~/`
+  expansion resolves against `os.homedir()`; a chmod-`0o000` file →
+  `Permission denied:`. The permission case is skipped when running as root
+  (`process.getuid?.() === 0`) or on win32, where the mode is not enforced.
+- `PARAM_VALIDATORS.temperature`: `-0.1` and `2.1` invalid; `0`, `1`, `2` valid.
+- `PARAM_VALIDATORS.maxTokens`: `0`, `-1`, `1.5` invalid; `1_000_001` invalid
+  with the maximum message; `1` and `1_000_000` valid.
+- `PARAM_VALIDATORS.contextLimit`: `0`, `-1`, `2.5` invalid; `1` valid.
+
+### AC4 — Provider/model loading errors and empty states
+
+New file: `packages/cli/src/ui/components/ModelDialog.test.tsx` rendering the
+real `ModelsDialog` with a stubbed `RuntimeContext` (infrastructure boundary).
+
+- While `listAvailableModels` is pending, the frame shows `Loading models...`
+  and no model table.
+- Once resolved, the loading frame is replaced by the table containing the
+  returned model ids.
+- `listProviders()` throwing → dialog leaves the loading state and renders a
+  zero-result frame (no model rows, `Found 0`; the ` of N` suffix only appears
+  when a search term or capability filter is active).
+- `listAvailableModels()` rejecting for the only provider → same zero-result
+  frame, and the dialog does not crash (`Promise.allSettled` path).
+- Mixed results: one provider resolves, one rejects → only the resolving
+  provider's models are listed.
+- A search term matching nothing → `Found 0 of N` where N is the loaded
+  baseline count (derived, not mirrored).
+
+Provider empty state, added to a new
+`packages/cli/src/ui/components/ProviderDialog.selection.test.tsx`:
+
+- A search term matching no provider renders `No providers match "<term>"` and
+  no provider rows.
+
+### AC5 — Provider/model switch cancellation and confirmation
+
+In `ProviderDialog.selection.test.tsx` (wide layout, real component, real
+`KeypressProvider`):
+
+- Enter on the focused row invokes `onSelect` exactly once with the focused
+  provider name and does not invoke `onClose` (confirmation-by-selection).
+- Escape with an empty search invokes `onClose` and never invokes `onSelect`
+  (cancellation has no side effect).
+- Escape while searching with a non-empty search term clears the search
+  (`Found`-count returns to the full list) and does NOT invoke `onClose` or
+  `onSelect`; a second Escape then closes.
+- Enter when the filter matches zero providers invokes neither callback.
+
+In `ModelDialog.test.tsx`:
+
+- Enter on the focused model invokes `onSelect` with that model and not
+  `onClose`.
+- Escape with a non-empty search clears the search instead of closing; Escape
+  with an empty search invokes `onClose` without `onSelect`.
+
+No new confirmation UI is introduced — the dialogs apply the switch on Enter
+today, and that is the behavior being pinned.
+
+### AC6 — Clean-runner onboarding tmux smoke
+
+New scenario: `scripts/tmux-script.onboarding.json`
+
+- Starts the CLI with `LLXPRT_CODE_WELCOME_CONFIG_PATH` pointed at a per-run
+  path `${TMPDIR:-/tmp}/llxprt-onboarding-welcome-$$.json`. The start command is
+  wrapped in `sh -c` so the file is removed before launch and again after the
+  CLI exits, which makes the scenario clean on entry and leaves nothing behind
+  even if a previous run crashed or a PID is later reused.
+- Waits for `Welcome to llxprt!` and the two choices.
+- Selects `Skip setup` (Down, Enter), waits for `Setup skipped`, presses Enter
+  to dismiss, and waits for the normal `Type your message` prompt — proving the
+  dialog dismisses and the app is usable.
+- Ends with `/quit` + `waitForExit`.
+
+Wiring:
+
+- `scripts/tests/interactive-ui.test.ts` gains one `runTmuxE2E` case invoking
+  the scenario and asserting a zero exit status through the existing
+  `assertHarnessSuccess` helper.
+- `.github/workflows/interactive-ui.yml` gains the new scenario path in BOTH
+  the `pull_request` and `push` `paths` lists (the existing
+  `interactive-ui-paths.bun.test.ts` asserts the two lists are symmetric). It
+  also gains `packages/cli/src/config/welcomeConfig.ts`, the one production
+  module the scenario depends on that lives outside `packages/cli/src/ui/**`.
+- `scripts/tests/interactive-ui-paths.bun.test.ts` is updated so the
+  "executed scenario JSON files" assertion covers the new scenario, and gains an
+  assertion for the welcome-config path — that guard exists precisely to keep
+  executed scenarios and their inputs in sync with the path filter.
+
+Evidence the smoke is not vacuous: repointing the same scenario at
+`scripts/fixtures/welcome-completed.json` (a completed config) makes it fail on
+the first `waitFor` with
+`Timed out waiting for step 0 (contains "Welcome to llxprt!")`. That negative
+control also demonstrates AC1 end to end.
+
+## 4. Out of scope (explicitly not doing)
+
+- Any change to production behavior in `welcomeConfig.ts`,
+  `useWelcomeOnboarding.ts`, `ProfileCreateWizard/*`, `ModelDialog.tsx`, or
+  `ProviderDialog.tsx`.
+- New confirmation UI for provider/model switching.
+- `ProfileCreateWizard` `CancelConfirmDialog` / `ConflictDialog` component
+  tests: the issue bullet is "profile create wizard **validation**", and
+  cancellation is scoped by its own bullet to provider/model switching.
+- Refactoring the dialogs to be more testable.
+- Touching unrelated project-plan files.
+
+## 5. Test rules that apply
+
+From `dev-docs/RULES.md` / the `typescript-test-writing` skill:
+
+- `bun:test` only, TypeScript, strict mode, no `any`, no new `.js`.
+- Behavior only. No mock-verification-only assertions, no mirror echoes
+  (never assert back a literal that a stub was configured with — assert derived
+  properties such as ordering, counts, and rendered frames).
+- Real components and real production functions; only the runtime API,
+  terminal size, and the filesystem location are stubbed/redirected.
+- Shared temp-dir lifecycle helpers rather than copy-pasted `beforeEach`
+  blocks.
+- New files carry a 2026 copyright header.
+
+## 6. Verification
+
+```bash
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+bun scripts/test-audit/scan.ts tmp/verify2023/scan-branch   # no new findings
+```
+
+The tmux smoke is CI-gated behind `LLXPRT_E2E_TMUX=1`; run locally with
+`npm run test:interactive-ui` where tmux is available.

--- a/scripts/tests/interactive-ui-paths.bun.test.ts
+++ b/scripts/tests/interactive-ui-paths.bun.test.ts
@@ -93,11 +93,14 @@ describe('interactive-ui.yml: direct harness inputs are included', () => {
     expect(prPaths).toContain(
       'scripts/tmux-script.issue2016-composer.fake.json',
     );
+    expect(prPaths).toContain('scripts/tmux-script.onboarding.json');
   });
 
-  it('includes the scenario config fixtures referenced by all scenarios', () => {
-    // All executed scenarios set LLXPRT_CODE_WELCOME_CONFIG_PATH and
-    // LLXPRT_SYSTEM_SETTINGS_PATH to these direct inputs.
+  it('includes the scenario config fixtures referenced by the scenarios', () => {
+    // Every executed scenario sets LLXPRT_SYSTEM_SETTINGS_PATH, and all but
+    // the onboarding scenario set LLXPRT_CODE_WELCOME_CONFIG_PATH to the
+    // welcome-completed fixture. The onboarding scenario deliberately points
+    // that variable at a per-run temp path so it starts as a clean runner.
     expect(prPaths).toContain('scripts/fixtures/welcome-completed.json');
     expect(prPaths).toContain('scripts/system-settings.interactive-ui.json');
   });
@@ -153,6 +156,14 @@ describe('interactive-ui.yml: conservative package/build/runtime inputs remain',
 
   it('includes CLI UI layer paths', () => {
     expect(prPaths).toContain('packages/cli/src/ui/**');
+  });
+
+  it('includes the welcome config module the onboarding scenario depends on', () => {
+    // tmux-script.onboarding.json drives first-run onboarding through
+    // LLXPRT_CODE_WELCOME_CONFIG_PATH, which only welcomeConfig.ts reads and
+    // writes. It sits outside packages/cli/src/ui/**, so without this entry a
+    // regression confined to that module would never reach this workflow.
+    expect(prPaths).toContain('packages/cli/src/config/welcomeConfig.ts');
   });
 
   it('does NOT include stale packages/ui/** (no such tracked package)', () => {

--- a/scripts/tests/interactive-ui.test.ts
+++ b/scripts/tests/interactive-ui.test.ts
@@ -9,8 +9,8 @@
  *
  * These tests exercise real terminal rendering, keyboard interaction,
  * and screen capture via tmux — covering slash autocomplete, approval dialog
- * rendering, and deterministic UI behavior that cannot be validated
- * with unit tests alone.
+ * rendering, first-run welcome onboarding, and deterministic UI behavior that
+ * cannot be validated with unit tests alone.
  *
  * All tests are gated behind LLXPRT_E2E_TMUX=1 and are skipped
  * unless that env var is set. The dedicated interactive-ui.yml
@@ -155,6 +155,22 @@ describe('Interactive UI (tmux harness)', () => {
             'scripts/fixtures/approval-ui.responses.jsonl',
           ),
         },
+      );
+      assertHarnessSuccess(result);
+    },
+    300_000,
+  );
+
+  runTmuxE2E(
+    'a clean welcome config shows onboarding, and skipping dismisses it',
+    () => {
+      // The scenario points LLXPRT_CODE_WELCOME_CONFIG_PATH at a per-run temp
+      // path that does not exist, so the CLI starts as a first-run/clean
+      // runner. Pointing it at a completed config instead makes the scenario
+      // fail on the first waitFor, which is what makes this smoke meaningful.
+      const result = runHarness(
+        'tmux-script.onboarding.json',
+        'onboarding-clean-runner',
       );
       assertHarnessSuccess(result);
     },

--- a/scripts/tests/interactive-ui.test.ts
+++ b/scripts/tests/interactive-ui.test.ts
@@ -164,10 +164,12 @@ describe('Interactive UI (tmux harness)', () => {
   runTmuxE2E(
     'a clean welcome config shows onboarding, and skipping dismisses it',
     () => {
-      // The scenario points LLXPRT_CODE_WELCOME_CONFIG_PATH at a per-run temp
-      // path that does not exist, so the CLI starts as a first-run/clean
-      // runner. Pointing it at a completed config instead makes the scenario
-      // fail on the first waitFor, which is what makes this smoke meaningful.
+      // The startCommand inside scripts/tmux-script.onboarding.json — not this
+      // test — sets LLXPRT_CODE_WELCOME_CONFIG_PATH to a per-run temp path and
+      // removes it before launch, so the CLI starts as a first-run/clean
+      // runner. Editing that scenario to point at a completed config instead
+      // makes it fail on the first waitFor, which is what makes this smoke
+      // meaningful rather than vacuous.
       const result = runHarness(
         'tmux-script.onboarding.json',
         'onboarding-clean-runner',

--- a/scripts/tmux-script.onboarding.json
+++ b/scripts/tmux-script.onboarding.json
@@ -1,0 +1,65 @@
+{
+  "tmux": {
+    "cols": 100,
+    "rows": 40,
+    "historyLimit": 20000,
+    "scrollbackLines": 2000,
+    "initialWaitMs": 6000
+  },
+  "startCommand": [
+    "sh -c 'W=\"${TMPDIR:-/tmp}/llxprt-onboarding-welcome-$$.json\"; rm -f \"$W\"; env CI=0 CONTINUOUS_INTEGRATION=0 NODE_OPTIONS= LLXPRT_CODE_NO_RELAUNCH=true LLXPRT_CODE_SKIP_TERMINAL_CAPABILITY_DETECTION=true LLXPRT_CODE_BUILTIN_COMMANDS_ONLY=true LLXPRT_CODE_SUPPRESS_STATIC_HEADER=true LLXPRT_CODE_WELCOME_CONFIG_PATH=\"$W\" LLXPRT_SYSTEM_SETTINGS_PATH=scripts/system-settings.interactive-ui.json ${bun} packages/cli/index.ts; status=$?; rm -f \"$W\"; exit $status'"
+  ],
+  "yolo": false,
+  "steps": [
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Welcome to llxprt!",
+      "timeoutMs": 30000
+    },
+    { "type": "capture", "label": "onboarding-welcome", "scope": "screen" },
+    {
+      "type": "expect",
+      "scope": "screen",
+      "contains": "Set up now (recommended)",
+      "timeoutMs": 0
+    },
+    {
+      "type": "expect",
+      "scope": "screen",
+      "contains": "Skip setup",
+      "timeoutMs": 0
+    },
+    { "type": "key", "key": "Down" },
+    { "type": "key", "key": "Enter" },
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Setup skipped",
+      "timeoutMs": 15000
+    },
+    { "type": "capture", "label": "onboarding-skipped", "scope": "screen" },
+    { "type": "key", "key": "Enter" },
+    {
+      "type": "waitFor",
+      "scope": "screen",
+      "contains": "Type your message",
+      "timeoutMs": 15000
+    },
+    {
+      "type": "expectCount",
+      "scope": "screen",
+      "contains": "Welcome to llxprt!",
+      "equals": 0
+    },
+    {
+      "type": "expectCount",
+      "scope": "screen",
+      "contains": "Setup skipped",
+      "equals": 0
+    },
+    { "type": "capture", "label": "onboarding-dismissed", "scope": "screen" },
+    { "type": "line", "text": "/quit", "submitKeys": ["Enter"] },
+    { "type": "waitForExit", "timeoutMs": 15000 }
+  ]
+}


### PR DESCRIPTION
## TLDR

Adds behavioral test coverage for onboarding, profile-wizard validation, and the
provider/model dialogs, plus one tmux smoke that drives first-run onboarding in a
real terminal. **No production code is changed** — this is a coverage-only PR.

Four modules that the issue named had no dedicated tests at all:
`packages/cli/src/config/welcomeConfig.ts`,
`packages/cli/src/ui/components/ProfileCreateWizard/validation.ts`,
`packages/cli/src/ui/components/ModelDialog.tsx`, and the keypress/selection half
of `packages/cli/src/ui/components/ProviderDialog.tsx`.

Reviewers should look hardest at two things: whether the tests would actually
fail if the production code broke, and whether the stubbing is honest. Both are
addressed below with mutation-test evidence.

Note: the CodeRabbit auto-plan on the issue is stale. It assumes Vitest, a
`vitest.config.ts` exclusion of `**/ui/components/*.test.tsx`, and a
`.spec.tsx`-under-`__tests__/` workaround. None of that exists any more — the CLI
workspace runs `bun test` only, discovery is structural, and `ink` is redirected
to a stub by a bun preload, so there is nothing to `vi.unmock`. Colocated
`*.test.tsx` is the current convention and is what this PR uses.

## Dive Deeper

### What each issue bullet is proved by

| Issue bullet | Where it is proved |
| --- | --- |
| Welcome completed config skips onboarding | `welcomeConfig.test.ts` (detection) + the tmux negative control below |
| Clean config shows onboarding | `useWelcomeOnboarding.bun.tsx` (pre-existing gate test) + `tmux-script.onboarding.json` |
| Skip and save paths persist expected state | `useWelcomeOnboarding.bun.tsx` — new skip/completion/saveProfile cases |
| Profile create wizard validation | `ProfileCreateWizard/validation.test.ts` |
| Provider/model loading errors and empty states | `ModelDialog.test.tsx`, `ProviderDialog.selection.test.tsx` |
| Provider/model switch cancellation and confirmation | `ModelDialog.test.tsx`, `ProviderDialog.selection.test.tsx` |
| One tmux smoke for clean-runner onboarding | `scripts/tmux-script.onboarding.json` |

### New files

**`packages/cli/src/config/welcomeConfig.test.ts`** (13 cases) — the real module
against real temp files, never a mocked `node:fs`. Covers the env-override and
`USER_SETTINGS_DIR` fallback for the config path, the missing-file and
malformed-JSON fallbacks, parent-directory creation, the `0o600` file mode, a
JSON round trip, `markWelcomeCompleted` for both skip values with a strict ISO
`completedAt` round trip, the process-lifetime cache the CLI depends on (including
that a malformed file is not cached into something else and that recovery works
once it is replaced), and the unwritable-path case where `saveWelcomeConfig` must
not throw.

**`packages/cli/src/ui/components/ProfileCreateWizard/validation.test.ts`**
(21 cases) — `validateBaseUrl`, `validateProfileName` (including that the
caller's array is not mutated), `validateKeyFile` against a real temp dir, and
the three `PARAM_VALIDATORS` at their boundaries. The bare-tilde case asserts
that `~` and the literal home path receive the *same* verdict rather than
asserting `~` is valid, because `validateKeyFile` currently accepts a directory
and that quirk must not be enshrined as specification (see #3402).

**`packages/cli/src/ui/components/ModelDialog.test.tsx`** (8 cases) — the real
`ModelsDialog`. Loading frame present and results frame absent while models are
in flight, then the reverse once they resolve; `listProviders()` throwing;
`listAvailableModels()` rejecting; a rejecting first provider not aborting the
fetch of the second; a search matching nothing showing `Found 0 of N` derived
from the loaded count; Enter confirming the focused row without closing; Escape
clearing a non-empty search rather than closing; Escape closing on an empty
search.

**`packages/cli/src/ui/components/ProviderDialog.selection.test.tsx`** (6 cases)
— the real `ProviderDialog` in a real `KeypressProvider`, pinned wide. Empty
search state, Enter confirmation at the initial focus and after navigating,
Escape cancelling with no side effects, Escape clearing the search before a
second Escape closes, and Enter with zero matches doing nothing.

**`scripts/tmux-script.onboarding.json`** — starts the CLI with
`LLXPRT_CODE_WELCOME_CONFIG_PATH` pointed at a per-run temp path, waits for
`Welcome to llxprt!`, asserts both choices render, selects Skip, waits for
`Setup skipped`, dismisses, waits for the normal `Type your message` prompt,
asserts the onboarding text is gone, then `/quit` and `waitForExit`. The start
command is wrapped in `sh -c` so the temp config is removed before launch and
again after the CLI exits, which keeps repeated runs clean and leaves nothing
behind.

### Extended files

**`packages/cli/src/ui/hooks/useWelcomeOnboarding.bun.tsx`** — the module-scope
runtime stub became a mutable holder that the hoisted `vi.mock` factory
dereferences lazily, so individual tests can vary runtime behavior, and the
env/temp-dir lifecycle moved to file scope. **The six pre-existing tests keep
their names, inputs, and assertions unchanged.** Six new cases assert what
actually lands on disk after skip-then-dismiss and after dismissing from the real
`completion` step (reached by driving `startSetup → selectProvider →
selectAuthMethod → onAuthComplete → selectModel`, with the step asserted before
dismissal), that `saveProfile` leaves the profile saved, defaulted, and loaded,
that a duplicate name rejects and leaves the store untouched, and both
`selectModel` outcomes.

**`scripts/tests/interactive-ui.test.ts`,
`scripts/tests/interactive-ui-paths.bun.test.ts`,
`.github/workflows/interactive-ui.yml`** — wire the scenario into the harness and
into the CI path filter (both `pull_request` and `push`, which the guard test
requires to stay symmetric). The filter also gains
`packages/cli/src/config/welcomeConfig.ts`: it is the one production module the
scenario depends on that lives outside `packages/cli/src/ui/**`, so without it a
regression confined there would never trigger this workflow.

### Evidence the tests are not vacuous

These were checked by mutating production code, confirming the test fails, and
reverting:

- Replacing `expandTilde`'s `path.join(os.homedir(), …)` with `path.resolve` →
  `expands a tilde-prefixed path against the home directory` fails.
- Replacing `expandTilde`'s bare-`~` branch with `path.resolve` →
  `treats a bare tilde exactly like the literal home directory path` fails.
- Moving `loadProfileByName` before `saveProfileSnapshot` in `useProfileSave` →
  `saveProfile leaves the new profile saved, defaulted, and loaded` fails,
  because the fake profile store rejects loading a profile that was never saved.
- Repointing the tmux scenario at `scripts/fixtures/welcome-completed.json` →
  the harness exits 1 with
  `Timed out waiting for step 0 (contains "Welcome to llxprt!")`. That negative
  control is also the end-to-end demonstration that a completed config skips
  onboarding.

`bun scripts/test-audit/scan.ts` reports no `MOCK_MIRROR`, `ALWAYS_TRUE`,
`SELF_CONFIRMING`, or `NO_ASSERT` findings on any of these files. The two
`DUP_ASSERT` findings are deliberate — asserting the same value before and after
an out-of-band file write is what proves the cache is being served, and asserting
`onSelect` was not called after each of two Escapes is what proves cancellation
stays side-effect free — and both now carry a comment saying so.

### What is stubbed, and why

Only external boundaries: the runtime API (`useRuntimeApi`), the terminal size
(`useTerminalSize`), `os.homedir()` (bun resolves it once at process start and
never rereads `$HOME`, so redirecting the module is the only way to make the
tilde test hermetic; every other `node:os` export is passed through, and the CLI
runner gives each test file its own process so the redirect cannot leak), and the
welcome-config file *location* — the file itself is real.

### Out of scope

No production behavior changed, no new confirmation UI for provider/model
switching, no `CancelConfirmDialog`/`ConflictDialog` component tests (the issue
bullet is wizard *validation*; cancellation is scoped by its own bullet to
provider/model switching), and no refactoring of the dialogs to be more testable.

### Bug found, filed separately

While writing the provider tests: in wide search mode, pressing Enter when zero
providers match appends the `\r` character to the search term, because
`isPrintableKeypress` accepts any single-character sequence and the
Enter-with-results branch is guarded on a non-empty filtered list. Filed as
**#3400** rather than fixed here. The test asserts only that no callback fires,
so it does not enshrine the bug and will keep passing once #3400 is fixed.

A second one surfaced during review, raised independently by CodeRabbit and
OpenCodeReview: `validateKeyFile` decides validity purely on `fs.access(R_OK)`,
so a readable *directory* passes as a valid key file. Filed as **#3402**, again
not fixed here, and the bare-tilde test was rewritten so it does not assert the
quirk is correct.

## Reviewer Test Plan

```bash
git fetch origin issue2023 && git checkout issue2023
npm install    # if your node_modules predates the current lockfile

# The five test files, all green
cd packages/cli
bun test ./src/config/welcomeConfig.test.ts
bun test ./src/ui/hooks/useWelcomeOnboarding.bun.tsx
bun test ./src/ui/components/ProfileCreateWizard/validation.test.ts
bun test ./src/ui/components/ModelDialog.test.tsx
bun test ./src/ui/components/ProviderDialog.selection.test.tsx
cd ../..

# CI path-filter guard
bun test ./scripts/tests/interactive-ui-paths.bun.test.ts

# The tmux smoke (needs tmux installed). Run it twice to see it is idempotent
# and leaves no temp config behind.
bun scripts/tmux-harness.ts --script scripts/tmux-script.onboarding.json --out-dir /tmp/ob1
bun scripts/tmux-harness.ts --script scripts/tmux-script.onboarding.json --out-dir /tmp/ob2
ls "${TMPDIR:-/tmp}"/llxprt-onboarding-welcome-*.json   # expect: no such file
```

To confirm the smoke is meaningful, edit the scenario's
`LLXPRT_CODE_WELCOME_CONFIG_PATH` to `scripts/fixtures/welcome-completed.json`
and re-run it — it should fail on the first `waitFor`.

Reading the captured frames in the artifact dir (`001-onboarding-welcome-screen.txt`,
`007-onboarding-skipped-screen.txt`, `012-onboarding-dismissed-screen.txt`) is the
quickest way to see that the scenario really drives the dialog.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS (arm64): `npm run test`, `npm run lint`, `npm run typecheck`,
`npm run format`, `npm run build`, the tmux scenario (twice), and the
`stepfun-37` startup smoke. Platform-sensitive cases are guarded rather than
assumed: the `0o600` mode assertion and the `EACCES` and tilde cases skip on
win32, and the permission case also skips when running as root.

Two pre-existing load flakes appeared in the full local suite and pass in
isolation: `packages/test-utils/src/interactive-run.test.ts` (PTY quota guard,
6 cases, 5s timeouts) and `packages/test-utils/src/model-request-ledger.test.ts`
(concurrent append, 30s timeout). Neither file is touched by this PR and this PR
adds no production code; they timed out while several other heavy processes were
running on the same machine.

## Linked issues / bugs

Fixes #2023

Found during this work and filed separately: #3400, #3402


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive coverage for the first-run welcome and onboarding experience.
  * Added end-to-end verification that onboarding completes successfully on a clean run.

* **Tests**
  * Expanded coverage for welcome configuration, model selection, provider selection, profile creation, and validation.
  * Improved workflow path checks so relevant onboarding changes trigger interactive UI testing.
  * Added coverage for onboarding persistence, profile setup, model selection, search, and keyboard interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
