### PR TITLE
fix(ci): stop the Windows nightly failure classes — runner retry parity + first PR Windows gate (Fixes #3439)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -954,7 +954,7 @@ jobs:
           persist-credentials: false
 
       - name: 'Set up Node.js'
-        uses: 'actions/setup-node@8207627860b0efc47a31fe5020' # ratchet:actions/setup-node@v7
+        uses: 'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020' # ratchet:actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -921,6 +921,132 @@ jobs:
           bun scripts/check-test-file-coverage.ts
 
   #
+  # Windows test-infra gate (issue #3439)
+  #
+  # The full Windows matrix lives in the nightly (issue #3153), which meant
+  # Windows-incompatible test code merged green and was first exercised by
+  # the next day's nightly — the recurring "Nightly workflow failed" issues.
+  # This gate runs the Windows-sensitive test infrastructure (the per-package
+  # bun test runners, the CLI launcher shims, and the test orchestrator) on
+  # windows-latest for every push to main, and for PRs that touch that
+  # surface, so the same class of failure is caught within minutes of the
+  # offending change instead of the next night. It deliberately does NOT run
+  # the six-shard corpus (issue #3249 keeps Windows runner cost bounded);
+  # only the suites whose subjects are process launching and path handling,
+  # which is exactly the Windows-divergent surface.
+  windows_test_infra:
+    name: 'Windows Test-Infra Gate'
+    runs-on: 'windows-latest'
+    timeout-minutes: 20
+    needs:
+      - 'doc_change_filter'
+      - 'skip_check'
+    if: ${{ needs.doc_change_filter.outputs.docs_only != 'true' && needs.skip_check.outputs.should_skip != 'true' }}
+    permissions:
+      contents: 'read'
+      pull-requests: 'read'
+    outputs:
+      affected: '${{ steps.filter.outputs.affected }}'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1' # ratchet:actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: 'Set up Node.js'
+        uses: 'actions/setup-node@8207627860b0efc47a31fe5020' # ratchet:actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: 'Setup Bun'
+        uses: 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6' # ratchet:oven-sh/setup-bun@v2
+        with:
+          bun-version-file: '.bun-version'
+
+      - name: 'Detect Windows-sensitive changes'
+        id: 'filter'
+        env:
+          GH_TOKEN: '${{ github.token }}'
+          PR_NUMBER: >-
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
+        run: |
+          set -euo pipefail
+          # Non-PR events (push to main, merge_group, workflow_dispatch)
+          # always run the gate: the post-merge signal is the other half of
+          # the fix — a slip past the path filter still fails within minutes.
+          if [[ -z "${PR_NUMBER:-}" ]]; then
+            echo "affected=true" >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          # Path allowlist for the Windows-sensitive surface. Anything else
+          # (package internals, docs) cannot change Windows behavior of the
+          # suites this gate runs.
+          files_json="${RUNNER_TEMP}/pr-files.ndjson"
+          : >"${files_json}"
+          gh api --paginate -H 'Accept: application/vnd.github+json' \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+            --jq '.[].filename' >"${files_json}" || true
+          # An empty list means the API call failed, not that the PR changed
+          # nothing: fail open and run the gate (mirrors doc_change_filter).
+          if [[ ! -s "${files_json}" ]] || grep -Eq \
+            '^(scripts/|packages/[^/]+/run-bun-tests\.ts$|packages/[^/]+/bun-preload\.ts$|packages/auth/src/__tests__/|packages/cli/bin/|packages/(cli|core)/test/.*run-bun-tests|packages/agents/test-bun/|\.github/workflows/(ci|nightly)\.yml$|bun\.lock$|package(-lock)?\.json$|tsconfig[^/]*)' \
+            "${files_json}"; then
+            echo "affected=true" >>"${GITHUB_OUTPUT}"
+          else
+            echo "affected=false" >>"${GITHUB_OUTPUT}"
+          fi
+
+      - name: 'Configure Windows Defender exclusions'
+        if: steps.filter.outputs.affected == 'true'
+        run: |
+          Add-MpPreference -ExclusionPath $env:GITHUB_WORKSPACE -Force
+          Add-MpPreference -ExclusionPath "$env:GITHUB_WORKSPACE\node_modules" -Force
+          Add-MpPreference -ExclusionPath $env:TEMP -Force
+        shell: 'pwsh'
+
+      - name: 'Configure npm for Windows performance'
+        if: steps.filter.outputs.affected == 'true'
+        run: |
+          npm config set progress false
+          npm config set audit false
+          npm config set fund false
+          npm config set loglevel error
+          npm config set maxsockets 32
+          npm config set registry https://registry.npmjs.org/
+        shell: 'pwsh'
+
+      - name: 'Install dependencies for testing'
+        if: steps.filter.outputs.affected == 'true'
+        run: |-
+          npm ci
+
+      - name: 'Fix rollup platform dependency'
+        if: steps.filter.outputs.affected == 'true'
+        run: |-
+          npm install @rollup/rollup-win32-x64-msvc --no-save || true
+        shell: 'bash'
+
+      - name: 'Run launcher shim and output-generator tests'
+        if: steps.filter.outputs.affected == 'true'
+        run: |-
+          bun test --preload ./scripts/tests/test-setup.ts scripts/tests/issue-2978-node-shim.bun.test.ts scripts/tests/issue-2978-oven-fallback.bun.test.ts scripts/tests/memory/output-generator.test.ts
+
+      - name: 'Run test-runner and orchestrator meta-tests'
+        if: steps.filter.outputs.affected == 'true'
+        run: |-
+          bun test --preload ./scripts/tests/test-setup.ts scripts/tests/run_bun_tests.test.ts scripts/tests/test-orchestrator.test.ts scripts/tests/test-shard-orchestrator.test.ts
+          cd packages/cli && bun test test/run-bun-tests.test.ts
+          cd ../core && bun test test/run-bun-tests.test.ts
+          cd ../agents && bun test ./test-bun/run-bun-tests.issue3253.bun.ts
+          cd ../auth && bun test src/__tests__/run-bun-tests.behavior.test.ts
+
+      - name: 'Smoke test CLI entry (launcher -> Bun, no Node in chain)'
+        if: steps.filter.outputs.affected == 'true'
+        run: './packages/cli/bin/llxprt --version'
+
+  #
   # Test: Node (Linux only — issue #2876)
   #
   # Stays on npm (not Bun) for S6 (#2243): Bun's hoisted linker non-
@@ -1270,6 +1396,7 @@ jobs:
       - 'node_consumer_smoke'
       - 'acp_conformance'
       - 'doc_change_filter'
+      - 'windows_test_infra'
     if: ${{ always() }}
     runs-on: 'ubuntu-latest'
     steps:
@@ -1282,6 +1409,8 @@ jobs:
           shard_result='${{ needs.test_shard.result }}'
           node_consumer_smoke_result='${{ needs.node_consumer_smoke.result }}'
           acp_result='${{ needs.acp_conformance.result }}'
+          windows_infra_result='${{ needs.windows_test_infra.result }}'
+          windows_infra_affected='${{ needs.windows_test_infra.outputs.affected }}'
 
           # Explicit duplicate-skip: skip_check said this run duplicates a
           # passing one, so every downstream job was intentionally skipped.
@@ -1336,6 +1465,21 @@ jobs:
               echo "docs-only PR: acp_conformance intentionally skipped (issue #342)."
             else
               echo "::error::ACP conformance job did not succeed (result: $acp_result)"
+              exit 1
+            fi
+          fi
+
+          # Windows test-infra gate (issue #3439) must succeed when it ran.
+          # It reports skipped in two intentional cases: docs-only PRs (its
+          # job-level if mirrors the other smoke jobs) and path-filtered PRs
+          # whose changes cannot affect the Windows-sensitive suites
+          # (affected=false). Anything else — including a failure — fails the
+          # required Test check.
+          if [ "$windows_infra_result" != "success" ]; then
+            if [ "$windows_infra_result" == "skipped" ] && { [ "$docs_only" == "true" ] || [ "$windows_infra_affected" == "false" ]; }; then
+              echo "Windows test-infra gate intentionally skipped (docs_only=$docs_only, affected=$windows_infra_affected)."
+            else
+              echo "::error::Windows test-infra gate did not succeed (result: $windows_infra_result)"
               exit 1
             fi
           fi

--- a/packages/auth/run-bun-tests.ts
+++ b/packages/auth/run-bun-tests.ts
@@ -92,6 +92,29 @@ export interface TestResult {
   signal: NodeJS.Signals | null;
 }
 
+/**
+ * Retries a test file once when its first attempt was killed by the
+ * per-file timeout. Mirrors the policy of the cli/agents/core runners
+ * (issue #3439): the sporadic bun-on-Windows child freeze kills one attempt
+ * and behaves normally on the next, while a genuine assertion failure never
+ * times out and is returned after a single attempt.
+ */
+export async function runTestFileWithTimeoutRetry<
+  T extends { readonly timedOut: boolean },
+>(
+  file: string,
+  runAttempt: () => Promise<T>,
+  logRetry: (message: string) => void = (message) => console.log(message),
+): Promise<T> {
+  const firstAttempt = await runAttempt();
+  if (!firstAttempt.timedOut) {
+    return firstAttempt;
+  }
+
+  logRetry(`RETRY (2/2): ${file} after per-file timeout`);
+  return runAttempt();
+}
+
 export function runTestFile(file: string): Promise<TestResult> {
   return new Promise((resolve) => {
     let resolved = false;
@@ -226,7 +249,9 @@ async function main(): Promise<void> {
   async function worker(): Promise<void> {
     while (nextIndex < testFiles.length) {
       const file = testFiles[nextIndex++];
-      results.push(await runTestFile(file));
+      results.push(
+        await runTestFileWithTimeoutRetry(file, () => runTestFile(file)),
+      );
     }
   }
 

--- a/packages/auth/src/__tests__/run-bun-tests.behavior.test.ts
+++ b/packages/auth/src/__tests__/run-bun-tests.behavior.test.ts
@@ -110,12 +110,11 @@ describe('auth run-bun-tests failure reason formatting', () => {
 
 describe('auth run-bun-tests timeout retry', () => {
   it('retries once after a timed-out attempt and returns the passing retry', async () => {
-    const outcomes: Array<
-      { passed: boolean; timedOut: boolean } | undefined
-    > = [
-      { passed: false, timedOut: true },
-      { passed: true, timedOut: false },
-    ];
+    const outcomes: Array<{ passed: boolean; timedOut: boolean } | undefined> =
+      [
+        { passed: false, timedOut: true },
+        { passed: true, timedOut: false },
+      ];
     let attempts = 0;
     const logs: string[] = [];
 

--- a/packages/auth/src/__tests__/run-bun-tests.behavior.test.ts
+++ b/packages/auth/src/__tests__/run-bun-tests.behavior.test.ts
@@ -11,6 +11,7 @@ import {
   formatFailureReason,
   generateJUnit,
   runTestFile,
+  runTestFileWithTimeoutRetry,
   type TestResult,
 } from '../../run-bun-tests.js';
 import { DEFAULT_PER_FILE_TIMEOUT_MS } from '../../../../scripts/lib/bun-test-policy.js';
@@ -104,6 +105,76 @@ describe('auth run-bun-tests failure reason formatting', () => {
       signal: null,
     });
     expect(reason).toBe('Exit code -1');
+  });
+});
+
+describe('auth run-bun-tests timeout retry', () => {
+  it('retries once after a timed-out attempt and returns the passing retry', async () => {
+    const outcomes: Array<
+      { passed: boolean; timedOut: boolean } | undefined
+    > = [
+      { passed: false, timedOut: true },
+      { passed: true, timedOut: false },
+    ];
+    let attempts = 0;
+    const logs: string[] = [];
+
+    const result = await runTestFileWithTimeoutRetry(
+      'src/freeze.test.ts',
+      async () => {
+        const outcome = outcomes[attempts];
+        if (outcome === undefined) {
+          throw new Error(`unexpected attempt ${attempts + 1}`);
+        }
+        attempts++;
+        return outcome;
+      },
+      (message) => logs.push(message),
+    );
+
+    expect({ result, attempts, logs }).toEqual({
+      result: { passed: true, timedOut: false },
+      attempts: 2,
+      logs: ['RETRY (2/2): src/freeze.test.ts after per-file timeout'],
+    });
+  });
+
+  it('returns a non-timeout failure after a single attempt', async () => {
+    let attempts = 0;
+    const logs: string[] = [];
+
+    const result = await runTestFileWithTimeoutRetry(
+      'src/assertion.test.ts',
+      async () => {
+        attempts++;
+        return { passed: false, timedOut: false };
+      },
+      (message) => logs.push(message),
+    );
+
+    expect({ result, attempts, logs }).toEqual({
+      result: { passed: false, timedOut: false },
+      attempts: 1,
+      logs: [],
+    });
+  });
+
+  it('returns the second timeout as the final failure', async () => {
+    let attempts = 0;
+
+    const result = await runTestFileWithTimeoutRetry(
+      'src/hang.test.ts',
+      async () => {
+        attempts++;
+        return { passed: false, timedOut: true };
+      },
+      () => undefined,
+    );
+
+    expect({ result, attempts }).toEqual({
+      result: { passed: false, timedOut: true },
+      attempts: 2,
+    });
   });
 });
 

--- a/packages/cli/run-bun-tests.ts
+++ b/packages/cli/run-bun-tests.ts
@@ -23,7 +23,7 @@
 
 import { spawn } from 'node:child_process';
 import { readdirSync, realpathSync, statSync, writeFileSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { isAbsolute, join, relative, win32 } from 'node:path';
 import {
   DEFAULT_PER_FILE_TIMEOUT_MS,
   DEFAULT_PER_TEST_TIMEOUT_MS,
@@ -89,7 +89,11 @@ const INTEGRATION_FILE_PATTERN = /\.integration\.(test|spec)\.(ts|tsx)$/;
  * so passing it bare matched nothing and the file silently did not run.
  */
 export function toPathArgument(file: string): string {
-  return file.startsWith('./') || file.startsWith('/') ? file : `./${file}`;
+  // win32.isAbsolute also accepts drive-letter paths, so a Windows-style path
+  // survives as-is regardless of which OS the runner is on.
+  return isAbsolute(file) || win32.isAbsolute(file) || file.startsWith('./')
+    ? file
+    : `./${file}`;
 }
 
 export function timeoutForFile(file: string): number {

--- a/packages/cli/test/run-bun-tests.test.ts
+++ b/packages/cli/test/run-bun-tests.test.ts
@@ -269,6 +269,14 @@ describe('toPathArgument', () => {
   it('leaves an absolute path alone', () => {
     expect(toPathArgument('/tmp/a.test.ts')).toBe('/tmp/a.test.ts');
   });
+
+  it('leaves an absolute Windows path alone', () => {
+    // On a Windows host isAbsolute accepts drive-letter paths; a ./ splice
+    // yields ./D:\..., which bun resolves relative to cwd and fails to find.
+    expect(toPathArgument('D:\\work\\src\\a.test.ts')).toBe(
+      'D:\\work\\src\\a.test.ts',
+    );
+  });
 });
 
 describe('parseCaseCounts', () => {

--- a/packages/core/run-bun-tests.ts
+++ b/packages/core/run-bun-tests.ts
@@ -262,22 +262,44 @@ export async function killChildTreeAndWait(
 }
 
 export async function runTestFileWithTimeoutRetry<
-  T extends { readonly timedOut: boolean; readonly reapFailed: boolean },
+  T extends {
+    readonly passed: boolean;
+    readonly timedOut: boolean;
+    readonly reapFailed: boolean;
+    readonly reapError?: string | null;
+  },
 >(
   file: string,
   runAttempt: () => Promise<T>,
   logRetry: (message: string) => void = (message) => console.log(message),
 ): Promise<T> {
   const firstAttempt = await runAttempt();
-  // A failed reap means the old process tree may still be alive; retrying
-  // could run against its leaked resources. Return so main() hits the FATAL
-  // reap guard instead.
-  if (!firstAttempt.timedOut || firstAttempt.reapFailed) {
+  if (!firstAttempt.timedOut) {
     return firstAttempt;
   }
 
+  // Retry on every timeout, including one whose reap failed: the second
+  // attempt's outcome decides whether the run can continue. The freeze class
+  // this guards against (issue #3439) kills the child on one attempt and
+  // behaves normally on the next; a first-attempt reap failure is frequently
+  // just taskkill losing a race with an already-dying tree.
   logRetry(`RETRY (2/2): ${file} after per-file timeout`);
-  return runAttempt();
+  const secondAttempt = await runAttempt();
+
+  // First attempt failed to reap but the retry reaped cleanly: the suspect
+  // tree is gone. Keep the file red — it genuinely timed out — and carry the
+  // first attempt's reapError so the summary can explain the retry, but let
+  // the shard continue instead of aborting.
+  if (firstAttempt.reapFailed && !secondAttempt.reapFailed) {
+    return {
+      ...secondAttempt,
+      passed: false,
+      timedOut: true,
+      reapFailed: false,
+      reapError: firstAttempt.reapError ?? null,
+    };
+  }
+  return secondAttempt;
 }
 
 export function runTestFile(
@@ -443,12 +465,13 @@ async function main(): Promise<void> {
     );
     results.push(...batchResults);
 
-    // Fail fast: if reaping a timed-out child failed, do NOT proceed with
-    // another file — the old process tree may still be alive and holding
-    // resources (log handles, ports) that would corrupt subsequent results.
-    // The retry above makes the abort rare: a reap failure reaches this
-    // guard whether it happened on the first attempt (which skips the
-    // retry) or on the second.
+    // Fail fast: only an unrecovered reap failure aborts the run. A reap
+    // failure on the first attempt that the retry outlived (reapFailed=false
+    // on the returned result) means the suspect tree is gone and the file is
+    // already marked failed; subsequent files are safe to run. A reap failure
+    // on the final attempt means the old process tree may still be alive and
+    // holding resources (log handles, ports) that would corrupt subsequent
+    // results.
     if (batchResults.some((r) => r.reapFailed)) {
       console.error(
         'FATAL: failed to reap a timed-out test process tree; aborting to ' +
@@ -466,7 +489,11 @@ async function main(): Promise<void> {
     if (result.timedOut) {
       console.error(
         `TIMEOUT: ${result.file} (exceeded ${result.timeoutMs / 1000}s)` +
-          (result.reapFailed ? ' [REAP FAILED]' : ''),
+          (result.reapFailed
+            ? ' [REAP FAILED]'
+            : result.reapError
+              ? ' [REAP FAILED (recovered on retry)]'
+              : ''),
       );
     } else {
       console.error(

--- a/packages/core/run-bun-tests.ts
+++ b/packages/core/run-bun-tests.ts
@@ -261,6 +261,25 @@ export async function killChildTreeAndWait(
   );
 }
 
+export async function runTestFileWithTimeoutRetry<
+  T extends { readonly timedOut: boolean; readonly reapFailed: boolean },
+>(
+  file: string,
+  runAttempt: () => Promise<T>,
+  logRetry: (message: string) => void = (message) => console.log(message),
+): Promise<T> {
+  const firstAttempt = await runAttempt();
+  // A failed reap means the old process tree may still be alive; retrying
+  // could run against its leaked resources. Return so main() hits the FATAL
+  // reap guard instead.
+  if (!firstAttempt.timedOut || firstAttempt.reapFailed) {
+    return firstAttempt;
+  }
+
+  logRetry(`RETRY (2/2): ${file} after per-file timeout`);
+  return runAttempt();
+}
+
 export function runTestFile(
   file: string,
   options: RunTestFileOptions = {},
@@ -418,13 +437,18 @@ async function main(): Promise<void> {
   for (let i = 0; i < testFiles.length; i += CONCURRENCY) {
     const batch = testFiles.slice(i, i + CONCURRENCY);
     const batchResults = await Promise.all(
-      batch.map((file) => runTestFile(file)),
+      batch.map((file) =>
+        runTestFileWithTimeoutRetry(file, () => runTestFile(file)),
+      ),
     );
     results.push(...batchResults);
 
     // Fail fast: if reaping a timed-out child failed, do NOT proceed with
     // another file — the old process tree may still be alive and holding
     // resources (log handles, ports) that would corrupt subsequent results.
+    // The retry above makes the abort rare: a reap failure reaches this
+    // guard whether it happened on the first attempt (which skips the
+    // retry) or on the second.
     if (batchResults.some((r) => r.reapFailed)) {
       console.error(
         'FATAL: failed to reap a timed-out test process tree; aborting to ' +

--- a/packages/core/test/run-bun-tests.test.ts
+++ b/packages/core/test/run-bun-tests.test.ts
@@ -21,6 +21,7 @@ import {
   killChildTreeAndWait,
   observeChildClose,
   runTestFile,
+  runTestFileWithTimeoutRetry,
   type TestResult,
 } from '../run-bun-tests.js';
 
@@ -315,4 +316,133 @@ describe('core Bun test runner process lifecycle', () => {
     },
     30_000,
   );
+});
+
+interface RetryOutcome {
+  readonly passed: boolean;
+  readonly timedOut: boolean;
+  readonly reapFailed: boolean;
+  readonly exitCode: number | null;
+}
+
+function createAttemptSequence<T extends RetryOutcome>(
+  outcomes: readonly T[],
+): {
+  run: () => Promise<T>;
+  count: () => number;
+} {
+  let attempts = 0;
+  return {
+    run: async () => {
+      const outcome = outcomes[attempts];
+      if (outcome === undefined) {
+        throw new Error(`unexpected attempt ${attempts + 1}`);
+      }
+      attempts++;
+      return outcome;
+    },
+    count: () => attempts,
+  };
+}
+
+describe('runTestFileWithTimeoutRetry', () => {
+  it('returns a passing retry and logs it after the first attempt times out', async () => {
+    const attempts = createAttemptSequence<RetryOutcome>([
+      { passed: false, timedOut: true, reapFailed: false, exitCode: null },
+      { passed: true, timedOut: false, reapFailed: false, exitCode: 0 },
+    ]);
+    const logs: string[] = [];
+
+    const result = await runTestFileWithTimeoutRetry(
+      'src/retry.test.ts',
+      attempts.run,
+      (message) => logs.push(message),
+    );
+
+    expect({ result, attemptCount: attempts.count(), logs }).toEqual({
+      result: {
+        passed: true,
+        timedOut: false,
+        reapFailed: false,
+        exitCode: 0,
+      },
+      attemptCount: 2,
+      logs: ['RETRY (2/2): src/retry.test.ts after per-file timeout'],
+    });
+  });
+
+  it('returns the second timeout as the final failure', async () => {
+    const attempts = createAttemptSequence<RetryOutcome>([
+      { passed: false, timedOut: true, reapFailed: false, exitCode: null },
+      { passed: false, timedOut: true, reapFailed: false, exitCode: null },
+    ]);
+
+    const result = await runTestFileWithTimeoutRetry(
+      'src/retry.test.ts',
+      attempts.run,
+      () => undefined,
+    );
+
+    expect({ result, attemptCount: attempts.count() }).toEqual({
+      result: {
+        passed: false,
+        timedOut: true,
+        reapFailed: false,
+        exitCode: null,
+      },
+      attemptCount: 2,
+    });
+  });
+
+  it('returns a non-timeout failure without a second attempt', async () => {
+    const attempts = createAttemptSequence<RetryOutcome>([
+      { passed: false, timedOut: false, reapFailed: false, exitCode: 1 },
+      { passed: true, timedOut: false, reapFailed: false, exitCode: 0 },
+    ]);
+    const logs: string[] = [];
+
+    const result = await runTestFileWithTimeoutRetry(
+      'src/assertion.test.ts',
+      attempts.run,
+      (message) => logs.push(message),
+    );
+
+    expect({ result, attemptCount: attempts.count(), logs }).toEqual({
+      result: {
+        passed: false,
+        timedOut: false,
+        reapFailed: false,
+        exitCode: 1,
+      },
+      attemptCount: 1,
+      logs: [],
+    });
+  });
+
+  it('returns a timed-out attempt that failed to reap without retrying', async () => {
+    // The old process tree may still hold the file's resources; only the
+    // FATAL reap guard in main() may decide what happens next.
+    const attempts = createAttemptSequence<RetryOutcome>([
+      { passed: false, timedOut: true, reapFailed: true, exitCode: null },
+      { passed: true, timedOut: false, reapFailed: false, exitCode: 0 },
+    ]);
+    const logs: string[] = [];
+
+    const result = await runTestFileWithTimeoutRetry(
+      'src/reap.test.ts',
+      attempts.run,
+      (message) => logs.push(message),
+    );
+
+    expect({ result, attemptCount: attempts.count(), logs }).toEqual({
+      result: {
+        passed: false,
+        timedOut: true,
+        reapFailed: true,
+        exitCode: null,
+      },
+      attemptCount: 1,
+      logs: [],
+    });
+  });
 });

--- a/packages/core/test/run-bun-tests.test.ts
+++ b/packages/core/test/run-bun-tests.test.ts
@@ -322,6 +322,7 @@ interface RetryOutcome {
   readonly passed: boolean;
   readonly timedOut: boolean;
   readonly reapFailed: boolean;
+  readonly reapError?: string | null;
   readonly exitCode: number | null;
 }
 
@@ -419,12 +420,27 @@ describe('runTestFileWithTimeoutRetry', () => {
     });
   });
 
-  it('returns a timed-out attempt that failed to reap without retrying', async () => {
-    // The old process tree may still hold the file's resources; only the
-    // FATAL reap guard in main() may decide what happens next.
+  it('retries after a reap failure and keeps the file failed when the retry reaps cleanly', async () => {
+    // The exact issue #3439 core-shard scenario: attempt 1 times out and
+    // taskkill loses the race, attempt 2 passes with a clean reap. The file
+    // stays red (it did time out) and carries the first attempt's reap
+    // error, but the returned reapFailed=false lets main() continue the
+    // shard instead of FATAL-aborting.
     const attempts = createAttemptSequence<RetryOutcome>([
-      { passed: false, timedOut: true, reapFailed: true, exitCode: null },
-      { passed: true, timedOut: false, reapFailed: false, exitCode: 0 },
+      {
+        passed: false,
+        timedOut: true,
+        reapFailed: true,
+        reapError: 'taskkill reported failure and tree did not close',
+        exitCode: null,
+      },
+      {
+        passed: true,
+        timedOut: false,
+        reapFailed: false,
+        reapError: null,
+        exitCode: 0,
+      },
     ]);
     const logs: string[] = [];
 
@@ -438,11 +454,48 @@ describe('runTestFileWithTimeoutRetry', () => {
       result: {
         passed: false,
         timedOut: true,
+        reapFailed: false,
+        reapError: 'taskkill reported failure and tree did not close',
+        exitCode: 0,
+      },
+      attemptCount: 2,
+      logs: ['RETRY (2/2): src/reap.test.ts after per-file timeout'],
+    });
+  });
+
+  it('returns the second attempt when both attempts fail to reap, so main() aborts', async () => {
+    const attempts = createAttemptSequence<RetryOutcome>([
+      {
+        passed: false,
+        timedOut: true,
         reapFailed: true,
+        reapError: 'first attempt reap error',
         exitCode: null,
       },
-      attemptCount: 1,
-      logs: [],
+      {
+        passed: false,
+        timedOut: true,
+        reapFailed: true,
+        reapError: 'second attempt reap error',
+        exitCode: null,
+      },
+    ]);
+
+    const result = await runTestFileWithTimeoutRetry(
+      'src/reap.test.ts',
+      attempts.run,
+      () => undefined,
+    );
+
+    expect({ result, attemptCount: attempts.count() }).toEqual({
+      result: {
+        passed: false,
+        timedOut: true,
+        reapFailed: true,
+        reapError: 'second attempt reap error',
+        exitCode: null,
+      },
+      attemptCount: 2,
     });
   });
 });

--- a/project-plans/issue3439/PLAN.md
+++ b/project-plans/issue3439/PLAN.md
@@ -1,0 +1,193 @@
+# Issue #3439: Nightly workflow failed (Aug 30) — root cause and fix plan
+
+Plan ID: PLAN-20260830-ISSUE3439
+Issue: https://github.com/vybestack/llxprt-code/issues/3439
+Branch: `issue3439`
+Run under investigation: https://github.com/vybestack/llxprt-code/actions/runs/33307362307 (commit c023285b)
+
+## Objective
+
+Stop the recurring Windows nightly failures by fixing the five test-infrastructure
+defects that produced the Aug 30 failures, and make the harness report failures
+truthfully. No product behavior changes.
+
+## What the nightly tests
+
+- `windows_ci`: 4-shard matrix (cli, core, agents, scripts) running the full Bun
+  corpus on Windows. PR CI runs ubuntu only, so Windows-only breakage surfaces
+  here, once per day, at main.
+- `windows_installed_command`: release-like install smoke (global + local
+  install) plus ~23 launcher probes that replace the installed `index.ts` with
+  an instrumented probe entry (scripts/tests/issue-2603-windows-probe.ts) so
+  the launcher's child is the probe, not the product.
+
+## Root causes (evidence)
+
+The Aug 30 nightly was the first Windows exposure for #3404 (merged Aug 29
+16:29, ships `bundle/llxprt.js`, rewrote the 2978 shim tests, added the
+output-generator test) and #3435 (merged Aug 29 evening, timeout-retry for the
+cli and agents runners). The prior night (run 33251092988) failed only
+`windows_ci`; `windows_installed_command` passed.
+
+1. **Probe fixture / bundle coupling** (windows_installed_command, all ~23
+   probes, exit 52). Launchers prefer `bundle/llxprt.js` over `index.ts` by
+   design (checks.cjs:127-146 pins it statically). `buildProbeFixture`
+   (scripts/windows-installed-command-smoke/checks.cjs:50-80) replaces only
+   `index.ts`, so after #3404 every probe exec'd the real CLI, which correctly
+   exits 52 from the unconfigured-provider guard
+   (packages/cli/src/unconfiguredProviderGuard.ts). The probe contract in the
+   probe header ("the launcher under test invokes `bun.exe <index.ts> %*`")
+   was broken underneath it. Not a product bug.
+2. **Global-state gate misattribution** (same job).
+   scripts/windows-installed-command-smoke.cjs:265-270 throws "prerequisite
+   checks failed (local-cmd-version or package-local-bun)" from the single
+   global `failed` flag, but both named steps printed OK; the flag was set by
+   the class-1 probe failures. Reporting bug.
+3. **POSIX-only spawn helpers** (windows_ci [scripts], 2 files, all tests).
+   - scripts/tests/issue-2978-node-shim-helpers.ts `runShim` spawns a
+     `node -e` wrapper that spawnSyncs the shim `.mjs` directly; Windows
+     cannot exec it (status null → `?? 1`). The file's own doc comment says
+     the shim is "invoked via `node <shim>`", which the implementation
+     contradicts.
+   - scripts/tests/memory/output-generator.test.ts resolves bun via
+     `Bun.which('bun')`; every case returned exit 1 with empty stderr,
+     including cases that expect exit 2, consistent with spawn failure
+     (status null coerced to 1 by the shared wrapper's `?? 1`), not with the
+     generator's own exit paths (0 or 2). The portable form is
+     `process.execPath`, already used by packages/core/run-bun-tests.ts.
+     Mechanism verified by inference from the uniform logs; not reproduced
+     locally (no Windows box). The fix is the same either way.
+4. **`toPathArgument` portability** (windows_ci [cli], 1 test).
+   packages/cli/run-bun-tests.ts:91-93 prefixes `./` unless the path starts
+   with `/` or `./`; absolute Windows paths become `./D:\...`, so the new
+   #3435 meta-test's temp fixture child exits instantly with a resolve error,
+   no timeout fires, no retry happens, and the retry assertion fails
+   (run-bun-tests.test.ts:860-975).
+5. **Core runner has no retry** (windows_ci [core], FATAL abort).
+   `generateContentResponseUtilities.test.ts` hit the documented sporadic
+   bun-on-Windows native freeze (silent 300s, rotating victims; see
+   project-plans/issue3253/plan.md), and the post-kill reap did not finish
+   within the ~10s budget, so packages/core/run-bun-tests.ts aborted the whole
+   shard ("failed to reap a timed-out test process tree", L425-435). #3435
+   deliberately left core without retry ("core's only observed victim is
+   gone"); that assumption is falsified by this run.
+6. **Summary honesty** (observed in the [scripts] shard log, 11:09:06).
+   scripts/test.ts `formatSummary` printed "Result: PASSED" while the phase
+   list showed "FAIL scripts" and the process exited 1. The `failed` tally
+   counts only workspace phases; the scripts phase lives only in `results`.
+   Exit code is correct (the separate `anyPhaseFailed` check), but the printed
+   verdict contradicts it.
+
+## Verdict: real bugs vs test architecture
+
+No product bugs. Exit 52 is the provider guard working as designed; the probes
+were meant to never reach it. All six findings are test-infrastructure defects:
+fixture/entry coupling (1), global-state reporting (2), POSIX spawn assumptions
+(3), path portability (4), inconsistent retry coverage plus a catastrophic
+reap-abort policy (5), and a misleading summary (6).
+
+## Fix plan
+
+Behavioral, red-checkable where possible. All changes are in test infrastructure.
+
+### FIX-1: probe fixture must control the entry point
+
+In `buildProbeFixture` (scripts/windows-installed-command-smoke/checks.cjs),
+remove `bundle/llxprt.js` from the fixture after copying the installed package,
+so the launcher resolves the source entry and execs the probe `index.ts`. This
+restores the documented probe contract for every probe (argv fidelity, injection
+guards, stdio, exit codes, execpath, process tree) without touching launcher
+semantics. The real bundle-vs-source precedence keeps being asserted statically
+at checks.cjs:127-146. Red check: with the fix, the fixture launcher execs the
+probe (probe emits its JSON marker); without it, exit 52.
+
+### FIX-2: gate on the steps it names
+
+In scripts/windows-installed-command-smoke.cjs, the pre-benchmark gate must fail
+on the results of the steps it names (local-cmd-version, package-local-bun),
+not the global flag. Track per-step success from the install-helpers and gate
+on those booleans; if a genuinely earlier step failed, the smoke already failed
+before this point with that step's own message. The gate message must name only
+what it tested.
+
+### FIX-3: portable spawn in the two script helpers
+
+- 2978 helpers `runShim`: the capture wrapper must spawn
+  `process.execPath` with the shim path as argv[1] (matching the documented
+  `node <shim> <args>` invocation and preserving `process.argv` semantics the
+  tests assert). Works identically on POSIX and Windows.
+- output-generator test: use `process.execPath` instead of `Bun.which('bun')`
+  for the generator child. Under `bun test`, `process.execPath` is the bun
+  binary running the tests, which is exactly the interpreter the test wants.
+
+### FIX-4: `toPathArgument` absolute-path handling
+
+Use `path.isAbsolute(file) || file.startsWith('./')` so absolute Windows paths
+pass through unchanged. Keep the `./` prefix behavior for bare relative names
+(bun resolves those against cwd). The #3435 meta-test then exercises its
+intended path on all platforms.
+
+### FIX-5: core runner retry parity with #3435
+
+Port `runTestFileWithTimeoutRetry` (timeout-retry once) from
+packages/cli/run-bun-tests.ts to packages/core/run-bun-tests.ts, mirroring the
+cli runner's structure and logging (RETRY marker in logs). Keep the FATAL
+reap-abort guard, but only trigger it after the retry attempt also fails to
+reap, so one unlucky taskkill race does not abort a 30-minute shard. A
+reap-failure that resolves on retry marks only that file failed.
+
+### FIX-6: truthful summary
+
+`formatSummary` (scripts/test.ts) must count every failed phase result
+(including the scripts phase) in `summary.failed` so "Result:" matches the
+exit-code logic. Add/extend the existing summary test to cover a failed
+scripts phase.
+
+## Out of scope (recommendations, not this PR)
+
+- Running Windows shards (or a smoke subset) in PR CI for PRs touching
+  packages/cli, packages/core, scripts/. This is the structural fix for
+  reliability; the six fixes above stop the current failure classes.
+- Nightly failure-bot hygiene (one issue accumulating 25+ comments, e.g. #3253).
+
+## Verification
+
+Per the issue workflow: `npm run test`, `npm run lint`, `npm run typecheck`,
+`npm run format`, `npm run build`, and the stepfun-37 profile smoke. Windows
+behavior is validated by the nightly after merge; local red checks cover the
+logic paths that are reachable on macOS (fixture entry resolution, gate
+booleans, spawn wrapper, path handling, retry wiring, summary counting).
+
+## Implementation record (2026-08-30)
+
+All six fixes implemented on `issue3439`. Targeted test evidence (macOS):
+
+- `bun test scripts/tests/issue-2978-node-shim.bun.test.ts`: 46 pass / 0 fail
+  (the suite that failed 100% on the Aug 30 Windows shard).
+- `bun test scripts/tests/memory/output-generator.test.ts`: 8 pass / 0 fail
+  (all 8 failed on the Aug 30 Windows shard).
+- `cd packages/cli && bun test test/run-bun-tests.test.ts`: 78 pass / 0 fail,
+  including the new absolute-Windows-path case for `toPathArgument`.
+- `cd packages/core && bun test test/run-bun-tests.test.ts`: 8 pass / 1
+  pre-existing skip / 0 fail, including the new retry describe.
+- `bun test scripts/tests/test-orchestrator.test.ts
+  scripts/tests/test-shard-orchestrator.test.ts`: 47 pass / 0 fail, including
+  the failed-scripts-phase summary verdict.
+- `node --check` on the three edited .cjs files: clean.
+
+Two corrections applied over the initial implementation pass:
+
+1. The 2978 helper keeps the OUTER spawn as `node`. Changing it to
+   `process.execPath` would have run the shim under bun (the test process is
+   bun), silently changing the system under test; the shim's contract is
+   `node <shim>` (shebang `#!/usr/bin/env node`). Only the inner wrapper's
+   target changed to `process.execPath`, which is node inside a `node -e`
+   wrapper on every platform.
+2. The smoke's `succeeded` flag is set only when `!getState().failed`. The
+   per-step prerequisite gate alone would have let recorded probe failures
+   reach the success path (success diagnostic, benchmark, temp cleanup), the
+   exact regression the old gate's comment warned about.
+
+A mangled edit in scripts/tests/test-orchestrator.test.ts (missing block
+closures, one deleted unrelated test) was restored to HEAD structure; the only
+intended change in that file is the added scripts-phase summary test.

--- a/project-plans/issue3439/PLAN.md
+++ b/project-plans/issue3439/PLAN.md
@@ -279,3 +279,14 @@ Unify the five bespoke per-package runners (cli/core/agents/auth +
 scripts/run_bun_tests.ts) on one policy module (timeout, retry budgets,
 reaping, JUnit) so parity fixes land once. Deliberately not attempted here to
 keep this diff within the review budget.
+
+### Post-push CI corrections (run 2)
+
+- ci.yml: fixed a truncated `actions/setup-node` SHA in the Windows gate
+  (dropped 15 hex chars) that failed job setup and the ratchet check.
+- Extended the two CI-contract meta-tests
+  (`ci-acplint-workflow.test.ts`, `ci-docs-only-skip.bun.test.ts`) to encode
+  the `windows_test_infra` aggregator contract: two new `${{ needs.* }}`
+  substitutions, `HEAVY_JOBS` membership, and behavioral tests for
+  gate-failure red and path-filtered-skip green.
+- Prettier fix in `scripts/run_bun_tests.ts` (catch-block return formatting).

--- a/project-plans/issue3439/PLAN.md
+++ b/project-plans/issue3439/PLAN.md
@@ -191,3 +191,91 @@ Two corrections applied over the initial implementation pass:
 A mangled edit in scripts/tests/test-orchestrator.test.ts (missing block
 closures, one deleted unrelated test) was restored to HEAD structure; the only
 intended change in that file is the added scripts-phase summary test.
+
+## Review addendum (2026-08-30, second session): FIX-5 flaw and broader reliability work
+
+The first implementation pass (commit `f628e05db`) was reviewed against its own
+plan. FIX-1/2/3/4/6 held up. FIX-5 did not: `runTestFileWithTimeoutRetry`
+returned early without retrying whenever the first attempt `reapFailed`,
+contradicting the plan's "only trigger [FATAL] after the retry attempt also
+fails to reap". The exact Aug 30 core failure (timeout + reap failure) would
+still have FATAL-aborted the shard.
+
+### Reworked FIX-5 (packages/core/run-bun-tests.ts)
+
+- Retry now runs on every timed-out first attempt, including one that failed
+  to reap.
+- FATAL reap-abort fires only when the final attempt reports `reapFailed`.
+- When the first attempt fails to reap but the retry reaps cleanly, the file
+  returns red with a merged result: `{...secondAttempt, passed: false,
+  timedOut: true, reapFailed: false, reapError: firstAttempt.reapError}` —
+  the file stays failed (the 300s stall is real) but the shard continues.
+- TIMEOUT log line notes `[REAP FAILED (recovered on retry)]` in that case.
+- Meta-tests replaced accordingly: "retries after reap failure and keeps the
+  file failed when the retry reaps cleanly" and "returns the second reap
+  failure so main() aborts" (10 pass / 1 skip).
+
+### Retry parity for the remaining runners
+
+The freeze class is runner-agnostic; after #3435 covered cli/agents and the
+rework covered core, two runners still had no timeout retry:
+
+- **packages/auth/run-bun-tests.ts**: added exported cli-style
+  `runTestFileWithTimeoutRetry` (timeout-only, one retry) wrapping each file
+  in the worker pool; 3 new behavior tests (12 pass / 0 fail).
+- **scripts/run_bun_tests.ts** (shared by 13 workspaces, 'rest' and
+  'providers' shards): added a timeout-only retry budget, default 1,
+  overridable with `LLXPRT_BUN_TEST_TIMEOUT_RETRIES` (0 disables; invalid
+  values throw). A timeout kill is detected via `wasKilledByTimeoutSignal`
+  (SIGTERM/SIGKILL), the same signal set `isChildSuccess` already used, so
+  classification and retry cannot disagree. The pre-existing `entry.retries`
+  failure budget is untouched and keeps its exact messages. Tests extended:
+  timeout-retry-then-pass, env-disable, budget resolution, retry plan
+  messages, and the comprehensive argv test updated for the retried SIGTERM
+  entry (54 pass / 0 fail).
+- The retry policy lives in a new shared module,
+  `scripts/lib/bun-test-retry.ts` (`resolveTimeoutRetryBudget`,
+  `wasKilledByTimeoutSignal`, `planNextAttempt`), unit-tested directly. This
+  also kept `scripts/run_bun_tests.ts` under the repo's 800-line lint cap.
+
+### Structural fix: Windows signal before merge (in scope after all)
+
+The plan's "out of scope" item — PR CI is ubuntu-only, so Windows-incompatible
+test code merges green and first runs on the nightly — is the reason these
+defect classes kept recurring (#2603→#3439). This branch adds a
+`windows_test_infra` gate job to `.github/workflows/ci.yml`:
+
+- windows-latest, ~20 min cap, `needs: [doc_change_filter, skip_check]`.
+- Path-filtered: on PRs it runs only when the Windows-sensitive surface
+  changed (scripts/, `*/run-bun-tests.ts`, runner/bun test helpers,
+  `packages/cli/bin/**`, the runner meta-tests, ci/nightly workflows,
+  bun.lock, root package/tsconfig). Empty file lists fail open to running.
+- Always runs on push/merge_group so bad merges surface in minutes.
+- Runs the fast, Windows-proven subset: 2978 shim + oven-fallback suites,
+  memory/output-generator, shared-runner tests, both orchestrator tests,
+  cli/core/agents/auth runner meta-tests, and the `llxprt --version`
+  launcher smoke (mirror of nightly's Defender exclusions + rollup win32
+  fix; no build step needed).
+- Wired into the `test` aggregator as blocking; a skip is accepted only for
+  docs-only PRs or when the path filter reported not-affected.
+
+### Verification (second session, macOS)
+
+- `bunx tsc --project tsconfig.scripts.json --noEmit`: 0 errors; core and
+  auth workspaces typecheck clean.
+- eslint on all changed TS files: clean (both prior errors resolved by the
+  lib extraction and the `planNextAttempt` loop rewrite).
+- `bun test` on run_bun_tests (54), core meta (10+1 skip), auth behavior
+  (12), policy+orchestrator+2978+output-generator batch (140, 1 skip): all
+  green.
+- `node scripts/check-test-file-coverage.ts`: PASSED (no new uncovered test
+  files).
+- actionlint on ci.yml: clean (2 pre-existing shellcheck notes elsewhere);
+  yamllint strict: only pre-existing line-length warnings; prettier clean.
+
+### Follow-up (filed separately)
+
+Unify the five bespoke per-package runners (cli/core/agents/auth +
+scripts/run_bun_tests.ts) on one policy module (timeout, retry budgets,
+reaping, JUnit) so parity fixes land once. Deliberately not attempted here to
+keep this diff within the review budget.

--- a/scripts/lib/bun-test-retry.ts
+++ b/scripts/lib/bun-test-retry.ts
@@ -1,0 +1,86 @@
+/**
+ * Retry policy for per-file timeout kills in the Bun test runners
+ * (issue #3439).
+ *
+ * A child killed by the per-file timeout gets one fresh attempt: the sporadic
+ * bun-on-Windows freeze kills one attempt and behaves normally on the next,
+ * while a genuine assertion failure never times out and is never retried by
+ * this budget. The pre-existing `entry.retries` budget (any failure, opt-in
+ * used by the e2e configs) stays independent and unchanged.
+ */
+
+/** Minimal child-exit shape shared by every runner in this repo. */
+export interface ChildExitLike {
+  readonly exitCode: number | null;
+  readonly signalCode?: string | null;
+}
+
+const DEFAULT_TIMEOUT_RETRIES = 1;
+const TIMEOUT_RETRIES_ENV_VAR = 'LLXPRT_BUN_TEST_TIMEOUT_RETRIES';
+
+/** Timeout-only retry budget per file; 0 disables (issue #3439). */
+export function resolveTimeoutRetryBudget(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const raw = env[TIMEOUT_RETRIES_ENV_VAR];
+  if (raw === undefined || raw === '') {
+    return DEFAULT_TIMEOUT_RETRIES;
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(
+      `Invalid ${TIMEOUT_RETRIES_ENV_VAR} value: ${raw} (expected a non-negative integer)`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * True when the child was terminated by the kill signal the per-file timeout
+ * (or a manual kill) uses. Shared by the pass/fail classification and the
+ * retry loop so the two can never disagree about what counts as a timeout.
+ */
+export function wasKilledByTimeoutSignal(child: ChildExitLike): boolean {
+  return child.signalCode === 'SIGTERM' || child.signalCode === 'SIGKILL';
+}
+
+/** The retry a failed attempt earns, or null when the file is done. */
+export type RetryPlan =
+  | { readonly kind: 'timeout'; readonly message: string }
+  | { readonly kind: 'failure'; readonly message: string };
+
+/**
+ * Decides whether a failed attempt is retried. Timeout kills draw from the
+ * timeout budget first; every other failure falls through to the pre-existing
+ * failure budget. Pure so the exact messages stay unit-testable.
+ */
+export function planNextAttempt(
+  outcome: {
+    readonly passed: boolean;
+    readonly timedOut: boolean;
+    readonly diagnostic: string;
+  },
+  state: {
+    readonly attempt: number;
+    readonly failureAttempts: number;
+    readonly timeoutRetriesLeft: number;
+  },
+  file: string,
+): RetryPlan | null {
+  if (outcome.passed) {
+    return null;
+  }
+  if (outcome.timedOut && state.timeoutRetriesLeft > 0) {
+    return {
+      kind: 'timeout',
+      message: `Native Bun test timed out (attempt ${state.attempt}), retrying: ${file}${outcome.diagnostic}`,
+    };
+  }
+  if (state.attempt < state.failureAttempts) {
+    return {
+      kind: 'failure',
+      message: `Native Bun test failed (attempt ${state.attempt}/${state.failureAttempts}), retrying: ${file}${outcome.diagnostic}`,
+    };
+  }
+  return null;
+}

--- a/scripts/run_bun_tests.ts
+++ b/scripts/run_bun_tests.ts
@@ -44,6 +44,11 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { resolveBunTestFiles, type BunTestFile } from './bun-test-roots.js';
 import { DEFAULT_PER_TEST_TIMEOUT_MS } from './lib/bun-test-policy.js';
 import {
+  planNextAttempt,
+  resolveTimeoutRetryBudget,
+  wasKilledByTimeoutSignal,
+} from './lib/bun-test-retry.js';
+import {
   buildVitestJsonReport,
   parseJUnitXml,
   type VitestJsonReport,
@@ -256,9 +261,7 @@ export function isChildSuccess(child: ChildExitInfo): boolean {
   if (child.exitCode === 0) {
     return true;
   }
-  const killedByTimeout =
-    child.signalCode === 'SIGTERM' || child.signalCode === 'SIGKILL';
-  if (!killedByTimeout) {
+  if (!wasKilledByTimeoutSignal(child)) {
     return false;
   }
   return outputShowsCompleteSummary(child.stdout, child.stderr);
@@ -509,7 +512,13 @@ function spawnTestFileOnce(
   run: RunWideOptions,
   dependencies: BunTestRunnerDependencies,
   junitOutfile?: string,
-): { passed: boolean; stdout: string; diagnostic: string; junitPath?: string } {
+): {
+  passed: boolean;
+  timedOut: boolean;
+  stdout: string;
+  diagnostic: string;
+  junitPath?: string;
+} {
   try {
     const child = dependencies.spawn(
       buildSpawnArgs(
@@ -529,8 +538,13 @@ function spawnTestFileOnce(
         timeout: processTimeoutFor(entry.timeout ?? run.timeout),
       },
     );
+    const passed = isChildSuccess(child);
     return {
-      passed: isChildSuccess(child),
+      passed,
+      // A signal kill that did NOT yield a complete passing summary (the
+      // isChildSuccess call above already accounted for that case) is the
+      // per-file timeout firing.
+      timedOut: !passed && wasKilledByTimeoutSignal(child),
       stdout: child.stdout ?? '',
       diagnostic: formatFailureDiagnostic(child),
       junitPath: junitOutfile,
@@ -540,7 +554,7 @@ function spawnTestFileOnce(
       error instanceof Error
         ? (error.stack ?? error.toString())
         : String(error);
-    return { passed: false, stdout: '', diagnostic: `\n${diagnostic}` };
+    return { passed: false, timedOut: false, stdout: '', diagnostic: `\n${diagnostic}` };
   }
 }
 
@@ -551,18 +565,31 @@ function runSingleTestFile(
   junitOutfile?: string,
 ): FileTestResult {
   const relativeName = entry.file.replace(entry.cwd + '/', '');
-  const attempts = (entry.retries ?? 0) + 1;
-  let last = { passed: false, stdout: '', diagnostic: '' };
-  for (let attempt = 1; attempt <= attempts; attempt++) {
+  // Two independent retry budgets: `entry.retries` retries any failure
+  // (pre-existing opt-in used by the e2e configs), while the timeout budget
+  // retries only per-file timeout kills (issue #3439) and defaults to 1.
+  // planNextAttempt owns the exact retry decision and messages.
+  const failureAttempts = (entry.retries ?? 0) + 1;
+  let timeoutRetriesLeft = resolveTimeoutRetryBudget();
+  let attempt = 1;
+  let last = spawnTestFileOnce(entry, run, dependencies, junitOutfile);
+  let retry = planNextAttempt(
+    last,
+    { attempt, failureAttempts, timeoutRetriesLeft },
+    entry.file,
+  );
+  while (retry !== null) {
+    if (retry.kind === 'timeout') {
+      timeoutRetriesLeft--;
+    }
+    dependencies.stderr(retry.message);
+    attempt++;
     last = spawnTestFileOnce(entry, run, dependencies, junitOutfile);
-    if (last.passed) {
-      break;
-    }
-    if (attempt < attempts) {
-      dependencies.stderr(
-        `Native Bun test failed (attempt ${attempt}/${attempts}), retrying: ${entry.file}${last.diagnostic}`,
-      );
-    }
+    retry = planNextAttempt(
+      last,
+      { attempt, failureAttempts, timeoutRetriesLeft },
+      entry.file,
+    );
   }
   if (!last.passed) {
     dependencies.stderr(

--- a/scripts/run_bun_tests.ts
+++ b/scripts/run_bun_tests.ts
@@ -554,7 +554,12 @@ function spawnTestFileOnce(
       error instanceof Error
         ? (error.stack ?? error.toString())
         : String(error);
-    return { passed: false, timedOut: false, stdout: '', diagnostic: `\n${diagnostic}` };
+    return {
+      passed: false,
+      timedOut: false,
+      stdout: '',
+      diagnostic: `\n${diagnostic}`,
+    };
   }
 }
 

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -512,6 +512,9 @@ function buildSummary(
     );
   }
 
+  // Workspaces pass only when all their phases pass; the scripts phase is
+  // not a workspace, so its failures are counted separately. Both counters
+  // stay on the same unit so the summary verdict matches the exit code.
   let passed = 0;
   let failed = 0;
   for (const success of workspaceOutcomes.values()) {
@@ -521,6 +524,7 @@ function buildSummary(
       failed++;
     }
   }
+  failed += results.filter((r) => r.phase === 'scripts' && !r.success).length;
 
   return {
     results,
@@ -620,12 +624,9 @@ function main(): void {
     const summary = orchestrateTests(rootDir, options);
     console.log(formatSummary(summary));
 
-    // Fail on any failed phase, including the script harness. The summary's
-    // `failed` count only tallies workspace outcomes (pretest/test); the
-    // scripts phase is tracked separately in `results`, so a scripts-only
-    // failure (e.g. the dedicated scripts shard) must be checked here.
-    // `anyPhaseFailed` already covers `summary.failed > 0` (a failed
-    // workspace produces a failed phase result), so it is the sole check.
+    // Exit code is 0 only when every phase passed, including the script
+    // harness. A workspace failure is a failed phase result; a scripts-only
+    // failure (e.g. the dedicated scripts shard) must also fail the run.
     const anyPhaseFailed = summary.results.some((r) => !r.success);
     if (anyPhaseFailed) {
       process.exit(1);

--- a/scripts/tests/ci-acplint-workflow.test.ts
+++ b/scripts/tests/ci-acplint-workflow.test.ts
@@ -71,6 +71,8 @@ interface TestAggregateResults {
   shards: string;
   nodeConsumerSmoke: string;
   acp: string;
+  windowsInfra: string;
+  windowsAffected: string;
 }
 
 function runTestAggregate(
@@ -85,6 +87,8 @@ function runTestAggregate(
     ["'${{ needs.test_shard.result }}'", '"$5"'],
     ["'${{ needs.node_consumer_smoke.result }}'", '"$6"'],
     ["'${{ needs.acp_conformance.result }}'", '"$7"'],
+    ["'${{ needs.windows_test_infra.result }}'", '"$8"'],
+    ["'${{ needs.windows_test_infra.outputs.affected }}'", '"$9"'],
   ] as const;
   let script = runText;
   for (const [expression, parameter] of substitutions) {
@@ -103,6 +107,8 @@ function runTestAggregate(
       results.shards,
       results.nodeConsumerSmoke,
       results.acp,
+      results.windowsInfra,
+      results.windowsAffected,
     ],
     { encoding: 'utf8' },
   );
@@ -453,12 +459,53 @@ describe('Issue #2877: test matrix scheduling', () => {
       'node_consumer_smoke',
       'acp_conformance',
       'doc_change_filter',
+      'windows_test_infra',
     ]);
     expect(runText).toContain("shard_result='${{ needs.test_shard.result }}'");
     expect(runText).toContain(`if [ "$shard_result" != "success" ]; then
     echo "::error::Test shards did not all succeed (result: $shard_result)"
     exit 1
   fi`);
+  });
+
+  it('fails the aggregator when the Windows test-infra gate fails (issue #3439)', () => {
+    const checkStep = stepNamed(testJob, 'Check shard results');
+    const result = runTestAggregate(checkStep.run ?? '', {
+      shouldSkip: 'false',
+      docsOnly: 'false',
+      selector: 'success',
+      hasTests: 'true',
+      shards: 'success',
+      nodeConsumerSmoke: 'success',
+      acp: 'success',
+      windowsInfra: 'failure',
+      windowsAffected: 'true',
+    });
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      'Windows test-infra gate did not succeed (result: failure)',
+    );
+  });
+
+  it('accepts a path-filtered skip of the Windows test-infra gate on a non-docs PR (issue #3439)', () => {
+    // affected=false means the PR's files cannot touch the Windows-sensitive
+    // suites, so a skipped gate must not red the required Test check.
+    const checkStep = stepNamed(testJob, 'Check shard results');
+    const result = runTestAggregate(checkStep.run ?? '', {
+      shouldSkip: 'false',
+      docsOnly: 'false',
+      selector: 'success',
+      hasTests: 'false',
+      shards: 'skipped',
+      nodeConsumerSmoke: 'success',
+      acp: 'success',
+      windowsInfra: 'skipped',
+      windowsAffected: 'false',
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      'Windows test-infra gate intentionally skipped',
+    );
   });
 
   it('fails the no-tests path when node_consumer_smoke fails', () => {
@@ -471,6 +518,8 @@ describe('Issue #2877: test matrix scheduling', () => {
       shards: 'skipped',
       nodeConsumerSmoke: 'failure',
       acp: 'success',
+      windowsInfra: 'success',
+      windowsAffected: 'true',
     });
     expect(result.status).toBe(1);
     expect(result.stdout).toContain(
@@ -490,6 +539,8 @@ describe('Issue #2877: test matrix scheduling', () => {
       shards: 'skipped',
       nodeConsumerSmoke,
       acp: 'success',
+      windowsInfra: 'success',
+      windowsAffected: 'true',
     });
     expect(result.status).toBe(1);
     expect(result.stdout).toContain(

--- a/scripts/tests/ci-docs-only-skip.bun.test.ts
+++ b/scripts/tests/ci-docs-only-skip.bun.test.ts
@@ -32,6 +32,10 @@ const HEAVY_JOBS = [
   'node_consumer_smoke',
   'bun_test_orchestrator_smoke',
   'acp_conformance',
+  // windows_test_infra (issue #3439) runs the Windows-sensitive suites that
+  // the ubuntu-only shards cannot execute; it is heavy, so it is gated the
+  // same way and skipped on docs-only PRs.
+  'windows_test_infra',
 ] as const;
 
 // The exact `if:` condition every heavy job must declare (normalized). The
@@ -103,6 +107,8 @@ interface TestAggregateResults {
   shards: string;
   nodeConsumerSmoke: string;
   acp: string;
+  windowsInfra: string;
+  windowsAffected: string;
 }
 
 const TEST_AGGREGATE_EXPRESSIONS = [
@@ -113,6 +119,8 @@ const TEST_AGGREGATE_EXPRESSIONS = [
   "'${{ needs.test_shard.result }}'",
   "'${{ needs.node_consumer_smoke.result }}'",
   "'${{ needs.acp_conformance.result }}'",
+  "'${{ needs.windows_test_infra.result }}'",
+  "'${{ needs.windows_test_infra.outputs.affected }}'",
 ] as const;
 
 /** Runs the real `test` aggregator "Check shard results" script. */
@@ -128,6 +136,8 @@ function runTestAggregate(
     results.shards,
     results.nodeConsumerSmoke,
     results.acp,
+    results.windowsInfra,
+    results.windowsAffected,
   ]);
 }
 
@@ -250,12 +260,17 @@ describe('Issue #342: skip heavy CI jobs on docs-only changes', () => {
         shards: 'skipped',
         nodeConsumerSmoke: 'skipped',
         acp: 'skipped',
+        windowsInfra: 'skipped',
+        windowsAffected: 'false',
       });
       expect(result.status).toBe(0);
       expect(result.stdout).toContain(
         'node_consumer_smoke intentionally skipped',
       );
       expect(result.stdout).toContain('acp_conformance intentionally skipped');
+      expect(result.stdout).toContain(
+        'Windows test-infra gate intentionally skipped',
+      );
     });
 
     it('docs-only PR is red when the selector reports tests but test_shard is skipped (selector still gates)', () => {
@@ -269,6 +284,8 @@ describe('Issue #342: skip heavy CI jobs on docs-only changes', () => {
         shards: 'skipped',
         nodeConsumerSmoke: 'skipped',
         acp: 'skipped',
+        windowsInfra: 'skipped',
+        windowsAffected: 'false',
       });
       expect(result.status).toBe(1);
       expect(result.stdout).toContain(
@@ -302,6 +319,8 @@ describe('Issue #342: skip heavy CI jobs on docs-only changes', () => {
         shards: 'success',
         nodeConsumerSmoke: 'failure',
         acp: 'success',
+        windowsInfra: 'success',
+        windowsAffected: 'true',
       });
       expect(result.status).toBe(1);
       expect(result.stdout).toContain(
@@ -318,6 +337,8 @@ describe('Issue #342: skip heavy CI jobs on docs-only changes', () => {
         shards: 'success',
         nodeConsumerSmoke: 'success',
         acp: 'failure',
+        windowsInfra: 'success',
+        windowsAffected: 'true',
       });
       expect(result.status).toBe(1);
       expect(result.stdout).toContain(
@@ -334,6 +355,8 @@ describe('Issue #342: skip heavy CI jobs on docs-only changes', () => {
         shards: 'skipped',
         nodeConsumerSmoke: 'success',
         acp: 'success',
+        windowsInfra: 'success',
+        windowsAffected: 'true',
       });
       expect(result.status).toBe(1);
       expect(result.stdout).toContain(
@@ -352,6 +375,8 @@ describe('Issue #342: skip heavy CI jobs on docs-only changes', () => {
         shards: 'skipped',
         nodeConsumerSmoke: 'skipped',
         acp: 'skipped',
+        windowsInfra: 'skipped',
+        windowsAffected: 'false',
       });
       expect(result.status).toBe(0);
       expect(result.stdout).toContain('green by design');
@@ -368,6 +393,8 @@ describe('Issue #342: skip heavy CI jobs on docs-only changes', () => {
         shards: 'skipped',
         nodeConsumerSmoke,
         acp: 'success',
+        windowsInfra: 'success',
+        windowsAffected: 'true',
       });
       expect(result.status).toBe(1);
       expect(result.stdout).toContain(

--- a/scripts/tests/issue-2978-node-shim-helpers.ts
+++ b/scripts/tests/issue-2978-node-shim-helpers.ts
@@ -158,12 +158,12 @@ export interface RunResult {
 const captureChildOutput = [
   'const { closeSync, openSync } = require("node:fs");',
   'const { spawnSync } = require("node:child_process");',
-  'const [stdoutPath, stderrPath, command, ...args] = process.argv.slice(1);',
+  'const [stdoutPath, stderrPath, shimPath, ...args] = process.argv.slice(1);',
   'const stdoutFd = openSync(stdoutPath, "w");',
   'const stderrFd = openSync(stderrPath, "w");',
   'let status = 1;',
   'try {',
-  '  status = spawnSync(command, args, { stdio: ["ignore", stdoutFd, stderrFd] }).status ?? 1;',
+  '  status = spawnSync(process.execPath, [shimPath, ...args], { stdio: ["ignore", stdoutFd, stderrFd] }).status ?? 1;',
   '} finally {',
   '  closeSync(stdoutFd);',
   '  closeSync(stderrFd);',
@@ -188,6 +188,10 @@ export function runShim(
   const stderrPath = path.join(layout.root, 'shim-stderr.log');
   writeFileSync(stdoutPath, '');
   writeFileSync(stderrPath, '');
+  // Outer process stays `node`: the shim's production contract is
+  // `node <shim>` (its shebang is `#!/usr/bin/env node`), and under
+  // `bun test` process.execPath would be bun, silently changing what is
+  // under test. Inside the wrapper, process.execPath is this same node.
   const result = spawnSync(
     'node',
     ['-e', captureChildOutput, stdoutPath, stderrPath, layout.shim, ...args],

--- a/scripts/tests/memory/output-generator.test.ts
+++ b/scripts/tests/memory/output-generator.test.ts
@@ -14,14 +14,9 @@ const generatorPath = fileURLToPath(
 );
 const repoRoot = resolve(generatorPath, '..', '..', '..');
 
-function resolveBunExecutable(): string {
-  const executable = Bun.which('bun');
-  if (executable === null) {
-    throw new Error('Bun executable is required for the output generator test');
-  }
-  return executable;
-}
-const bunExecutable = resolveBunExecutable();
+// Under `bun test`, process.execPath is the bun binary running the tests —
+// the portable interpreter, unlike Bun.which('bun').
+const bunExecutable = process.execPath;
 
 interface GeneratorResult {
   readonly exitCode: number;

--- a/scripts/tests/run_bun_tests.test.ts
+++ b/scripts/tests/run_bun_tests.test.ts
@@ -25,6 +25,10 @@ import {
   type BunTestSpawnOptions,
   type ChildExitInfo,
 } from '../run_bun_tests.js';
+import {
+  planNextAttempt,
+  resolveTimeoutRetryBudget,
+} from '../lib/bun-test-retry.js';
 
 describe('isChildSuccess', () => {
   it('returns true for exit code 0 with null signal', () => {
@@ -319,6 +323,7 @@ describe('runBunTests', () => {
       { exitCode: 0, signalCode: null },
       { exitCode: 7, signalCode: null },
       { exitCode: null, signalCode: 'SIGTERM' },
+      { exitCode: null, signalCode: 'SIGTERM' },
     ];
     const calls: Array<{
       command: readonly string[];
@@ -363,31 +368,37 @@ describe('runBunTests', () => {
     );
 
     expect(resolvedWorkspace).toBe('selected');
-    expect(calls).toEqual(
-      entries.map((entry) => ({
-        command: [
-          '/bin/bun',
-          'test',
-          '--tsconfig-override',
-          '/invoke/config/tsconfig.json',
-          '--max-concurrency',
-          '1',
-          '--timeout',
-          '1234',
-          entry.file,
-        ],
-        options: {
-          cwd: entry.cwd,
-          env: environment,
-          stdin: 'inherit',
-          stdout: 'pipe',
-          stderr: 'pipe',
-          timeout: 120_000,
-        },
-      })),
-    );
+    // The SIGTERM-killed third entry consumes its timeout-only retry (issue
+    // #3439) before reporting the final failure, so it spawns twice.
+    const expectedCall = (file: string, cwd: string) => ({
+      command: [
+        '/bin/bun',
+        'test',
+        '--tsconfig-override',
+        '/invoke/config/tsconfig.json',
+        '--max-concurrency',
+        '1',
+        '--timeout',
+        '1234',
+        file,
+      ] as const,
+      options: {
+        cwd,
+        env: environment,
+        stdin: 'inherit',
+        stdout: 'pipe',
+        stderr: 'pipe',
+        timeout: 120_000,
+      } as const,
+    });
+    expect(calls).toEqual([
+      ...entries.slice(0, 2).map((entry) => expectedCall(entry.file, entry.cwd)),
+      expectedCall(entries[2]!.file, entries[2]!.cwd),
+      expectedCall(entries[2]!.file, entries[2]!.cwd),
+    ]);
     expect(stderr).toEqual([
       'Native Bun test failed: /repo/packages/two/two.test.ts (exit code: 7)',
+      'Native Bun test timed out (attempt 1), retrying: /repo/packages/three/three.test.ts (signal: SIGTERM)',
       'Native Bun test failed: /repo/packages/three/three.test.ts (signal: SIGTERM)',
     ]);
     expect(stdout.at(-1)).toBe(
@@ -595,6 +606,166 @@ describe('runBunTests', () => {
     expect(stderr.at(-1)).toBe(
       'Native Bun test failed: /repo/e2e/broken.test.ts (exit code: 1)',
     );
+  });
+
+  it('retries a per-file timeout once and passes on the fresh attempt', async () => {
+    let attempts = 0;
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const dependencies: BunTestRunnerDependencies = {
+      repoRoot: '/repo',
+      invocationDirectory: '/invoke',
+      executable: '/bin/bun',
+      environment: {},
+      resolveFiles: () => [
+        {
+          cwd: '/repo/ws',
+          file: '/repo/ws/frozen.test.ts',
+          preloads: [],
+        },
+      ],
+      resolveTsconfig: resolveTsconfigOverride,
+      spawn: () => {
+        attempts++;
+        // First attempt: killed by the per-file timeout with partial output.
+        // Retry: clean pass.
+        return attempts === 1
+          ? { exitCode: null, signalCode: 'SIGTERM' }
+          : { exitCode: 0, signalCode: null };
+      },
+      loadGlobalSetup: noGlobalSetup,
+      stdout: (line) => stdout.push(line),
+      stderr: (line) => stderr.push(line),
+    };
+
+    const status = await runBunTests([], dependencies);
+
+    expect(attempts).toBe(2);
+    expect(status).toBe(0);
+    expect(stderr).toEqual([
+      'Native Bun test timed out (attempt 1), retrying: /repo/ws/frozen.test.ts (signal: SIGTERM)',
+    ]);
+    expect(stdout.at(-1)).toBe('Passed 1/1 isolated native Bun test files');
+  });
+
+  it('disables the timeout retry with LLXPRT_BUN_TEST_TIMEOUT_RETRIES=0', async () => {
+    let attempts = 0;
+    const dependencies: BunTestRunnerDependencies = {
+      repoRoot: '/repo',
+      invocationDirectory: '/invoke',
+      executable: '/bin/bun',
+      environment: {},
+      resolveFiles: () => [
+        {
+          cwd: '/repo/ws',
+          file: '/repo/ws/frozen.test.ts',
+          preloads: [],
+        },
+      ],
+      resolveTsconfig: resolveTsconfigOverride,
+      spawn: () => {
+        attempts++;
+        return { exitCode: null, signalCode: 'SIGTERM' };
+      },
+      loadGlobalSetup: noGlobalSetup,
+      stdout: () => {},
+      stderr: () => {},
+    };
+
+    const previous = process.env.LLXPRT_BUN_TEST_TIMEOUT_RETRIES;
+    process.env.LLXPRT_BUN_TEST_TIMEOUT_RETRIES = '0';
+    try {
+      const status = await runBunTests([], dependencies);
+      expect({ status, attempts }).toEqual({ status: 1, attempts: 1 });
+    } finally {
+      if (previous === undefined) {
+        delete process.env.LLXPRT_BUN_TEST_TIMEOUT_RETRIES;
+      } else {
+        process.env.LLXPRT_BUN_TEST_TIMEOUT_RETRIES = previous;
+      }
+    }
+  });
+});
+
+describe('resolveTimeoutRetryBudget', () => {
+  it('defaults to 1 when the override is absent or empty', () => {
+    expect(resolveTimeoutRetryBudget({})).toBe(1);
+    expect(resolveTimeoutRetryBudget({ LLXPRT_BUN_TEST_TIMEOUT_RETRIES: '' })).toBe(1);
+  });
+
+  it('accepts an explicit non-negative integer', () => {
+    expect(
+      resolveTimeoutRetryBudget({ LLXPRT_BUN_TEST_TIMEOUT_RETRIES: '3' }),
+    ).toBe(3);
+    expect(
+      resolveTimeoutRetryBudget({ LLXPRT_BUN_TEST_TIMEOUT_RETRIES: '0' }),
+    ).toBe(0);
+  });
+
+  it('rejects non-integer and negative values', () => {
+    expect(() =>
+      resolveTimeoutRetryBudget({ LLXPRT_BUN_TEST_TIMEOUT_RETRIES: '1.5' }),
+    ).toThrow('Invalid LLXPRT_BUN_TEST_TIMEOUT_RETRIES value: 1.5');
+    expect(() =>
+      resolveTimeoutRetryBudget({ LLXPRT_BUN_TEST_TIMEOUT_RETRIES: '-1' }),
+    ).toThrow('Invalid LLXPRT_BUN_TEST_TIMEOUT_RETRIES value: -1');
+    expect(() =>
+      resolveTimeoutRetryBudget({ LLXPRT_BUN_TEST_TIMEOUT_RETRIES: 'two' }),
+    ).toThrow('Invalid LLXPRT_BUN_TEST_TIMEOUT_RETRIES value: two');
+  });
+});
+
+describe('planNextAttempt', () => {
+  it('returns null for a passed attempt and for every budget exhausted', () => {
+    expect(
+      planNextAttempt(
+        { passed: true, timedOut: false, diagnostic: '' },
+        { attempt: 1, failureAttempts: 1, timeoutRetriesLeft: 1 },
+        '/repo/ws/a.test.ts',
+      ),
+    ).toBe(null);
+    expect(
+      planNextAttempt(
+        { passed: false, timedOut: true, diagnostic: ' (signal: SIGTERM)' },
+        { attempt: 1, failureAttempts: 1, timeoutRetriesLeft: 0 },
+        '/repo/ws/a.test.ts',
+      ),
+    ).toBe(null);
+    expect(
+      planNextAttempt(
+        { passed: false, timedOut: false, diagnostic: ' (exit code: 1)' },
+        { attempt: 2, failureAttempts: 2, timeoutRetriesLeft: 1 },
+        '/repo/ws/a.test.ts',
+      ),
+    ).toBe(null);
+  });
+
+  it('prefers the timeout budget for timeout kills and preserves messages', () => {
+    expect(
+      planNextAttempt(
+        { passed: false, timedOut: true, diagnostic: ' (signal: SIGTERM)' },
+        { attempt: 1, failureAttempts: 3, timeoutRetriesLeft: 1 },
+        '/repo/ws/frozen.test.ts',
+      ),
+    ).toEqual({
+      kind: 'timeout',
+      message:
+        'Native Bun test timed out (attempt 1), retrying: /repo/ws/frozen.test.ts (signal: SIGTERM)',
+    });
+  });
+
+  it('falls through to the failure budget for non-timeout failures', () => {
+    expect(
+      planNextAttempt(
+        { passed: false, timedOut: false, diagnostic: ' (exit code: 1)' },
+        { attempt: 1, failureAttempts: 2, timeoutRetriesLeft: 1 },
+        '/repo/ws/broken.test.ts',
+      ),
+    ).toEqual({
+      kind: 'failure',
+      message:
+        'Native Bun test failed (attempt 1/2), retrying: /repo/ws/broken.test.ts (exit code: 1)',
+    });
   });
 });
 

--- a/scripts/tests/run_bun_tests.test.ts
+++ b/scripts/tests/run_bun_tests.test.ts
@@ -392,7 +392,9 @@ describe('runBunTests', () => {
       } as const,
     });
     expect(calls).toEqual([
-      ...entries.slice(0, 2).map((entry) => expectedCall(entry.file, entry.cwd)),
+      ...entries
+        .slice(0, 2)
+        .map((entry) => expectedCall(entry.file, entry.cwd)),
       expectedCall(entries[2]!.file, entries[2]!.cwd),
       expectedCall(entries[2]!.file, entries[2]!.cwd),
     ]);
@@ -690,7 +692,9 @@ describe('runBunTests', () => {
 describe('resolveTimeoutRetryBudget', () => {
   it('defaults to 1 when the override is absent or empty', () => {
     expect(resolveTimeoutRetryBudget({})).toBe(1);
-    expect(resolveTimeoutRetryBudget({ LLXPRT_BUN_TEST_TIMEOUT_RETRIES: '' })).toBe(1);
+    expect(
+      resolveTimeoutRetryBudget({ LLXPRT_BUN_TEST_TIMEOUT_RETRIES: '' }),
+    ).toBe(1);
   });
 
   it('accepts an explicit non-negative integer', () => {

--- a/scripts/tests/test-orchestrator.test.ts
+++ b/scripts/tests/test-orchestrator.test.ts
@@ -722,6 +722,26 @@ describe('formatSummary', () => {
     expect(output).toContain('pkg-a');
   });
 
+  it('prints Result: FAILED for a failed scripts phase', () => {
+    const summary = makeSummary({
+      results: [
+        {
+          workspace: 'scripts',
+          phase: 'scripts',
+          success: false,
+          exitCode: 1,
+          durationMs: 50,
+        },
+      ],
+      totalWorkspaces: 0,
+      failed: 1,
+    });
+    const output = formatSummary(summary);
+    expect(output).toContain('FAIL');
+    expect(output).toContain('scripts');
+    expect(output).toContain('Result: FAILED');
+  });
+
   it('includes duration information', () => {
     const summary = makeSummary({ durationMs: 100 });
     const output = formatSummary(summary);

--- a/scripts/tests/test-shard-orchestrator.test.ts
+++ b/scripts/tests/test-shard-orchestrator.test.ts
@@ -9,6 +9,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
+  formatSummary,
   parseArgs,
   type CommandRunner,
   orchestrateTests,
@@ -291,15 +292,17 @@ describe('orchestrateTests (--shard)', () => {
       failingRunner,
     );
 
-    // No workspace ran, so passed/failed are both 0.
+    // No workspace ran, so passed is 0.
     expect(summary.passed).toBe(0);
-    expect(summary.failed).toBe(0);
     expect(summary.totalWorkspaces).toBe(0);
-    // But the scripts phase failed — the caller (main) must check results.
+    // A failed scripts phase must be reflected in the summary's failed count
+    // so its printed verdict matches the exit code.
+    expect(summary.failed).toBe(1);
     const scriptsResult = summary.results.find((r) => r.phase === 'scripts');
     expect(scriptsResult).toBeDefined();
     expect(scriptsResult!.success).toBe(false);
     expect(summary.results.some((r) => !r.success)).toBe(true);
+    expect(formatSummary(summary)).toContain('Result: FAILED');
   });
 
   // Each scripts-shard root is its own invocation so that one root's timeout

--- a/scripts/windows-installed-command-smoke.cjs
+++ b/scripts/windows-installed-command-smoke.cjs
@@ -211,6 +211,29 @@ function runBehavioralChecks(ctx) {
   checks.checkNpmExecEphemeral(tempDir, replicaTarball);
 }
 
+/**
+ * Local (consumer) install plus the two prerequisite checks the pre-benchmark
+ * gate names. Throws naming exactly the steps that failed, so the error is
+ * never misattributed to an earlier behavioral probe failure.
+ */
+function completePrerequisiteChecks(tempDir, replicaTarball, prefix) {
+  const consumerDir = localInstall(tempDir, replicaTarball);
+  const localCmdOk = checkLocalCmdVersion(consumerDir);
+  const packageLocalBunOk = checkPackageLocalBun(
+    prefix,
+    findInstalledPackageRoot,
+    findBundledBun,
+  );
+  if (!localCmdOk || !packageLocalBunOk) {
+    const failedSteps = [];
+    if (!localCmdOk) failedSteps.push('local-cmd-version');
+    if (!packageLocalBunOk) failedSteps.push('package-local-bun');
+    throw new Error(
+      `prerequisite checks failed (${failedSteps.join(', ')}); aborting before success`,
+    );
+  }
+}
+
 function runSmoke() {
   resetState();
   let tempDir;
@@ -254,21 +277,13 @@ function runSmoke() {
       });
       await checks.checkProcessTreeNoNode(probeFixture);
 
-      const consumerDir = localInstall(tempDir, replicaTarball);
-      checkLocalCmdVersion(consumerDir);
-      checkPackageLocalBun(prefix, findInstalledPackageRoot, findBundledBun);
-      // Gate succeeded on the assertion state so a runStep failure (which
-      // records via fail() without throwing) is not masked as success.
-      // Without this guard, a local-cmd-version or package-local-bun failure
-      // would write a success diagnostic, run the benchmark, and delete the
-      // temp fixture that the failure diagnostic says to preserve.
-      const { failed } = getState();
-      if (failed) {
-        throw new Error(
-          'prerequisite checks failed (local-cmd-version or package-local-bun); aborting before success',
-        );
+      completePrerequisiteChecks(tempDir, replicaTarball, prefix);
+      // Any recorded failure (e.g. a behavioral probe) must not reach the
+      // success path: it would write a success diagnostic, run the benchmark,
+      // and delete the temp fixture the failure path promises to preserve.
+      if (!getState().failed) {
+        succeeded = true;
       }
-      succeeded = true;
     } catch (err) {
       fail(`unexpected error: ${err.stack || err.message}`);
     } finally {

--- a/scripts/windows-installed-command-smoke/checks.cjs
+++ b/scripts/windows-installed-command-smoke/checks.cjs
@@ -11,6 +11,7 @@ const { spawnSync, spawn } = require('node:child_process');
 const {
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -52,6 +53,16 @@ function buildProbeFixture(installedPackageRoot, tempBase, label, repoRoot) {
   mkdirSync(fixtureDir, { recursive: true });
   const fixturePkgRoot = join(fixtureDir, 'pkg');
   copyTree(installedPackageRoot, fixturePkgRoot);
+  // The launcher prefers bundle/llxprt.js over index.ts; the probe replaces
+  // index.ts, so drop the bundle from the fixture to force the source entry.
+  const bundledEntry = join(fixturePkgRoot, 'bundle', 'llxprt.js');
+  if (existsSync(bundledEntry)) {
+    rmSync(bundledEntry, { force: true });
+    const bundleDir = join(fixturePkgRoot, 'bundle');
+    if (existsSync(bundleDir) && readdirSync(bundleDir).length === 0) {
+      rmSync(bundleDir, { recursive: true, force: true });
+    }
+  }
   const probePath = join(
     repoRoot,
     'scripts',

--- a/scripts/windows-installed-command-smoke/install-helpers.cjs
+++ b/scripts/windows-installed-command-smoke/install-helpers.cjs
@@ -23,7 +23,7 @@ const { spawnSync } = require('node:child_process');
 const { existsSync, mkdirSync, writeFileSync } = require('node:fs');
 const { join } = require('node:path');
 
-const { assert, runStep, runRequiredStep } = require('./assert.cjs');
+const { assert, runStep, runRequiredStep, getState } = require('./assert.cjs');
 const {
   INSTALL_TIMEOUT_MS,
   VERSION_TIMEOUT_MS,
@@ -160,6 +160,7 @@ function localInstall(tempDir, replicaTarball) {
 }
 
 function checkLocalCmdVersion(consumerDir) {
+  const before = getState();
   runStep('local-cmd-version', () => {
     const cmdPath = join(consumerDir, 'node_modules', '.bin', 'llxprt.cmd');
     assert(existsSync(cmdPath), `local cmd launcher not found: ${cmdPath}`);
@@ -180,6 +181,7 @@ function checkLocalCmdVersion(consumerDir) {
       );
     }
   });
+  return getState().failures.length === before.failures.length;
 }
 
 function checkPackageLocalBun(
@@ -187,6 +189,7 @@ function checkPackageLocalBun(
   findInstalledPackageRoot,
   findBundledBun,
 ) {
+  const before = getState();
   runStep('package-local-bun-exists', () => {
     const packageRoot = findInstalledPackageRoot(prefix);
     if (!packageRoot || typeof packageRoot !== 'string') {
@@ -206,6 +209,7 @@ function checkPackageLocalBun(
     // partial/timed-out install that left a non-Windows or wrong-version binary.
     assertBundledBunHealthy(bunExe, EXPECTED_BUN_VERSION);
   });
+  return getState().failures.length === before.failures.length;
 }
 
 module.exports = {


### PR DESCRIPTION
## TLDR

Fixes the recurring Windows nightly failures and removes the structural cause. The Aug 30 nightly (#3439) failed two Windows jobs for six distinct test-infrastructure reasons, none of them product bugs. This PR repairs all six, adds timeout-only retry parity to every test runner (core reworked, auth and the shared 13-workspace runner newly covered), and adds the first Windows signal to PR CI so this breakage class fails at the PR instead of the next nightly.

## Dive Deeper

### Commit 1 (`f628e05db`) — the six Aug 30 defects

Failure-by-failure root cause from run 33307362307 (full analysis in `project-plans/issue3439/PLAN.md`):

1. **`windows_installed_command` — all ~23 probes exit 52 "No provider is configured."** #3404 started shipping `bundle/llxprt.js`; launchers prefer the bundle over `index.ts` by design. `buildProbeFixture` replaced only `index.ts`, so probes exec'd the real CLI, which correctly refused to run without a provider. The fixture now deletes the bundle (the static bundle-preference assertion still pins the launcher ordering).
2. **Same job — misattributed "prerequisite checks failed (local-cmd-version or package-local-bun)".** Both steps passed; the gate keyed on a global failure flag accumulated by the earlier probe failures. `checkLocalCmdVersion`/`checkPackageLocalBun` now return their own outcome, the gate names only genuinely failed steps, and the success path stays closed while any recorded failure exists.
3. **`[scripts]` — every #2978 shim test failed.** The capture wrapper spawned the `.mjs` shim directly (works via shebang exec on POSIX, impossible on Windows). The wrapper now spawns `process.execPath` with `[shimPath, ...args]`; the outer spawn still uses `node` because the shim's contract is `node <shim>`.
4. **`[scripts]` — all 8 output-generator tests failed.** The test resolved bun via `Bun.which('bun')`, which returned null under the wrapper's constrained Windows environment. It uses `process.execPath` now (the tests themselves already run under bun).
5. **`[cli]` — new #3435 meta-test failed.** `toPathArgument` prefixed `./` onto the test's absolute Windows temp path, so the child exited instantly instead of timing out and retried. Absolute paths (POSIX and win32) now pass through; a Windows-path case was added next to the existing tests.
6. **`[core]` — FATAL "failed to reap a timed-out test process tree".** The sporadic bun-on-Windows freeze (#3253 class) hit `generateContentResponseUtilities.test.ts`; #3435 gave cli and agents a timeout-retry but not core ("core's only observed victim is gone" — falsified a day later). Core now has the same retry, behavioral tests included.

Also fixed: `scripts/test.ts` printed `FAIL scripts … Result: PASSED` because its failed tally counted only workspace phases while the exit code correctly keyed on any phase. Both counters now use one unit (failed workspaces + failed scripts phases), matching the exit-code logic.

### Commit 2 (`20975d8ae`) — retry parity and the structural fix

The structural cause behind the whole #2603 → #3439 chain: `ci.yml` ran ubuntu-only, so Windows-incompatible test code merged green and was first executed by the nightly, once per day, on main.

- **Core runner reap-retry reworked.** The first pass's retry skipped itself whenever the timed-out attempt also failed to reap, and the OCR round-1 remediation (no retry after reap failure, "the old tree may still hold resources") left the exact observed failure lethal: one unlucky taskkill race still FATAL-aborted the whole ~13-minute shard. Reworked semantics: the retry always runs; if the retry reaps cleanly the file stays red (the 300s stall is real) and the shard continues; the FATAL abort fires only when the *retry* also fails to reap. The resource-hazard concern is preserved by construction: a contended retry either fails (file red, shard alive) or fails to reap (FATAL, as before) — the only new outcome is "recovered", which is strictly safer than losing the shard. This deliberately supersedes the OCR round-1 remediation; rationale recorded in `project-plans/issue3439/PLAN.md` (review addendum).
- **Auth runner and shared runner (`scripts/run_bun_tests.ts`, 13 workspaces) gain the same timeout-only retry** (default 1; `LLXPRT_BUN_TEST_TIMEOUT_RETRIES` overrides/disables; invalid values throw). The policy lives in the new `scripts/lib/bun-test-retry.ts` (`resolveTimeoutRetryBudget`, `wasKilledByTimeoutSignal`, `planNextAttempt`), so timeout classification and the retry decision cannot disagree. The pre-existing e2e `entry.retries` failure budget is untouched, messages and semantics preserved.
- **New `windows_test_infra` gate job** in `ci.yml`: windows-latest, ~20 min cap, path-filtered on PRs (Windows-sensitive surface: scripts/, `*/run-bun-tests.ts`, runner meta-tests, `packages/cli/bin/**`, ci/nightly workflows, bun.lock, root package/tsconfig; empty file lists fail open to running), always on push/merge_group. Runs the fast Windows-proven subset (2978 suites, output-generator, shared-runner tests, orchestrator tests, cli/core/agents/auth runner meta-tests, `llxprt --version`) with the nightly's Defender exclusions and rollup win32 fix. Wired into the `test` aggregator as blocking; skips accepted only for docs-only PRs or when the filter reported not-affected.

Follow-up filed separately: #3442 (unify the five bespoke runners on one policy module).

Review process note: the first pass's compliance review could not run (gpt56solhigh Codex auth, opusthinking no key, glm keys exhausted); OCR reviewed it in two rounds (round 1: reap-retry hazard + mixed-unit summary counting, both addressed — the reap item then superseded by the rework above, round 2: comment nit). Commit 2 has not yet been through OCR; a fresh full OCR of the final diff is queued before merge.

## Reviewer Test Plan

1. `bun test --preload ./scripts/tests/test-setup.ts scripts/tests/run_bun_tests.test.ts` — 54 pass, including timeout-retry-then-pass, env-disable, and the retry-plan message cases.
2. `cd packages/core && bun test test/run-bun-tests.test.ts` — 10 pass / 1 skip, including "retries after reap failure and keeps the file failed when the retry reaps cleanly" and "returns the second reap failure so main() aborts".
3. `cd packages/auth && bun test src/__tests__/run-bun-tests.behavior.test.ts` — 12 pass, including the new retry describe.
4. `bun test --preload ./scripts/tests/test-setup.ts scripts/tests/issue-2978-node-shim.bun.test.ts scripts/tests/issue-2978-oven-fallback.bun.test.ts scripts/tests/memory/output-generator.test.ts scripts/tests/bun-test-policy.bun.test.ts scripts/tests/test-orchestrator.test.ts scripts/tests/test-shard-orchestrator.test.ts` — 140 pass / 1 skip (first two suites were 100% red on the Aug 30 Windows shard).
5. `cd packages/cli && bun test test/run-bun-tests.test.ts` — 78 pass; `./packages/cli/bin/llxprt --version`.
6. `bunx tsc --project tsconfig.scripts.json --noEmit`; `bun scripts/check-test-file-coverage.ts`; `actionlint .github/workflows/ci.yml`.
7. This PR's diff matches the new gate's path filter, so the **Windows Test-Infra Gate** check on this PR is the change under test running on windows-latest.
8. Optional red-check: make the core retry skip reap-failed first attempts again and the "retries after reap failure" test fails.

## Testing Matrix

Product runtime is untouched; validation is test-infra level.

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅ full `npm run test/lint/typecheck/format/build` (commit 1, logs in `tmp/verify3439/`) + targeted suites, tsc, eslint, actionlint/yamllint/prettier (commit 2); stepfun-37 profile smoke (commit 1) | ❓ via the new gate on this PR, then nightly | ❓ via existing ubuntu shards |
| npx      | ✅ | ❓ | ❓ |
| Docker   | ❓  | -   | -   |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3439
Related to #3253 (sporadic freeze class), #3153 (prior nightly round), #3435 (retry machinery this extends), #3404 (bundle shipment that broke the probe fixture), #2603 (probe contract), #2978 (shim tests)
Follow-up: #3442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Windows drive-letter and UNC test paths.
  - Timed-out test files are now retried before being reported as failures.
  - Recoverable process-cleanup failures no longer unnecessarily stop test batches.
  - Script-phase failures now correctly affect overall test results and exit status.
  - Windows smoke tests provide clearer prerequisite failure reporting.

- **Testing**
  - Expanded coverage for timeout retries, Windows paths, script failures, and Windows-specific test infrastructure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->