### PR TITLE
fix(ci): stop the macOS nightly smoke-hang failure class — timeout-only retry (Fixes #3447)

### DIFF
--- a/project-plans/issue-3447-macos-nightly-smoke-hang.md
+++ b/project-plans/issue-3447-macos-nightly-smoke-hang.md
@@ -1,0 +1,171 @@
+# Issue #3447: Nightly workflow failed — macos_ci (scripts shard)
+
+## Investigation summary
+
+**Failed run:** 33389396733 (2026-08-31 11:57 UTC), job `macOS CI (Nightly) [scripts]`,
+commit `393a0080f` on `main`.
+
+**Failing test:** `scripts/tests/nightly-bun-native-smoke.test.ts` →
+`Bun native-module smoke harness > passes its real checks for the current platform`
+at exactly 300024.73 ms.
+
+**Evidence chain:**
+
+1. The harness subprocess (`bun scripts/bun-native-modules-smoke.ts`) stdout stops
+   after `[PASS] web-tree-sitter + tree-sitter-pwsh WASM` (#3181). On POSIX the
+   next check is `checkBunPty` (Bun.Terminal PTY adapter, POSIX-only). Neither its
+   `[PASS]`/`[FAIL]` line, nor the harness's own 5 s exit-promise fail-safe, nor
+   the final summary ever appeared.
+2. A 5 s in-process timer failing to fire means the harness event loop was
+   blocked — consistent with a synchronous/loop-blocking hang inside
+   `Bun.spawn(..., { terminal })` (the adapter's own header documents Bun PTY
+   edge cases, e.g. oven-sh/bun#25822). No in-process guard can bound this.
+3. The test's 300 s `AbortSignal` killed the subprocess; the test converted that
+   into a clean assertion failure; `bun test` exited 1; the job went red.
+4. The exact same commit passed the previous nightly (run 33335701069,
+   2026-08-30 21:10 UTC, all jobs green). **Flaky, load-dependent** — not a
+   code regression.
+5. Not reproducible locally: 20/20 clean sub-second runs on macOS.
+6. Prior nightly failures (8/25–8/30) were the Windows classes fixed by #3441;
+   this is a distinct macOS class.
+7. Precedent: #3439/#3441 established the repo's remedy for exactly this flake
+   family — **timeout-only retry** ("a child killed by the per-file timeout gets
+   one fresh attempt; a genuine assertion failure never times out and is never
+   retried"), owned in `scripts/lib/bun-test-retry.ts`. That policy cannot catch
+   this case: the runner classifies timeouts by SIGTERM/SIGKILL kill signals, but
+   this test converts its timeout into a normal exit-1 assertion failure.
+
+**Budget math (drives the design):**
+
+- Runner per-file process kill: `processTimeoutFor(entry.timeout ?? run.timeout)`
+  = `max(120s, 2 × 180s)` = 360 s for this file today — why the 300.27 s file run
+  survived.
+- A bounded retry inside the test raises worst-case file time to
+  ~2 × 300 s + overhead > 360 s; without a matching per-file override the runner
+  would kill the file mid-attempt and convert the flake into a different failure
+  class.
+- `macos_ci` job budget is 45 min; the shard currently uses ~15 min. A 2-attempt
+  worst case (~620 s) fits comfortably.
+
+## Acceptance criteria
+
+- **AC1 — Timeout retry:** When a harness attempt is aborted by the subprocess
+  timeout (`ABORT_ERR`/`AbortError`), the test retries the harness subprocess
+  within a bounded timeout-retry budget (default 1 retry → 2 attempts, mirroring
+  `bun-test-retry.ts`), and passes when a later attempt succeeds.
+- **AC2 — Timeout-only policy:** Non-timeout failures (real check failures with
+  non-zero exit codes, ENOENT, other execution errors) are never retried; they
+  fail on the first attempt with today's diagnostics, preserving deterministic
+  breakage detection (identical policy statement to #3439).
+- **AC3 — Fail-closed on persistent hang:** When every attempt times out, the
+  test fails with a diagnostic naming the per-attempt timeout, the attempt
+  count, and each attempt's captured output.
+- **AC4 — Knob:** `LLXPRT_BUN_SMOKE_TIMEOUT_RETRIES` — non-negative integer,
+  default 1; `0` restores exact single-attempt behavior; invalid values throw a
+  clear error (loud-misconfiguration convention of `LLXPRT_BUN_TEST_TIMEOUT_RETRIES`).
+  The existing `LLXPRT_BUN_SMOKE_TIMEOUT_MS` knob and its 300 s default are
+  unchanged.
+- **AC5 — Budget coherence:** The test's bun-test timeout covers the worst case
+  `(retries + 1) × (HARNESS_TIMEOUT_MS + 10_000)`, and the `scripts-tests` root
+  gains a `timeoutOverrides` entry for `nightly-bun-native-smoke.test.ts` sized
+  to the same worst case (issue-2603 pattern), so the runner's per-file kill
+  (`2 × entry.timeout`) never fires first.
+- **AC6 — Coverage preserved:** The main test still runs the real harness and
+  requires `All native-module smoke checks passed under Bun`; the three
+  workflow-contract tests in the file are unchanged.
+
+## Test plan (behavioral; real subprocesses, no mock theater)
+
+New fixture `scripts/tests/fixtures/bun-smoke-harness-fixture.ts` — a real bun
+script controlled by `SMOKE_FIXTURE_MODE`:
+
+- `pass` → prints `All native-module smoke checks passed under Bun.`, exit 0
+- `fail` → prints a `[FAIL]` line, exit 1
+- `hang` → stays alive forever (real event-loop hang)
+- `hang-once` → hangs unless a marker file exists (created on first hang), so
+  attempt 2 passes — drives the retry-then-pass path end-to-end
+
+Tests (in `scripts/tests/nightly-bun-native-smoke.test.ts`, next to the code they
+cover, using a small per-attempt timeout of ~1.5–2 s so the suite stays fast):
+
+1. **timeout then pass** — `hang-once` fixture + 1 retry → resolves; exactly 2
+   attempts ran.
+2. **persistent hang fails closed** — `hang` fixture + 1 retry → fails; message
+   names the timeout and both attempts.
+3. **no retry on check failure** — `fail` fixture + retries available → fails
+   immediately, 1 attempt, exit-code diagnostic.
+4. **no retry on ENOENT** — nonexistent executable → install-hint error, 1 attempt.
+5. **retries=0 is today's behavior** — `hang` fixture, budget 0 → fails after
+   exactly 1 attempt.
+6. **knob resolution** — default 1; `0` → 0; `3` → 3; `abc`/`-1`/`1.5` → throw.
+7. **root override wiring** — extend the existing
+   `applies the slow timeout override to the release-install smoke` meta-test in
+   `bun-test-roots.bun.test.ts` to also assert the smoke file's override value
+   (and keep the negative case).
+
+## Implementation shape
+
+- New `scripts/lib/bun-smoke-harness.ts`: one-attempt execution (execFileAsync +
+  AbortSignal) with discriminated outcome classification, the timeout-only retry
+  loop, and knob resolution; exported pure decision parts for unit tests. This
+  mirrors the placement and role of `scripts/lib/bun-test-retry.ts` (created for
+  the analogous #3439 fix) — the established pattern, not a new subsystem.
+- `scripts/tests/nightly-bun-native-smoke.test.ts`: the harness-execution test
+  delegates to the lib; new behavioral tests as listed.
+- `scripts/bun-test-roots.ts`: `timeoutOverrides` +=
+  `{ pattern: /nightly-bun-native-smoke\.test\.ts$/, timeout: 620_000 }`
+  (620_000 = 2 × (300_000 + 10_000)).
+
+## Out of scope
+
+- No changes to `bunPtyAdapter.ts`, the harness checks, or the Bun pin — no
+  root-cause access to the runtime flake; retry is the repo's established remedy
+  for this class.
+- No changes to the Windows smoke job, other runners, or `bun-test-retry.ts`.
+- No workflow/YAML changes.
+
+## Verification
+
+Full cycle per the issue workflow: `npm run test`, `npm run lint`,
+`npm run typecheck`, `npm run format`, `npm run build`, then the smoke test
+`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.
+
+## Review round 1 (deepthinker)
+
+- **MEDIUM:** The static `620_000` registry override was coherent only with the
+  default knobs. Non-default retries or harness timeouts could collide with the
+  runner's per-file kill budget.
+- **Disposition:** In-scope-Fix.
+- **Remediation:** Use one shared `smokeTestFileTimeoutMs` formula for both the
+  registry override and the test timeout.
+
+## Review round 2 (deepthinker)
+
+- **MEDIUM:** Extreme accepted knob values could push the shared budget past
+  Bun's `--timeout` domain of 2^32-1, such as timeout `2147473648` or retries
+  `13854`.
+- **Disposition:** In-scope-Fix.
+- **Remediation:** Fail fast when the computed budget exceeds Bun's maximum and
+  cover the rejected values and accepted boundary with tests.
+- Review rounds are capped at two per policy, so no third review round runs.
+
+## OCR review round 1 (local, pre-push)
+
+- **MEDIUM (bug):** On attempt timeout, `execFile`'s `AbortSignal` kills only
+  the direct child, so a genuinely hung harness could leak PTY-backed
+  grandchildren across retry attempts.
+- **Disposition:** Defer (documented known follow-up).
+- **Rationale:**
+  - Pre-existing boundary: the original test used the identical
+    `execFileAsync` + `AbortSignal.timeout` single-attempt kill semantics;
+    retries only marginally amplify a narrow scenario on an already-red
+    pipeline.
+  - In the observed nightly hang the PTY child (`sh -c echo ...`) completes in
+    milliseconds; when the harness dies, the PTY master fd closes and the
+    kernel SIGHUPs the slave's process group, covering the common leak path.
+  - The suggested remediation (detached session-leader spawn + group kill)
+    plausibly changes Bun.Terminal PTY allocation semantics for the real
+    harness — the exact subsystem whose flake this change routes around — and
+    cannot be validated against macOS CI runners locally. That is a behavioral
+    change beyond this issue's scope.
+- OCR rounds used: 1 of 2.

--- a/scripts/bun-test-roots.ts
+++ b/scripts/bun-test-roots.ts
@@ -17,6 +17,7 @@
 
 import { readdirSync, realpathSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { smokeTestFileTimeoutMs } from './lib/bun-smoke-harness.ts';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -216,6 +217,14 @@ export const BUN_TEST_ROOTS: readonly BunTestRoot[] = [
     ],
     timeoutOverrides: [
       { pattern: /issue-2603-release-install\.test\.ts$/, timeout: 300_000 },
+      // Derived from the same #3447 env knobs and formula as TEST_TIMEOUT_MS;
+      // processTimeoutFor's 2× kill budget therefore stays above the test's
+      // timeout for every knob combination. Invalid retry values intentionally
+      // throw at module load so the error names LLXPRT_BUN_SMOKE_TIMEOUT_RETRIES.
+      {
+        pattern: /nightly-bun-native-smoke\.test\.ts$/,
+        timeout: smokeTestFileTimeoutMs(),
+      },
     ],
   },
   {

--- a/scripts/lib/bun-smoke-harness.ts
+++ b/scripts/lib/bun-smoke-harness.ts
@@ -1,0 +1,261 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Timeout-only retry policy for the Bun native-module smoke harness.
+ *
+ * Issue #3447 applies the issue #3439 policy at the harness subprocess boundary:
+ * a timed-out child gets one fresh attempt by default, while deterministic
+ * failures are reported immediately and are never retried.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_SMOKE_TIMEOUT_RETRIES = 1;
+const SMOKE_TIMEOUT_RETRIES_ENV_VAR = 'LLXPRT_BUN_SMOKE_TIMEOUT_RETRIES';
+// Bun rejects --timeout above 2^32-1. This shared #3447 budget reaches that
+// runner flag, so fail here with a diagnostic naming both knobs.
+const MAX_BUN_TEST_TIMEOUT_MS = 4_294_967_295;
+export const SMOKE_TEST_FILE_TIMEOUT_PAD_MS = 10_000;
+const BUN_INSTALL_HINT =
+  'Bun is required to run the native-module smoke harness; install the version pinned in .bun-version and ensure bun is on PATH.';
+
+export interface SmokeHarnessCommand {
+  readonly executable: string;
+  readonly args: readonly string[];
+  readonly env?: Readonly<Record<string, string | undefined>>;
+}
+
+export interface SmokeHarnessAttemptOptions {
+  readonly cwd: string;
+  readonly timeoutMs: number;
+}
+
+export type SmokeHarnessAttemptOutcome =
+  | { readonly kind: 'passed'; readonly stdout: string }
+  | {
+      readonly kind: 'timeout';
+      readonly diagnostics: string;
+      readonly cause: unknown;
+    }
+  | { readonly kind: 'enoent'; readonly cause: unknown }
+  | {
+      readonly kind: 'exit';
+      readonly code: number;
+      readonly diagnostics: string;
+      readonly cause: unknown;
+    }
+  | {
+      readonly kind: 'exec-error';
+      readonly message: string;
+      readonly diagnostics: string;
+      readonly cause: unknown;
+    };
+
+export interface SmokeHarnessRunOptions extends SmokeHarnessAttemptOptions {
+  readonly retries: number;
+}
+
+export interface SmokeHarnessRunResult {
+  readonly stdout: string;
+  readonly attempts: number;
+}
+
+export class SmokeHarnessRunError extends Error {
+  readonly attempts: number;
+
+  constructor(message: string, attempts: number, cause: unknown) {
+    super(message, { cause });
+    this.name = 'SmokeHarnessRunError';
+    this.attempts = attempts;
+  }
+}
+
+export function resolveHarnessTimeoutMs(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const DEFAULT = 300_000;
+  const raw = env.LLXPRT_BUN_SMOKE_TIMEOUT_MS;
+  if (raw === undefined || raw === '') return DEFAULT;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT;
+  return Math.floor(parsed);
+}
+
+/** Resolves the timeout-only retry budget; 0 restores one attempt. */
+export function resolveSmokeTimeoutRetries(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const raw = env[SMOKE_TIMEOUT_RETRIES_ENV_VAR];
+  if (raw === undefined || raw === '') {
+    return DEFAULT_SMOKE_TIMEOUT_RETRIES;
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(
+      `Invalid ${SMOKE_TIMEOUT_RETRIES_ENV_VAR} value: ${raw} (expected a non-negative integer)`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * The scripts runner's per-file kill budget is max(120_000, 2 × registry
+ * timeout). Deriving the registry override and test timeout here keeps that
+ * kill budget strictly above the test timeout for every #3447 knob combination.
+ */
+export function smokeTestFileTimeoutMs(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const total =
+    (resolveSmokeTimeoutRetries(env) + 1) *
+    (resolveHarnessTimeoutMs(env) + SMOKE_TEST_FILE_TIMEOUT_PAD_MS);
+  if (!Number.isFinite(total) || total > MAX_BUN_TEST_TIMEOUT_MS) {
+    throw new Error(
+      `Computed smoke test file timeout ${total}ms exceeds the Bun --timeout maximum ${MAX_BUN_TEST_TIMEOUT_MS}ms; lower LLXPRT_BUN_SMOKE_TIMEOUT_MS or LLXPRT_BUN_SMOKE_TIMEOUT_RETRIES.`,
+    );
+  }
+  return total;
+}
+
+function errorProperty(error: object, property: string): unknown {
+  return Reflect.get(error, property);
+}
+
+function collectProcessDiagnostics(error: object): string {
+  return [errorProperty(error, 'stdout'), errorProperty(error, 'stderr')]
+    .filter(
+      (output): output is string =>
+        typeof output === 'string' && output.trim().length > 0,
+    )
+    .join('\n')
+    .trim();
+}
+
+function classifyExecutionError(error: unknown): SmokeHarnessAttemptOutcome {
+  if (typeof error !== 'object' || error === null) {
+    return {
+      kind: 'exec-error',
+      message: String(error),
+      diagnostics: '',
+      cause: error,
+    };
+  }
+
+  const code = errorProperty(error, 'code');
+  if (code === 'ENOENT') {
+    return { kind: 'enoent', cause: error };
+  }
+
+  const diagnostics = collectProcessDiagnostics(error);
+  if (code === 'ABORT_ERR' && errorProperty(error, 'name') === 'AbortError') {
+    return { kind: 'timeout', diagnostics, cause: error };
+  }
+  if (typeof code === 'number') {
+    return { kind: 'exit', code, diagnostics, cause: error };
+  }
+
+  const rawMessage = error instanceof Error ? error.message : String(error);
+  return {
+    kind: 'exec-error',
+    message: rawMessage.trim() || `system error ${String(code)}`,
+    diagnostics,
+    cause: error,
+  };
+}
+
+/** Runs one bounded harness subprocess and classifies its observable outcome. */
+export async function runSmokeHarnessAttempt(
+  command: SmokeHarnessCommand,
+  options: SmokeHarnessAttemptOptions,
+): Promise<SmokeHarnessAttemptOutcome> {
+  try {
+    const { stdout } = await execFileAsync(
+      command.executable,
+      [...command.args],
+      {
+        cwd: options.cwd,
+        encoding: 'utf8',
+        env: command.env === undefined ? process.env : { ...command.env },
+        signal: AbortSignal.timeout(options.timeoutMs),
+      },
+    );
+    return { kind: 'passed', stdout };
+  } catch (error: unknown) {
+    return classifyExecutionError(error);
+  }
+}
+
+function formatFailure(
+  outcome: Exclude<SmokeHarnessAttemptOutcome, { kind: 'passed' | 'timeout' }>,
+): string {
+  if (outcome.kind === 'enoent') {
+    return BUN_INSTALL_HINT;
+  }
+  if (outcome.kind === 'exit') {
+    return `Bun native-module smoke harness failed with exit code ${outcome.code}${outcome.diagnostics ? `:\n${outcome.diagnostics}` : '.'}`;
+  }
+  return `Bun native-module smoke harness could not execute: ${outcome.message}${outcome.diagnostics ? `\n${outcome.diagnostics}` : ''}`;
+}
+
+function formatTimeoutFailure(
+  timeoutMs: number,
+  diagnostics: readonly string[],
+): string {
+  const attempts = diagnostics.length;
+  const attemptWord = attempts === 1 ? 'attempt' : 'attempts';
+  const output = diagnostics
+    .map(
+      (diagnostic, index) =>
+        `Attempt ${index + 1}:\n${diagnostic || '(no output captured)'}`,
+    )
+    .join('\n');
+  return `Bun native-module smoke harness exceeded its ${timeoutMs}ms subprocess timeout after ${attempts} ${attemptWord}:\n${output}`;
+}
+
+function throwFailure(
+  outcome: Exclude<SmokeHarnessAttemptOutcome, { kind: 'passed' | 'timeout' }>,
+  attempts: number,
+): never {
+  throw new SmokeHarnessRunError(
+    formatFailure(outcome),
+    attempts,
+    outcome.cause,
+  );
+}
+
+/** Retries only timed-out attempts and returns the successful attempt count. */
+export async function runSmokeHarnessWithTimeoutRetry(
+  command: SmokeHarnessCommand,
+  options: SmokeHarnessRunOptions,
+): Promise<SmokeHarnessRunResult> {
+  let attempts = 0;
+  let retriesLeft = options.retries;
+  let timeoutDiagnostics: readonly string[] = [];
+
+  while (true) {
+    attempts += 1;
+    const outcome = await runSmokeHarnessAttempt(command, options);
+    if (outcome.kind === 'passed') {
+      return { stdout: outcome.stdout, attempts };
+    }
+    if (outcome.kind !== 'timeout') {
+      throwFailure(outcome, attempts);
+    }
+
+    timeoutDiagnostics = [...timeoutDiagnostics, outcome.diagnostics];
+    if (retriesLeft === 0) {
+      throw new SmokeHarnessRunError(
+        formatTimeoutFailure(options.timeoutMs, timeoutDiagnostics),
+        attempts,
+        outcome.cause,
+      );
+    }
+    retriesLeft -= 1;
+  }
+}

--- a/scripts/lib/bun-smoke-harness.ts
+++ b/scripts/lib/bun-smoke-harness.ts
@@ -84,7 +84,9 @@ export function resolveHarnessTimeoutMs(
   if (raw === undefined || raw === '') return DEFAULT;
   const parsed = Number(raw);
   if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT;
-  return Math.floor(parsed);
+  // AbortSignal.timeout(0) aborts instantly; any accepted positive value must
+  // resolve to a usable timeout of at least 1ms.
+  return Math.max(1, Math.floor(parsed));
 }
 
 /** Resolves the timeout-only retry budget; 0 restores one attempt. */
@@ -234,6 +236,13 @@ export async function runSmokeHarnessWithTimeoutRetry(
   command: SmokeHarnessCommand,
   options: SmokeHarnessRunOptions,
 ): Promise<SmokeHarnessRunResult> {
+  // Fail fast: the loop below exits only when a non-negative integer retry
+  // budget reaches zero, so any other value would retry forever.
+  if (!Number.isSafeInteger(options.retries) || options.retries < 0) {
+    throw new RangeError(
+      `retries must be a non-negative safe integer, got ${options.retries}`,
+    );
+  }
   let attempts = 0;
   let retriesLeft = options.retries;
   let timeoutDiagnostics: readonly string[] = [];

--- a/scripts/tests/bun-test-roots.bun.test.ts
+++ b/scripts/tests/bun-test-roots.bun.test.ts
@@ -31,6 +31,7 @@ import {
   resolveRootCwd,
   selectsRoot,
 } from '../bun-test-roots.js';
+import { smokeTestFileTimeoutMs } from '../lib/bun-smoke-harness.js';
 
 const repoRoot = resolve(import.meta.dir, '..', '..');
 
@@ -578,6 +579,12 @@ describe('resolveBunTestFiles (real repository)', () => {
     );
     expect(slow).toBeDefined();
     expect(slow?.timeout).toBe(300_000);
+
+    const nativeSmoke = files.find((f) =>
+      f.file.endsWith('nightly-bun-native-smoke.test.ts'),
+    );
+    expect(nativeSmoke).toBeDefined();
+    expect(nativeSmoke?.timeout).toBe(smokeTestFileTimeoutMs());
 
     const ordinary = files.find((f) =>
       f.file.endsWith('run_bun_tests.test.ts'),

--- a/scripts/tests/fixtures/bun-smoke-harness-fixture.ts
+++ b/scripts/tests/fixtures/bun-smoke-harness-fixture.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { existsSync, writeFileSync } from 'node:fs';
+
+const PASS_MESSAGE = 'All native-module smoke checks passed under Bun.';
+const HANG_MESSAGE = '[HANG] fixture remains alive';
+
+function pass(): void {
+  console.log(PASS_MESSAGE);
+}
+
+function hang(): void {
+  console.log(HANG_MESSAGE);
+  setInterval(() => {}, 60_000);
+}
+
+function hangOnce(): void {
+  const marker = process.env['SMOKE_FIXTURE_MARKER'];
+  if (marker === undefined || marker === '') {
+    throw new Error('SMOKE_FIXTURE_MARKER is required for hang-once mode');
+  }
+  if (existsSync(marker)) {
+    pass();
+    return;
+  }
+  writeFileSync(marker, 'first attempt timed out\n');
+  hang();
+}
+
+switch (process.env['SMOKE_FIXTURE_MODE']) {
+  case 'pass':
+    pass();
+    break;
+  case 'fail':
+    console.error('[FAIL] fixture check failed');
+    process.exitCode = 1;
+    break;
+  case 'hang':
+    hang();
+    break;
+  case 'hang-once':
+    hangOnce();
+    break;
+  default:
+    throw new Error(
+      `Unsupported SMOKE_FIXTURE_MODE: ${String(process.env['SMOKE_FIXTURE_MODE'])}`,
+    );
+}

--- a/scripts/tests/nightly-bun-native-smoke.test.ts
+++ b/scripts/tests/nightly-bun-native-smoke.test.ts
@@ -13,9 +13,22 @@ import { describe, expect, it } from 'bun:test';
 import { asRecord, parseWorkflowYaml, jobSteps } from './typed-test-helpers.ts';
 import type { WorkflowJob, WorkflowStep } from './typed-test-helpers.ts';
 import { beforeAll } from 'bun:test';
+import {
+  resolveHarnessTimeoutMs,
+  resolveSmokeTimeoutRetries,
+  smokeTestFileTimeoutMs,
+  runSmokeHarnessWithTimeoutRetry,
+  SmokeHarnessRunError,
+  type SmokeHarnessCommand,
+} from '../lib/bun-smoke-harness.ts';
 
 const ROOT = path.resolve(import.meta.dirname, '../..');
 const execFileAsync = promisify(execFile);
+const FIXTURE_PATH = path.join(
+  ROOT,
+  'scripts/tests/fixtures/bun-smoke-harness-fixture.ts',
+);
+const FIXTURE_TIMEOUT_MS = 1_500;
 
 /**
  * The Bun native-module smoke harness spawns a real `bun` subprocess. In
@@ -30,30 +43,9 @@ const execFileAsync = promisify(execFile);
  * fail-closed without flapping under load.
  */
 
-function resolveHarnessTimeoutMs(
-  env: Record<string, string | undefined> = process.env,
-): number {
-  const DEFAULT = 300_000;
-  const raw = env.LLXPRT_BUN_SMOKE_TIMEOUT_MS;
-  if (raw === undefined || raw === '') return DEFAULT;
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT;
-  return Math.floor(parsed);
-}
-
 const HARNESS_TIMEOUT_MS = resolveHarnessTimeoutMs();
-const TEST_TIMEOUT_MS = HARNESS_TIMEOUT_MS + 10_000;
-
-function collectProcessDiagnostics(error: object): string {
-  const errRecord = asRecord(error);
-  return [errRecord['stdout'], errRecord['stderr']]
-    .filter(
-      (output): output is string =>
-        typeof output === 'string' && output.trim().length > 0,
-    )
-    .join('\n')
-    .trim();
-}
+const SMOKE_TIMEOUT_RETRIES = resolveSmokeTimeoutRetries();
+const TEST_TIMEOUT_MS = smokeTestFileTimeoutMs();
 
 function stepNamed(job: WorkflowJob | undefined, name: string): WorkflowStep {
   expect(
@@ -65,6 +57,41 @@ function stepNamed(job: WorkflowJob | undefined, name: string): WorkflowStep {
   expect(step, `job should contain step: ${name}`).toBeTruthy();
   if (!step) throw new Error(`job should contain step: ${name}`);
   return step;
+}
+
+function fixtureCommand(
+  mode: 'pass' | 'fail' | 'hang' | 'hang-once',
+  marker?: string,
+): SmokeHarnessCommand {
+  const env =
+    marker === undefined
+      ? { ...process.env, SMOKE_FIXTURE_MODE: mode }
+      : {
+          ...process.env,
+          SMOKE_FIXTURE_MODE: mode,
+          SMOKE_FIXTURE_MARKER: marker,
+        };
+  return {
+    executable: 'bun',
+    args: [FIXTURE_PATH],
+    env,
+  };
+}
+
+async function captureHarnessError(
+  operation: Promise<unknown>,
+): Promise<SmokeHarnessRunError> {
+  let captured: unknown;
+  try {
+    await operation;
+  } catch (error: unknown) {
+    captured = error;
+  }
+  expect(captured).toBeInstanceOf(SmokeHarnessRunError);
+  if (!(captured instanceof SmokeHarnessRunError)) {
+    throw new Error('Expected the smoke harness operation to fail');
+  }
+  return captured;
 }
 
 describe('nightly Windows Bun native-module smoke', () => {
@@ -195,58 +222,211 @@ describe('Bun native-module smoke harness', () => {
   it(
     'passes its real checks for the current platform',
     async () => {
-      let stdout: string | undefined;
-      try {
-        ({ stdout } = await execFileAsync(
-          'bun',
-          ['scripts/bun-native-modules-smoke.ts'],
-          {
-            cwd: ROOT,
-            encoding: 'utf8',
-            signal: AbortSignal.timeout(HARNESS_TIMEOUT_MS),
-          },
-        ));
-      } catch (error: unknown) {
-        if (error && typeof error === 'object') {
-          const errRecord = asRecord(error);
-          if (errRecord['code'] === 'ENOENT') {
-            throw new Error(
-              'Bun is required to run the native-module smoke harness; install the version pinned in .bun-version and ensure bun is on PATH.',
-              { cause: error },
-            );
-          }
-          const diagnostics = collectProcessDiagnostics(error);
-          if (
-            errRecord['code'] === 'ABORT_ERR' &&
-            errRecord['name'] === 'AbortError'
-          ) {
-            throw new Error(
-              `Bun native-module smoke harness exceeded its ${HARNESS_TIMEOUT_MS}ms subprocess timeout${diagnostics ? `:\n${diagnostics}` : '.'}`,
-              { cause: error },
-            );
-          }
-          if (typeof errRecord['code'] === 'number') {
-            throw new Error(
-              `Bun native-module smoke harness failed with exit code ${errRecord['code']}${diagnostics ? `:\n${diagnostics}` : '.'}`,
-              { cause: error },
-            );
-          }
-          const rawMessage =
-            error instanceof Error ? error.message : String(error);
-          const detail =
-            rawMessage.trim() || `system error ${String(errRecord['code'])}`;
-          throw new Error(
-            `Bun native-module smoke harness could not execute: ${detail}${diagnostics ? `\n${diagnostics}` : ''}`,
-            { cause: error },
-          );
-        }
-        throw error;
-      }
+      const { stdout } = await runSmokeHarnessWithTimeoutRetry(
+        {
+          executable: 'bun',
+          args: ['scripts/bun-native-modules-smoke.ts'],
+        },
+        {
+          cwd: ROOT,
+          timeoutMs: HARNESS_TIMEOUT_MS,
+          retries: SMOKE_TIMEOUT_RETRIES,
+        },
+      );
 
       expect(stdout).toContain(
         'All native-module smoke checks passed under Bun',
       );
     },
     TEST_TIMEOUT_MS,
+  );
+});
+
+describe('Bun native-module smoke timeout retry', () => {
+  it('retries a timed-out attempt once and passes when the next attempt succeeds', async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'llxprt-smoke-retry-'),
+    );
+    const marker = path.join(tempDir, 'attempt.marker');
+
+    try {
+      const result = await runSmokeHarnessWithTimeoutRetry(
+        fixtureCommand('hang-once', marker),
+        {
+          cwd: ROOT,
+          timeoutMs: FIXTURE_TIMEOUT_MS,
+          retries: 1,
+        },
+      );
+
+      expect(result.attempts).toBe(2);
+      expect(result.stdout).toContain(
+        'All native-module smoke checks passed under Bun.',
+      );
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  }, 10_000);
+
+  it('fails closed when every attempt times out', async () => {
+    const error = await captureHarnessError(
+      runSmokeHarnessWithTimeoutRetry(fixtureCommand('hang'), {
+        cwd: ROOT,
+        timeoutMs: FIXTURE_TIMEOUT_MS,
+        retries: 1,
+      }),
+    );
+
+    expect(error.attempts).toBe(2);
+    expect(error.message).toContain(`${FIXTURE_TIMEOUT_MS}ms`);
+    expect(error.message).toContain('2 attempts');
+    expect(error.message).toContain('Attempt 1:');
+    expect(error.message).toContain('Attempt 2:');
+    expect(error.message.split('[HANG] fixture remains alive')).toHaveLength(3);
+  }, 10_000);
+
+  it('never retries a non-timeout failure', async () => {
+    const error = await captureHarnessError(
+      runSmokeHarnessWithTimeoutRetry(fixtureCommand('fail'), {
+        cwd: ROOT,
+        timeoutMs: FIXTURE_TIMEOUT_MS,
+        retries: 3,
+      }),
+    );
+
+    expect(error.attempts).toBe(1);
+    expect(error.message).toContain('failed with exit code 1');
+    expect(error.message).toContain('[FAIL] fixture check failed');
+  });
+
+  it('never retries ENOENT', async () => {
+    const error = await captureHarnessError(
+      runSmokeHarnessWithTimeoutRetry(
+        { executable: 'llxprt-definitely-missing-bun', args: [] },
+        {
+          cwd: ROOT,
+          timeoutMs: FIXTURE_TIMEOUT_MS,
+          retries: 3,
+        },
+      ),
+    );
+
+    expect(error.attempts).toBe(1);
+    expect(error.message).toBe(
+      'Bun is required to run the native-module smoke harness; install the version pinned in .bun-version and ensure bun is on PATH.',
+    );
+  });
+
+  it('preserves single-attempt behavior when retries is zero', async () => {
+    const error = await captureHarnessError(
+      runSmokeHarnessWithTimeoutRetry(fixtureCommand('hang'), {
+        cwd: ROOT,
+        timeoutMs: FIXTURE_TIMEOUT_MS,
+        retries: 0,
+      }),
+    );
+
+    expect(error.attempts).toBe(1);
+    expect(error.message).toContain('1 attempt');
+  }, 10_000);
+});
+
+describe('smokeTestFileTimeoutMs', () => {
+  it('uses the default retry and harness timeout knobs', () => {
+    expect(smokeTestFileTimeoutMs({})).toBe(620_000);
+  });
+
+  it('scales with non-default retry and harness timeout knobs', () => {
+    expect(
+      smokeTestFileTimeoutMs({
+        LLXPRT_BUN_SMOKE_TIMEOUT_RETRIES: '3',
+        LLXPRT_BUN_SMOKE_TIMEOUT_MS: '400000',
+      }),
+    ).toBe(1_640_000);
+  });
+
+  it('rejects a harness timeout that pushes the file budget past the Bun maximum', () => {
+    expect(() =>
+      smokeTestFileTimeoutMs({
+        LLXPRT_BUN_SMOKE_TIMEOUT_MS: '2147473648',
+      }),
+    ).toThrow(/LLXPRT_BUN_SMOKE_TIMEOUT_MS.*LLXPRT_BUN_SMOKE_TIMEOUT_RETRIES/);
+  });
+
+  it('rejects a retry count that pushes the file budget past the Bun maximum', () => {
+    expect(() =>
+      smokeTestFileTimeoutMs({
+        LLXPRT_BUN_SMOKE_TIMEOUT_RETRIES: '13854',
+      }),
+    ).toThrow(/LLXPRT_BUN_SMOKE_TIMEOUT_MS.*LLXPRT_BUN_SMOKE_TIMEOUT_RETRIES/);
+  });
+
+  it('accepts a file budget below the Bun maximum', () => {
+    expect(
+      smokeTestFileTimeoutMs({
+        LLXPRT_BUN_SMOKE_TIMEOUT_MS: '2147463647',
+      }),
+    ).toBe(4_294_947_294);
+  });
+});
+
+describe('resolveHarnessTimeoutMs', () => {
+  it('defaults when the setting is absent or empty', () => {
+    expect(resolveHarnessTimeoutMs({})).toBe(300_000);
+    expect(resolveHarnessTimeoutMs({ LLXPRT_BUN_SMOKE_TIMEOUT_MS: '' })).toBe(
+      300_000,
+    );
+  });
+
+  it('accepts a positive finite timeout', () => {
+    expect(
+      resolveHarnessTimeoutMs({ LLXPRT_BUN_SMOKE_TIMEOUT_MS: '450000' }),
+    ).toBe(450_000);
+  });
+
+  it.each(['abc', '-1', '0'])(
+    'defaults for the invalid timeout setting %s',
+    (raw) => {
+      expect(
+        resolveHarnessTimeoutMs({ LLXPRT_BUN_SMOKE_TIMEOUT_MS: raw }),
+      ).toBe(300_000);
+    },
+  );
+
+  it('floors a positive fractional timeout', () => {
+    expect(
+      resolveHarnessTimeoutMs({ LLXPRT_BUN_SMOKE_TIMEOUT_MS: '1.5' }),
+    ).toBe(1);
+  });
+});
+
+describe('resolveSmokeTimeoutRetries', () => {
+  it('defaults to one retry when the setting is absent or empty', () => {
+    expect(resolveSmokeTimeoutRetries({})).toBe(1);
+    expect(
+      resolveSmokeTimeoutRetries({ LLXPRT_BUN_SMOKE_TIMEOUT_RETRIES: '' }),
+    ).toBe(1);
+  });
+
+  it.each([
+    ['0', 0],
+    ['3', 3],
+  ])('accepts the non-negative integer %s', (raw, expected) => {
+    expect(
+      resolveSmokeTimeoutRetries({
+        LLXPRT_BUN_SMOKE_TIMEOUT_RETRIES: raw,
+      }),
+    ).toBe(expected);
+  });
+
+  it.each(['abc', '-1', '1.5'])(
+    'rejects the invalid retry setting %s',
+    (raw) => {
+      expect(() =>
+        resolveSmokeTimeoutRetries({
+          LLXPRT_BUN_SMOKE_TIMEOUT_RETRIES: raw,
+        }),
+      ).toThrow('expected a non-negative integer');
+    },
   );
 });

--- a/scripts/tests/nightly-bun-native-smoke.test.ts
+++ b/scripts/tests/nightly-bun-native-smoke.test.ts
@@ -329,6 +329,19 @@ describe('Bun native-module smoke timeout retry', () => {
     expect(error.attempts).toBe(1);
     expect(error.message).toContain('1 attempt');
   }, 10_000);
+
+  it.each([-1, 0.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects the invalid programmatic retries %s before running any attempt',
+    async (retries) => {
+      await expect(
+        runSmokeHarnessWithTimeoutRetry(fixtureCommand('pass'), {
+          cwd: ROOT,
+          timeoutMs: FIXTURE_TIMEOUT_MS,
+          retries,
+        }),
+      ).rejects.toThrow('retries must be a non-negative safe integer');
+    },
+  );
 });
 
 describe('smokeTestFileTimeoutMs', () => {
@@ -396,6 +409,12 @@ describe('resolveHarnessTimeoutMs', () => {
   it('floors a positive fractional timeout', () => {
     expect(
       resolveHarnessTimeoutMs({ LLXPRT_BUN_SMOKE_TIMEOUT_MS: '1.5' }),
+    ).toBe(1);
+  });
+
+  it('clamps a sub-millisecond positive timeout to 1ms so the attempt cannot abort instantly', () => {
+    expect(
+      resolveHarnessTimeoutMs({ LLXPRT_BUN_SMOKE_TIMEOUT_MS: '0.5' }),
     ).toBe(1);
   });
 });


### PR DESCRIPTION
## TLDR

The 8/31 nightly (run 33389396733) failed only in `macOS CI (Nightly) [scripts]`: `scripts/tests/nightly-bun-native-smoke.test.ts` > "passes its real checks for the current platform" aborted at exactly 300024ms. The harness subprocess (`scripts/bun-native-modules-smoke.ts`) hung inside the POSIX-only `checkBunPty` (Bun.Terminal PTY) with its event loop blocked — stdout stops right after the pwsh PASS and the harness's own 5s fail-safe never fired — so the test's 300s AbortSignal was the only thing that ended it. The same commit passed the prior nightly and 20/20 local runs, so this is a load-dependent Bun runtime flake, not a deterministic bug.

This PR applies the repo's #3439/#3441 precedent at the harness subprocess boundary: a timed-out harness attempt gets one fresh retry by default; deterministic failures (non-zero exit, ENOENT, exec errors) are never retried and keep their original diagnostics. No changes to the harness checks, `bunPtyAdapter.ts`, the Bun pin, any workflow YAML, or `bun-test-retry.ts` (runner-level retry cannot catch this class: the test exits 1 normally, with no kill signal).

## Dive Deeper

**Root cause evidence** (full logs in the run linked from #3447):

- stdout ends after `[PASS] web-tree-sitter + tree-sitter-pwsh WASM …`; the next POSIX check is `checkBunPty`. Neither its `[PASS]`/`[FAIL]` line nor the final summary ever printed.
- `checkBunPty` arms a 5s exit-promise timeout before spawning; if the runtime were healthy the worst case is a `[FAIL] … timeout waiting for PTY exit`. Nothing printed means the event loop itself was blocked (the 5s timer could not fire), matching the known Bun PTY edge cases documented in `bunPtyAdapter.ts`.
- Flakiness: run 33335701069 (8/30 21:10, same code) was green; 20/20 local runs green; the failure converts a hang into a normal test exit 1, which is exactly the class #3439 solved with timeout-only retry.

**What changed:**

- New `scripts/lib/bun-smoke-harness.ts`: `runSmokeHarnessAttempt` (one bounded subprocess via `execFileAsync` + `AbortSignal.timeout`, outcome classified as passed/timeout/enoent/exit/exec-error) and `runSmokeHarnessWithTimeoutRetry` (retries only `timeout` outcomes; default 1 retry; fail-closed error names the timeout, attempt count, and per-attempt output). Knob `LLXPRT_BUN_SMOKE_TIMEOUT_RETRIES` (default 1; empty/undefined → default; anything but a non-negative integer throws, mirroring `LLXPRT_BUN_TEST_TIMEOUT_RETRIES`; programmatic callers get the same fail-fast guard, and an invalid value can never enter the retry loop). `LLXPRT_BUN_SMOKE_TIMEOUT_MS` semantics preserved, with one hardening: any accepted positive value resolves to at least 1ms so `AbortSignal.timeout(0)` is unreachable.
- `smokeTestFileTimeoutMs()`: one shared formula `(retries + 1) × (timeout + 10s)` used for BOTH the test's `TEST_TIMEOUT_MS` and the `bun-test-roots.ts` registry override, so the runner's `max(120s, 2×)` kill budget stays above the test timeout for every knob combination, and the value stays within Bun's `--timeout` domain (2³²−1) — exceeding it fails fast naming both knobs (defaults: 620s test timeout, 1.24s×10³ runner kill, well inside the 45-min nightly job).
- `scripts/tests/nightly-bun-native-smoke.test.ts`: the three workflow-contract tests are untouched; the real-harness test now delegates to the retry lib; behavioral tests drive a real bun subprocess fixture (`scripts/tests/fixtures/bun-smoke-harness-fixture.ts`, modes pass/fail/hang/hang-once via marker file) proving: hang → retry → pass reports attempts=2; hang → hang fails closed with both attempts' output; non-zero exit and ENOENT are never retried (1 attempt, original diagnostics/hint preserved); retries=0 runs exactly one attempt; invalid programmatic retries (`-1`, `0.5`, `NaN`, `Infinity`) reject before any attempt. Plus knob-resolution and budget-boundary tests.
- `scripts/tests/bun-test-roots.bun.test.ts`: meta-test asserts the registry override equals the shared formula.

**Deferred (documented in the plan doc):** OCR round 1 flagged that on timeout, `execFile`'s signal reaches only the direct child, so a hung harness could theoretically leak PTY grandchildren across attempts. Triaged Defer: the kill boundary is byte-identical to the pre-existing single-attempt test, the observed hang leaves the PTY child long-exited (master-fd close SIGHUPs the slave's process group), and the suggested detached/session-leader spawn plausibly changes Bun.Terminal PTY allocation for the real harness — the exact subsystem whose flake this routes around — which is outside this issue's scope.

## Reviewer Test Plan

- `bun test scripts/tests/nightly-bun-native-smoke.test.ts` — expect 31 pass / 0 fail; the retry-then-pass test takes ~1.5s (fixture timeout × 2), fail-closed ~3s.
- `bun test scripts/tests/bun-test-roots.bun.test.ts` — expect 54 pass / 0 fail, including the new registry-override assertion.
- Invalid `LLXPRT_BUN_SMOKE_TIMEOUT_RETRIES` values throw at module load with the knob named (covered by unit tests).
- Watch the next few nightlies: the macOS [scripts] shard should stay green when the hang recurs (retry absorbs it) and produce a two-attempt diagnostic if it ever hangs twice.

## Testing Matrix

|          | 🍏 | 🪟 | 🐧 |
| -------- | --- | --- | --- |
| npm run  | ✅ | ❓ | ❓ |
| npx      | ❓ | ❓ | ❓ |
| Docker   | - | - | ❓ |
| Podman   | - | - | - |
| Seatbelt | ❓ | - | - |

macOS (this machine, Bun 1.3.14): four full verification cycles (final on the review-hardening head: `npm run test` exit 0, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`, and the startup smoke all green). Windows/Linux validation is via CI on this PR (the fixture and lib are platform-neutral; the real-harness test's PTY path is the pre-existing one).

## Linked issues / bugs

Fixes #3447