### PR TITLE
fix(evals): isolate save_memory from todo tools (Fixes #3256)

### DIFF
--- a/evals/save_memory.eval.ts
+++ b/evals/save_memory.eval.ts
@@ -15,7 +15,9 @@ describe('save_memory', () => {
   evalTest('ALWAYS_PASSES', {
     name: 'should be able to save to memory',
     params: {
-      settings: { tools: { core: ['save_memory'] } },
+      settings: {
+        excludeTools: ['todo_read', 'todo_write', 'todo_pause'],
+      },
     },
     prompt: [
       'Follow these instructions exactly.',

--- a/project-plans/issue3256.md
+++ b/project-plans/issue3256.md
@@ -1,0 +1,94 @@
+# Issue 3256: Stabilize the save-memory nightly eval
+
+Plan ID: `PLAN-20260828-ISSUE3256`
+
+## Failure evidence
+
+The reported runs fail in `save_memory.eval.ts` after `save_memory` succeeds with the exact fact `My favorite color is blue`. Available artifacts show that the model also uses `todo_write`, then sometimes appends task-status prose after producing `$blue$`. The strict output assertion correctly rejects that extra text. For example, run 33070289550 attempt 2 returned `$blue$Task completed.` while its `save_memory` call succeeded with the expected fact.
+
+The same input passes when the provider does not add the extra task-status response. The August 28 nightly run passed all three attempts, but five of the previous nine nightly runs failed this same assertion. This is a recurring eval-isolation problem rather than missing provider configuration, report collection, or a broken `save_memory` call.
+
+## Accepted behavior
+
+### AC-1: Isolate the eval from todo bookkeeping
+
+Given the `save_memory` behavioral eval, when its CLI test settings are created, then `todo_read`, `todo_write`, and `todo_pause` are excluded while `save_memory` remains available.
+
+This keeps an unrelated task-management loop from adding model turns to an eval that measures memory persistence and an exact response.
+
+### AC-2: Preserve the existing memory contract
+
+Given a model tool call, when the eval validates it, then only a successful `save_memory` call whose normalized `fact` is exactly `My favorite color is blue` passes.
+
+Paraphrases, negations, malformed arguments, missing facts, and wrong colors continue to fail.
+
+### AC-3: Preserve the existing response contract
+
+Given the extracted CLI response, when the eval validates it, then only `$blue$`, allowing case changes and outer whitespace, passes.
+
+Empty output, missing delimiters, wrong colors, multiple answers, and surrounding prose continue to fail. The fix must not weaken this assertion or treat model assertion failures as successful workflow results.
+
+## Inputs and boundaries
+
+- Relevant tools: `save_memory` and the todo tool family observed in failed artifacts.
+- Relevant provider behavior: a provider may attempt task bookkeeping even for this focused prompt.
+- Out of scope: changing the todo subsystem, changing system prompts or agent memory, changing workflow failure semantics, adding retries or pass-rate thresholds, changing providers, and relaxing exact-value assertions.
+- Infrastructure failures, missing reports, malformed reports, and genuine model assertion failures must continue to fail as they do now.
+
+## Test-first implementation
+
+1. Add a failing Bun test that reads the eval declaration and proves all three todo tools are excluded while `save_memory` remains available.
+2. Run the focused test and record the expected RED failure.
+3. Add only the eval settings needed to exclude the three todo tools.
+4. Run the focused test and existing deterministic assertion tests. Confirm the tests that reject wrong facts and extra response prose still pass.
+5. Run the full verification cycle and the `stepfun-37` smoke test.
+6. Review the final diff for issue scope, then run local Open Code Review.
+
+## Behavioral evidence required for completion
+
+- The new focused test fails before the eval settings change and passes after it.
+- Existing exact fact and exact response tests pass unchanged.
+- The full local verification cycle passes.
+- Candidate-head CI passes.
+- Reviews are complete, every finding is classified as Blocker-Fix, In-scope-Fix, Reject, or Defer, and every Blocker-Fix or In-scope-Fix item is resolved.
+- The pull request is conflict-free and based on the current `main` ancestry.
+
+## TDD evidence
+
+- RED: the two new tool-isolation tests were run against an isolated `origin/main` snapshot. The existing 42 assertion tests passed, while both isolation tests failed because `excludeTools` was absent. The command exited 1 as expected. Evidence: `tmp/issue3256/red-snapshot/red-focused-test.log`.
+- GREEN: after the focused settings change, the complete assertion and isolation file passed with 44 tests and 50 expectations. Evidence: `tmp/issue3256/remediation/focused-test.log`.
+- The exact fact and exact response assertions were not modified.
+
+## Review findings and dispositions
+
+### Independent compliance review
+
+The initial `deepthinker` review found that the first standalone regression test was not included in the script TypeScript project. This was classified **In-scope-Fix**. The coverage moved into the existing, typechecked `evals-save-memory-assertion.test.ts`; no TypeScript configuration changed. The follow-up review passed with no unresolved findings.
+
+### Local Open Code Review round 1
+
+1. **Blocker-Fix:** nested `tools.exclude` denied execution but left todo tools in the advertised registry. Resolved by using operative flat `excludeTools`.
+2. **In-scope-Fix:** the first test asserted inert `tools.core` configuration. Resolved by removing that setting and assertion; `save_memory` remains registered by default because it is not excluded.
+3. **Reject:** make the AST locator support multiple eval declarations and compare tool names without order sensitivity. The file has one focused eval, and the test intentionally checks its exact settings declaration. Multi-case support would be speculative.
+4. **In-scope-Fix:** the standalone test lacked script-project typecheck coverage. Resolved together with the compliance finding by moving coverage into the existing typechecked test file.
+
+### Local Open Code Review round 2
+
+The final follow-up confirmed that flat `excludeTools` removes the three todo tools from the registry and policy while leaving `save_memory` registered, and that both changed files are typechecked. It reported three test-maintenance suggestions:
+
+1. **Reject:** change the AST locator to validate every future eval case. This repeats the speculative multi-case suggestion rejected in round 1. The accepted behavior covers the one existing eval case.
+2. **Reject:** parse the small source file once in `beforeAll`. The repeated parse is negligible, changes no accepted behavior, and is optional test cleanup.
+3. **Reject:** combine the explicit `save_memory` reachability assertion with the exact exclusion-list assertion. The second assertion maps directly to AC-1 and gives that requirement a named test, even though exact array equality also implies it.
+
+No Blocker-Fix or In-scope-Fix findings remain.
+
+## Local verification
+
+- `npm run test`: passed on the remediated candidate (`tmp/issue3256/deepthinker-review/npm-test-rerun.log`). A later loaded rerun hit the unrelated 10-second subprocess timeout in `modelLimitsParity.test.ts`; its other 12 tests and all other suites passed. The timed-out test passed immediately in isolation (`tmp/issue3256/final/modelLimitsParity-rerun.log`).
+- Focused assertion and isolation tests: 44 passed, 0 failed.
+- `npm run lint`: passed.
+- `npm run typecheck`: passed after generated package outputs were refreshed by the build.
+- `npm run format`: passed.
+- `npm run build`: passed.
+- Required `stepfun-37` smoke test: passed and returned a haiku.
+- Test audit: no finding for the touched test and no parse failures.

--- a/project-plans/issue3256.md
+++ b/project-plans/issue3256.md
@@ -84,11 +84,18 @@ No Blocker-Fix or In-scope-Fix findings remain.
 
 ## Local verification
 
-- `npm run test`: passed on the remediated candidate (`tmp/issue3256/deepthinker-review/npm-test-rerun.log`). A later loaded rerun hit the unrelated 10-second subprocess timeout in `modelLimitsParity.test.ts`; its other 12 tests and all other suites passed. The timed-out test passed immediately in isolation (`tmp/issue3256/final/modelLimitsParity-rerun.log`).
+- `npm run test`: passed on the final remediated candidate (`tmp/verify3256/full-test-remediation-rerun.log`). The first post-lint-remediation attempt hit an unrelated timing failure in `turn.watchdog.test.ts`; that file passed immediately in isolation before the complete suite rerun passed.
 - Focused assertion and isolation tests: 44 passed, 0 failed.
-- `npm run lint`: passed.
-- `npm run typecheck`: passed after generated package outputs were refreshed by the build.
-- `npm run format`: passed.
-- `npm run build`: passed.
-- Required `stepfun-37` smoke test: passed and returned a haiku.
+- `npm run lint`: passed (`tmp/verify3256/full-lint-remediation-rerun.log`).
+- `npm run typecheck`: passed (`tmp/verify3256/full-typecheck-remediation-rerun.log`).
+- `npm run format`: passed (`tmp/verify3256/full-format-remediation-rerun.log`).
+- `npm run build`: passed (`tmp/verify3256/full-build-remediation-rerun.log`).
+- Required `stepfun-37` smoke test: passed and returned a haiku (`tmp/verify3256/full-smoke-remediation-rerun.log`).
 - Test audit: no finding for the touched test and no parse failures.
+
+## PR stage
+
+- **Candidate-head CI lint (In-scope-Fix):** the candidate-head `eslint . --max-warnings 0` run reported `sonarjs/todo-tag` at `scripts/tests/evals-save-memory-assertion.test.ts` lines 448 and 450 because prose comments used the ordinary word `todo` while describing the tool family. The comment phrases were rewritten to `task bookkeeping` and `task-management`; the tool identifiers `todo_read`, `todo_write`, and `todo_pause` are unchanged. No assertion, behavior, suppression, or config changed.
+- **PR OCR - future multiple evalTest cases (Reject):** the suggestion to make the AST locator validate every future eval case is speculative. The accepted behavior covers the one existing eval case and does not define multi-case support, which is not part of this issue.
+- **PR OCR - order-insensitive comparison / DRY (Reject):** exact ordered declaration comparison is intentional, since the test checks the exact `excludeTools` declaration, and extracting a helper is optional cleanup rather than an accepted behavior change.
+- **CodeRabbit - docstring coverage (Reject):** adding docstrings to the small local test AST helpers is unrelated cleanup, and CodeRabbit generated no actionable comments.

--- a/scripts/tests/evals-save-memory-assertion.test.ts
+++ b/scripts/tests/evals-save-memory-assertion.test.ts
@@ -445,10 +445,10 @@ function stringArrayProperty(
 }
 
 /**
- * Issue #3256: The save_memory eval isolates itself from todo bookkeeping via the
+ * Issue #3256: The save_memory eval isolates itself from task bookkeeping via the
  * flat `excludeTools` settings list, which drives both registry exclusion and policy
- * denial. The exactly-three todo tools must be excluded and `save_memory` must not
- * be excluded (it is registered by default and must remain reachable).
+ * denial. The exactly-three task-management tools must be excluded and `save_memory`
+ * must not be excluded (it is registered by default and must remain reachable).
  */
 describe('save_memory eval tool isolation (operative flat excludeTools)', () => {
   it('uses the operative flat excludeTools list for exactly the three todo tools', () => {

--- a/scripts/tests/evals-save-memory-assertion.test.ts
+++ b/scripts/tests/evals-save-memory-assertion.test.ts
@@ -5,10 +5,13 @@
  */
 
 import { beforeAll, describe, it, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 import { join, resolve } from 'node:path';
+import * as ts from 'typescript';
 
 const ROOT = resolve(import.meta.dirname, '../..');
+const TODO_TOOLS = ['todo_read', 'todo_write', 'todo_pause'];
 describe('eval JSON output contract', () => {
   let buildEvalArgs: (prompt: string) => string[];
   let extractModelResponse: (output: string) => string;
@@ -362,5 +365,109 @@ describe('assertFavoriteColorBlueOutput predicate (deterministic exact-value)', 
       /some output/i,
     );
     expect(() => assertFavoriteColorBlueOutput(42)).toThrow(/some output/i);
+  });
+});
+
+function loadSaveMemoryEval(): ts.SourceFile {
+  const filePath = join(ROOT, 'evals/save_memory.eval.ts');
+  return ts.createSourceFile(
+    filePath,
+    readFileSync(filePath, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+}
+
+function findEvalCase(sourceFile: ts.SourceFile): ts.ObjectLiteralExpression {
+  let evalCase: ts.ObjectLiteralExpression | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'evalTest'
+    ) {
+      const candidate = node.arguments[1];
+      if (candidate && ts.isObjectLiteralExpression(candidate)) {
+        evalCase = candidate;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!evalCase) {
+    throw new Error('save_memory eval must declare an evalTest case');
+  }
+  return evalCase;
+}
+
+function propertyValue(
+  object: ts.ObjectLiteralExpression,
+  propertyName: string,
+): ts.Expression {
+  const property = object.properties.find(
+    (candidate) =>
+      ts.isPropertyAssignment(candidate) &&
+      ts.isIdentifier(candidate.name) &&
+      candidate.name.text === propertyName,
+  );
+  if (!property || !ts.isPropertyAssignment(property)) {
+    throw new Error(`Expected property ${propertyName}`);
+  }
+  return property.initializer;
+}
+
+function objectProperty(
+  object: ts.ObjectLiteralExpression,
+  propertyName: string,
+): ts.ObjectLiteralExpression {
+  const value = propertyValue(object, propertyName);
+  if (!ts.isObjectLiteralExpression(value)) {
+    throw new Error(`Expected ${propertyName} to be an object literal`);
+  }
+  return value;
+}
+
+function stringArrayProperty(
+  object: ts.ObjectLiteralExpression,
+  propertyName: string,
+): string[] {
+  const value = propertyValue(object, propertyName);
+  if (!ts.isArrayLiteralExpression(value)) {
+    throw new Error(`Expected ${propertyName} to be an array literal`);
+  }
+  return value.elements.map((element) => {
+    if (!ts.isStringLiteral(element)) {
+      throw new Error(`${propertyName} must contain only string literals`);
+    }
+    return element.text;
+  });
+}
+
+/**
+ * Issue #3256: The save_memory eval isolates itself from todo bookkeeping via the
+ * flat `excludeTools` settings list, which drives both registry exclusion and policy
+ * denial. The exactly-three todo tools must be excluded and `save_memory` must not
+ * be excluded (it is registered by default and must remain reachable).
+ */
+describe('save_memory eval tool isolation (operative flat excludeTools)', () => {
+  it('uses the operative flat excludeTools list for exactly the three todo tools', () => {
+    const settings = objectProperty(
+      objectProperty(findEvalCase(loadSaveMemoryEval()), 'params'),
+      'settings',
+    );
+
+    expect(stringArrayProperty(settings, 'excludeTools')).toEqual(TODO_TOOLS);
+  });
+
+  it('does not exclude save_memory', () => {
+    const settings = objectProperty(
+      objectProperty(findEvalCase(loadSaveMemoryEval()), 'params'),
+      'settings',
+    );
+
+    expect(stringArrayProperty(settings, 'excludeTools')).not.toContain(
+      'save_memory',
+    );
   });
 });


### PR DESCRIPTION
## TLDR

The nightly `save_memory` eval intermittently saved the required fact and then used `todo_write`, which prompted extra task-status prose after the required `$blue$` response. This PR removes `todo_read`, `todo_write`, and `todo_pause` from that eval through the operative flat `excludeTools` setting.

The saved-fact assertion and exact `$blue$` response assertion are unchanged.

## Dive Deeper

Failure artifacts from the reported nightly runs showed successful `save_memory` calls with the exact fact `My favorite color is blue`. Failed attempts differed from passing siblings because the model also called todo bookkeeping and returned responses such as `$blue$Task completed.`

The eval previously set nested `tools.core`, which does not control the advertised tool registry. The replacement flat `excludeTools` setting removes the three todo tools from the registry and applies the corresponding policy denial. `save_memory` remains available by default because it is not excluded.

Regression tests parse the eval declaration and verify that:

- `excludeTools` contains exactly `todo_read`, `todo_write`, and `todo_pause`.
- `save_memory` is not excluded.
- Existing exact-fact and exact-response boundary tests remain unchanged and pass.

The issue plan records acceptance criteria, RED/GREEN evidence, review findings, dispositions, and local verification.

## Reviewer Test Plan

From `scripts/tests`, run:

```bash
bun test evals-save-memory-assertion.test.ts
```

Expected result: 44 tests pass. The final two tests verify the operative exclusion list and continued `save_memory` reachability. The preceding tests verify that paraphrased or incorrect facts fail and that surrounding prose, missing delimiters, wrong answers, multiple answers, and empty output still fail.

Full local verification completed on the final candidate with:

```bash
npm run test
npm run lint
npm run typecheck
npm run format
npm run build
bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
```

The final full test rerun and every remaining verification gate passed. Candidate-head CI also passed, including the scripts test shard, JavaScript lint, typecheck, Linux E2E with and without Docker, CodeQL, and smoke checks.

## Testing Matrix

|          | 🍏 | 🪟 | 🐧 |
| -------- | -- | -- | -- |
| npm run  | ✅ | ❓ | ✅ |
| npx      | ❓ | ❓ | ❓ |
| Docker   | ❓ | ❓ | ✅ |
| Podman   | ❓ | -  | -  |
| Seatbelt | ❓ | -  | -  |

## Linked issues / bugs

Fixes #3256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added automated validation for the save-memory evaluation’s tool configuration.
  - Confirmed todo tools are excluded while save-memory remains available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->