### PR TITLE
fix(agents): stop repeating the context-overflow guard and actually reduce context (Fixes #3406)

### DIFF
--- a/packages/agents/src/compression/CompressionHandler.ts
+++ b/packages/agents/src/compression/CompressionHandler.ts
@@ -40,15 +40,13 @@ import { emitCompressionLifecycleEvent } from './compressionLifecycleTelemetry.j
  * @requirement:REQ-DEP-001
  * @pseudocode component-boundaries.md C-CB-08, lines 80-85
  *
- * extractThinkingBlocks and estimateThinkingTokens are retained from
- * the providers path for backward compatibility. The ReasoningOutput
- * contract is available for the injection path where providers pass
- * pre-extracted reasoning data through the RuntimeProvider contract.
+ * Reasoning-aware token accounting lives in effectiveTokenCount.ts, which
+ * still uses the providers-path extractThinkingBlocks/estimateThinkingTokens
+ * helpers. The ReasoningOutput contract is available for the injection path
+ * where providers pass pre-extracted reasoning data through the
+ * RuntimeProvider contract.
  */
-import {
-  extractThinkingBlocks,
-  estimateThinkingTokens,
-} from './reasoningUtils.js';
+import { computeEffectiveTokenCount } from './effectiveTokenCount.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import { retryWithBackoff } from '@vybestack/llxprt-code-core/utils/retry.js';
 import { tokenLimit } from '@vybestack/llxprt-code-core/core/tokenLimits.js';
@@ -132,49 +130,7 @@ export class CompressionHandler {
    * @requirement REQ-THINK-005.1, REQ-THINK-005.2
    */
   getEffectiveTokenCount(): number {
-    const includeInContext =
-      this.runtimeContext.ephemerals.reasoning.includeInContext();
-    const stripPolicy =
-      this.runtimeContext.ephemerals.reasoning.stripFromContext();
-
-    // If reasoning IS included in context, all tokens count
-    if (includeInContext) {
-      return this.historyService.getTotalTokens();
-    }
-
-    // If reasoning is NOT included, calculate actual reduction
-    const allContents = this.historyService.getCurated();
-    const rawTokens = this.historyService.getTotalTokens();
-
-    let thinkingTokensToStrip = 0;
-
-    if (stripPolicy === 'allButLast') {
-      // Find last content with thinking blocks
-      let lastIndexWithThinking = -1;
-      for (let i = allContents.length - 1; i >= 0; i--) {
-        if (extractThinkingBlocks(allContents[i]).length > 0) {
-          lastIndexWithThinking = i;
-          break;
-        }
-      }
-
-      // Strip thinking from all except that last one
-      for (let i = 0; i < allContents.length; i++) {
-        if (i !== lastIndexWithThinking) {
-          const thinkingBlocks = extractThinkingBlocks(allContents[i]);
-          thinkingTokensToStrip += estimateThinkingTokens(thinkingBlocks);
-        }
-      }
-    } else {
-      // stripPolicy === 'all' explicitly strips all thinking; stripPolicy === 'none'
-      // also removes all thinking from the effective count when includeInContext=false.
-      for (const content of allContents) {
-        const thinkingBlocks = extractThinkingBlocks(content);
-        thinkingTokensToStrip += estimateThinkingTokens(thinkingBlocks);
-      }
-    }
-
-    return Math.max(0, rawTokens - thinkingTokensToStrip);
+    return computeEffectiveTokenCount(this.historyService, this.runtimeContext);
   }
 
   /**
@@ -508,10 +464,16 @@ export class CompressionHandler {
       restorePromptTokenBaseline: (baseline) => {
         this.lastPromptTokenCount = baseline;
       },
-      performFallbackCompression: async (promptId, applyResult) => {
+      performFallbackCompression: async (
+        promptId,
+        applyResult,
+        targetTokenCount,
+      ) => {
         this.pushSuppressDensityDirty();
         try {
-          const context = await this.buildCompressionContext(promptId);
+          const context = await this.buildCompressionContext(promptId, {
+            targetTokenCount,
+          });
           const outcome = await this.performFallbackCompression(
             context,
             new Error('Provider content fallback truncation triggered'),
@@ -575,8 +537,8 @@ export class CompressionHandler {
       ensureDensityOptimized: () => this.ensureDensityOptimized(),
       performCompression: (activePromptId, options) =>
         this.performCompression(activePromptId, options),
-      buildCompressionContext: (activePromptId) =>
-        this.buildCompressionContext(activePromptId),
+      buildCompressionContext: (activePromptId, targetTokenCount) =>
+        this.buildCompressionContext(activePromptId, { targetTokenCount }),
       compressWithFallbackStrategy: (context) =>
         this.compressWithFallbackStrategy(context),
       applyFallbackCompressionResult: (result, applyResult) =>
@@ -1064,7 +1026,10 @@ export class CompressionHandler {
    * @plan PLAN-20260211-COMPRESSION.P14
    * @requirement REQ-CS-001.6
    */
-  async buildCompressionContext(promptId: string): Promise<CompressionContext> {
+  async buildCompressionContext(
+    promptId: string,
+    options?: { targetTokenCount?: number },
+  ): Promise<CompressionContext> {
     return buildContext(
       promptId,
       this.runtimeContext,
@@ -1072,6 +1037,7 @@ export class CompressionHandler {
       (profileName?) => Promise.resolve(this.providerResolver(profileName)),
       this.activeTodosProvider,
       this.logger,
+      options,
     );
   }
 

--- a/packages/agents/src/compression/TopDownTruncationStrategy.test.ts
+++ b/packages/agents/src/compression/TopDownTruncationStrategy.test.ts
@@ -115,6 +115,7 @@ function buildContext(
     compressionThreshold: number;
     contextLimit: number;
     currentTokenCount: number;
+    targetTokenCount: number;
     estimateTokens: (contents: readonly IContent[]) => Promise<number>;
   }> = {},
 ): CompressionContext {
@@ -166,6 +167,9 @@ function buildContext(
     runtimeState,
     estimateTokens,
     currentTokenCount: overrides.currentTokenCount ?? 5000,
+    ...(overrides.targetTokenCount !== undefined
+      ? { targetTokenCount: overrides.targetTokenCount }
+      : {}),
     logger: noopLogger,
     resolveProvider: () => ({
       provider: throwingProvider,
@@ -345,6 +349,88 @@ describe('TopDownTruncationStrategy', () => {
       expect(result.kind).toBe('noop');
       expect(result.reason).toBe('already-under-target');
       expect(result.metadata.originalMessageCount).toBe(5);
+    });
+
+    // -------------------------------------------------------------------
+    // Issue #3406 — hard-limit enforcement supplies the real target.
+    //
+    // The ephemeral target (compressionThreshold × contextLimit × 0.6) is
+    // derived from committed history alone, but the enforcer must fit the
+    // whole finalized envelope (system prompt + tool schemas + history +
+    // pending content) into the context budget. When the enforcer knows the
+    // real deficit it passes an explicit targetTokenCount, and the strategy
+    // must honour it instead of declaring itself already under target.
+    // -------------------------------------------------------------------
+
+    it('truncates to an explicit target even when the ephemeral target says it is already under', async () => {
+      // 20 messages × 500 tokens = 10000 committed tokens.
+      // Ephemeral target = 0.8 * 40000 * 0.6 = 19200, so currentTokenCount
+      // (10000) is comfortably under it and today this is a no-op.
+      // Hard-limit enforcement needs history down to 3000 tokens.
+      const history = generateHistory(20);
+      const ctx = buildContext({
+        history,
+        currentTokenCount: 10000,
+        contextLimit: 40000,
+        compressionThreshold: 0.8,
+        targetTokenCount: 3000,
+        estimateTokens: async (contents) => contents.length * 500,
+      });
+
+      const strategy = new TopDownTruncationStrategy();
+      const result = await strategy.compress(ctx);
+
+      expect(result.kind).toBe('applied');
+      if (result.kind !== 'applied') return;
+      // 5 messages × 500 = 2500 < 3000; 6 × 500 = 3000 is not < 3000.
+      expect(result.newHistory.length).toBeLessThanOrEqual(5);
+      expect(result.newHistory.length).toBeGreaterThanOrEqual(2);
+      // The survivors are the newest messages; the oldest were dropped.
+      const kept = result.newHistory.length;
+      for (let i = 0; i < kept; i++) {
+        expect(result.newHistory[i]).toBe(history[history.length - kept + i]);
+      }
+    });
+
+    it('still reports a structural no-op when the explicit target is above the current count', async () => {
+      const history = generateHistory(5);
+      const ctx = buildContext({
+        history,
+        currentTokenCount: 500,
+        contextLimit: 10000,
+        compressionThreshold: 0.8,
+        targetTokenCount: 4000,
+        estimateTokens: async (contents) => contents.length * 100,
+      });
+
+      const strategy = new TopDownTruncationStrategy();
+      const result = await strategy.compress(ctx);
+
+      expect(result.kind).toBe('noop');
+      expect(result.reason).toBe('already-under-target');
+    });
+
+    it('truncates deeper than the ephemeral target when the explicit target is lower', async () => {
+      // Ephemeral target = 0.8 * 10000 * 0.6 = 4800 would stop at 9
+      // messages (4500 tokens). The explicit target of 1000 must drive a
+      // deeper truncation than the ephemeral one would.
+      const history = generateHistory(20);
+      const ctx = buildContext({
+        history,
+        currentTokenCount: 10000,
+        contextLimit: 10000,
+        compressionThreshold: 0.8,
+        targetTokenCount: 1000,
+        estimateTokens: async (contents) => contents.length * 500,
+      });
+
+      const strategy = new TopDownTruncationStrategy();
+      const result = await strategy.compress(ctx);
+
+      expect(result.kind).toBe('applied');
+      if (result.kind !== 'applied') return;
+      // 1 message × 500 < 1000, but minKeep clamps the removal at 2 kept.
+      expect(result.newHistory.length).toBe(2);
     });
 
     it('removes specific number of messages to get under target', async () => {

--- a/packages/agents/src/compression/TopDownTruncationStrategy.test.ts
+++ b/packages/agents/src/compression/TopDownTruncationStrategy.test.ts
@@ -382,9 +382,9 @@ describe('TopDownTruncationStrategy', () => {
 
       expect(result.kind).toBe('applied');
       if (result.kind !== 'applied') return;
-      // 5 messages × 500 = 2500 < 3000; 6 × 500 = 3000 is not < 3000.
-      expect(result.newHistory.length).toBeLessThanOrEqual(5);
-      expect(result.newHistory.length).toBeGreaterThanOrEqual(2);
+      // An explicit target is a maximum, so 6 messages × 500 = 3000 exactly
+      // satisfies it and no further message is dropped.
+      expect(result.newHistory.length).toBe(6);
       // The survivors are the newest messages; the oldest were dropped.
       const kept = result.newHistory.length;
       for (let i = 0; i < kept; i++) {

--- a/packages/agents/src/compression/TopDownTruncationStrategy.ts
+++ b/packages/agents/src/compression/TopDownTruncationStrategy.ts
@@ -41,8 +41,13 @@ export class TopDownTruncationStrategy implements CompressionStrategy {
   async compress(
     context: CompressionContext,
   ): Promise<StrategyCompressionResult> {
-    const { history, runtimeContext, estimateTokens, currentTokenCount } =
-      context;
+    const {
+      history,
+      runtimeContext,
+      estimateTokens,
+      currentTokenCount,
+      targetTokenCount,
+    } = context;
     const originalCount = history.length;
 
     if (originalCount === 0) {
@@ -52,7 +57,11 @@ export class TopDownTruncationStrategy implements CompressionStrategy {
     const compressionThreshold =
       runtimeContext.ephemerals.compressionThreshold();
     const contextLimit = runtimeContext.ephemerals.contextLimit();
-    const target = compressionThreshold * contextLimit * 0.6;
+    // Hard-limit enforcement supplies the real target because it is the only
+    // layer that knows the finalized envelope's deficit; the ephemeral target
+    // below only sees committed history (issue #3406).
+    const target =
+      targetTokenCount ?? compressionThreshold * contextLimit * 0.6;
 
     if (currentTokenCount <= target) {
       return this.structuralNoop(originalCount, 'already-under-target');

--- a/packages/agents/src/compression/TopDownTruncationStrategy.ts
+++ b/packages/agents/src/compression/TopDownTruncationStrategy.ts
@@ -62,6 +62,11 @@ export class TopDownTruncationStrategy implements CompressionStrategy {
     // below only sees committed history (issue #3406).
     const target =
       targetTokenCount ?? compressionThreshold * contextLimit * 0.6;
+    // An explicit target is a maximum, so landing exactly on it is done —
+    // matching the `<=` no-op guard below. The threshold-derived fallback
+    // keeps its historical strict comparison.
+    const isSatisfied = (tokens: number): boolean =>
+      targetTokenCount !== undefined ? tokens <= target : tokens < target;
 
     if (currentTokenCount <= target) {
       return this.structuralNoop(originalCount, 'already-under-target');
@@ -74,7 +79,7 @@ export class TopDownTruncationStrategy implements CompressionStrategy {
     for (let i = 1; i <= originalCount - minKeep; i++) {
       const remaining = history.slice(i);
       const tokens = await estimateTokens(remaining);
-      if (tokens < target) {
+      if (isSatisfied(tokens)) {
         removeCount = i;
         break;
       }

--- a/packages/agents/src/compression/__tests__/pendingContextWindowEnforcement.historyTruncationTarget.test.ts
+++ b/packages/agents/src/compression/__tests__/pendingContextWindowEnforcement.historyTruncationTarget.test.ts
@@ -1,0 +1,189 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral regression for issue #3406 on the HTTP 413 recovery path.
+ *
+ * PendingContextWindowEnforcer has the same defect the provider-content path
+ * had: its TopDownTruncation fallback used to derive its own target from
+ * `compressionThreshold * contextLimit * 0.6`, which only measures committed
+ * history, while the enforcer has to fit committed history plus the pending
+ * request plus the completion reservation under the context limit. When the
+ * pending request supplied the overage, the truncator declared itself already
+ * under target and recovery failed with nothing compressed.
+ *
+ * These tests drive the REAL PendingContextWindowEnforcer against a REAL
+ * HistoryService, building a REAL compression context and running the REAL
+ * TopDownTruncationStrategy behind the enforcer's dependencies.
+ */
+
+import { describe, it, expect, vi } from 'bun:test';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
+import { createAgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
+import { createAgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/createAgentRuntimeContext.js';
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import { PerformCompressionResult } from '@vybestack/llxprt-code-core/core/turn.js';
+import {
+  PendingContextWindowEnforcer,
+  type PendingContextWindowEnforcerDeps,
+} from '../pendingContextWindowEnforcement.js';
+import { TopDownTruncationStrategy } from '../TopDownTruncationStrategy.js';
+import { buildCompressionContext } from '../compressionContextBuilder.js';
+import { computeMarginAdjustedLimit } from '../contextLimitPolicy.js';
+
+const MODEL = 'test-model';
+const COMPRESSION_THRESHOLD = 0.8;
+const CONTEXT_LIMIT = 20_000;
+const COMPLETION_BUDGET = 10_000;
+const PENDING_TOKENS = 600;
+
+function makeLogger(): DebugLogger {
+  return {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  } as unknown as DebugLogger;
+}
+
+function textContent(speaker: IContent['speaker'], text: string): IContent {
+  return { speaker, blocks: [{ type: 'text', text }] };
+}
+
+function buildRuntimeContext(
+  historyService: HistoryService,
+): AgentRuntimeContext {
+  const state = createAgentRuntimeState({
+    runtimeId: 'pending-history-target-test',
+    provider: 'test',
+    model: MODEL,
+    sessionId: 'test-session',
+  });
+  return createAgentRuntimeContext({
+    state,
+    history: historyService,
+    settings: {
+      compressionThreshold: COMPRESSION_THRESHOLD,
+      contextLimit: CONTEXT_LIMIT,
+      preserveThreshold: 0.2,
+      telemetry: { enabled: false, target: null },
+      'reasoning.includeInContext': true,
+    },
+    provider: {} as never,
+    telemetry: {} as never,
+    tools: {} as never,
+    providerRuntime: {
+      runtimeId: 'test-runtime',
+      settingsService: { get: vi.fn(() => undefined) } as never,
+      config: {} as never,
+    } as never,
+  });
+}
+
+interface Harness {
+  enforcer: PendingContextWindowEnforcer;
+  historyService: HistoryService;
+  marginAdjustedLimit: number;
+}
+
+async function buildHarness(): Promise<Harness> {
+  const historyService = new HistoryService();
+  const runtimeContext = buildRuntimeContext(historyService);
+  const logger = makeLogger();
+  const marginAdjustedLimit = computeMarginAdjustedLimit(CONTEXT_LIMIT);
+
+  for (let i = 0; i < 12; i++) {
+    historyService.add(
+      textContent(
+        i % 2 === 0 ? 'human' : 'ai',
+        `message ${i} ${'word '.repeat(550)}`,
+      ),
+    );
+  }
+  await historyService.waitForTokenUpdates();
+
+  const deps: PendingContextWindowEnforcerDeps = {
+    historyService,
+    logger,
+    ineffectiveCompressionReductionThreshold: 0.05,
+    getContextLimits: () => ({
+      completionBudget: COMPLETION_BUDGET,
+      limit: CONTEXT_LIMIT,
+      marginAdjustedLimit,
+    }),
+    computeProjectedTokens: (pendingTokens, completionBudget) =>
+      historyService.getTotalTokens() +
+      Math.max(0, pendingTokens) +
+      completionBudget,
+    ensureDensityOptimized: async () => {},
+    // Middle-out and one-shot both refuse on a small number of large
+    // messages, which is the shape the reported session hit.
+    performCompression: async () => PerformCompressionResult.NOOP,
+    buildCompressionContext: (promptId, targetTokenCount) =>
+      buildCompressionContext(
+        promptId,
+        runtimeContext,
+        historyService,
+        () => Promise.resolve({ provider: {} as never, runtime: {} as never }),
+        undefined,
+        logger,
+        { targetTokenCount },
+      ),
+    compressWithFallbackStrategy: (context) =>
+      new TopDownTruncationStrategy().compress(context),
+    applyFallbackCompressionResult: async (result, applyResult) => {
+      if (result.kind === 'noop') {
+        return;
+      }
+      await applyResult(result.newHistory, undefined, 0);
+    },
+    setSuppressDensityDirty: () => {},
+    recordCompressionFailure: () => {},
+    resetLastPromptTokenCount: () => {},
+    getRuntimeModel: () => MODEL,
+    estimateBlockTokensAsync: async () => 0,
+  };
+
+  return {
+    enforcer: new PendingContextWindowEnforcer(deps),
+    historyService,
+    marginAdjustedLimit,
+  };
+}
+
+describe('PendingContextWindowEnforcer history-truncation target (issue #3406)', () => {
+  it('truncates history to fit when the pending request supplies the overage', async () => {
+    const { enforcer, historyService, marginAdjustedLimit } =
+      await buildHarness();
+
+    const historyTokens = historyService.getTotalTokens();
+    const ephemeralTarget = COMPRESSION_THRESHOLD * CONTEXT_LIMIT * 0.6;
+    const projected = historyTokens + PENDING_TOKENS + COMPLETION_BUDGET;
+
+    // Preconditions that define the bug: the request overflows, yet committed
+    // history alone sits under the strategy's own target.
+    expect(projected).toBeGreaterThan(marginAdjustedLimit);
+    expect(historyTokens).toBeLessThanOrEqual(ephemeralTarget);
+
+    await enforcer.enforce(PENDING_TOKENS, 'prompt-3406-pending', undefined);
+
+    const remaining = historyService.getTotalTokens();
+    expect(remaining).toBeLessThan(historyTokens);
+    expect(remaining + PENDING_TOKENS + COMPLETION_BUDGET).toBeLessThanOrEqual(
+      marginAdjustedLimit,
+    );
+  });
+
+  it('leaves history alone when the pending request already fits', async () => {
+    const { enforcer, historyService } = await buildHarness();
+    const historyTokens = historyService.getTotalTokens();
+
+    await enforcer.enforce(1, 'prompt-3406-pending-fits', undefined);
+
+    expect(historyService.getTotalTokens()).toBe(historyTokens);
+  });
+});

--- a/packages/agents/src/compression/__tests__/providerContentEnforcement.historyTruncationTarget.test.ts
+++ b/packages/agents/src/compression/__tests__/providerContentEnforcement.historyTruncationTarget.test.ts
@@ -1,0 +1,251 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral regression for issue #3406.
+ *
+ * TopDownTruncation is the last-resort history truncator for hard-limit
+ * enforcement, but it used to decide whether to act by comparing committed
+ * history against `compressionThreshold * contextLimit * 0.6`. The enforcer
+ * that invokes it has to fit the whole finalized envelope — system prompt,
+ * tool schemas, committed history and pending content — under the context
+ * budget. Those are different quantities, so whenever the envelope overhead
+ * pushed the request over the limit while committed history stayed under the
+ * strategy's own target, the truncator declared `already-under-target` and did
+ * nothing. Every reduction stage then declined and the user got the overflow
+ * guard with nothing compressed.
+ *
+ * These tests use the REAL ProviderContentEnforcer over a REAL HistoryService
+ * with real token estimation, and drive the REAL TopDownTruncationStrategy
+ * through the REAL compression-context builder behind the
+ * performFallbackCompression dependency — the same wiring CompressionHandler
+ * uses. Nothing asserts on a mock call; the assertions are about whether the
+ * payload genuinely came back under budget.
+ */
+
+import { describe, it, expect, vi } from 'bun:test';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
+import { createAgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
+import { createAgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/createAgentRuntimeContext.js';
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import { PerformCompressionResult } from '@vybestack/llxprt-code-core/core/turn.js';
+import type { ProviderContentEnvelope } from '@vybestack/llxprt-code-core/services/history/historyProviderPipeline.js';
+import {
+  ProviderContentEnforcer,
+  type ProviderContentEnforcementDeps,
+} from '../providerContentEnforcement.js';
+import { TopDownTruncationStrategy } from '../TopDownTruncationStrategy.js';
+import { buildCompressionContext } from '../compressionContextBuilder.js';
+import { computeMarginAdjustedLimit } from '../contextLimitPolicy.js';
+
+const MODEL = 'test-model';
+const COMPRESSION_THRESHOLD = 0.8;
+const CONTEXT_LIMIT = 20_000;
+const COMPLETION_BUDGET = 10_000;
+
+function makeLogger(): DebugLogger {
+  return {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  } as unknown as DebugLogger;
+}
+
+function buildRuntimeContext(
+  historyService: HistoryService,
+): AgentRuntimeContext {
+  const state = createAgentRuntimeState({
+    runtimeId: 'pce-history-target-test',
+    provider: 'test',
+    model: MODEL,
+    sessionId: 'test-session',
+  });
+  return createAgentRuntimeContext({
+    state,
+    history: historyService,
+    settings: {
+      compressionThreshold: COMPRESSION_THRESHOLD,
+      contextLimit: CONTEXT_LIMIT,
+      preserveThreshold: 0.2,
+      telemetry: { enabled: false, target: null },
+      'reasoning.includeInContext': true,
+    },
+    provider: {} as never,
+    telemetry: {} as never,
+    tools: {} as never,
+    providerRuntime: {
+      runtimeId: 'test-runtime',
+      settingsService: { get: vi.fn(() => undefined) } as never,
+      config: {} as never,
+    } as never,
+  });
+}
+
+function textContent(speaker: IContent['speaker'], text: string): IContent {
+  return { speaker, blocks: [{ type: 'text', text }] };
+}
+
+function buildEnvelope(
+  contents: IContent[],
+  pendingContents: IContent[],
+): ProviderContentEnvelope {
+  return { contents, pendingContents } as ProviderContentEnvelope;
+}
+
+/**
+ * Wire performFallbackCompression exactly as CompressionHandler does: build a
+ * real compression context carrying the caller-supplied target, run the real
+ * TopDownTruncationStrategy, and commit its candidate history.
+ */
+function buildFallbackCompression(
+  historyService: HistoryService,
+  runtimeContext: AgentRuntimeContext,
+  logger: DebugLogger,
+): ProviderContentEnforcementDeps['performFallbackCompression'] {
+  return async (promptId, applyResult, targetTokenCount) => {
+    const context = await buildCompressionContext(
+      promptId,
+      runtimeContext,
+      historyService,
+      () =>
+        Promise.resolve({
+          provider: {} as never,
+          runtime: {} as never,
+        }),
+      undefined,
+      logger,
+      { targetTokenCount },
+    );
+    const result = await new TopDownTruncationStrategy().compress(context);
+    if (result.kind === 'noop') {
+      return false;
+    }
+    await applyResult(result.newHistory);
+    return true;
+  };
+}
+
+interface Harness {
+  enforcer: ProviderContentEnforcer;
+  historyService: HistoryService;
+  pending: IContent[];
+  envelope: ProviderContentEnvelope;
+}
+
+/**
+ * Build a conversation whose committed history sits UNDER the strategy's own
+ * ephemeral target while the finalized envelope (history plus pending) sits
+ * OVER the enforcer's budget. That is the shape that used to defeat every
+ * reduction stage.
+ */
+async function buildHarness(): Promise<Harness> {
+  const historyService = new HistoryService();
+  const runtimeContext = buildRuntimeContext(historyService);
+  const logger = makeLogger();
+
+  for (let i = 0; i < 12; i++) {
+    historyService.add(
+      textContent(
+        i % 2 === 0 ? 'human' : 'ai',
+        `message ${i} ${'word '.repeat(550)}`,
+      ),
+    );
+  }
+  await historyService.waitForTokenUpdates();
+
+  const pending = [textContent('human', `pending ${'word '.repeat(500)}`)];
+
+  const deps: ProviderContentEnforcementDeps = {
+    historyService,
+    runtimeContext,
+    generationConfig: { maxOutputTokens: COMPLETION_BUDGET },
+    providerRuntimeNullable: undefined,
+    logger,
+    ensureDensityOptimized: vi.fn().mockResolvedValue(undefined),
+    // Middle-out and one-shot both refuse on a small number of large
+    // messages, which is what the reported session hit.
+    performCompression: vi
+      .fn()
+      .mockResolvedValue(PerformCompressionResult.NOOP),
+    performFallbackCompression: buildFallbackCompression(
+      historyService,
+      runtimeContext,
+      logger,
+    ),
+    getPromptTokenBaseline: () => null,
+    resetPromptTokenBaseline: () => {},
+    restorePromptTokenBaseline: () => {},
+  };
+
+  return {
+    enforcer: new ProviderContentEnforcer(deps),
+    historyService,
+    pending,
+    envelope: buildEnvelope(
+      [...historyService.getCurated(), ...pending],
+      pending,
+    ),
+  };
+}
+
+describe('ProviderContentEnforcer history-truncation target (issue #3406)', () => {
+  it('truncates history to fit when the envelope overflows but committed history is under the strategy target', async () => {
+    const { enforcer, historyService, pending } = await buildHarness();
+
+    const marginAdjustedLimit = computeMarginAdjustedLimit(CONTEXT_LIMIT);
+    const inputBudget = marginAdjustedLimit - COMPLETION_BUDGET;
+    const ephemeralTarget = COMPRESSION_THRESHOLD * CONTEXT_LIMIT * 0.6;
+    const historyTokens = historyService.getTotalTokens();
+    const envelopeTokens = await historyService.estimateTokensForContents(
+      [...historyService.getCurated(), ...pending],
+      MODEL,
+    );
+
+    // Preconditions that define the bug. If token estimation drifts these
+    // fail loudly rather than letting the regression silently stop applying.
+    expect(envelopeTokens).toBeGreaterThan(inputBudget);
+    expect(historyTokens).toBeLessThanOrEqual(ephemeralTarget);
+
+    const envelope = buildEnvelope(
+      [...historyService.getCurated(), ...pending],
+      pending,
+    );
+    const result = await enforcer.enforce(envelope, 'prompt-3406', undefined);
+
+    const finalTokens = await historyService.estimateTokensForContents(
+      result,
+      MODEL,
+    );
+    expect(finalTokens).toBeLessThanOrEqual(inputBudget);
+    // Truncation really removed the oldest entries rather than reporting
+    // success over an unchanged history.
+    expect(historyService.getTotalTokens()).toBeLessThan(historyTokens);
+  });
+
+  it('leaves history alone when the envelope already fits', async () => {
+    const { enforcer, historyService } = await buildHarness();
+    const historyTokens = historyService.getTotalTokens();
+
+    // A tiny pending message against the same history is comfortably inside
+    // the budget once the completion reservation is small.
+    const smallPending = [textContent('human', 'hi')];
+    const envelope = buildEnvelope(
+      [...historyService.getCurated(), ...smallPending],
+      smallPending,
+    );
+
+    const result = await enforcer.enforce(
+      envelope,
+      'prompt-3406-fits',
+      undefined,
+    );
+
+    expect(result.length).toBeGreaterThan(0);
+    expect(historyService.getTotalTokens()).toBe(historyTokens);
+  });
+});

--- a/packages/agents/src/compression/compressionContextBuilder.ts
+++ b/packages/agents/src/compression/compressionContextBuilder.ts
@@ -29,6 +29,7 @@ export async function buildCompressionContext(
   ) => Promise<CompressionProviderResult>,
   activeTodosProvider: (() => Promise<string | undefined>) | undefined,
   logger: DebugLogger,
+  options?: { targetTokenCount?: number },
 ): Promise<CompressionContext> {
   const promptResolver = new PromptResolver();
   const promptBaseDir = path.join(Storage.getGlobalConfigDir(), 'prompts');
@@ -51,6 +52,9 @@ export async function buildCompressionContext(
     estimateTokens: (contents) =>
       historyService.estimateTokensForContents(contents as IContent[]),
     currentTokenCount: historyService.getTotalTokens(),
+    ...(options?.targetTokenCount !== undefined
+      ? { targetTokenCount: options.targetTokenCount }
+      : {}),
     logger,
     resolveProvider: providerResolver,
     promptResolver,

--- a/packages/agents/src/compression/contextLimitPolicy.ts
+++ b/packages/agents/src/compression/contextLimitPolicy.ts
@@ -8,6 +8,28 @@ export const TOKEN_SAFETY_MARGIN = 1000;
 export const CONTEXT_LIMIT_FUDGE_FACTOR = 0.005;
 export const INEFFECTIVE_COMPRESSION_REDUCTION_THRESHOLD = 0.05;
 
+/**
+ * Convert a projected-token overage into the committed-history token target
+ * that hard-limit truncation has to reach.
+ *
+ * The projection covers the whole finalized envelope (system prompt, tool
+ * schemas, committed history and pending content), but truncation can only
+ * remove committed history, so the target is the current history total less
+ * the overage. Returns undefined when there is no overage, leaving strategies
+ * on their own threshold-derived target (issue #3406).
+ */
+export function computeHistoryTruncationTarget(
+  projected: number,
+  marginAdjustedLimit: number,
+  currentHistoryTokens: number,
+): number | undefined {
+  const overage = projected - marginAdjustedLimit;
+  if (overage <= 0) {
+    return undefined;
+  }
+  return Math.max(0, currentHistoryTokens - overage);
+}
+
 export function computeMarginAdjustedLimit(limit: number): number {
   const safetyAdjustedLimit = Math.max(0, limit - TOKEN_SAFETY_MARGIN);
   return Math.max(

--- a/packages/agents/src/compression/effectiveTokenCount.ts
+++ b/packages/agents/src/compression/effectiveTokenCount.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Reasoning-aware effective token accounting, extracted from
+ * CompressionHandler. Thinking blocks that will be stripped before the request
+ * reaches the provider must not count against the context budget.
+ *
+ * @plan PLAN-20251202-THINKING.P15
+ * @requirement REQ-THINK-005.1, REQ-THINK-005.2
+ */
+
+import type { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
+import {
+  extractThinkingBlocks,
+  estimateThinkingTokens,
+} from './reasoningUtils.js';
+
+/**
+ * Calculate the effective token count for the committed history, discounting
+ * thinking blocks that the active reasoning settings will strip before the
+ * request is sent.
+ */
+export function computeEffectiveTokenCount(
+  historyService: HistoryService,
+  runtimeContext: AgentRuntimeContext,
+): number {
+  const includeInContext =
+    runtimeContext.ephemerals.reasoning.includeInContext();
+  const stripPolicy = runtimeContext.ephemerals.reasoning.stripFromContext();
+
+  // If reasoning IS included in context, all tokens count.
+  if (includeInContext) {
+    return historyService.getTotalTokens();
+  }
+
+  const allContents = historyService.getCurated();
+  const rawTokens = historyService.getTotalTokens();
+
+  let thinkingTokensToStrip = 0;
+
+  if (stripPolicy === 'allButLast') {
+    let lastIndexWithThinking = -1;
+    for (let i = allContents.length - 1; i >= 0; i--) {
+      if (extractThinkingBlocks(allContents[i]).length > 0) {
+        lastIndexWithThinking = i;
+        break;
+      }
+    }
+
+    for (let i = 0; i < allContents.length; i++) {
+      if (i !== lastIndexWithThinking) {
+        thinkingTokensToStrip += estimateThinkingTokens(
+          extractThinkingBlocks(allContents[i]),
+        );
+      }
+    }
+  } else {
+    // stripPolicy === 'all' explicitly strips all thinking; stripPolicy ===
+    // 'none' also removes all thinking from the effective count when
+    // includeInContext=false.
+    for (const content of allContents) {
+      thinkingTokensToStrip += estimateThinkingTokens(
+        extractThinkingBlocks(content),
+      );
+    }
+  }
+
+  return Math.max(0, rawTokens - thinkingTokensToStrip);
+}

--- a/packages/agents/src/compression/pendingContextWindowEnforcement.ts
+++ b/packages/agents/src/compression/pendingContextWindowEnforcement.ts
@@ -29,6 +29,7 @@ import type {
 import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import { PerformCompressionResult } from '@vybestack/llxprt-code-core/core/turn.js';
 import { buildContextOverflowError } from './contextOverflowError.js';
+import { computeHistoryTruncationTarget } from './contextLimitPolicy.js';
 import {
   truncateLargestToolResponses,
   type ToolResponseTruncationResult,
@@ -62,7 +63,10 @@ export interface PendingContextWindowEnforcerDeps {
     promptId: string,
     options: { bypassCooldown: true; trigger: 'auto' },
   ): Promise<PerformCompressionResult>;
-  buildCompressionContext(promptId: string): Promise<CompressionContext>;
+  buildCompressionContext(
+    promptId: string,
+    targetTokenCount?: number,
+  ): Promise<CompressionContext>;
   compressWithFallbackStrategy(
     context: CompressionContext,
   ): Promise<StrategyCompressionResult>;
@@ -402,7 +406,14 @@ export class PendingContextWindowEnforcer {
     this.deps.setSuppressDensityDirty(true);
     let truncationFailure: Error | undefined;
     try {
-      const context = await this.deps.buildCompressionContext(input.promptId);
+      const context = await this.deps.buildCompressionContext(
+        input.promptId,
+        computeHistoryTruncationTarget(
+          input.postCompressionProjected,
+          input.marginAdjustedLimit,
+          this.deps.historyService.getTotalTokens(),
+        ),
+      );
       const result = await this.deps.compressWithFallbackStrategy(context);
       await this.applyFallbackCompressionResult(result);
       this.deps.logger.debug(

--- a/packages/agents/src/compression/providerContentEnforcement.ts
+++ b/packages/agents/src/compression/providerContentEnforcement.ts
@@ -21,6 +21,7 @@ import { buildProviderContent } from '@vybestack/llxprt-code-core/services/histo
 import { buildContextOverflowError } from './contextOverflowError.js';
 import {
   INEFFECTIVE_COMPRESSION_REDUCTION_THRESHOLD,
+  computeHistoryTruncationTarget,
   computeMarginAdjustedLimit,
 } from './contextLimitPolicy.js';
 import {
@@ -47,6 +48,7 @@ export interface ProviderContentEnforcementDeps {
   performFallbackCompression: (
     promptId: string,
     applyResult: (newHistory: IContent[]) => Promise<void>,
+    targetTokenCount?: number,
   ) => Promise<boolean>;
   getPromptTokenBaseline: () => number | null;
   resetPromptTokenBaseline: () => void;
@@ -153,6 +155,7 @@ export class ProviderContentEnforcer {
       model,
       initialProjected,
       retryResult.compressionFailure,
+      retryResult.projected,
     );
   }
 
@@ -180,6 +183,7 @@ export class ProviderContentEnforcer {
     model: string,
     initialProjected: number,
     compressionFailure: Error | undefined,
+    projectedBeforeTruncation: number,
   ): Promise<IContent[]> {
     const truncationResult = await this.forceTruncation(
       promptId,
@@ -187,6 +191,11 @@ export class ProviderContentEnforcer {
       limits.completionBudget,
       model,
       compressionFailure,
+      computeHistoryTruncationTarget(
+        projectedBeforeTruncation,
+        limits.marginAdjustedLimit,
+        this.deps.historyService.getTotalTokens(),
+      ),
     );
     if (
       truncationResult.truncationApplied &&
@@ -513,8 +522,12 @@ export class ProviderContentEnforcer {
     completionBudget: number,
     model: string,
     compressionFailure: Error | undefined,
+    targetTokenCount: number | undefined,
   ): Promise<OverflowReductionResult> {
-    const fallbackOutcome = await this.executeFallbackTruncation(promptId);
+    const fallbackOutcome = await this.executeFallbackTruncation(
+      promptId,
+      targetTokenCount,
+    );
     await this.deps.historyService.waitForTokenUpdates();
     const contents = this.recomposeProviderContents(pendingContents);
     const projected = await this.estimateProviderProjection(
@@ -581,7 +594,10 @@ export class ProviderContentEnforcer {
    * The existing history remains untouched unless the complete candidate is
    * accepted and its token accounting succeeds.
    */
-  private async executeFallbackTruncation(promptId: string): Promise<{
+  private async executeFallbackTruncation(
+    promptId: string,
+    targetTokenCount: number | undefined,
+  ): Promise<{
     truncationApplied: boolean;
     truncationFailure?: Error;
   }> {
@@ -602,6 +618,7 @@ export class ProviderContentEnforcer {
           this.deps.resetPromptTokenBaseline();
           candidate.committed = true;
         },
+        targetTokenCount,
       );
       if (!fallbackSucceeded && candidate.installed) {
         throw new Error(

--- a/packages/agents/src/core/MessageStreamOrchestrator.contextOverflow.test.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.contextOverflow.test.ts
@@ -75,9 +75,9 @@ function overflowStream(): AsyncGenerator<ServerAgentStreamEvent> {
   })();
 }
 
-function contentStream(): AsyncGenerator<ServerAgentStreamEvent> {
+function contentStream(text: string): AsyncGenerator<ServerAgentStreamEvent> {
   return (async function* (): AsyncGenerator<ServerAgentStreamEvent> {
-    yield { type: AgentEventType.Content, value: 'hello' };
+    yield { type: AgentEventType.Content, value: text };
     yield {
       type: AgentEventType.Finished,
       value: {
@@ -332,12 +332,22 @@ describe('MessageStreamOrchestrator context-overflow terminal handling', () => {
   });
 
   it('still continues a non-overflow turn while todos remain active', async () => {
+    let attempt = 0;
     const { orchestrator } = buildOrchestrator({
-      turnStreamFactory: contentStream,
+      turnStreamFactory: () => {
+        attempt += 1;
+        return contentStream(`answer-${attempt}`);
+      },
     });
 
-    await collectEvents(orchestrator);
+    const events = await collectEvents(orchestrator);
+    const contentValues = events
+      .filter((event) => event.type === AgentEventType.Content)
+      .map((event) => event.value);
 
-    expect(mockTurnRun.mock.calls.length).toBeGreaterThan(1);
+    // The consumer receives content from more than one model attempt, so the
+    // continuation loop still drives follow-up turns after this change.
+    expect(contentValues).toContain('answer-1');
+    expect(contentValues).toContain('answer-2');
   });
 });

--- a/packages/agents/src/core/MessageStreamOrchestrator.contextOverflow.test.ts
+++ b/packages/agents/src/core/MessageStreamOrchestrator.contextOverflow.test.ts
@@ -1,0 +1,343 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi, type Mock } from 'bun:test';
+import type { AgentMessageInput } from '@vybestack/llxprt-code-core/llm-types/index.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import { tokenLimit } from '@vybestack/llxprt-code-core/core/tokenLimits.js';
+import type { Todo } from '@vybestack/llxprt-code-tools';
+import type { ChatSession } from './chatSession.js';
+import type { ComplexityAnalyzer } from '@vybestack/llxprt-code-core/services/complexity-analyzer.js';
+import type { LoopDetectionService } from '@vybestack/llxprt-code-core/services/loopDetectionService.js';
+import type { ServerAgentStreamEvent } from './turn.js';
+import { AgentEventType } from './turn.js';
+import {
+  MessageStreamOrchestrator,
+  type MessageStreamDeps,
+} from './MessageStreamOrchestrator.js';
+
+const mockTurnRun = vi.fn();
+
+const actualTokenLimits = {
+  ...(await import('@vybestack/llxprt-code-core/core/tokenLimits.js')),
+};
+void vi.mock('@vybestack/llxprt-code-core/core/tokenLimits.js', () => {
+  const buildExports = (
+    actual: typeof import('@vybestack/llxprt-code-core/core/tokenLimits.js'),
+  ) => ({
+    ...actual,
+    tokenLimit: vi.fn(
+      (_model: string, userContextLimit?: number) =>
+        userContextLimit ?? 1_000_000,
+    ),
+  });
+  return buildExports(actualTokenLimits);
+});
+
+const actualTurn = { ...(await import('./turn.js')) };
+void vi.mock('./turn.js', () => {
+  class MockTurn {
+    pendingToolCalls: unknown[] = [];
+    run = mockTurnRun;
+  }
+  return {
+    ...actualTurn,
+    Turn: MockTurn as unknown as typeof actualTurn.Turn,
+  };
+});
+
+interface BuildOptions {
+  activeTodos?: Todo[];
+  /**
+   * Reminder level the continuation service reaches while observing model
+   * activity during the turn. Mirrors TodoContinuationService, which raises
+   * the level from recordModelActivity() — that is, after the orchestrator's
+   * per-prompt reset to 'none'.
+   */
+  raisedReminderLevel?: 'base' | 'escalated';
+  turnStreamFactory?: () => AsyncGenerator<ServerAgentStreamEvent>;
+  shouldClearContext?: boolean;
+}
+
+function overflowStream(): AsyncGenerator<ServerAgentStreamEvent> {
+  return (async function* (): AsyncGenerator<ServerAgentStreamEvent> {
+    yield {
+      type: AgentEventType.ContextWindowWillOverflow,
+      value: {
+        estimatedRequestTokenCount: 135262,
+        remainingTokenCount: 134144,
+      },
+    };
+  })();
+}
+
+function contentStream(): AsyncGenerator<ServerAgentStreamEvent> {
+  return (async function* (): AsyncGenerator<ServerAgentStreamEvent> {
+    yield { type: AgentEventType.Content, value: 'hello' };
+    yield {
+      type: AgentEventType.Finished,
+      value: {
+        reason: 'stop',
+        outcome: {
+          hadVisibleOutput: true,
+          hadThinking: false,
+          hadToolCalls: false,
+        },
+      },
+    };
+  })();
+}
+
+function buildOrchestrator(options: BuildOptions): {
+  orchestrator: InstanceType<typeof MessageStreamOrchestrator>;
+  deps: MessageStreamDeps;
+} {
+  const mockChat = {
+    getLastPromptTokenCount: vi.fn().mockReturnValue(100),
+    getProjectedPromptBaseline: vi.fn().mockReturnValue(100),
+    addHistory: vi.fn(),
+    getHistory: vi.fn().mockReturnValue([]),
+    getContextLimit: vi.fn(() => tokenLimit('gpt-4')),
+  };
+  const providerManager = {
+    getActiveProviderName: vi.fn(() => 'openai'),
+    getActiveProvider: vi.fn(() => ({
+      name: 'openai',
+      getCurrentModel: vi.fn(() => ''),
+      getDefaultModel: vi.fn(() => ''),
+    })),
+  };
+  const config = {
+    getContentGeneratorConfig: vi.fn(() => ({
+      providerManager,
+      model: 'gpt-4',
+    })),
+    getMaxSessionTurns: vi.fn(() => 0),
+    getIdeMode: vi.fn(() => false),
+    getContinueOnFailedApiCall: vi.fn(() => false),
+    getModel: vi.fn(() => 'gpt-4'),
+    getEphemeralSetting: vi.fn(() => undefined),
+    getSettingsService: vi.fn(() => ({
+      getCurrentProfileName: vi.fn(() => null),
+      get: vi.fn(() => undefined),
+    })),
+  } as unknown as Config;
+
+  const activeTodos = options.activeTodos ?? [
+    { id: 'todo-1', content: 'Active task', status: 'in_progress' },
+  ];
+  const turnStreamFactory = options.turnStreamFactory ?? overflowStream;
+  mockTurnRun.mockImplementation(() => turnStreamFactory());
+
+  const afterHookOutput =
+    options.shouldClearContext === true
+      ? {
+          isBlockingDecision: () => false,
+          shouldStopExecution: () => false,
+          getEffectiveReason: () => 'context cleared',
+          shouldClearContext: () => true,
+        }
+      : undefined;
+  const raisedReminderLevel = options.raisedReminderLevel;
+  const reminderState: { level: 'none' | 'base' | 'escalated' } = {
+    level: 'none',
+  };
+
+  const todoContinuationService = {
+    clearPausedState: vi.fn().mockResolvedValue(undefined),
+    toolActivityCount: 0,
+    get toolCallReminderLevel(): 'none' | 'base' | 'escalated' {
+      return reminderState.level;
+    },
+    set toolCallReminderLevel(value: 'none' | 'base' | 'escalated') {
+      reminderState.level = value;
+    },
+    consecutiveComplexTurns: 0,
+    lastTodoSnapshot: [],
+    recordModelActivity: vi.fn((): void => {
+      if (raisedReminderLevel !== undefined) {
+        reminderState.level = raisedReminderLevel;
+      }
+    }),
+    isSuccessfulTodoPauseResponse: vi.fn().mockReturnValue(false),
+    isTodoToolCall: vi.fn().mockReturnValue(false),
+    applyPendingReminder: vi.fn((request: AgentMessageInput) =>
+      Promise.resolve(request),
+    ),
+    getTodoReminderForCurrentState: vi.fn().mockResolvedValue({
+      todos: activeTodos,
+      activeTodos,
+      reminder: 'Please continue working on the following task...',
+    }),
+    areTodoSnapshotsEqual: vi.fn().mockReturnValue(true),
+    processComplexityAnalysis: vi.fn().mockReturnValue(undefined),
+    appendTodoSuffixToRequest: vi.fn(),
+    appendSystemReminderToRequest: vi.fn(
+      (request: AgentMessageInput) => request,
+    ),
+    updateTodoToolAvailabilityFromDeclarations: vi.fn(),
+    setLastTodoToolTurn: vi.fn(),
+    checkpoint: vi.fn().mockReturnValue({}),
+    restore: vi.fn(),
+    shouldDeferStreamEvent: vi.fn().mockReturnValue(false),
+  } as unknown as MessageStreamDeps['todoContinuationService'];
+
+  const deps: MessageStreamDeps = {
+    config,
+    getChat: () => mockChat as unknown as ChatSession,
+    logger: {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+    } as unknown as DebugLogger,
+    loopDetector: {
+      reset: vi.fn(),
+      turnStarted: vi.fn().mockResolvedValue(false),
+      addAndCheck: vi.fn().mockReturnValue(false),
+      checkpoint: vi.fn().mockReturnValue({}),
+      restore: vi.fn(),
+    } as unknown as LoopDetectionService,
+    todoContinuationService,
+    ideContextTracker: {
+      getContextParts: vi.fn().mockReturnValue({
+        contextParts: [],
+        newIdeContext: undefined,
+      }),
+      recordSentContext: vi.fn(),
+    } as unknown as MessageStreamDeps['ideContextTracker'],
+    agentHookManager: {
+      cleanupOldHookState: vi.fn(),
+      fireBeforeAgentHookSafe: vi.fn().mockResolvedValue(undefined),
+      fireAfterAgentHookSafe: vi.fn().mockResolvedValue(afterHookOutput),
+    } as unknown as MessageStreamDeps['agentHookManager'],
+    getEffectiveModelIdentity: () => ({
+      providerName: 'openai',
+      model: 'gpt-4',
+    }),
+    getHistory: vi.fn().mockResolvedValue([]),
+    getSessionTurnCount: vi.fn().mockReturnValue(2),
+    incrementSessionTurnCount: vi.fn(),
+    lazyInitialize: vi.fn().mockResolvedValue(undefined),
+    startChat: vi.fn().mockResolvedValue(mockChat),
+    getPreviousHistory: vi.fn().mockReturnValue(undefined),
+    setChat: vi.fn(),
+    hasChat: vi.fn().mockReturnValue(true),
+    complexityAnalyzer: {
+      analyzeComplexity: vi.fn().mockReturnValue({
+        complexityScore: 0.2,
+        isComplex: false,
+        detectedTasks: [],
+        sequentialIndicators: [],
+        questionCount: 0,
+        shouldSuggestTodos: false,
+      }),
+    } as unknown as ComplexityAnalyzer,
+    getLastPromptId: () => undefined,
+    setLastPromptId: vi.fn(),
+    resetCurrentSequenceModel: vi.fn(),
+    updateTelemetryTokenCount: vi.fn(),
+    sendMessageStream: vi.fn(
+      async function* (): AsyncGenerator<ServerAgentStreamEvent> {
+        // No follow-up stream is needed for these tests.
+      },
+    ),
+  };
+
+  return { orchestrator: new MessageStreamOrchestrator(deps), deps };
+}
+
+async function collectEvents(
+  orchestrator: InstanceType<typeof MessageStreamOrchestrator>,
+): Promise<ServerAgentStreamEvent[]> {
+  const events: ServerAgentStreamEvent[] = [];
+  for await (const event of orchestrator.execute(
+    [{ text: 'test' }] as AgentMessageInput,
+    new AbortController().signal,
+    'prompt-1',
+    1,
+    false,
+  )) {
+    events.push(event);
+  }
+  return events;
+}
+
+describe('MessageStreamOrchestrator context-overflow terminal handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (tokenLimit as Mock<typeof tokenLimit>).mockImplementation(
+      (_model: string, userContextLimit?: number) =>
+        userContextLimit ?? 1_000_000,
+    );
+  });
+
+  it('emits the context-overflow guard once and stops when a todo is still active', async () => {
+    const { orchestrator } = buildOrchestrator({});
+
+    const events = await collectEvents(orchestrator);
+    const overflowEvents = events.filter(
+      (event) => event.type === AgentEventType.ContextWindowWillOverflow,
+    );
+
+    expect(overflowEvents).toHaveLength(1);
+    expect(mockTurnRun.mock.calls.length).toBe(1);
+    expect(overflowEvents[0]).toMatchObject({
+      value: {
+        estimatedRequestTokenCount: 135262,
+        remainingTokenCount: 134144,
+      },
+    });
+  });
+
+  it('emits the context-overflow guard once and stops when a tool-call reminder is pending', async () => {
+    const { orchestrator } = buildOrchestrator({
+      activeTodos: [],
+      raisedReminderLevel: 'base',
+    });
+
+    const events = await collectEvents(orchestrator);
+    const overflowEvents = events.filter(
+      (event) => event.type === AgentEventType.ContextWindowWillOverflow,
+    );
+
+    expect(overflowEvents).toHaveLength(1);
+    expect(mockTurnRun.mock.calls.length).toBe(1);
+    expect(overflowEvents[0]).toMatchObject({
+      value: {
+        estimatedRequestTokenCount: 135262,
+        remainingTokenCount: 134144,
+      },
+    });
+  });
+
+  it('runs AfterAgent context clearing when the turn ends on context overflow', async () => {
+    const { orchestrator } = buildOrchestrator({ shouldClearContext: true });
+
+    const events = await collectEvents(orchestrator);
+    const overflowIndex = events.findIndex(
+      (event) => event.type === AgentEventType.ContextWindowWillOverflow,
+    );
+    const stoppedIndex = events.findIndex(
+      (event) => event.type === AgentEventType.AgentExecutionStopped,
+    );
+
+    expect(mockTurnRun.mock.calls.length).toBe(1);
+    expect(stoppedIndex).toBeGreaterThan(overflowIndex);
+    expect(events[stoppedIndex]).toMatchObject({ contextCleared: true });
+  });
+
+  it('still continues a non-overflow turn while todos remain active', async () => {
+    const { orchestrator } = buildOrchestrator({
+      turnStreamFactory: contentStream,
+    });
+
+    await collectEvents(orchestrator);
+
+    expect(mockTurnRun.mock.calls.length).toBeGreaterThan(1);
+  });
+});

--- a/packages/agents/src/core/MessageStreamTerminalHandler.ts
+++ b/packages/agents/src/core/MessageStreamTerminalHandler.ts
@@ -408,6 +408,30 @@ async function* handleErrorEvent(
   });
 }
 
+async function* handleContextWindowWillOverflowEvent(
+  deps: MessageStreamDeps,
+  ctx: StreamContext,
+  deferredEvents: ServerAgentStreamEvent[],
+  state: TerminalState,
+): AsyncGenerator<ServerAgentStreamEvent, IterationResult> {
+  deps.logger.warn(
+    () =>
+      `[stream:orchestrator] context window will overflow; ending iteration`,
+    {
+      deferredEventCount: deferredEvents.length,
+      hadToolCallsThisTurn: state.hadToolCallsThisTurn,
+      hadContent: state.hadContent,
+      hadThinking: state.hadThinking,
+    },
+  );
+  for (const d of deferredEvents) yield d;
+  yield* fireAfterHookAndEmitClearContext(deps, ctx);
+  return earlyIterResult(state.hadToolCallsThisTurn, {
+    ...state,
+    deferredEvents,
+  });
+}
+
 async function* handleInvalidStreamEvent(
   deps: MessageStreamDeps,
   signal: AbortSignal,
@@ -473,6 +497,15 @@ export async function* handleTerminalEvent(
       deferredEvents,
       state,
       initialRequest,
+    );
+  }
+
+  if (event.type === AgentEventType.ContextWindowWillOverflow) {
+    return yield* handleContextWindowWillOverflowEvent(
+      deps,
+      ctx,
+      deferredEvents,
+      state,
     );
   }
 

--- a/packages/agents/src/core/MessageStreamTerminalHandler.ts
+++ b/packages/agents/src/core/MessageStreamTerminalHandler.ts
@@ -408,6 +408,17 @@ async function* handleErrorEvent(
   });
 }
 
+/**
+ * Context-window overflow is terminal for the turn: enforcement already ran
+ * every reduction path it has and still could not fit the request, so
+ * resubmitting cannot succeed. Without this the overflow turn looks like an
+ * empty turn (no content, thinking or tool calls) and falls through to the
+ * continuation path, which resubmits the same oversized request until
+ * MAX_RETRIES, showing the user the identical guard three times (issue #3406).
+ *
+ * The caller already yielded the overflow event before dispatching here, so
+ * this handler must not re-yield it.
+ */
 async function* handleContextWindowWillOverflowEvent(
   deps: MessageStreamDeps,
   ctx: StreamContext,

--- a/packages/agents/src/core/agenticLoop/AgenticLoop.ts
+++ b/packages/agents/src/core/agenticLoop/AgenticLoop.ts
@@ -78,12 +78,16 @@ function deduplicateToolCallRequests(
 }
 
 function isTerminalStreamOutcome(type: AgentEventType): boolean {
-  return (
-    type === AgentEventType.Error ||
-    type === AgentEventType.StreamIdleTimeout ||
-    type === AgentEventType.UserCancelled ||
-    type === AgentEventType.LoopDetected
-  );
+  switch (type) {
+    case AgentEventType.Error:
+    case AgentEventType.StreamIdleTimeout:
+    case AgentEventType.UserCancelled:
+    case AgentEventType.LoopDetected:
+    case AgentEventType.ContextWindowWillOverflow:
+      return true;
+    default:
+      return false;
+  }
 }
 
 /** A mutable holder so promise callbacks can communicate state to the loop. */

--- a/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.terminal-outcomes.test.ts
+++ b/packages/agents/src/core/agenticLoop/__tests__/agenticLoop.terminal-outcomes.test.ts
@@ -65,6 +65,16 @@ describe('AgenticLoop integration - terminal outcomes and bus scoping', () => {
         type: AgentEventType.LoopDetected,
       } satisfies ServerAgentStreamEvent,
     ],
+    [
+      'ContextWindowWillOverflow',
+      {
+        type: AgentEventType.ContextWindowWillOverflow,
+        value: {
+          estimatedRequestTokenCount: 135262,
+          remainingTokenCount: 134144,
+        },
+      } satisfies ServerAgentStreamEvent,
+    ],
   ])(
     'does not execute collected tools after %s',
     async (_name, terminalEvent) => {

--- a/packages/core/src/core/compression/types.ts
+++ b/packages/core/src/core/compression/types.ts
@@ -142,6 +142,18 @@ export interface CompressionContext {
   readonly runtimeState: AgentRuntimeState;
   readonly estimateTokens: (contents: readonly IContent[]) => Promise<number>;
   readonly currentTokenCount: number;
+  /**
+   * Maximum committed-history token count the caller requires after this
+   * compression.
+   *
+   * Only hard-limit enforcement knows this number. The finalized provider
+   * envelope it has to fit includes the system prompt, tool schemas and
+   * pending content, none of which are part of `currentTokenCount`, so a
+   * strategy cannot derive the real deficit from ephemerals (issue #3406).
+   * Absent for threshold-triggered compression, where strategies keep
+   * deriving their own target.
+   */
+  readonly targetTokenCount?: number;
   readonly logger: DebugLogger;
   readonly resolveProvider: (
     profileName?: string,

--- a/project-plans/issue3406-context-overflow-guard-repeat.md
+++ b/project-plans/issue3406-context-overflow-guard-repeat.md
@@ -1,0 +1,156 @@
+# Issue #3406 — Context-overflow guard repeats three times and cannot compress
+
+## Problem statement
+
+A user on `claudecode:claude-opus-5` saw the context-overflow guard printed three
+times in a row inside a single submit:
+
+```
+Sending this message (135262 tokens) might exceed the remaining context window limit (134144 tokens). ...
+Sending this message (135382 tokens) might exceed the remaining context window limit (134144 tokens). ...
+Sending this message (135382 tokens) might exceed the remaining context window limit (134144 tokens). ...
+```
+
+`/compress` then reported nothing to compress, and continuing produced the guard
+again. The user's objection is precise: "3 times means it retrying without
+compressing and its retrying on the guard not on an error".
+
+## Root cause (proven from source)
+
+`Turn` maps `ContextOverflowError` to a `ContextWindowWillOverflow` event and
+returns (`packages/agents/src/core/turn.ts:567-576`).
+
+`MessageStreamOrchestrator._processStreamIteration` yields that event and then
+calls `handleTerminalEvent` (`MessageStreamOrchestrator.ts:562-575`).
+`handleTerminalEvent` only recognises `AgentEventType.Error` and
+`AgentEventType.InvalidStream`; every other event falls through as non-terminal
+(`MessageStreamTerminalHandler.ts:458-490`).
+
+An overflow turn emits no `ToolCallRequest`, no `Content` and no `Thought`, so
+`state.hadToolCallsThisTurn`, `hadContent` and `hadThinking` are all false
+(`MessageStreamOrchestrator.ts:545-548`). `_evaluatePostTurn` therefore skips the
+tool-call and thinking-only branches and reaches `_evaluateTodoContinuation`
+(`MessageStreamOrchestrator.ts:600-651`). With an active todo or a pending
+tool-call reminder, that method increments `retryCount` and resubmits
+(`MessageStreamOrchestrator.ts:667-713`).
+
+`_runRetryLoop` is bounded by `MAX_RETRIES = 3` and runs for retry counts 0, 1
+and 2 (`MessageStreamOrchestrator.ts:443-492`). That is exactly three model
+attempts and exactly three guard messages. The ~120-token jump between the first
+and later attempts matches `todoContinuationService.applyPendingReminder` adding
+the todo reminder on the resubmitted request (`MessageStreamOrchestrator.ts:464-465`).
+
+The same event-classification omission exists one level up:
+`isTerminalStreamOutcome` in `packages/agents/src/core/agenticLoop/AgenticLoop.ts:80-87`
+lists `Error`, `StreamIdleTimeout`, `UserCancelled` and `LoopDetected` but not
+`ContextWindowWillOverflow`, so collected tool-call requests are not dropped and
+tool scheduling is not disabled after an overflow (`AgenticLoop.ts:487-497`).
+
+The public API layer already treats overflow as terminal: `eventAdapter` sets
+`state.pendingDoneReason = 'context-overflow'`
+(`packages/agents/src/api/eventAdapter.ts:363-375`). The two internal loops are
+the outliers.
+
+### Numbers check
+
+`buildContextOverflowError` reports
+`estimatedRequestTokenCount = finalProjected - completionBudget` and
+`remainingTokenCount = marginAdjustedLimit - completionBudget`
+(`packages/agents/src/compression/contextOverflowError.ts:36-71`).
+`262144 - 128000 = 134144`, matching the reported remaining budget exactly for a
+262,144-token context limit with the Claude Code 128,000-token output
+reservation. The arithmetic in the guard is correct; the overflow itself is real
+(1,118 tokens over on the first attempt).
+
+### Explicitly NOT treated as defects in this effort
+
+- The guard's token arithmetic. It is correct for the session's configured
+  context limit and completion budget.
+- `/compress` returning NOOP. Manual compression operates on curated committed
+  history (`compressionContextBuilder.ts:47-53`); middle-out and its one-shot
+  route both require a minimum number of compressible messages, so a truthful
+  structural no-op is possible. Changing compression strategy minimums is a
+  different, unproven change and is out of scope.
+- `TopDownTruncationStrategy` returning `kind: 'applied'` with unchanged history
+  when `finalRemoveCount === 0`. A truthfulness wart with no proven user-visible
+  symptom here. Deferred.
+
+## Acceptance criteria
+
+**AC1 — Overflow ends the turn.** When a turn's stream yields
+`AgentEventType.ContextWindowWillOverflow`, `MessageStreamOrchestrator` ends the
+current submit immediately. With an active todo present, exactly one
+`ContextWindowWillOverflow` event is emitted and `Turn.run` is invoked exactly
+once (today: three of each).
+
+**AC2 — Overflow ends the turn with a pending tool-call reminder.** Same as AC1
+when `todoContinuationService.toolCallReminderLevel !== 'none'` and there are no
+active todos.
+
+**AC3 — Terminal bookkeeping still runs.** The overflow terminal path flushes any
+deferred events and fires the AfterAgent hook, emitting
+`AgentExecutionStopped` with `contextCleared: true` when the hook asks to clear
+context — matching the existing `Error` / `InvalidStream` terminal paths
+(`MessageStreamTerminalHandler.ts:393-456`).
+
+**AC4 — No tool scheduling after overflow.** `AgenticLoop` treats
+`ContextWindowWillOverflow` as a terminal stream outcome: collected tool-call
+requests are discarded and no tool is executed.
+
+**AC5 — No regression for non-overflow turns.** A turn with active todos and no
+overflow still continues up to `MAX_RETRIES`; `Error` and `InvalidStream`
+handling, including the 413 recovery path, is unchanged.
+
+### Boundary cases to cover
+
+- Overflow with no active todos and no reminder: still exactly one guard (must
+  not regress; this already works today).
+- Overflow arriving after a `ToolCallRequest` in the same turn: the turn still
+  terminates and no tools are scheduled.
+- Deferred events present when overflow arrives: they are flushed, not dropped.
+
+## Test plan (write these first, watch them fail)
+
+All new tests are `bun:test`, TypeScript, behavioral.
+
+1. `packages/agents/src/core/MessageStreamOrchestrator.contextOverflow.test.ts`
+   (new). Drives the real `MessageStreamOrchestrator` with a mocked `Turn.run`
+   that yields a `ContextWindowWillOverflow` event and a fresh generator per
+   call (use `mockImplementation`, not `mockReturnValue`, so repeat attempts are
+   observable). Mirror the dependency harness in
+   `MessageStreamOrchestrator.todoPause.test.ts:122-281`.
+   - AC1: active todo present → assert `mockTurnRun` call count is 1 and the
+     collected events contain exactly one `ContextWindowWillOverflow`.
+   - AC2: no active todos but `toolCallReminderLevel: 'warning'` → same
+     assertions.
+   - AC3: AfterAgent hook returns `shouldClearContext() === true` → assert an
+     `AgentExecutionStopped` event with `contextCleared: true` is emitted after
+     the overflow event.
+   - AC5 guard: a non-overflow turn (content + finished) with an active todo
+     still produces more than one `Turn.run` invocation.
+
+2. `packages/agents/src/core/agenticLoop/__tests__/agenticLoop.terminal-outcomes.test.ts`
+   (existing). Add `ContextWindowWillOverflow` to the existing `it.each` terminal
+   table at lines 41-68 so the "does not execute collected tools after %s" case
+   covers it. This satisfies AC4 with zero new harness code.
+
+## Implementation plan
+
+1. `packages/agents/src/core/MessageStreamTerminalHandler.ts`: add a
+   `handleContextWindowOverflowEvent` generator that logs, flushes
+   `deferredEvents`, runs `fireAfterHookAndEmitClearContext`, and returns
+   `earlyIterResult(state.hadToolCallsThisTurn, { ...state, deferredEvents })`.
+   Dispatch to it from `handleTerminalEvent` for
+   `AgentEventType.ContextWindowWillOverflow`. The overflow event itself has
+   already been yielded by the caller, so the handler must not re-yield it.
+2. `packages/agents/src/core/agenticLoop/AgenticLoop.ts`: add
+   `type === AgentEventType.ContextWindowWillOverflow` to
+   `isTerminalStreamOutcome`.
+
+No other production files change. No new public abstractions, no dependency,
+workflow or settings changes.
+
+## Verification
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+`npm run build`, and the `stepfun-37` smoke prompt.

--- a/project-plans/issue3406-context-overflow-guard-repeat.md
+++ b/project-plans/issue3406-context-overflow-guard-repeat.md
@@ -62,18 +62,101 @@ the outliers.
 reservation. The arithmetic in the guard is correct; the overflow itself is real
 (1,118 tokens over on the first attempt).
 
-### Explicitly NOT treated as defects in this effort
+## Second root cause: the last-resort truncator measures the wrong thing
 
-- The guard's token arithmetic. It is correct for the session's configured
-  context limit and completion budget.
-- `/compress` returning NOOP. Manual compression operates on curated committed
-  history (`compressionContextBuilder.ts:47-53`); middle-out and its one-shot
-  route both require a minimum number of compressible messages, so a truthful
-  structural no-op is possible. Changing compression strategy minimums is a
-  different, unproven change and is out of scope.
+The reporter's other complaint — "it should have either compressed or truncated a
+tool call" — is a separate, provable defect.
+
+Hard-limit enforcement runs five reduction stages. On this configuration each one
+declines:
+
+1. **Density optimization** returns immediately: the default strategy is
+   middle-out, which has no `optimize()` and is threshold-triggered rather than
+   continuous (`MiddleOutStrategy.ts:86-93`, `CompressionHandler.ts:187-203`).
+2. **Compression** runs, but middle-out needs 4 messages in its compressible
+   middle (`MINIMUM_MIDDLE_MESSAGES`) and its no-op routes to one-shot, which
+   needs 4 too (`MINIMUM_COMPRESS_MESSAGES`). Those are message-count guards, so
+   a handful of very large messages passes straight through both.
+3. **Compression retry** is skipped: the provider path converts a structural
+   NOOP into a `compressionFailure` (`providerContentEnforcement.ts:436-449`) and
+   the retry is gated on `compressionFailure === undefined` (lines 466-470).
+4. **TopDownTruncation fallback** — the defect.
+5. **Tool-response truncation** only has candidates when the bulk sits in
+   `tool_response` blocks.
+
+`TopDownTruncationStrategy.ts:52-59` decided whether to act with:
+
+```ts
+const target = compressionThreshold * contextLimit * 0.6;
+if (currentTokenCount <= target) return this.structuralNoop(originalCount, 'already-under-target');
+```
+
+`currentTokenCount` is `historyService.getTotalTokens()` — committed history only
+(`compressionContextBuilder.ts:53`). The enforcer that invoked it needs the
+finalized prompt envelope (system prompt + tool schemas + committed history +
+pending content) under `marginAdjustedLimit`, with `completionBudget` reserved.
+`CompressionContext` had no field to carry the real deficit
+(`core/compression/types.ts:139-177`), so the strategy invented its own yardstick
+and was never told how many tokens had to go.
+
+On the reported session:
+
+```
+context limit          262,144
+completion budget      128,000
+enforcer input budget  134,144   (matches the reported "remaining" exactly)
+reported input         135,262   → over by 1,118
+TopDown's own target   0.85 × 262,144 × 0.6 = 133,693
+```
+
+TopDown refuses unless committed history alone exceeds 133,693, but the whole
+envelope has to fit in 134,144. The 451-token gap is far smaller than the system
+prompt plus tool schemas, so committed history is essentially always under
+TopDown's target by the time the finalized payload is over budget. The last-resort
+truncator structurally refuses in exactly the situation it exists to rescue.
+
+### Fix
+
+`CompressionContext` gains an optional `targetTokenCount`, set only by hard-limit
+enforcement, which is the only layer that knows the real deficit. TopDown prefers
+it and keeps its ephemeral target when absent, so threshold-triggered compression
+is unchanged. Both enforcers compute it through one shared helper,
+`computeHistoryTruncationTarget(projected, marginAdjustedLimit, historyTokens)` in
+`contextLimitPolicy.ts`: truncation can only remove committed history, so the
+target is the current history total less the overage. No arbitrary safety cushion
+— the enforcer re-projects afterwards and still falls through to tool-response
+truncation when it comes up short.
+
+### Additional acceptance criteria
+
+**AC6 — Explicit target honoured.** TopDownTruncation truncates when given an
+explicit `targetTokenCount` below `currentTokenCount`, even when its own
+ephemeral target says it is already under.
+
+**AC7 — No target, no change.** With no explicit target the strategy behaves
+exactly as before.
+
+**AC8 — Provider path recovers.** When the finalized envelope overflows while
+committed history is under the ephemeral target, `ProviderContentEnforcer.enforce`
+resolves with contents that fit instead of throwing ContextOverflowError.
+
+**AC9 — 413 recovery path recovers.** Same for `PendingContextWindowEnforcer`
+when the pending request supplies the overage.
+
+**AC10 — Requests that fit are untouched.** Neither enforcer truncates history
+when the request is already within budget.
+
+### Still NOT treated as defects
+
+- The guard's token arithmetic. It is correct for the configured context limit
+  and completion budget.
+- `/compress` returning NOOP. Manual compression sees only curated committed
+  history, and middle-out and one-shot both require a minimum number of
+  compressible messages, so a truthful structural no-op is reachable. Changing
+  strategy minimums is a different, unproven change.
 - `TopDownTruncationStrategy` returning `kind: 'applied'` with unchanged history
   when `finalRemoveCount === 0`. A truthfulness wart with no proven user-visible
-  symptom here. Deferred.
+  symptom.
 
 ## Acceptance criteria
 


### PR DESCRIPTION
## TLDR

A single submit that overflowed the context window printed the same guard three times and compressed nothing:

```
Sending this message (135262 tokens) might exceed the remaining context window limit (134144 tokens). ...
Sending this message (135382 tokens) might exceed the remaining context window limit (134144 tokens). ...
Sending this message (135382 tokens) might exceed the remaining context window limit (134144 tokens). ...
```

There are two independent defects behind that, and this PR fixes both.

1. **It repeated.** `ContextWindowWillOverflow` was never classified as a terminal stream outcome, so the overflow turn looked like an *empty* turn and got resubmitted through todo continuation until `MAX_RETRIES = 3`.
2. **It never reduced anything.** The last-resort history truncator decides whether to act by measuring a quantity that has almost nothing to do with the budget it is trying to satisfy, so it structurally refused in exactly the situation it exists to rescue.

Reviewers should focus on `MessageStreamTerminalHandler.handleTerminalEvent`, `AgenticLoop.isTerminalStreamOutcome`, and the new `targetTokenCount` on `CompressionContext`.

## Defect 1: overflow was not terminal

`Turn` maps `ContextOverflowError` to a `ContextWindowWillOverflow` event and returns (`turn.ts:567-576`). That turn emits nothing else: no `Content`, no `Thought`, no `ToolCallRequest`.

`MessageStreamOrchestrator._processStreamIteration` yields the event and calls `handleTerminalEvent` (`MessageStreamOrchestrator.ts:562-575`), which recognised only `Error` and `InvalidStream` (`MessageStreamTerminalHandler.ts:458-490`). With `hadToolCallsThisTurn`, `hadContent` and `hadThinking` all false, `_evaluatePostTurn` skipped its tool-call and thinking-only branches and landed in `_evaluateTodoContinuation`, which incremented `retryCount` and resubmitted while `retryCount < MAX_RETRIES` (3). Three attempts, three guards. The ~120-token growth on attempts 2 and 3 is `applyPendingReminder` re-adding the todo reminder, which is why the last two readings match each other exactly.

The same omission sat in `AgenticLoop.isTerminalStreamOutcome` (`AgenticLoop.ts:80-87`), leaving tool scheduling enabled after an overflow. The public event adapter already mapped the event to `done{context-overflow}` (`eventAdapter.ts:363-375`); the two internal loops were the outliers.

**Fix:** a terminal handler for the overflow event mirroring the existing `Error`/`InvalidStream` tails (flush deferred events, fire the AfterAgent hook, return early), plus the missing enum case in `isTerminalStreamOutcome`.

## Defect 2: the last-resort truncator measured the wrong thing

Hard-limit enforcement runs five reduction stages, and on this configuration every one declines:

1. **Density optimization** returns immediately: middle-out has no `optimize()` and is threshold-triggered, not continuous (`MiddleOutStrategy.ts:86-93`, `CompressionHandler.ts:187-203`).
2. **Compression** runs, but middle-out needs 4 messages in its compressible middle and its no-op routes to one-shot, which needs 4 too. Those are *message-count* guards, so a handful of very large messages sails past both.
3. **Compression retry** is skipped: the provider path converts a structural NOOP into a `compressionFailure` (`providerContentEnforcement.ts:436-449`) and the retry is gated on `compressionFailure === undefined` (lines 466-470).
4. **TopDownTruncation fallback** — the defect.
5. **Tool-response truncation** only has candidates when the bulk sits in `tool_response` blocks.

`TopDownTruncationStrategy.ts:52-59` decided whether to act with:

```ts
const target = compressionThreshold * contextLimit * 0.6;
if (currentTokenCount <= target) return this.structuralNoop(originalCount, 'already-under-target');
```

`currentTokenCount` is `historyService.getTotalTokens()` — committed history only (`compressionContextBuilder.ts:53`). The enforcer needs the **finalized prompt envelope** (system prompt + tool schemas + committed history + pending content) under `marginAdjustedLimit`, with `completionBudget` reserved. `CompressionContext` had no field to carry the real deficit, so the strategy invented its own yardstick and was never told how many tokens had to go.

On the reported session:

```
context limit          262,144
completion budget      128,000
enforcer input budget  134,144   (matches the reported "remaining" exactly)
reported input         135,262   → over by 1,118
TopDown's own target   0.85 × 262,144 × 0.6 = 133,693
```

TopDown refuses unless committed history *alone* exceeds 133,693, but the whole envelope has to fit in 134,144. The 451-token gap is far smaller than the system prompt plus tool schemas, so committed history is essentially always under the strategy's target by the time the finalized payload is over budget.

**Fix:** `CompressionContext` gains an optional `targetTokenCount`, set only by hard-limit enforcement, which is the only layer that knows the deficit. TopDown prefers it and keeps its ephemeral target when absent, so threshold-triggered compression is unchanged. Both enforcers compute it through one shared helper in `contextLimitPolicy.ts`: truncation can only remove committed history, so the target is the current history total less the overage. No arbitrary safety cushion — the enforcer re-projects afterwards and still falls through to tool-response truncation when it comes up short.

The same fix is applied to `PendingContextWindowEnforcer`, the HTTP 413 recovery path, which had the identical defect.

## What this PR deliberately does not change

- **The guard's arithmetic.** It is correct. `262144 - 128000 = 134144` reproduces the reported budget exactly. The request really was over the limit.
- **`/compress` returning NOOP.** Manual compression sees only curated committed history, and middle-out and one-shot each require a minimum number of compressible messages, so a truthful structural no-op is reachable.
- **`TopDownTruncationStrategy` reporting `applied` with unchanged history** when `finalRemoveCount === 0`. A truthfulness wart with no proven user-visible symptom.

Root-cause analysis, acceptance criteria and test plan are in `project-plans/issue3406-context-overflow-guard-repeat.md`.

## Reviewer Test Plan

Both fixes have tests that are genuinely red beforehand.

**Defect 1** — stash the two production files and watch the bug reproduce:

```bash
git stash push -- packages/agents/src/core/MessageStreamTerminalHandler.ts \
                  packages/agents/src/core/agenticLoop/AgenticLoop.ts
bun test packages/agents/src/core/MessageStreamOrchestrator.contextOverflow.test.ts \
         packages/agents/src/core/agenticLoop/__tests__/agenticLoop.terminal-outcomes.test.ts
git stash pop
```

Without it: `Expected length: 1 / Received length: 3` on overflow events, `Expected: 1 / Received: 3` on model attempts, and `expect(executed).toBe(false) / Received: true` for a tool running after overflow.

**Defect 2** — revert just the one line in `TopDownTruncationStrategy.compress` to `const target = compressionThreshold * contextLimit * 0.6;` and run:

```bash
bun test packages/agents/src/compression/__tests__/providerContentEnforcement.historyTruncationTarget.test.ts \
         packages/agents/src/compression/__tests__/pendingContextWindowEnforcement.historyTruncationTarget.test.ts
```

Without it, both fail with the user's exact symptom:

```
ContextOverflowError: Request still exceeds the safety-adjusted context limit (19095 tokens).
density optimization and compression reduced 0 tokens (from 19281 to 19281 projected).
```

New coverage:

- `MessageStreamOrchestrator.contextOverflow.test.ts` — overflow with an active todo, with a pending tool-call reminder, AfterAgent context clearing, plus a control test proving ordinary todo continuation still drives follow-up turns (asserted through the emitted content stream, not mock call counts).
- `agenticLoop.terminal-outcomes.test.ts` — `ContextWindowWillOverflow` added to the terminal-outcome table.
- `TopDownTruncationStrategy.test.ts` — explicit target honoured, explicit target above the current count still a no-op, explicit target drives deeper truncation than the ephemeral one.
- `providerContentEnforcement.historyTruncationTarget.test.ts` and `pendingContextWindowEnforcement.historyTruncationTarget.test.ts` — real enforcer, real `HistoryService`, real token estimation, real `TopDownTruncationStrategy` behind the fallback dependency. Nothing asserts on a mock call; the assertions are about whether the payload came back under budget. Each has a companion test proving a request that already fits is left alone.

Manually: run a session with an active todo list, drive the context past the limit, and confirm the overflow notice appears once per submit and that history is actually truncated rather than the guard repeating.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified locally on macOS: `npm run format`, `npm run typecheck`, `npm run lint`, `npm run test` (full suite clean, exit 0), `npm run build`, plus the `stepfun-37` startup smoke prompt. Reasoning-aware token accounting was extracted to `effectiveTokenCount.ts` to keep `CompressionHandler.ts` under the 800-line `max-lines` cap; the lint rule was not relaxed. Changes are platform-agnostic logic in `packages/agents` and one optional interface field in `packages/core`.

## Linked issues / bugs

Fixes #3406


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when conversations approach the context window limit.
  - Agent runs now stop cleanly with the appropriate terminal status instead of continuing unexpectedly.
  - Prevented pending tool calls from executing after a context-overflow condition.
  - Ensured follow-up cleanup runs when an agent stops because of context limits.
  - Improved recovery by truncating conversation history to the required size when requests exceed provider limits.

- **Tests**
  - Added coverage for context-overflow handling, cleanup behavior, continued processing without overflow, and history truncation recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->