### PR TITLE
fix(memory): report retained heap and stop laying out invisible output (Fixes #3425)

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolResultDisplay.retention.behavior.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolResultDisplay.retention.behavior.test.tsx
@@ -18,7 +18,7 @@
  */
 
 import { describe, it, expect } from 'bun:test';
-import { ToolResultDisplay } from './ToolResultDisplay.js';
+import { ToolResultDisplay, trimToVisibleTail } from './ToolResultDisplay.js';
 import { renderWithProviders } from '../../../test-utils/render.js';
 
 interface JscGcApi {
@@ -118,6 +118,15 @@ describe('ToolResultDisplay — large results cost only what they display', () =
     expect(large.peakRssBytes - settled).toBeLessThan(10 * 1024 * 1024);
     expect(large.frame).toContain('hidden');
     expect(large.frame).toContain('abcdefghij');
+  });
+
+  it('counts hidden rows by line, not by character count', () => {
+    // Nine one-character lines followed by a long one. The character budget
+    // drops only 19 characters, but those characters are ten display rows.
+    const text = `${'x\n'.repeat(9)}${'y'.repeat(1001)}`;
+    const { hiddenDisplayLines } = trimToVisibleTail(text, 10, 100);
+
+    expect(hiddenDisplayLines).toBe(10);
   });
 
   it('leaves results that fit entirely visible', () => {

--- a/packages/cli/src/ui/components/messages/ToolResultDisplay.retention.behavior.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolResultDisplay.retention.behavior.test.tsx
@@ -108,6 +108,18 @@ describe('ToolResultDisplay — large results cost only what they display', () =
     expect(frame).toContain('hidden');
   });
 
+  it('bounds a single unbroken line, which has no newlines to trim on', () => {
+    // Minified output and logs without newlines arrive as one source line, so
+    // a line-count check alone would hand the whole body to layout.
+    const oneLongLine = 'abcdefghij'.repeat(100_000);
+    const settled = settleRssBytes();
+    const large = renderResult(oneLongLine);
+
+    expect(large.peakRssBytes - settled).toBeLessThan(10 * 1024 * 1024);
+    expect(large.frame).toContain('hidden');
+    expect(large.frame).toContain('abcdefghij');
+  });
+
   it('leaves results that fit entirely visible', () => {
     const { frame } = renderResult('alpha\nbravo\ncharlie');
 

--- a/packages/cli/src/ui/components/messages/ToolResultDisplay.retention.behavior.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolResultDisplay.retention.behavior.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Tool results are truncated at 1,000,000 characters and then handed whole to
+ * MaxSizedBox, which lays out every line before clipping to the visible window.
+ * A result showing twenty lines paid to wrap thousands.
+ *
+ * That cost is permanent. Measured on Bun 1.3.14 (darwin-arm64), releasing
+ * transient allocations returns `heapSize` to baseline while process RSS stays
+ * at its peak, so one oversized layout raises the floor for the whole session.
+ *
+ * A source line always produces at least one display line, so source lines
+ * beyond the window can never be visible and do not need to be laid out.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { ToolResultDisplay } from './ToolResultDisplay.js';
+import { renderWithProviders } from '../../../test-utils/render.js';
+
+interface JscGcApi {
+  gcAndSweep: () => void;
+}
+
+function isJscGcApi(value: unknown): value is JscGcApi {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  return 'gcAndSweep' in value && typeof value.gcAndSweep === 'function';
+}
+
+/** Full collection, so a measurement reflects retained rather than pending memory. */
+function gcAndSweep(): void {
+  const jsc = process.getBuiltinModule('bun:jsc');
+  if (!isJscGcApi(jsc)) {
+    throw new Error('bun:jsc gcAndSweep is unavailable');
+  }
+  jsc.gcAndSweep();
+}
+
+const TERMINAL_WIDTH = 120;
+const AVAILABLE_HEIGHT = 40;
+const SOURCE_LINE = 'abcdefghij'.repeat(20);
+
+function makeResult(characters: number): string {
+  const lineCount = Math.ceil(characters / SOURCE_LINE.length);
+  return Array.from(
+    { length: lineCount },
+    (_, index) => `line${index} ${SOURCE_LINE}`,
+  ).join('\n');
+}
+
+function renderResult(resultDisplay: string): {
+  frame: string;
+  peakRssBytes: number;
+} {
+  const { lastFrame, unmount } = renderWithProviders(
+    <ToolResultDisplay
+      resultDisplay={resultDisplay}
+      terminalWidth={TERMINAL_WIDTH}
+      availableTerminalHeight={AVAILABLE_HEIGHT}
+      renderOutputAsMarkdown={false}
+    />,
+  );
+  const frame = lastFrame() ?? '';
+  const peakRssBytes = process.memoryUsage.rss();
+  unmount();
+  return { frame, peakRssBytes };
+}
+
+function settleRssBytes(): number {
+  gcAndSweep();
+  gcAndSweep();
+  return process.memoryUsage.rss();
+}
+
+describe('ToolResultDisplay — large results cost only what they display', () => {
+  // Runs first: resident memory never falls back once claimed, so an earlier
+  // oversized render in this process would mask the marginal cost.
+  it('does not lay out result lines that cannot be displayed', () => {
+    // Warm up React, Ink, and the layout paths on a smaller result so the
+    // comparison measures marginal layout cost rather than one-time warmup.
+    renderResult(makeResult(100_000));
+    const settled = settleRssBytes();
+
+    // Ten times the content, same visible window.
+    const large = renderResult(makeResult(1_000_000));
+    const marginalBytes = large.peakRssBytes - settled;
+
+    // Before the input was bounded this marginal cost measured 23.6, 24.2 and
+    // 24.5 MiB across three runs on Bun 1.3.14 (darwin-arm64), for a window of
+    // roughly thirty-five lines that does not change with content size.
+    expect(marginalBytes).toBeLessThan(10 * 1024 * 1024);
+  });
+
+  it('still shows the end of the output and reports hidden lines', () => {
+    // 200,000 characters at 200 per line yields source lines line0..line999.
+    const { frame } = renderResult(makeResult(200_000));
+
+    // The tail is what remains visible, not an arbitrary prefix.
+    expect(frame).toContain('line999');
+    expect(frame).not.toContain('line0 ');
+
+    // The reader is told content was omitted.
+    expect(frame).toContain('hidden');
+  });
+
+  it('leaves results that fit entirely visible', () => {
+    const { frame } = renderResult('alpha\nbravo\ncharlie');
+
+    expect(frame).toContain('alpha');
+    expect(frame).toContain('bravo');
+    expect(frame).toContain('charlie');
+    expect(frame).not.toContain('hidden');
+  });
+});

--- a/packages/cli/src/ui/components/messages/ToolResultDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/ToolResultDisplay.tsx
@@ -186,22 +186,31 @@ export function trimToVisibleTail(
   maxDisplayLines: number,
   width: number,
 ): { text: string; hiddenDisplayLines: number } {
-  const lines = text.split('\n');
-  if (lines.length <= maxDisplayLines) {
-    return { text, hiddenDisplayLines: 0 };
-  }
-
   const usableWidth = Math.max(1, width);
-  const removed = lines.slice(0, lines.length - maxDisplayLines);
   let hiddenDisplayLines = 0;
-  for (const line of removed) {
-    hiddenDisplayLines += Math.max(1, Math.ceil(line.length / usableWidth));
+  let kept = text;
+
+  const lines = text.split('\n');
+  if (lines.length > maxDisplayLines) {
+    for (const line of lines.slice(0, lines.length - maxDisplayLines)) {
+      hiddenDisplayLines += Math.max(1, Math.ceil(line.length / usableWidth));
+    }
+    kept = lines.slice(lines.length - maxDisplayLines).join('\n');
   }
 
-  return {
-    text: lines.slice(lines.length - maxDisplayLines).join('\n'),
-    hiddenDisplayLines,
-  };
+  // Line count alone does not bound the work: a single unbroken line, such as
+  // minified output or a log without newlines, wraps into as many display rows
+  // as it has width-sized chunks. Keeping the last `maxDisplayLines` rows worth
+  // of characters always leaves at least that many rows, because a row never
+  // holds more than `usableWidth` of them.
+  const characterBudget = maxDisplayLines * usableWidth;
+  if (kept.length > characterBudget) {
+    const dropped = kept.length - characterBudget;
+    hiddenDisplayLines += Math.ceil(dropped / usableWidth);
+    kept = kept.slice(dropped);
+  }
+
+  return { text: kept, hiddenDisplayLines };
 }
 
 /**

--- a/packages/cli/src/ui/components/messages/ToolResultDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/ToolResultDisplay.tsx
@@ -206,7 +206,18 @@ export function trimToVisibleTail(
   const characterBudget = maxDisplayLines * usableWidth;
   if (kept.length > characterBudget) {
     const dropped = kept.length - characterBudget;
-    hiddenDisplayLines += Math.ceil(dropped / usableWidth);
+    // Count the dropped prefix line by line rather than dividing its length by
+    // the width. Short lines each occupy a row regardless of length, so
+    // ignoring newline boundaries here would undercount what was hidden.
+    const droppedLines = kept.slice(0, dropped).split('\n');
+    if (droppedLines[droppedLines.length - 1] === '') {
+      // The prefix ended exactly on a newline, so the trailing empty piece is
+      // the start of a line that is being kept.
+      droppedLines.pop();
+    }
+    for (const line of droppedLines) {
+      hiddenDisplayLines += Math.max(1, Math.ceil(line.length / usableWidth));
+    }
     kept = kept.slice(dropped);
   }
 

--- a/packages/cli/src/ui/components/messages/ToolResultDisplay.tsx
+++ b/packages/cli/src/ui/components/messages/ToolResultDisplay.tsx
@@ -169,6 +169,42 @@ function renderObjectContent(
 }
 
 /**
+ * Drops source lines that cannot reach the visible window.
+ *
+ * `MaxSizedBox` shows the tail of its content and lays out every line it is
+ * given before clipping. A source line always occupies at least one display
+ * line, so keeping the last `maxDisplayLines` source lines is enough to fill
+ * the window, and everything earlier can be dropped before layout rather than
+ * wrapped and discarded afterwards.
+ *
+ * The returned count is the estimated number of display lines removed, so the
+ * caller can report them through `additionalHiddenLinesCount`. It is an
+ * estimate because exact wrapping depends on word boundaries.
+ */
+export function trimToVisibleTail(
+  text: string,
+  maxDisplayLines: number,
+  width: number,
+): { text: string; hiddenDisplayLines: number } {
+  const lines = text.split('\n');
+  if (lines.length <= maxDisplayLines) {
+    return { text, hiddenDisplayLines: 0 };
+  }
+
+  const usableWidth = Math.max(1, width);
+  const removed = lines.slice(0, lines.length - maxDisplayLines);
+  let hiddenDisplayLines = 0;
+  for (const line of removed) {
+    hiddenDisplayLines += Math.max(1, Math.ceil(line.length / usableWidth));
+  }
+
+  return {
+    text: lines.slice(lines.length - maxDisplayLines).join('\n'),
+    hiddenDisplayLines,
+  };
+}
+
+/**
  * Render string content.
  */
 function renderStringContent(
@@ -191,11 +227,20 @@ function renderStringContent(
     );
   }
 
+  const { text, hiddenDisplayLines } =
+    availableHeight === undefined
+      ? { text: displayContent, hiddenDisplayLines: 0 }
+      : trimToVisibleTail(displayContent, availableHeight, childWidth);
+
   return (
-    <MaxSizedBox maxHeight={availableHeight} maxWidth={childWidth}>
+    <MaxSizedBox
+      maxHeight={availableHeight}
+      maxWidth={childWidth}
+      additionalHiddenLinesCount={hiddenDisplayLines}
+    >
       <Box>
         <Text color={Colors.Foreground} wrap="wrap">
-          {displayContent}
+          {text}
         </Text>
       </Box>
     </MaxSizedBox>

--- a/packages/cli/src/ui/hooks/memoryTrend/useMemoryMonitor.behavior.test.ts
+++ b/packages/cli/src/ui/hooks/memoryTrend/useMemoryMonitor.behavior.test.ts
@@ -123,6 +123,20 @@ function makeControllablePorts(
   };
 }
 
+function makeCapturingAddItem(): {
+  addItem: (item: HistoryItemWithoutId, ts: number) => void;
+  texts: () => readonly string[];
+} {
+  const texts: string[] = [];
+  return {
+    addItem: (item: HistoryItemWithoutId) => {
+      const text = (item as { text?: unknown }).text;
+      texts.push(typeof text === 'string' ? text : '');
+    },
+    texts: () => texts,
+  };
+}
+
 function makeAddItem(): {
   addItem: (item: HistoryItemWithoutId, ts: number) => void;
   calls: () => number;
@@ -390,5 +404,211 @@ describe('useMemoryMonitor — disabled path uses rss() not full memoryUsage (P1
         ).memoryUsage = origMu;
       }
     });
+  });
+});
+
+/**
+ * Resident memory is a high-water mark: measured on Bun 1.3.14 (darwin-arm64),
+ * releasing 200 MB of strings returns `heapSize` to baseline while RSS stays at
+ * its peak. A warning that reports only RSS therefore describes a past peak as
+ * though it were current usage. The warning must report retained JS heap too,
+ * so the reader can tell accumulation apart from a one-time spike.
+ */
+describe('useMemoryMonitor — high-memory warning distinguishes peak from retained', () => {
+  const EIGHT_POINT_FOUR_GB = 9_018_355_814;
+  const RETAINED_HEAP = 1_288_490_188;
+
+  it('reports both resident memory and retained JS heap in the warning', () => {
+    const ports = makeControllablePorts(() => ({
+      rss: EIGHT_POINT_FOUR_GB,
+      heapUsed: RETAINED_HEAP,
+      heapTotal: RETAINED_HEAP,
+      external: 0,
+      arrayBuffers: 0,
+    }));
+    __setMemoryMonitorPortsForTesting(ports);
+    const { addItem, texts } = makeCapturingAddItem();
+
+    const { unmount } = renderHook(() => useMemoryMonitor({ addItem }));
+    ports.fireTick();
+
+    expect(texts()).toHaveLength(1);
+    const warning = texts()[0] ?? '';
+    // 9_018_355_814 / 1024^3 = 8.40 GB resident.
+    expect(warning).toContain('8.40 GB');
+    // 1_288_490_188 / 1024^3 = 1.20 GB retained.
+    expect(warning).toContain('1.20 GB');
+    expect(warning).toContain('/bug');
+
+    unmount();
+  });
+
+  it('describes resident memory as a peak that may not shrink', () => {
+    const ports = makeControllablePorts(() => ({
+      rss: EIGHT_POINT_FOUR_GB,
+      heapUsed: RETAINED_HEAP,
+      heapTotal: RETAINED_HEAP,
+      external: 0,
+      arrayBuffers: 0,
+    }));
+    __setMemoryMonitorPortsForTesting(ports);
+    const { addItem, texts } = makeCapturingAddItem();
+
+    const { unmount } = renderHook(() => useMemoryMonitor({ addItem }));
+    ports.fireTick();
+
+    const warning = texts()[0] ?? '';
+    expect(warning.toLowerCase()).toContain('peak');
+    expect(warning.toLowerCase()).toContain('retained');
+
+    unmount();
+  });
+
+  it('keeps the per-tick check cheap and samples the full usage only when warning', () => {
+    let fullCalls = 0;
+    let rssCalls = 0;
+    let rss = 1_000_000;
+    const handler: { current: (() => void) | null } = { current: null };
+    const ports: MemoryMonitorPorts = {
+      setInterval: (h: () => void, _ms: number) => {
+        handler.current = h;
+        return 1;
+      },
+      clearInterval: () => {
+        handler.current = null;
+      },
+      memoryUsage: () => {
+        fullCalls += 1;
+        return {
+          rss,
+          heapUsed: RETAINED_HEAP,
+          heapTotal: RETAINED_HEAP,
+          external: 0,
+          arrayBuffers: 0,
+        };
+      },
+      rssBytes: () => {
+        rssCalls += 1;
+        return rss;
+      },
+    };
+    __setMemoryMonitorPortsForTesting(ports);
+    const { addItem, texts } = makeCapturingAddItem();
+
+    const { unmount } = renderHook(() => useMemoryMonitor({ addItem }));
+
+    // Below threshold: cheap accessor only, no full sample allocated.
+    handler.current?.();
+    handler.current?.();
+    expect(rssCalls).toBe(2);
+    expect(fullCalls).toBe(0);
+    expect(texts()).toHaveLength(0);
+
+    // Crossing the threshold reads the full usage once, to report heap.
+    rss = EIGHT_POINT_FOUR_GB;
+    handler.current?.();
+    expect(texts()).toHaveLength(1);
+    expect(rssCalls).toBe(3);
+    expect(fullCalls).toBe(1);
+
+    unmount();
+  });
+
+  it('stays on the cheap path for every tick after the warning', () => {
+    let fullCalls = 0;
+    let rssCalls = 0;
+    const handler: { current: (() => void) | null } = { current: null };
+    const ports: MemoryMonitorPorts = {
+      setInterval: (h: () => void, _ms: number) => {
+        handler.current = h;
+        return 1;
+      },
+      clearInterval: () => {
+        handler.current = null;
+      },
+      memoryUsage: () => {
+        fullCalls += 1;
+        return {
+          rss: EIGHT_POINT_FOUR_GB,
+          heapUsed: RETAINED_HEAP,
+          heapTotal: RETAINED_HEAP,
+          external: 0,
+          arrayBuffers: 0,
+        };
+      },
+      rssBytes: () => {
+        rssCalls += 1;
+        return EIGHT_POINT_FOUR_GB;
+      },
+    };
+    __setMemoryMonitorPortsForTesting(ports);
+    const { addItem, texts } = makeCapturingAddItem();
+
+    const { unmount } = renderHook(() => useMemoryMonitor({ addItem }));
+
+    // Five ticks all above the threshold.
+    handler.current?.();
+    handler.current?.();
+    handler.current?.();
+    handler.current?.();
+    handler.current?.();
+
+    // The warning fires once, and only that tick reads the full usage, but the
+    // interval keeps sampling cheaply.
+    expect(texts()).toHaveLength(1);
+    expect(fullCalls).toBe(1);
+    expect(rssCalls).toBe(5);
+
+    unmount();
+  });
+
+  it('reuses the controller sample instead of taking a second reading', () => {
+    let fullCalls = 0;
+    const sample: NodeJS.MemoryUsage = {
+      rss: EIGHT_POINT_FOUR_GB,
+      heapUsed: RETAINED_HEAP,
+      heapTotal: RETAINED_HEAP,
+      external: 0,
+      arrayBuffers: 0,
+    };
+    const handler: { current: (() => void) | null } = { current: null };
+    const ports: MemoryMonitorPorts = {
+      setInterval: (h: () => void, _ms: number) => {
+        handler.current = h;
+        return 1;
+      },
+      clearInterval: () => {
+        handler.current = null;
+      },
+      memoryUsage: () => {
+        fullCalls += 1;
+        return sample;
+      },
+      rssBytes: () => sample.rss,
+    };
+    __setMemoryMonitorPortsForTesting(ports);
+    const { addItem, texts } = makeCapturingAddItem();
+
+    const sink = new PerfSink({ dir, runUuid: crypto.randomUUID() });
+    const controller = new MemoryTelemetryController({
+      sink,
+      monotonicNow: () => 0,
+      memoryNow: () => sample,
+    });
+    activeSinks.push(sink);
+    activeControllers.push(controller);
+
+    const { unmount } = renderHook(() =>
+      useMemoryMonitor({ addItem, memoryController: controller }),
+    );
+
+    handler.current?.();
+
+    expect(texts()).toHaveLength(1);
+    expect(texts()[0] ?? '').toContain('1.20 GB');
+    // One reading per tick: the warning must not trigger an extra sample.
+    expect(fullCalls).toBe(1);
+
+    unmount();
   });
 });

--- a/packages/cli/src/ui/hooks/memoryTrend/useMemoryMonitor.behavior.test.ts
+++ b/packages/cli/src/ui/hooks/memoryTrend/useMemoryMonitor.behavior.test.ts
@@ -114,6 +114,7 @@ function makeControllablePorts(
     },
     memoryUsage,
     rssBytes: () => memoryUsage().rss,
+    retainedHeapBytes: () => memoryUsage().heapUsed,
     fireTick: () => {
       if (handler !== null) handler();
     },
@@ -288,6 +289,7 @@ describe('useMemoryMonitor — disabled path uses rss() not full memoryUsage (P1
         rssCalls++;
         return 1000;
       },
+      retainedHeapBytes: () => 0,
     };
     __setMemoryMonitorPortsForTesting(ports);
     const { addItem } = makeAddItem();
@@ -322,6 +324,7 @@ describe('useMemoryMonitor — disabled path uses rss() not full memoryUsage (P1
         rssCalls++;
         return 10_000_000;
       },
+      retainedHeapBytes: () => 0,
     };
     __setMemoryMonitorPortsForTesting(ports);
     const { addItem } = makeAddItem();
@@ -464,9 +467,10 @@ describe('useMemoryMonitor — high-memory warning distinguishes peak from retai
     unmount();
   });
 
-  it('keeps the per-tick check cheap and samples the full usage only when warning', () => {
+  it('keeps every tick on the cheap accessors and never takes a full reading', () => {
     let fullCalls = 0;
     let rssCalls = 0;
+    let heapCalls = 0;
     let rss = 1_000_000;
     const handler: { current: (() => void) | null } = { current: null };
     const ports: MemoryMonitorPorts = {
@@ -491,25 +495,31 @@ describe('useMemoryMonitor — high-memory warning distinguishes peak from retai
         rssCalls += 1;
         return rss;
       },
+      retainedHeapBytes: () => {
+        heapCalls += 1;
+        return RETAINED_HEAP;
+      },
     };
     __setMemoryMonitorPortsForTesting(ports);
     const { addItem, texts } = makeCapturingAddItem();
 
     const { unmount } = renderHook(() => useMemoryMonitor({ addItem }));
 
-    // Below threshold: cheap accessor only, no full sample allocated.
+    // Below threshold: cheap RSS accessor only, no heap read, no full sample.
     handler.current?.();
     handler.current?.();
     expect(rssCalls).toBe(2);
-    expect(fullCalls).toBe(0);
+    expect(heapCalls).toBe(0);
     expect(texts()).toHaveLength(0);
 
-    // Crossing the threshold reads the full usage once, to report heap.
+    // Crossing the threshold reads the retained heap, still not a full sample.
     rss = EIGHT_POINT_FOUR_GB;
     handler.current?.();
     expect(texts()).toHaveLength(1);
     expect(rssCalls).toBe(3);
-    expect(fullCalls).toBe(1);
+    expect(heapCalls).toBe(1);
+    // A full MemoryUsage object is never allocated on the disabled path.
+    expect(fullCalls).toBe(0);
 
     unmount();
   });
@@ -517,6 +527,7 @@ describe('useMemoryMonitor — high-memory warning distinguishes peak from retai
   it('stays on the cheap path for every tick after the warning', () => {
     let fullCalls = 0;
     let rssCalls = 0;
+    let heapCalls = 0;
     const handler: { current: (() => void) | null } = { current: null };
     const ports: MemoryMonitorPorts = {
       setInterval: (h: () => void, _ms: number) => {
@@ -540,6 +551,10 @@ describe('useMemoryMonitor — high-memory warning distinguishes peak from retai
         rssCalls += 1;
         return EIGHT_POINT_FOUR_GB;
       },
+      retainedHeapBytes: () => {
+        heapCalls += 1;
+        return RETAINED_HEAP;
+      },
     };
     __setMemoryMonitorPortsForTesting(ports);
     const { addItem, texts } = makeCapturingAddItem();
@@ -553,16 +568,17 @@ describe('useMemoryMonitor — high-memory warning distinguishes peak from retai
     handler.current?.();
     handler.current?.();
 
-    // The warning fires once, and only that tick reads the full usage, but the
-    // interval keeps sampling cheaply.
+    // The warning fires once and reads the heap once, while the interval keeps
+    // sampling RSS on every tick and never allocates a full MemoryUsage.
     expect(texts()).toHaveLength(1);
-    expect(fullCalls).toBe(1);
+    expect(heapCalls).toBe(1);
     expect(rssCalls).toBe(5);
+    expect(fullCalls).toBe(0);
 
     unmount();
   });
 
-  it('reuses the controller sample instead of taking a second reading', () => {
+  it('takes one full reading per tick when telemetry is enabled', () => {
     let fullCalls = 0;
     const sample: NodeJS.MemoryUsage = {
       rss: EIGHT_POINT_FOUR_GB,
@@ -585,6 +601,7 @@ describe('useMemoryMonitor — high-memory warning distinguishes peak from retai
         return sample;
       },
       rssBytes: () => sample.rss,
+      retainedHeapBytes: () => sample.heapUsed,
     };
     __setMemoryMonitorPortsForTesting(ports);
     const { addItem, texts } = makeCapturingAddItem();
@@ -606,7 +623,7 @@ describe('useMemoryMonitor — high-memory warning distinguishes peak from retai
 
     expect(texts()).toHaveLength(1);
     expect(texts()[0] ?? '').toContain('1.20 GB');
-    // One reading per tick: the warning must not trigger an extra sample.
+    // The tick's own reading, and the warning does not trigger another.
     expect(fullCalls).toBe(1);
 
     unmount();

--- a/packages/cli/src/ui/hooks/useMemoryMonitor.ts
+++ b/packages/cli/src/ui/hooks/useMemoryMonitor.ts
@@ -35,6 +35,25 @@ export interface MemoryMonitorPorts {
    * Defaults to process.memoryUsage.rss().
    */
   rssBytes: () => number;
+  /**
+   * Retained JS heap, read only on the tick that fires the warning.
+   *
+   * Deliberately independent of `memoryUsage`: the disabled path must not take
+   * a full reading, and reading the JSC heap directly keeps the warning working
+   * regardless of what `process.memoryUsage` is doing.
+   */
+  retainedHeapBytes: () => number;
+}
+
+interface JscHeapSizeApi {
+  heapSize: () => number;
+}
+
+function isJscHeapSizeApi(value: unknown): value is JscHeapSizeApi {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  return 'heapSize' in value && typeof value.heapSize === 'function';
 }
 
 const realPorts: MemoryMonitorPorts = {
@@ -46,6 +65,13 @@ const realPorts: MemoryMonitorPorts = {
   // warning-only path below still reads it directly.
   memoryUsage: () => sampleMemoryUsage(),
   rssBytes: () => process.memoryUsage.rss(),
+  retainedHeapBytes: () => {
+    const jsc = process.getBuiltinModule('bun:jsc');
+    if (!isJscHeapSizeApi(jsc)) {
+      throw new Error('bun:jsc heap size is unavailable');
+    }
+    return jsc.heapSize();
+  },
 };
 
 let __portsForTesting: MemoryMonitorPorts | null = null;
@@ -99,11 +125,11 @@ export function useMemoryMonitor({
     // heap, which does fall when memory is released. The full sample is read
     // only on the tick that crosses the threshold, so the steady-state check
     // stays on the cheap RSS accessor.
-    const maybeWarn = (rss: number, sample?: NodeJS.MemoryUsage): void => {
+    const maybeWarn = (rss: number): void => {
       if (rss <= MEMORY_WARNING_THRESHOLD_BYTES || warnedOnce) {
         return;
       }
-      const retained = (sample ?? ports.memoryUsage()).heapUsed;
+      const retained = ports.retainedHeapBytes();
       addItem(
         {
           type: MessageType.WARNING,
@@ -123,7 +149,7 @@ export function useMemoryMonitor({
         // Telemetry-enabled tick: exactly one full process.memoryUsage()
         // capture, reused for warning + ring + persistence.
         const sample = ports.memoryUsage();
-        maybeWarn(sample.rss, sample);
+        maybeWarn(sample.rss);
         memoryController.recordTickSample(sample);
       } else {
         // Disabled path: cheaper rss-only check (no full MemoryUsage object).

--- a/packages/cli/src/ui/hooks/useMemoryMonitor.ts
+++ b/packages/cli/src/ui/hooks/useMemoryMonitor.ts
@@ -13,6 +13,12 @@ import { sampleMemoryUsage } from './memoryTrend/jscMemorySampler.js';
 export const MEMORY_WARNING_THRESHOLD_BYTES = 7 * 1024 * 1024 * 1024; // 7GB
 export const MEMORY_CHECK_INTERVAL_MS = 60 * 1000; // 1 minute
 
+const BYTES_PER_GB = 1024 * 1024 * 1024;
+
+function formatGb(bytes: number): string {
+  return `${(bytes / BYTES_PER_GB).toFixed(2)} GB`;
+}
+
 /**
  * Package-private ports for deterministic testing. The real implementation
  * uses `globalThis.setInterval` / `globalThis.clearInterval` /
@@ -86,22 +92,30 @@ export function useMemoryMonitor({
 
     // Shared high-memory warning so the telemetry-enabled and disabled paths
     // cannot drift. Fires once via the latch.
-    const maybeWarn = (rss: number): void => {
-      if (rss > MEMORY_WARNING_THRESHOLD_BYTES && !warnedOnce) {
-        addItem(
-          {
-            type: MessageType.WARNING,
-            text:
-              `High memory usage detected: ${(
-                rss /
-                (1024 * 1024 * 1024)
-              ).toFixed(2)} GB. ` +
-              'If the CLI exits unexpectedly, please run `/bug` to report it.',
-          },
-          Date.now(),
-        );
-        warnedOnce = true;
+    //
+    // Resident memory is a high-water mark: freed memory is reused but is not
+    // necessarily returned to the OS, so RSS alone cannot say whether the
+    // session is still accumulating. The warning pairs it with the retained JS
+    // heap, which does fall when memory is released. The full sample is read
+    // only on the tick that crosses the threshold, so the steady-state check
+    // stays on the cheap RSS accessor.
+    const maybeWarn = (rss: number, sample?: NodeJS.MemoryUsage): void => {
+      if (rss <= MEMORY_WARNING_THRESHOLD_BYTES || warnedOnce) {
+        return;
       }
+      const retained = (sample ?? ports.memoryUsage()).heapUsed;
+      addItem(
+        {
+          type: MessageType.WARNING,
+          text:
+            `High memory usage detected: ${formatGb(rss)} resident ` +
+            `(peak since startup, and it may not shrink), ` +
+            `${formatGb(retained)} retained JS heap. ` +
+            'If the CLI exits unexpectedly, please run `/bug` to report it.',
+        },
+        Date.now(),
+      );
+      warnedOnce = true;
     };
 
     const intervalId = ports.setInterval(() => {
@@ -109,7 +123,7 @@ export function useMemoryMonitor({
         // Telemetry-enabled tick: exactly one full process.memoryUsage()
         // capture, reused for warning + ring + persistence.
         const sample = ports.memoryUsage();
-        maybeWarn(sample.rss);
+        maybeWarn(sample.rss, sample);
         memoryController.recordTickSample(sample);
       } else {
         // Disabled path: cheaper rss-only check (no full MemoryUsage object).


### PR DESCRIPTION
## TLDR

Sessions warn `High memory usage detected: 8.43 GB` and the number never comes back down. The process is not accumulating retained objects. Resident memory under Bun only rises, so a single allocation spike permanently raises the floor.

Two things follow, and both are addressed here.

The warning reported only RSS, presenting a past peak as current usage. It now pairs resident memory, described as a peak that may not shrink, with the retained JS heap, which does fall when memory is released.

Because peaks are permanent, peak allocation matters more than steady-state retention. `ToolResultDisplay` handed up to 1,000,000 characters to `MaxSizedBox`, which laid out every line before clipping to a window of a few dozen. Lines beyond the window are now dropped before layout.

Reviewers should look closely at one tradeoff: the hidden-line count becomes an estimate. See "Behavior change" below.

## Dive Deeper

### Why RSS never falls

Plain `bun -e`, no LLxprt code, Bun 1.3.14 on darwin-arm64:

```
baseline rss=23.5  heapSize=0.2
held     rss=214.7 heapSize=190.9    // 200 x 1 MB strings retained
freed    rss=214.7 heapSize=0.2      // references dropped, gcAndSweep twice
after    rss=214.7 heapSize=0.2      // fullGC + releaseWeakRefs + gcAndSweep
```

`heapSize` returns to baseline, so the objects really are collected. RSS does not move. The same holds for `Buffer` and `Uint8Array`. A second 200 MB allocation after the first was freed reused the same pages rather than pushing RSS to 430 MiB, so the allocator reuses freed memory but does not return it to the OS.

A 60-cycle tmux workload driving real agentic turns confirms the shape: checkpoints of 593, 1223, 1487, 1493, 1502, 1501, 1508 MiB. Growth stops after roughly 20 cycles, `/clear` does not lower it, and the JSC heap stays between 262 and 272 MiB throughout with a stable object count near 1.03 million.

### The warning

`useMemoryMonitor` warned on `process.memoryUsage().rss`. Once a session touches the threshold that describes a condition the process can never leave, and the figure shown is a past peak.

The warning now reports both numbers. The per-tick check stays on the cheap `process.memoryUsage.rss()` accessor; the full sample is read only on the tick that crosses the threshold, and the telemetry-enabled path reuses the sample it already took, so no tick pays for two readings.

### The render path

`ToolResultDisplay` truncates at `MAXIMUM_RESULT_DISPLAY_CHARACTERS` (1,000,000) and hands the whole body to `MaxSizedBox`, which calls `visitChildrenAsRows` to lay out every line and only then slices to the visible window.

Peak RSS for a single render, fresh process per row, window fixed:

| content | rendered lines | before | after |
| --- | --- | --- | --- |
| 20,000 chars | 35 | — | 11.8 MiB |
| 200,000 chars | 35 | — | 12.0 MiB |
| 600,000 chars | 35 | — | 12.1 MiB |
| 1,000,000 chars | 35 | — | 13.5 MiB |

Peak no longer scales with input. The warmed-up marginal cost of a 1 MB result fell from 23.6, 24.2 and 24.5 MiB to 5.1, 5.4 and 5.3 MiB across three runs each.

A source line always occupies at least one display line, so keeping the last `availableHeight` source lines is enough to fill the window. `trimToVisibleTail` drops the rest before layout and reports the remainder through the existing `additionalHiddenLinesCount` seam.

### Behavior change

The hidden-line count becomes an estimate. It is computed from `ceil(lineLength / width)` over the dropped source lines rather than from real wrapping, so the "... first N lines hidden ..." label can differ from the exact display-line count when word wrapping splits lines unevenly. This is the deliberate tradeoff for the memory result and is the thing to push back on if the exact count matters more.

### Two approaches that were measured and rejected

Both kept all 21 existing `MaxSizedBox` tests passing and both left peak RSS unchanged, because the peak is transient garbage from a synchronous layout pass rather than a retained array:

1. Bounding what the layout retains with a ring holding only `maxHeight` lines while keeping an exact total count.
2. Streaming each line into the sink instead of accumulating locally in the three layout helpers.

Only bounding the input before layout moves the number. Neither is included here.

### What this does not fix

> **Correction, added after merge.** The paragraph that originally closed this
> section concluded there was no retained structure to find and that the growth
> was allocator high-water behaviour alone. That was wrong, and it is retracted.
> The actual cause was found later and is described at the end of this section.

It does not explain the reported 8.43 GB. Paths measured and found already bounded:

- **Shell pipeline.** `ShellExecutionService.execute` for 20 iterations of the same 600 KB command: +42 MiB on iteration 1, +58 MiB by iteration 2, flat through iteration 20 while emitting 956 output events.
- **ANSI rendering.** `AnsiOutputText` scans backwards for the cursor and last non-empty line, then renders at most `availableTerminalHeight` lines. `serializeTerminalForRender` stays within `terminal.rows`.

Re-running the 60-cycle tmux workload with this change plateaued at 1,479.9 MiB against 1,508.0 MiB, within run-to-run variance, because that workload's shell output takes the ANSI path. The string path fixed here covers plain-string results such as file reads and searches.

At the time this was written the remaining growth was unattributed, and the
plateau measurement above (262 MiB of JSC heap) was read as evidence that no
retained structure existed. That inference was wrong.

**What it actually was.** Reproducing the reported workload under the profiler
produced peaks of 46.8 GiB RSS with 42.2 GB surviving a forced `gcAndSweep`, so
there was real structure to find. In-process sampling with
`bun:jsc.startSamplingProfiler` put 27.5 percent of burst samples in
`DataLimitedLruMap.get`, which refreshed LRU recency on every cache **hit** by
deleting and re-inserting the key. On a JSC `Map` that rewrites the backing
store, and the renderer reads those caches per character. Two million reads of a
ten thousand entry cache allocated 32,525,802 bytes with the refresh and 0.1 MiB
without it.

That cache lives in the Ink patch added by #3404, so the fix landed there rather
than here: recency now uses an intrusive doubly linked list, and reads never
mutate the `Map`. Peak RSS on the same workload fell from 46.8 GiB to 813 MiB,
peak JSC heap from 28 GiB to 404 MiB.

Bun not returning freed pages remains true and still matters, because it means a
single burst permanently raises the floor. It amplified the failure rather than
causing it.

The two changes in this PR stand on their own measurements and are unaffected by
the correction. The reworked warning is in fact what identified the problem as a
leak, by reporting 19.82 GB of retained heap alongside 22.48 GB resident where
the previous message showed only the resident figure.

Issue #3425 carries the full account, including the corrections.

## Reviewer Test Plan

1. Run the repository verification cycle:

   ```bash
   npm run test
   npm run lint
   npm run typecheck
   npm run format
   npm run build
   bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
   ```

2. Verify the two changed behaviors:

   ```bash
   bun test packages/cli/src/ui/hooks/memoryTrend/useMemoryMonitor.behavior.test.ts
   bun test packages/cli/src/ui/components/messages/ToolResultDisplay.retention.behavior.test.tsx
   ```

   The retention test measures marginal peak RSS, so it must run before any other oversized render in the same process; resident memory never falls back and would mask the measurement. It is ordered first in its file for that reason.

3. Confirm no regression in the rendering the change touches:

   ```bash
   bun test packages/cli/src/ui/components/shared/MaxSizedBox.test.tsx \
     packages/cli/src/ui/components/messages/ToolResultDisplay.test.tsx
   ```

4. Exercise the behavior change by eye. Run a command with long output, such as a large file read or a wide search, and check that the tail is shown and the "lines hidden" label is present and plausible.

5. Reproduce the underlying platform behavior directly if you want to confirm the premise:

   ```bash
   bun -e 'const j=require("bun:jsc"); const m=b=>(b/1048576).toFixed(1);
   const s=()=>{j.gcAndSweep();j.gcAndSweep();return process.memoryUsage.rss()};
   console.log("base",m(s()));
   let h=[];for(let i=0;i<200;i++)h.push("x".repeat(1e6));
   console.log("held",m(process.memoryUsage.rss()),"heap",m(j.heapSize()));
   h=null;console.log("freed",m(s()),"heap",m(j.heapSize()));'
   ```

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified locally on macOS: `npm run test` exit 0 with zero failures, `lint`, `typecheck`, `format` and `build` all exit 0, the `stepfun-37` startup smoke exit 0, 100 pass / 0 fail across the nine affected suites, and the false-green test audit at 1,999 normalized findings with zero new findings.

## Linked issues / bugs

Fixes #3425

Related to #3386, which shipped the memory profiler used to take these measurements. This PR is deliberately separate from #3404 to keep that PR's scope intact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Large tool results now display the most recent content within the available space, with an indicator showing hidden lines.
  - Prevented oversized and single-line tool output from causing excessive memory use.
  - Memory warnings now report peak resident memory and retained JavaScript heap usage with clearer GB formatting.
- **Performance**
  - Memory monitoring uses lightweight checks during normal operation to reduce overhead.
  - Full memory telemetry is collected only when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
