### PR TITLE
fix(sandbox): deliver the empty SSH-agent warning instead of dropping it (Fixes #3408)

### DIFF
--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -935,7 +935,7 @@ ssh-add ~/.ssh/id_ed25519
 
 LLxprt Code prints a startup warning when it detects this empty-agent state.
 The warning now also appears in the TUI startup-warnings box (and on stderr
-for non-interactive runs) instead of only on host stderr.
+for text-mode non-interactive runs) instead of only on host stderr.
 
 **"socat not found" error** — the sandbox container image needs `socat` for SSH
 agent and credential proxy tunneling. Use the official sandbox image.

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -934,6 +934,8 @@ ssh-add ~/.ssh/id_ed25519
 ```
 
 LLxprt Code prints a startup warning when it detects this empty-agent state.
+The warning now also appears in the TUI startup-warnings box (and on stderr
+for non-interactive runs) instead of only on host stderr.
 
 **"socat not found" error** — the sandbox container image needs `socat` for SSH
 agent and credential proxy tunneling. Use the official sandbox image.

--- a/packages/cli/src/__tests__/cliSessionDispatch.characterization.test.tsx
+++ b/packages/cli/src/__tests__/cliSessionDispatch.characterization.test.tsx
@@ -982,7 +982,7 @@ describe('session-dispatch characterization', () => {
   // ---------------------------------------------------------------------------
 
   describe('session-dispatch characterization — sandbox empty-agent handoff warning delivery', () => {
-    const originalEnv = { ...process.env };
+    const originalEnv = process.env;
 
     // Created per test: afterEach(vi.restoreAllMocks) would otherwise kill a
     // suite-scoped spy after the first test.
@@ -1002,6 +1002,10 @@ describe('session-dispatch characterization', () => {
     });
 
     afterEach(() => {
+      // Restore the original env object identity, not a copy, so a throwing
+      // test cannot leak the substituted object or the handoff flag into
+      // suites that run later in this worker.
+      process.env = originalEnv;
       vi.restoreAllMocks();
     });
 
@@ -1036,6 +1040,15 @@ describe('session-dispatch characterization', () => {
       );
     }
 
+    it('pins the mocked handoff text to the warning the production preflight emits', async () => {
+      // Imported lazily: referencing this binding from the hoisted vi.mock
+      // factory above would read it before the module is evaluated.
+      const { SSH_AGENT_EMPTY_WARNING } = await import(
+        '../utils/sandbox-ssh.js'
+      );
+      expect(TEST_SSH_AGENT_EMPTY_WARNING).toBe(SSH_AGENT_EMPTY_WARNING);
+    });
+
     it('interactive: prepends the empty-agent warning to the startup warnings rendered by the TUI when the env flag is set', async () => {
       process.env.LLXPRT_SANDBOX_SSH_AGENT_EMPTY = '1';
 
@@ -1061,13 +1074,13 @@ describe('session-dispatch characterization', () => {
     it('non-interactive: writes the empty-agent warning to stderr before the session runs when the env flag is set', async () => {
       process.env.LLXPRT_SANDBOX_SSH_AGENT_EMPTY = '1';
 
-      // The stderr spy records fd-direct calls and the mocked runNonInteractive
-      // records the session run, so the sequence proves the warning was written
-      // on the way to the session rather than after it.
+      // Sampling the dispatch trace at the moment of the write puts both
+      // events on one timeline, so a regression that warned only after the
+      // session ran would be caught.
       const order: string[] = [];
       stderrWriteSpy.mockImplementation((chunk: unknown) => {
         if (String(chunk) === TEST_SSH_AGENT_EMPTY_WARNING) {
-          order.push('warning');
+          order.push(...dispatchTrace, 'warning');
         }
         return true;
       });
@@ -1079,7 +1092,9 @@ describe('session-dispatch characterization', () => {
         ),
       ).rejects.toThrow('process.exit');
 
-      expect(order).toContain('warning');
+      // The warning was the only event on the timeline when it was written:
+      // runNonInteractive had not run yet, and it did run afterwards.
+      expect(order).toStrictEqual(['warning']);
       expect(dispatchTrace).toContain('runNonInteractive');
     });
 

--- a/packages/cli/src/__tests__/cliSessionDispatch.characterization.test.tsx
+++ b/packages/cli/src/__tests__/cliSessionDispatch.characterization.test.tsx
@@ -35,6 +35,7 @@ const { mockWriteToStderr } = {
   mockWriteToStderr: vi.fn<(chunk: string | Uint8Array) => boolean>(() => true),
 };
 
+import * as coreModule from '@vybestack/llxprt-code-core';
 import {
   coreEvents,
   CoreEvent,
@@ -93,8 +94,19 @@ void vi.mock('../cliAgentBootstrap.js', () => ({
 }));
 
 // The actual module path used by session-dispatch is utils/startupWarnings.js
+const TEST_SSH_AGENT_EMPTY_WARNING =
+  [
+    'SSH agent socket is present, but no identities are loaded (ssh-add -l reported empty).',
+    'SSH forwarding is enabled, but git SSH auth will fail until a key is loaded.',
+    'Try: ssh-add ~/.ssh/id_ed25519',
+  ].join('\n') + '\n';
 void vi.mock('../utils/startupWarnings.js', () => ({
   getStartupWarnings: vi.fn(async () => []),
+  getSandboxHandoffWarning: vi.fn((env: NodeJS.ProcessEnv) =>
+    env.LLXPRT_SANDBOX_SSH_AGENT_EMPTY === '1'
+      ? TEST_SSH_AGENT_EMPTY_WARNING
+      : undefined,
+  ),
 }));
 
 void vi.mock('../utils/userStartupWarnings.js', () => ({
@@ -140,6 +152,32 @@ void vi.mock('../utils/cleanup.js', () => ({
 // Uses the __setRenderForTesting seam in interactiveUI.tsx instead of
 // module mocking, which deadlocks during module evaluation under Bun.
 const renderCalls: unknown[] = [];
+
+/**
+ * Walks the rendered React element tree (StrictMode → ErrorBoundary →
+ * SettingsContext.Provider → AppWrapper) to the startupWarnings prop, exposing
+ * the warnings array delivered to the TUI root as an observable effect.
+ */
+function findStartupWarningsProp(node: unknown): unknown[] | undefined {
+  if (node === null || node === undefined || typeof node !== 'object') {
+    return undefined;
+  }
+  const el = node as { props?: Record<string, unknown> };
+  const props = el.props;
+  if (props) {
+    if (Array.isArray(props.startupWarnings)) {
+      return props.startupWarnings;
+    }
+    const childProps = (props as { children?: unknown }).children;
+    const viaChildren = Array.isArray(childProps)
+      ? childProps
+          .map(findStartupWarningsProp)
+          .find((found) => found !== undefined)
+      : findStartupWarningsProp(childProps);
+    if (viaChildren !== undefined) return viaChildren;
+  }
+  return undefined;
+}
 
 // ---------------------------------------------------------------------------
 // Helpers for building minimal Config/Settings stubs consumed by the real
@@ -936,6 +974,194 @@ describe('session-dispatch characterization', () => {
       } finally {
         stdoutWrite.mockRestore();
       }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Suite 8: Sandbox empty-agent handoff warning delivery (#3408)
+  // ---------------------------------------------------------------------------
+
+  describe('session-dispatch characterization — sandbox empty-agent handoff warning delivery', () => {
+    const originalEnv = { ...process.env };
+
+    // Created per test: afterEach(vi.restoreAllMocks) would otherwise kill a
+    // suite-scoped spy after the first test.
+    function installStderrSpy() {
+      return vi
+        .spyOn(coreModule, 'writeToStderr')
+        .mockImplementation(() => true);
+    }
+    let stderrWriteSpy: ReturnType<typeof installStderrSpy>;
+
+    beforeEach(() => {
+      stderrWriteSpy = installStderrSpy();
+      process.env = { ...originalEnv };
+      dispatchTrace.length = 0;
+      renderCalls.length = 0;
+      installSafeProcessExit();
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('interactive: prepends the empty-agent warning to the startup warnings rendered by the TUI when the env flag is set', async () => {
+      process.env.LLXPRT_SANDBOX_SSH_AGENT_EMPTY = '1';
+      const config = createMinimalConfig({ interactive: true });
+      const settings = createMinimalSettings({ hideWindowTitle: true });
+
+      await dispatchInteractiveOrNonInteractive({
+        config: config as never,
+        agent: createFakeAgent() as never,
+        settings: settings as never,
+        workspaceRoot: '/tmp/test',
+        recording: {
+          recordingIntegration: undefined,
+          resumedHistory: undefined,
+          recordingService: undefined,
+          resumedLockHandle: null,
+        } as never,
+        hasPipedInput: false,
+        readStdinData: async () => '',
+      });
+
+      const delivered = renderCalls
+        .map((args) => findStartupWarningsProp((args as unknown[])[0]))
+        .find((warnings) => warnings !== undefined);
+      expect(delivered?.[0]).toBe(TEST_SSH_AGENT_EMPTY_WARNING);
+    });
+
+    it('interactive: startup warnings are unchanged when the env flag is unset', async () => {
+      delete process.env.LLXPRT_SANDBOX_SSH_AGENT_EMPTY;
+      const config = createMinimalConfig({ interactive: true });
+      const settings = createMinimalSettings({ hideWindowTitle: true });
+
+      await dispatchInteractiveOrNonInteractive({
+        config: config as never,
+        agent: createFakeAgent() as never,
+        settings: settings as never,
+        workspaceRoot: '/tmp/test',
+        recording: {
+          recordingIntegration: undefined,
+          resumedHistory: undefined,
+          recordingService: undefined,
+          resumedLockHandle: null,
+        } as never,
+        hasPipedInput: false,
+        readStdinData: async () => '',
+      });
+
+      const delivered = renderCalls
+        .map((args) => findStartupWarningsProp((args as unknown[])[0]))
+        .find((warnings) => warnings !== undefined);
+      expect(delivered).toStrictEqual([]);
+    });
+
+    it('non-interactive: writes the empty-agent warning to stderr before the session runs when the env flag is set', async () => {
+      process.env.LLXPRT_SANDBOX_SSH_AGENT_EMPTY = '1';
+      const config = createMinimalConfig({
+        interactive: false,
+        question: 'prompt',
+      });
+      const settings = createMinimalSettings();
+
+      // The stderr spy records fd-direct calls; the mocked runNonInteractive
+      // records when the session run is reached, so both records together
+      // prove the warning was written on the way to the session run.
+      const order: string[] = [];
+      stderrWriteSpy.mockImplementation((chunk: unknown) => {
+        if (String(chunk) === TEST_SSH_AGENT_EMPTY_WARNING) {
+          order.push('warning');
+        }
+        return true;
+      });
+
+      await expect(
+        dispatchInteractiveOrNonInteractive({
+          config: config as never,
+          agent: createFakeAgent() as never,
+          settings: settings as never,
+          workspaceRoot: '/tmp/test',
+          recording: {
+            recordingIntegration: undefined,
+            resumedHistory: undefined,
+            recordingService: undefined,
+            resumedLockHandle: null,
+          } as never,
+          hasPipedInput: false,
+          readStdinData: async () => '',
+        }),
+      ).rejects.toThrow('process.exit');
+
+      expect(order).toContain('warning');
+      expect(dispatchTrace).toContain('runNonInteractive');
+    });
+
+    it('non-interactive: withholds the handoff warning in JSON output mode so it cannot reach the payload stream', async () => {
+      process.env.LLXPRT_SANDBOX_SSH_AGENT_EMPTY = '1';
+      const config = createMinimalConfig({
+        interactive: false,
+        question: 'prompt',
+        outputFormat: OutputFormat.JSON,
+      });
+      const settings = createMinimalSettings();
+
+      await expect(
+        dispatchInteractiveOrNonInteractive({
+          config: config as never,
+          agent: createFakeAgent() as never,
+          settings: settings as never,
+          workspaceRoot: '/tmp/test',
+          recording: {
+            recordingIntegration: undefined,
+            resumedHistory: undefined,
+            recordingService: undefined,
+            resumedLockHandle: null,
+          } as never,
+          hasPipedInput: false,
+          readStdinData: async () => '',
+        }),
+      ).rejects.toThrow('process.exit');
+
+      expect(
+        stderrWriteSpy.mock.calls.some((call) =>
+          String(call[0]).includes('SSH agent socket is present'),
+        ),
+      ).toBe(false);
+      expect(dispatchTrace).toContain('runNonInteractive');
+    });
+
+    it('non-interactive: writes nothing for the handoff when the env flag is unset', async () => {
+      delete process.env.LLXPRT_SANDBOX_SSH_AGENT_EMPTY;
+      const config = createMinimalConfig({
+        interactive: false,
+        question: 'prompt',
+      });
+      const settings = createMinimalSettings();
+
+      await expect(
+        dispatchInteractiveOrNonInteractive({
+          config: config as never,
+          agent: createFakeAgent() as never,
+          settings: settings as never,
+          workspaceRoot: '/tmp/test',
+          recording: {
+            recordingIntegration: undefined,
+            resumedHistory: undefined,
+            recordingService: undefined,
+            resumedLockHandle: null,
+          } as never,
+          hasPipedInput: false,
+          readStdinData: async () => '',
+        }),
+      ).rejects.toThrow('process.exit');
+
+      expect(
+        stderrWriteSpy.mock.calls.some((call) =>
+          String(call[0]).includes('SSH agent socket is present'),
+        ),
+      ).toBe(false);
+      expect(dispatchTrace).toContain('runNonInteractive');
     });
   });
 });

--- a/packages/cli/src/__tests__/cliSessionDispatch.characterization.test.tsx
+++ b/packages/cli/src/__tests__/cliSessionDispatch.characterization.test.tsx
@@ -1005,12 +1005,9 @@ describe('session-dispatch characterization', () => {
       vi.restoreAllMocks();
     });
 
-    it('interactive: prepends the empty-agent warning to the startup warnings rendered by the TUI when the env flag is set', async () => {
-      process.env.LLXPRT_SANDBOX_SSH_AGENT_EMPTY = '1';
-      const config = createMinimalConfig({ interactive: true });
-      const settings = createMinimalSettings({ hideWindowTitle: true });
-
-      await dispatchInteractiveOrNonInteractive({
+    /** Runs dispatch with the fixed recording/stdin arguments these cases share. */
+    function runDispatch(config: unknown, settings: unknown) {
+      return dispatchInteractiveOrNonInteractive({
         config: config as never,
         agent: createFakeAgent() as never,
         settings: settings as never,
@@ -1024,50 +1021,49 @@ describe('session-dispatch characterization', () => {
         hasPipedInput: false,
         readStdinData: async () => '',
       });
+    }
 
-      const delivered = renderCalls
+    /** The startupWarnings array the TUI root was rendered with. */
+    function renderedStartupWarnings(): unknown[] | undefined {
+      return renderCalls
         .map((args) => findStartupWarningsProp((args as unknown[])[0]))
         .find((warnings) => warnings !== undefined);
-      expect(delivered?.[0]).toBe(TEST_SSH_AGENT_EMPTY_WARNING);
+    }
+
+    function wroteEmptyAgentWarning(): boolean {
+      return stderrWriteSpy.mock.calls.some((call) =>
+        String(call[0]).includes('SSH agent socket is present'),
+      );
+    }
+
+    it('interactive: prepends the empty-agent warning to the startup warnings rendered by the TUI when the env flag is set', async () => {
+      process.env.LLXPRT_SANDBOX_SSH_AGENT_EMPTY = '1';
+
+      await runDispatch(
+        createMinimalConfig({ interactive: true }),
+        createMinimalSettings({ hideWindowTitle: true }),
+      );
+
+      expect(renderedStartupWarnings()?.[0]).toBe(TEST_SSH_AGENT_EMPTY_WARNING);
     });
 
     it('interactive: startup warnings are unchanged when the env flag is unset', async () => {
       delete process.env.LLXPRT_SANDBOX_SSH_AGENT_EMPTY;
-      const config = createMinimalConfig({ interactive: true });
-      const settings = createMinimalSettings({ hideWindowTitle: true });
 
-      await dispatchInteractiveOrNonInteractive({
-        config: config as never,
-        agent: createFakeAgent() as never,
-        settings: settings as never,
-        workspaceRoot: '/tmp/test',
-        recording: {
-          recordingIntegration: undefined,
-          resumedHistory: undefined,
-          recordingService: undefined,
-          resumedLockHandle: null,
-        } as never,
-        hasPipedInput: false,
-        readStdinData: async () => '',
-      });
+      await runDispatch(
+        createMinimalConfig({ interactive: true }),
+        createMinimalSettings({ hideWindowTitle: true }),
+      );
 
-      const delivered = renderCalls
-        .map((args) => findStartupWarningsProp((args as unknown[])[0]))
-        .find((warnings) => warnings !== undefined);
-      expect(delivered).toStrictEqual([]);
+      expect(renderedStartupWarnings()).toStrictEqual([]);
     });
 
     it('non-interactive: writes the empty-agent warning to stderr before the session runs when the env flag is set', async () => {
       process.env.LLXPRT_SANDBOX_SSH_AGENT_EMPTY = '1';
-      const config = createMinimalConfig({
-        interactive: false,
-        question: 'prompt',
-      });
-      const settings = createMinimalSettings();
 
-      // The stderr spy records fd-direct calls; the mocked runNonInteractive
-      // records when the session run is reached, so both records together
-      // prove the warning was written on the way to the session run.
+      // The stderr spy records fd-direct calls and the mocked runNonInteractive
+      // records the session run, so the sequence proves the warning was written
+      // on the way to the session rather than after it.
       const order: string[] = [];
       stderrWriteSpy.mockImplementation((chunk: unknown) => {
         if (String(chunk) === TEST_SSH_AGENT_EMPTY_WARNING) {
@@ -1077,20 +1073,10 @@ describe('session-dispatch characterization', () => {
       });
 
       await expect(
-        dispatchInteractiveOrNonInteractive({
-          config: config as never,
-          agent: createFakeAgent() as never,
-          settings: settings as never,
-          workspaceRoot: '/tmp/test',
-          recording: {
-            recordingIntegration: undefined,
-            resumedHistory: undefined,
-            recordingService: undefined,
-            resumedLockHandle: null,
-          } as never,
-          hasPipedInput: false,
-          readStdinData: async () => '',
-        }),
+        runDispatch(
+          createMinimalConfig({ interactive: false, question: 'prompt' }),
+          createMinimalSettings(),
+        ),
       ).rejects.toThrow('process.exit');
 
       expect(order).toContain('warning');
@@ -1099,68 +1085,33 @@ describe('session-dispatch characterization', () => {
 
     it('non-interactive: withholds the handoff warning in JSON output mode so it cannot reach the payload stream', async () => {
       process.env.LLXPRT_SANDBOX_SSH_AGENT_EMPTY = '1';
-      const config = createMinimalConfig({
-        interactive: false,
-        question: 'prompt',
-        outputFormat: OutputFormat.JSON,
-      });
-      const settings = createMinimalSettings();
 
       await expect(
-        dispatchInteractiveOrNonInteractive({
-          config: config as never,
-          agent: createFakeAgent() as never,
-          settings: settings as never,
-          workspaceRoot: '/tmp/test',
-          recording: {
-            recordingIntegration: undefined,
-            resumedHistory: undefined,
-            recordingService: undefined,
-            resumedLockHandle: null,
-          } as never,
-          hasPipedInput: false,
-          readStdinData: async () => '',
-        }),
+        runDispatch(
+          createMinimalConfig({
+            interactive: false,
+            question: 'prompt',
+            outputFormat: OutputFormat.JSON,
+          }),
+          createMinimalSettings(),
+        ),
       ).rejects.toThrow('process.exit');
 
-      expect(
-        stderrWriteSpy.mock.calls.some((call) =>
-          String(call[0]).includes('SSH agent socket is present'),
-        ),
-      ).toBe(false);
+      expect(wroteEmptyAgentWarning()).toBe(false);
       expect(dispatchTrace).toContain('runNonInteractive');
     });
 
     it('non-interactive: writes nothing for the handoff when the env flag is unset', async () => {
       delete process.env.LLXPRT_SANDBOX_SSH_AGENT_EMPTY;
-      const config = createMinimalConfig({
-        interactive: false,
-        question: 'prompt',
-      });
-      const settings = createMinimalSettings();
 
       await expect(
-        dispatchInteractiveOrNonInteractive({
-          config: config as never,
-          agent: createFakeAgent() as never,
-          settings: settings as never,
-          workspaceRoot: '/tmp/test',
-          recording: {
-            recordingIntegration: undefined,
-            resumedHistory: undefined,
-            recordingService: undefined,
-            resumedLockHandle: null,
-          } as never,
-          hasPipedInput: false,
-          readStdinData: async () => '',
-        }),
+        runDispatch(
+          createMinimalConfig({ interactive: false, question: 'prompt' }),
+          createMinimalSettings(),
+        ),
       ).rejects.toThrow('process.exit');
 
-      expect(
-        stderrWriteSpy.mock.calls.some((call) =>
-          String(call[0]).includes('SSH agent socket is present'),
-        ),
-      ).toBe(false);
+      expect(wroteEmptyAgentWarning()).toBe(false);
       expect(dispatchTrace).toContain('runNonInteractive');
     });
   });

--- a/packages/cli/src/cliSandbox.test.ts
+++ b/packages/cli/src/cliSandbox.test.ts
@@ -239,59 +239,53 @@ describe('maybeHopIntoSandbox hop-exit stdio flush (#3408)', () => {
     // Mirror cli.tsx setupProcessLifecycle: patch stdio and register the
     // sync-cleanup flush that runExitCleanup drains on the hop exit path.
     const cleanupStdio = coreModule.patchStdio();
-    registerSyncCleanup(() => {
-      initializeOutputListenersAndFlush();
-      cleanupStdio();
-    });
 
-    // The marker written through the patched stream is buffered (no Output
-    // listener yet); it must reach the fd-direct writer when runExitCleanup
-    // drains the backlog. The order array pins flush-before-exit.
-    const order: string[] = [];
-    const writeSpy = vi
-      .spyOn(coreModule, 'writeToStderr')
-      .mockImplementation((chunk: unknown) => {
-        const text = String(chunk);
-        if (text.includes('HOP-EXIT-MARKER')) {
-          order.push('flush');
-        }
-        return true;
-      });
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
-      order.push('exit');
-      throw new Error('exit sentinel');
-    }) as typeof process.exit);
-
-    process.stderr.write('HOP-EXIT-MARKER\n');
-
-    // The exit sentinel throws out of the hop, which is the only way to observe
-    // the call without terminating the runner.
-    await expect(maybeHopIntoSandbox(buildHopOptions())).rejects.toThrow(
-      'exit sentinel',
-    );
-
-    let exitCode: number | undefined;
+    // A failing assertion must not leave the stdio patch installed for the
+    // rest of the file, so every restore runs in the finally block.
     try {
-      exitCode = exitSpy.mock.calls[0]?.[0] as number | undefined;
+      registerSyncCleanup(() => {
+        initializeOutputListenersAndFlush();
+        cleanupStdio();
+      });
+
+      // The marker written through the patched stream is buffered (no Output
+      // listener yet); it must reach the fd-direct writer when runExitCleanup
+      // drains the backlog. The order array pins flush-before-exit.
+      const order: string[] = [];
+      vi.spyOn(coreModule, 'writeToStderr').mockImplementation(
+        (chunk: unknown) => {
+          if (String(chunk).includes('HOP-EXIT-MARKER')) {
+            order.push('flush');
+          }
+          return true;
+        },
+      );
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+        order.push('exit');
+        throw new Error('exit sentinel');
+      }) as typeof process.exit);
+
+      process.stderr.write('HOP-EXIT-MARKER\n');
+
+      // The exit sentinel throws out of the hop, which is the only way to
+      // observe the call without terminating the runner.
+      await expect(maybeHopIntoSandbox(buildHopOptions())).rejects.toThrow(
+        'exit sentinel',
+      );
+
+      expect(exitSpy.mock.calls[0]?.[0]).toBe(7);
+      // The buffered marker reached the fd-direct writer, and it did so before
+      // the hop-exit sentinel fired (runExitCleanup is awaited first).
+      expect(order).toStrictEqual(['flush', 'exit']);
     } finally {
-      exitSpy.mockRestore();
-      writeSpy.mockRestore();
+      // Restores the spies (including process.exit) before anything else.
+      vi.restoreAllMocks();
+      if (originalSandbox === undefined) {
+        delete process.env.SANDBOX;
+      } else {
+        process.env.SANDBOX = originalSandbox;
+      }
+      cleanupStdio();
     }
-
-    expect(exitCode).toBe(7);
-    // The buffered marker reached the fd-direct writer, and it did so before
-    // the hop-exit sentinel fired (runExitCleanup is awaited first).
-    expect(order).toStrictEqual(['flush', 'exit']);
-
-    if (originalSandbox === undefined) {
-      delete process.env.SANDBOX;
-    } else {
-      process.env.SANDBOX = originalSandbox;
-    }
-
-    coreEvents.removeAllListeners(CoreEvent.Output);
-    coreEvents.removeAllListeners(CoreEvent.ConsoleLog);
-    __resetCleanupStateForTesting();
-    cleanupStdio();
   });
 });

--- a/packages/cli/src/cliSandbox.test.ts
+++ b/packages/cli/src/cliSandbox.test.ts
@@ -11,12 +11,28 @@
  * the full sandbox hop.
  */
 
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it, afterEach, vi } from 'bun:test';
+import * as coreModule from '@vybestack/llxprt-code-core';
 import {
   resolveContainerMemoryMB,
   findFirstPositionalArgIndex,
   injectStdinIntoArgs,
+  maybeHopIntoSandbox,
+  type SandboxHopOptions,
 } from './cliSandbox.js';
+import { coreEvents, CoreEvent } from '@vybestack/llxprt-code-core';
+import { initializeOutputListenersAndFlush } from './session/outputListeners.js';
+import {
+  registerSyncCleanup,
+  __resetCleanupStateForTesting,
+} from './utils/cleanup.js';
+
+void vi.mock('./utils/sandbox.js', () => ({
+  start_sandbox: vi.fn(async () => 7),
+}));
+void vi.mock('./config/config.js', () => ({
+  loadCliConfig: vi.fn(async () => ({})),
+}));
 
 describe('resolveContainerMemoryMB', () => {
   it('returns undefined when no memory env vars are set', () => {
@@ -186,5 +202,96 @@ describe('injectStdinIntoArgs', () => {
     injectStdinIntoArgs(args, 'piped data');
 
     expect(args).toStrictEqual(original);
+  });
+});
+
+describe('maybeHopIntoSandbox hop-exit stdio flush (#3408)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    coreEvents.removeAllListeners(CoreEvent.Output);
+    coreEvents.removeAllListeners(CoreEvent.ConsoleLog);
+    __resetCleanupStateForTesting();
+  });
+
+  function buildHopOptions(): SandboxHopOptions {
+    return {
+      config: {
+        getSandbox: () => ({ command: 'docker', image: 'test-image' }),
+        getDebugMode: () => false,
+      } as SandboxHopOptions['config'],
+      settings: {
+        merged: { ui: { autoConfigureMaxOldSpaceSize: false } },
+      } as SandboxHopOptions['settings'],
+      argv: {} as SandboxHopOptions['argv'],
+      workspaceRoot: '/tmp/ws',
+      runtimeSettingsService: {} as SandboxHopOptions['runtimeSettingsService'],
+      initialAuthFailed: false,
+      readStdin: async () => '',
+      hasPipedInput: false,
+      bootstrapSelection: null,
+    };
+  }
+
+  it('flushes the patched-stdio backlog to the fd-direct writer before the hop exit sentinel fires', async () => {
+    const originalSandbox = process.env.SANDBOX;
+    delete process.env.SANDBOX;
+
+    // Mirror cli.tsx setupProcessLifecycle: patch stdio and register the
+    // sync-cleanup flush that runExitCleanup drains on the hop exit path.
+    const cleanupStdio = coreModule.patchStdio();
+    registerSyncCleanup(() => {
+      initializeOutputListenersAndFlush();
+      cleanupStdio();
+    });
+
+    // The marker written through the patched stream is buffered (no Output
+    // listener yet); it must reach the fd-direct writer when runExitCleanup
+    // drains the backlog. The order array pins flush-before-exit.
+    const order: string[] = [];
+    const writeSpy = vi
+      .spyOn(coreModule, 'writeToStderr')
+      .mockImplementation((chunk: unknown) => {
+        const text = String(chunk);
+        if (text.includes('HOP-EXIT-MARKER')) {
+          order.push('flush');
+        }
+        return true;
+      });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      order.push('exit');
+      throw new Error('exit sentinel');
+    }) as typeof process.exit);
+
+    process.stderr.write('HOP-EXIT-MARKER\n');
+
+    // The exit sentinel throws out of the hop, which is the only way to observe
+    // the call without terminating the runner.
+    await expect(maybeHopIntoSandbox(buildHopOptions())).rejects.toThrow(
+      'exit sentinel',
+    );
+
+    let exitCode: number | undefined;
+    try {
+      exitCode = exitSpy.mock.calls[0]?.[0] as number | undefined;
+    } finally {
+      exitSpy.mockRestore();
+      writeSpy.mockRestore();
+    }
+
+    expect(exitCode).toBe(7);
+    // The buffered marker reached the fd-direct writer, and it did so before
+    // the hop-exit sentinel fired (runExitCleanup is awaited first).
+    expect(order).toStrictEqual(['flush', 'exit']);
+
+    if (originalSandbox === undefined) {
+      delete process.env.SANDBOX;
+    } else {
+      process.env.SANDBOX = originalSandbox;
+    }
+
+    coreEvents.removeAllListeners(CoreEvent.Output);
+    coreEvents.removeAllListeners(CoreEvent.ConsoleLog);
+    __resetCleanupStateForTesting();
+    cleanupStdio();
   });
 });

--- a/packages/cli/src/cliSandbox.ts
+++ b/packages/cli/src/cliSandbox.ts
@@ -205,5 +205,8 @@ export async function maybeHopIntoSandbox(
     partialConfig,
     finalSandboxArgs,
   );
+  // Drains the patched-stdio backlog (registered flush) before the bare exit
+  // that terminates this process, mirroring the initialAuthFailed branch.
+  await runExitCleanup();
   process.exit(exitCode);
 }

--- a/packages/cli/src/session/nonInteractiveSession.ts
+++ b/packages/cli/src/session/nonInteractiveSession.ts
@@ -3,6 +3,7 @@ import {
   writeToStderr,
   triggerSessionEndHook,
   SessionEndReason,
+  OutputFormat,
 } from '@vybestack/llxprt-code-core';
 import {
   debugLogger,
@@ -11,7 +12,10 @@ import {
 } from '@vybestack/llxprt-code-telemetry';
 import type { Agent } from '@vybestack/llxprt-code-agents';
 import { type LoadedSettings } from '../config/settings.js';
-import { getStartupWarnings } from '../utils/startupWarnings.js';
+import {
+  getStartupWarnings,
+  getSandboxHandoffWarning,
+} from '../utils/startupWarnings.js';
 import { getUserStartupWarnings } from '../utils/userStartupWarnings.js';
 import { runNonInteractive } from '../nonInteractiveCli.js';
 import type { SessionRecordingSetup } from '../cliSessionBootstrap.js';
@@ -89,6 +93,10 @@ export async function dispatchInteractiveOrNonInteractive({
   // from the public accessor rather than a separately-threaded instance.
   const sessionMessageBus = agent.getMessageBus();
 
+  // The supervisor sets the handoff flag only when the host empty-agent
+  // preflight fired; the in-container session is where the user sees it.
+  const sandboxHandoffWarning = getSandboxHandoffWarning(process.env);
+
   // Render UI, passing necessary config values. Check that there is no command line question.
   if (typeof config.isInteractive === 'function' && config.isInteractive()) {
     // Startup warnings are only consumed by the interactive UI, so compute
@@ -98,7 +106,11 @@ export async function dispatchInteractiveOrNonInteractive({
       getStartupWarnings(),
       getUserStartupWarnings(settings.merged),
     ]);
-    const startupWarnings = [...systemWarnings, ...userWarnings];
+    const startupWarnings = [
+      ...(sandboxHandoffWarning !== undefined ? [sandboxHandoffWarning] : []),
+      ...systemWarnings,
+      ...userWarnings,
+    ];
 
     // The single interactive Agent was created at the composition root and is
     // threaded in here. `fromConfig` fired the SessionStart hook internally
@@ -119,6 +131,17 @@ export async function dispatchInteractiveOrNonInteractive({
       suppressStartupWelcome,
     );
     return;
+  }
+
+  if (
+    sandboxHandoffWarning !== undefined &&
+    config.getOutputFormat() === OutputFormat.TEXT
+  ) {
+    // fd-direct bypass: reaches physical stderr immediately even though
+    // patchStdio() redirected process.stderr.write to the event bus. Held back
+    // for machine-readable formats, which a TTY-allocating container engine
+    // merges onto stdout alongside the payload.
+    writeToStderr(sandboxHandoffWarning);
   }
 
   await runPipedOrPromptSession({

--- a/packages/cli/src/utils/sandbox-ssh-agent-preflight.test.ts
+++ b/packages/cli/src/utils/sandbox-ssh-agent-preflight.test.ts
@@ -30,6 +30,8 @@ void vi.mock('node:child_process', () => ({
 }));
 
 import { setupSshAgentForwarding } from './sandbox.js';
+import { getSandboxHandoffWarning } from './startupWarnings.js';
+import { SSH_AGENT_EMPTY_WARNING } from './sandbox-ssh.js';
 
 const HOST_SOCKET = '/tmp/test-ssh-agent.sock';
 const CONTAINER_SOCKET_ENV = 'SSH_AUTH_SOCK=/ssh-agent';
@@ -127,9 +129,11 @@ describe('setupSshAgentForwarding SSH agent identity preflight', () => {
     const stderrText = captureStderr();
     mockSshAdd({ status: 1, stdout: EMPTY_AGENT_STDOUT });
 
-    await runForwarding();
+    const { args } = await runForwarding();
 
     expect(stderrText()).toBe(EXPECTED_WARNING);
+    expect(args).toContain('--env');
+    expect(args).toContain('LLXPRT_SANDBOX_SSH_AGENT_EMPTY=1');
   });
 
   it('still configures forwarding when the agent reports no identities', async () => {
@@ -141,6 +145,8 @@ describe('setupSshAgentForwarding SSH agent identity preflight', () => {
 
     expect(result).toStrictEqual({});
     expect(args).toContain(CONTAINER_SOCKET_ENV);
+    expect(args).toContain('--env');
+    expect(args).toContain('LLXPRT_SANDBOX_SSH_AGENT_EMPTY=1');
   });
 
   it('stays silent when the agent has identities loaded', async () => {
@@ -152,6 +158,7 @@ describe('setupSshAgentForwarding SSH agent identity preflight', () => {
 
     expect(stderrText()).toBe('');
     expect(args).toContain(CONTAINER_SOCKET_ENV);
+    expect(args).not.toContain('LLXPRT_SANDBOX_SSH_AGENT_EMPTY=1');
   });
 
   it('stays silent when listing identities fails for a reason other than an empty agent', async () => {
@@ -164,6 +171,7 @@ describe('setupSshAgentForwarding SSH agent identity preflight', () => {
 
     expect(stderrText()).toBe('');
     expect(args).toContain(CONTAINER_SOCKET_ENV);
+    expect(args).not.toContain('LLXPRT_SANDBOX_SSH_AGENT_EMPTY=1');
   });
 
   it('stays silent when the agent cannot be contacted', async () => {
@@ -179,6 +187,7 @@ describe('setupSshAgentForwarding SSH agent identity preflight', () => {
 
     expect(stderrText()).toBe('');
     expect(args).toContain(CONTAINER_SOCKET_ENV);
+    expect(args).not.toContain('LLXPRT_SANDBOX_SSH_AGENT_EMPTY=1');
   });
 
   it('stays silent when ssh-add is not installed', async () => {
@@ -195,6 +204,7 @@ describe('setupSshAgentForwarding SSH agent identity preflight', () => {
 
     expect(stderrText()).toBe('');
     expect(args).toContain(CONTAINER_SOCKET_ENV);
+    expect(args).not.toContain('LLXPRT_SANDBOX_SSH_AGENT_EMPTY=1');
   });
 
   it('stays silent when the probe is killed after exceeding its timeout', async () => {
@@ -207,6 +217,7 @@ describe('setupSshAgentForwarding SSH agent identity preflight', () => {
 
     expect(stderrText()).toBe('');
     expect(args).toContain(CONTAINER_SOCKET_ENV);
+    expect(args).not.toContain('LLXPRT_SANDBOX_SSH_AGENT_EMPTY=1');
   });
 
   it('queries the agent that is being forwarded, under a bounded timeout', async () => {
@@ -233,10 +244,11 @@ describe('setupSshAgentForwarding SSH agent identity preflight', () => {
     vi.spyOn(fs, 'existsSync').mockReturnValue(true);
     const stderrText = captureStderr();
 
-    await runForwarding();
+    const { args } = await runForwarding();
 
     expect(child_process.spawn).not.toHaveBeenCalled();
     expect(stderrText()).toBe('');
+    expect(args).not.toContain('LLXPRT_SANDBOX_SSH_AGENT_EMPTY=1');
   });
 
   it('does not query the agent when SSH_AUTH_SOCK is unset', async () => {
@@ -245,10 +257,11 @@ describe('setupSshAgentForwarding SSH agent identity preflight', () => {
     silenceDebugWarnings();
     const stderrText = captureStderr();
 
-    await runForwarding();
+    const { args } = await runForwarding();
 
     expect(child_process.spawn).not.toHaveBeenCalled();
     expect(stderrText()).toBe('');
+    expect(args).not.toContain('LLXPRT_SANDBOX_SSH_AGENT_EMPTY=1');
   });
 
   it('does not query the agent when the socket path is missing', async () => {
@@ -258,10 +271,11 @@ describe('setupSshAgentForwarding SSH agent identity preflight', () => {
     silenceDebugWarnings();
     const stderrText = captureStderr();
 
-    await runForwarding();
+    const { args } = await runForwarding();
 
     expect(child_process.spawn).not.toHaveBeenCalled();
     expect(stderrText()).toBe('');
+    expect(args).not.toContain('LLXPRT_SANDBOX_SSH_AGENT_EMPTY=1');
   });
 
   it('does not claim forwarding is enabled when Podman declines to override the network mode', async () => {
@@ -278,5 +292,32 @@ describe('setupSshAgentForwarding SSH agent identity preflight', () => {
     expect(args).toStrictEqual(['--network', 'none']);
     expect(child_process.spawn).not.toHaveBeenCalled();
     expect(stderrText()).toBe('');
+  });
+});
+
+describe('getSandboxHandoffWarning', () => {
+  it('returns the empty-agent warning text when the handoff flag is "1"', () => {
+    expect(
+      getSandboxHandoffWarning({ LLXPRT_SANDBOX_SSH_AGENT_EMPTY: '1' }),
+    ).toBe(SSH_AGENT_EMPTY_WARNING);
+  });
+
+  it('returns undefined when the handoff flag is absent', () => {
+    expect(getSandboxHandoffWarning({})).toBeUndefined();
+  });
+
+  it('returns undefined when the handoff flag is empty', () => {
+    expect(
+      getSandboxHandoffWarning({ LLXPRT_SANDBOX_SSH_AGENT_EMPTY: '' }),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for any other handoff flag value', () => {
+    expect(
+      getSandboxHandoffWarning({ LLXPRT_SANDBOX_SSH_AGENT_EMPTY: '0' }),
+    ).toBeUndefined();
+    expect(
+      getSandboxHandoffWarning({ LLXPRT_SANDBOX_SSH_AGENT_EMPTY: 'true' }),
+    ).toBeUndefined();
   });
 });

--- a/packages/cli/src/utils/sandbox-ssh.ts
+++ b/packages/cli/src/utils/sandbox-ssh.ts
@@ -37,7 +37,7 @@ const SSH_TUNNEL_POLL_TIMEOUT_MS = 10000;
 const SSH_AGENT_PROBE_TIMEOUT_MS = 5000;
 const SSH_AGENT_ENV_PREFIX = 'SSH_AUTH_SOCK=';
 const SSH_AGENT_NO_IDENTITIES_PATTERN = /agent has no identities/i;
-const SSH_AGENT_EMPTY_WARNING =
+export const SSH_AGENT_EMPTY_WARNING =
   [
     'SSH agent socket is present, but no identities are loaded (ssh-add -l reported empty).',
     'SSH forwarding is enabled, but git SSH auth will fail until a key is loaded.',
@@ -119,7 +119,9 @@ function listSshAgentIdentities(sshAuthSock: string): Promise<SshAgentProbe> {
 /**
  * Warns when the agent being forwarded is reachable but holds no identities —
  * the cause of "Permission denied (publickey)" inside a sandbox whose
- * forwarding is otherwise wired up correctly.
+ * forwarding is otherwise wired up correctly. Resolves true only when the
+ * empty-agent warning was written, so the caller can hand the condition off
+ * to the container.
  *
  * `ssh-add -l` exits 1 for any identity-listing failure, including a
  * communication error with the agent, so the empty case is confirmed from the
@@ -128,18 +130,18 @@ function listSshAgentIdentities(sshAuthSock: string): Promise<SshAgentProbe> {
  */
 async function warnIfSshAgentHasNoIdentities(
   sshAuthSock: string,
-): Promise<void> {
+): Promise<boolean> {
   const probe = await listSshAgentIdentities(sshAuthSock);
 
   if (probe.spawnError) {
     debugLogger.warn(
       `Could not run ssh-add to check for loaded SSH agent identities: ${probe.spawnError.message}`,
     );
-    return;
+    return false;
   }
 
   if (probe.status === 0) {
-    return;
+    return false;
   }
 
   if (
@@ -147,12 +149,13 @@ async function warnIfSshAgentHasNoIdentities(
     SSH_AGENT_NO_IDENTITIES_PATTERN.test(probe.output)
   ) {
     process.stderr.write(SSH_AGENT_EMPTY_WARNING);
-    return;
+    return true;
   }
 
   debugLogger.warn(
     `Could not determine whether the SSH agent has identities loaded; ssh-add -l exited with status ${probe.status}.`,
   );
+  return false;
 }
 
 /**
@@ -216,7 +219,13 @@ export async function setupSshAgentForwarding(
   );
 
   if (containerWillReceiveSshAgent(args)) {
-    await warnIfSshAgentHasNoIdentities(sshAuthSock);
+    const warned = await warnIfSshAgentHasNoIdentities(sshAuthSock);
+    if (warned) {
+      // Carry the empty-agent condition across the host→container boundary so
+      // the in-container session can surface the warning it cannot see from
+      // the host. Boolean flag; no secret or key material crossed.
+      args.push('--env', 'LLXPRT_SANDBOX_SSH_AGENT_EMPTY=1');
+    }
   }
 
   return result;

--- a/packages/cli/src/utils/startupWarnings.ts
+++ b/packages/cli/src/utils/startupWarnings.ts
@@ -8,8 +8,24 @@ import fs from 'fs/promises';
 import os from 'os';
 import { join as pathJoin } from 'node:path';
 import { getErrorMessage } from '@vybestack/llxprt-code-core';
+import { SSH_AGENT_EMPTY_WARNING } from './sandbox-ssh.js';
 
 const warningsFilePath = pathJoin(os.tmpdir(), 'gemini-cli-warnings.txt');
+
+/**
+ * Returns the empty-SSH-agent warning when the sandbox supervisor handed the
+ * condition across the host→container boundary via
+ * `LLXPRT_SANDBOX_SSH_AGENT_EMPTY=1`, undefined otherwise. The flag is only
+ * ever set by the supervisor; a non-sandbox run never sees it.
+ */
+export function getSandboxHandoffWarning(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  if (env.LLXPRT_SANDBOX_SSH_AGENT_EMPTY === '1') {
+    return SSH_AGENT_EMPTY_WARNING;
+  }
+  return undefined;
+}
 
 export async function getStartupWarnings(): Promise<string[]> {
   try {

--- a/project-plans/issue3408-sandbox-ssh-agent-warning-delivery/PLAN.md
+++ b/project-plans/issue3408-sandbox-ssh-agent-warning-delivery/PLAN.md
@@ -1,0 +1,201 @@
+# Issue #3408 — Sandbox empty SSH-agent warning: flush the stdio backlog on the hop exit path and deliver the warning into the in-container session
+
+## Problem
+
+The #1699 empty-agent preflight fires correctly but its warning never reaches
+any user-visible stream. Two independent defects in the delivery path:
+
+1. **The sandbox supervisor drops all patched stdio output.** `main()` installs
+   `patchStdio()` (packages/cli/src/cli.tsx:139) before anything else, which
+   replaces `process.stderr.write` with a stub that buffers into
+   `coreEvents._outputBacklog`. Every ordinary exit path drains that backlog
+   (`initializeOutputListenersAndFlush()`, either during session startup or via
+   the sync cleanup that `runExitCleanup()` drains). The sandbox hop path in
+   `maybeHopIntoSandbox()` (packages/cli/src/cliSandbox.ts:208) ends with a bare
+   `process.exit(exitCode)` and never calls `runExitCleanup()`, so the backlog
+   dies with the process. The `initialAuthFailed` branch in the same function
+   does the cleanup correctly.
+2. **The warning is generated in the wrong process for interactive users.** The
+   host supervisor generates it before the container starts; the TUI the user
+   actually watches runs inside the container and never sees it. Even with the
+   flush fixed, the host-side write only appears after the container exits.
+
+## Scope
+
+In scope:
+
+- Call the exit cleanup on the sandbox hop exit path before `process.exit`, so
+  all supervisor-side buffered output (including this warning) reaches real
+  stderr.
+- Hand the empty-agent condition from the host supervisor to the container via
+  a non-secret `--env` flag pushed into the same args the forwarding helpers
+  already mutate, for both docker and podman.
+- Consume the flag in the in-container CLI: interactive sessions render the
+  warning through the existing startup-warnings UI (Notifications
+  startup-warnings box); non-interactive sessions write it to real stderr via
+  `writeToStderr` (which bypasses the stdio patch by design).
+
+Out of scope (tracked separately in #3408's companion follow-ups):
+
+- The host-absolute `credential.https://github.com.helper` passthrough.
+- Tunnel supervision and orphaned-container lifecycle.
+- Any change to forwarding itself, to the `sshAgent: auto` semantics, or to
+  the probe. The warning text and firing conditions from #1699 are unchanged.
+- The Zed/ACP integration path, which bypasses session dispatch.
+
+## Design
+
+### Fix A: flush before exit on the hop path
+
+In `maybeHopIntoSandbox()` (packages/cli/src/cliSandbox.ts), replace:
+
+```ts
+process.exit(exitCode);
+```
+
+with:
+
+```ts
+await runExitCleanup();
+process.exit(exitCode);
+```
+
+This mirrors the `initialAuthFailed` branch twelve lines above. `runExitCleanup()`
+drains sync cleanups, which runs the registered stdio flush
+(`initializeOutputListenersAndFlush()` + `cleanupStdio()` from cli.tsx:140-144),
+so buffered supervisor output reaches the real file descriptors. This is a
+generic correctness fix for every supervisor-side `process.std*.write`, not
+scoped to the SSH warning.
+
+### Fix B: host-to-container warning handoff
+
+**Host side** (`packages/cli/src/utils/sandbox-ssh.ts`):
+
+- Export `SSH_AGENT_EMPTY_WARNING` (currently module-private) so the
+  in-container consumer renders the identical text without duplication.
+- Change `warnIfSshAgentHasNoIdentities()` to return `Promise<boolean>`: true
+  when the empty-agent warning fired, false for every silent outcome. The
+  write to `process.stderr.write` stays (Fix A makes it visible).
+- In `setupSshAgentForwarding()`, inside the existing
+  `containerWillReceiveSshAgent(args)` guard:
+
+```ts
+const warned = await warnIfSshAgentHasNoIdentities(sshAuthSock);
+if (warned) {
+  args.push('--env', 'LLXPRT_SANDBOX_SSH_AGENT_EMPTY=1');
+}
+```
+
+Engine-agnostic: docker and podman both consume repeated `--env KEY=VAL` args,
+and both forwarding helpers already push `--env SSH_AUTH_SOCK=...` through this
+same array, so no per-engine work is needed. The flag is a boolean; no secret
+or key material crosses the boundary.
+
+**Container side** (`packages/cli/src/utils/startupWarnings.ts` or a sibling
+module, imported by `packages/cli/src/session/nonInteractiveSession.ts`):
+
+- `getSandboxHandoffWarning(env): string | undefined` returns
+  `SSH_AGENT_EMPTY_WARNING` when `env.LLXPRT_SANDBOX_SSH_AGENT_EMPTY === '1'`,
+  undefined otherwise. Import the constant from `sandbox-ssh.js` (same package,
+  no drift).
+- In `dispatchInteractiveOrNonInteractive()`:
+  - Interactive branch: prepend the handoff warning to `startupWarnings` before
+    `startInteractiveUI`, so it renders in the Notifications startup-warnings
+    box from the first frame and persists for the session (the box has no
+    dismiss control; the warnings array lives in App state for the session).
+  - Non-interactive branch: before `runPipedOrPromptSession`, write the warning
+    with `writeToStderr` (real fd 2, unaffected by `patchStdio`; stdout JSON
+    stays clean).
+
+The #1699 plan rejected the startup-warnings *file* because host and container
+`os.tmpdir()` differ. This design does not use the file: the flag travels via
+container env, and the in-container code injects the text directly into the
+warnings array.
+
+### Expected duplicate in non-interactive mode
+
+A sandboxed non-interactive run now shows the warning twice: once immediately
+from the in-container `writeToStderr`, once from the host flush at supervisor
+exit. Both land on the same terminal. This is accepted: Fix A is a generic
+flush that cannot suppress individual items, and immediate visibility beats a
+single delayed copy. Interactive users see the in-TUI box, plus the host-side
+copy after the TUI exits, for the same reason.
+
+## Acceptance criteria
+
+- **AC1** On the hop exit path, patched stdio output written before the
+  container spawns is flushed to the real stderr before the process exits
+  (supervisor no longer drops its own output).
+- **AC2** When the empty-agent warning fires, the container args gain
+  `--env LLXPRT_SANDBOX_SSH_AGENT_EMPTY=1`; when the probe finds identities, is
+  inconclusive, or forwarding is off/declined, no such arg is added.
+- **AC3** The handoff arg is added only inside the existing
+  `containerWillReceiveSshAgent` guard (a declined helper still produces no
+  flag, matching #1699 AC6).
+- **AC4** In-container interactive session: with the env flag set, the
+  three-line warning is part of `startupWarnings` passed to
+  `startInteractiveUI` and rendered by the Notifications startup-warnings box;
+  without the flag, startup warnings are unchanged.
+- **AC5** In-container non-interactive session: with the env flag set, the
+  warning is written to real stderr before the prompt runs; without the flag,
+  nothing is written.
+- **AC6** `sshAgent: auto` remains strictly non-blocking: forwarding args, the
+  `SshAgentResult`, and container startup are identical in every outcome; only
+  the extra `--env` pair on the warned branch differs.
+- **AC7** Both engines get the flag through the shared `setupSshAgentForwarding`
+  args mutation (no engine-specific code).
+
+## Boundary cases
+
+- Probe inconclusive (timeout, ENOENT, exit 2, non-empty failure output): no
+  flag, no warning (unchanged #1699 AC5).
+- `sshAgent: off`, missing `SSH_AUTH_SOCK`, missing socket, podman-macOS
+  non-host network decline: no flag, no probe (unchanged #1699 AC6).
+- Env flag already present in the environment for non-sandbox reasons: only the
+  in-container display branch reads it; it is only ever set by the supervisor
+  via `--env`.
+- Double-hop or nested sandbox: the flag is boolean and idempotent in effect
+  (the warning simply renders); no accumulation concern beyond one box entry.
+- Zed/ACP path does not consume the handoff (out of scope; no behavior change
+  there).
+
+## Test plan (behavioral, no mock theater)
+
+1. **Hop exit flush (AC1)** — in a new or extended `cliSandbox` test: call
+   `patchStdio()`, write a marker via `process.stderr.write` (buffered), then
+   run the hop exit sequence with `process.exit` replaced by a sentinel
+   (throwing stub). Assert the marker reached real stderr (captured fd) and the
+   sentinel fired, in that order. Use the real `registerSyncCleanup` /
+   `runExitCleanup` machinery, not a mocked drain.
+2. **Flag on warn (AC2/AC3/AC6)** — extend
+   `sandbox-ssh-agent-preflight.test.ts`: empty-agent case now also asserts the
+  `--env LLXPRT_SANDBOX_SSH_AGENT_EMPTY=1` pair in args (both orderings of the
+   pair tolerated) and unchanged `SshAgentResult`; loaded-agent,
+   inconclusive-probe, off/declined cases assert no such arg. These tests drive
+   the public `setupSshAgentForwarding` with realistic probe outcomes as today.
+3. **Handoff reader (AC4/AC5 seam)** — unit test of
+   `getSandboxHandoffWarning`: flag `'1'` returns exactly
+   `SSH_AGENT_EMPTY_WARNING`; unset, `''`, or other values return undefined.
+4. **Interactive delivery (AC4)** — session-dispatch level test (extend the
+   characterization suite or a focused test): env flag set → `startupWarnings`
+   passed to `startInteractiveUI` starts with the warning; flag unset →
+   unchanged warnings. If the existing harness renders the real App, assert the
+   Notifications startup-warnings box content on first render.
+5. **Non-interactive delivery (AC5)** — same dispatch level: env flag set → the
+   exact warning text is written to stderr (via a captured `writeToStderr`
+   target) before the session runs; flag unset → no write.
+
+## Documentation
+
+docs/sandbox.md troubleshooting ("SSH agent forwarded but git auth still
+fails") gains one sentence: the warning now appears in the TUI startup-warnings
+box (and on stderr for non-interactive runs) instead of only on host stderr.
+
+## Verification
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+`npm run build`, and the CLI smoke test
+(`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`).
+Manual podman check on this machine: with the empty launchd agent, a sandboxed
+non-interactive run's stderr contains the warning, and an interactive sandboxed
+run shows the startup-warnings box entry.


### PR DESCRIPTION
## TLDR

The empty-SSH-agent warning added in #1699 fired correctly and then vanished. Nobody ever saw it, in any mode. Two separate defects were swallowing it, and this fixes both.

First, the sandbox supervisor was throwing away its own output. `main()` calls `patchStdio()` before the sandbox hop, which replaces `process.stderr.write` with a stub that buffers into an event-bus backlog. Ordinary exits drain that backlog through a registered sync cleanup. The hop path ended in a bare `process.exit(exitCode)` that never called `runExitCleanup()`, so everything the supervisor had written died with the process. The `initialAuthFailed` branch a dozen lines above already awaits the cleanup, so this makes the two exits agree.

Second, the warning was being produced in the wrong process for interactive users. The host generates it before the container starts, while the TUI the user is actually looking at runs inside the container. Fixing the flush alone would only surface it after the container exits. When the preflight fires, the supervisor now passes `LLXPRT_SANDBOX_SSH_AGENT_EMPTY=1` into the container, and the in-container session turns the flag back into the same warning text.

Reviewers may want to look closely at two things: the flush fix affects every supervisor-side write on the hop path, not just this warning; and the handoff is deliberately a boolean flag rather than a message, so no key material or credentials cross the host to container boundary.

## Dive Deeper

The failure was reproducible and the diagnosis is pinned to specific lines. `patchStdio()` (packages/core/src/utils/stdio.ts:147) installs a stderr stub that calls `coreEvents.emitOutput` and returns true without touching a file descriptor. `emitOutput` (packages/core/src/utils/events.ts:346) buffers into a backlog when nothing is listening. The listener registration and drain live in `initializeOutputListenersAndFlush()`, which the hop path never reached because of the bare exit at packages/cli/src/cliSandbox.ts. A PATH shim confirmed the probe really did run on the host with the right socket, and a direct call into `setupSshAgentForwarding` printed all three warning lines, which narrowed it to delivery rather than detection.

For the in-container half, #1699 had considered and rejected the startup-warnings file because the host and container `os.tmpdir()` differ. This does not use the file. The flag rides in on the same args array the forwarding helpers already mutate for `SSH_AUTH_SOCK`, so docker and podman are covered by one code path, and the in-container session injects the text directly into the warnings array that the Notifications startup-warnings box renders. Non-interactive text runs get it on real stderr through `writeToStderr`, which bypasses the stdio patch by design.

Machine-readable output formats are excluded from the in-container write. An engine that allocates a TTY merges container stderr onto stdout, which put the warning next to the JSON payload during testing. This follows the `stderr: !jsonOutput` convention already used in `runNonInteractive`. The host-side copy still reports in those runs.

Two behaviors are unchanged on purpose. `sshAgent: auto` stays strictly non-blocking, because an empty agent is a legitimate state, and no private key is ever mounted into the sandbox.

One consequence worth naming: a sandboxed text-mode run now prints the warning twice, once immediately from inside the container and once from the host flush when the supervisor exits. The flush is generic and cannot suppress individual items, and immediate visibility seemed worth more than a single delayed copy.

Two adjacent problems were found while investigating and are deliberately left out of scope: the `credential.https://github.com.helper` passthrough carries a host-absolute path to a binary that does not exist in the Linux image, and reverse tunnels are unsupervised so containers can outlive their parent. Both need their own reproduction and issues.

## Reviewer Test Plan

The bug needs a host SSH agent that is running but holds no identities, which is the default state on a fresh macOS login where git authenticates from a key file rather than the agent. Confirm with `ssh-add -l`, which should report that the agent has no identities. If your agent does have keys, `ssh-add -D` clears them for the test.

On main, this prints nothing about the agent:

```
llxprt --sandbox --sandbox-engine podman -y "say ok" 2>err.log
```

On this branch the same command puts the three-line warning in `err.log`, and an interactive `llxprt --sandbox` shows it in the startup-warnings box inside the container TUI. Verifying the in-container half requires an image built from this branch (`LLXPRT_SANDBOX=podman npm run build:sandbox`), since the container runs its own copy of the CLI.

Worth checking that the quiet paths stay quiet: with keys loaded (`ssh-add ~/.ssh/id_ed25519`) there should be no warning and no `LLXPRT_SANDBOX_SSH_AGENT_EMPTY` in the container args, and the same with `sshAgent: off`. With `--output-format json` the payload should parse cleanly while the host stderr copy still appears.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ✅  | -   | -   |
| Seatbelt | -   | -   | -   |

Verified on macOS with podman, in text and JSON output modes, against a sandbox image built from this branch. The docker path shares the same arg-building code as podman but was not exercised on hardware. Seatbelt does not forward an SSH agent, so it is not affected.

## Linked issues / bugs

Fixes #3408


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandbox SSH-agent warnings now appear in the interactive startup warning panel.
  * Non-interactive text sessions display the warning on stderr.
  * Machine-readable output remains free of human-readable warnings.

* **Bug Fixes**
  * Ensured pending stderr output is flushed before the CLI exits during sandbox transitions.

* **Documentation**
  * Documented the updated locations of sandbox SSH-agent startup warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->