### PR TITLE
fix(sandbox): stop capability env dirs leaking into $HOME (Fixes #3440)

### DIFF
--- a/packages/cli/src/utils/sandbox-capability.test.ts
+++ b/packages/cli/src/utils/sandbox-capability.test.ts
@@ -1,0 +1,430 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for host-only capability env-file placement, reclamation,
+ * permissions, and failure cleanup.
+ *
+ * @plan project-plans/issue-3440-capability-env-reclamation.md
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  createHostOnlyCapabilityEnvFile,
+  reclaimOrphanCapabilityDirs,
+  type HostOnlyCapabilityResult,
+} from './sandbox-capability.js';
+
+const VALID_TOKEN = 'a'.repeat(64);
+
+function useTempDir(
+  registerBefore: (fn: () => void) => void,
+  registerAfter: (fn: () => void) => void,
+): () => string {
+  let tmpDir = '';
+  registerBefore(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scap-'));
+  });
+  registerAfter(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+  return () => tmpDir;
+}
+
+function requireCapabilityResult(
+  result: HostOnlyCapabilityResult | undefined,
+): HostOnlyCapabilityResult {
+  expect(result).toBeDefined();
+  if (result === undefined) {
+    throw new Error('Expected capability env-file result');
+  }
+  return result;
+}
+
+const realOsTmpdir: () => string = os.tmpdir;
+
+/**
+ * Overrides os.tmpdir for the code under test. Bun exposes os.tmpdir as an
+ * accessor property, which vi.spyOn cannot wrap, and once TMPDIR is deleted
+ * after being set, os.tmpdir keeps returning the stale value for the rest of
+ * the process. Redefining the property avoids both pitfalls.
+ */
+function overrideOsTmpdir(value: string): void {
+  Object.defineProperty(os, 'tmpdir', {
+    value: () => value,
+    configurable: true,
+  });
+}
+
+function restoreOsTmpdir(): void {
+  Object.defineProperty(os, 'tmpdir', {
+    value: realOsTmpdir,
+    configurable: true,
+  });
+}
+
+describe('host-only capability env-file (AC1, F4)', () => {
+  const getTmpDir = useTempDir(beforeEach, afterEach);
+  let environmentSnapshot: NodeJS.ProcessEnv;
+  let runtimeRoot = '';
+  let isolatedHome = '';
+  let sessionMount = '';
+
+  beforeEach(() => {
+    environmentSnapshot = { ...process.env };
+    runtimeRoot = path.join(getTmpDir(), 'runtime');
+    isolatedHome = path.join(getTmpDir(), 'home');
+    fs.mkdirSync(runtimeRoot);
+    fs.mkdirSync(isolatedHome);
+    sessionMount = fs.mkdtempSync(path.join(runtimeRoot, 'llxprt-sandbox-'));
+    process.env.LLXPRT_CAPABILITY_TOKEN = VALID_TOKEN;
+    delete process.env.XDG_RUNTIME_DIR;
+    overrideOsTmpdir(runtimeRoot);
+    vi.spyOn(os, 'homedir').mockReturnValue(isolatedHome);
+  });
+
+  afterEach(() => {
+    process.env = environmentSnapshot;
+    restoreOsTmpdir();
+    vi.restoreAllMocks();
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'writes under the runtime root outside HOME and the session mount with mode 0700 dir / 0600 file; raw token not in argv',
+    () => {
+      const result = requireCapabilityResult(
+        createHostOnlyCapabilityEnvFile(VALID_TOKEN),
+      );
+      const hostDir = path.dirname(result.envFilePath);
+
+      try {
+        expect(path.dirname(hostDir)).toBe(runtimeRoot);
+        expect(hostDir.startsWith(`${isolatedHome}${path.sep}`)).toBe(false);
+        expect(hostDir.startsWith(`${sessionMount}${path.sep}`)).toBe(false);
+        expect(fs.statSync(hostDir).mode & 0o777).toBe(0o700);
+        expect(fs.statSync(result.envFilePath).mode & 0o777).toBe(0o600);
+        expect(fs.readFileSync(result.envFilePath, 'utf8')).toContain(
+          VALID_TOKEN,
+        );
+        for (const arg of result.args) expect(arg).not.toContain(VALID_TOKEN);
+        expect(result.args[result.args.indexOf('--env-file') + 1]).toBe(
+          result.envFilePath,
+        );
+      } finally {
+        result.cleanup();
+      }
+    },
+  );
+
+  it('places Linux capability files under XDG_RUNTIME_DIR when it is non-empty', () => {
+    const xdgRuntimeRoot = path.join(getTmpDir(), 'xdg-runtime');
+    fs.mkdirSync(xdgRuntimeRoot);
+    process.env.XDG_RUNTIME_DIR = xdgRuntimeRoot;
+    vi.spyOn(os, 'platform').mockReturnValue('linux');
+
+    const result = requireCapabilityResult(
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN),
+    );
+    try {
+      expect(path.dirname(path.dirname(result.envFilePath))).toBe(
+        process.env.XDG_RUNTIME_DIR,
+      );
+    } finally {
+      result.cleanup();
+    }
+  });
+
+  it('places Linux capability files under os.tmpdir when XDG_RUNTIME_DIR is absent', () => {
+    vi.spyOn(os, 'platform').mockReturnValue('linux');
+
+    const result = requireCapabilityResult(
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN),
+    );
+    try {
+      expect(path.dirname(path.dirname(result.envFilePath))).toBe(runtimeRoot);
+    } finally {
+      result.cleanup();
+    }
+  });
+
+  it('places Linux capability files under os.tmpdir when XDG_RUNTIME_DIR is blank', () => {
+    process.env.XDG_RUNTIME_DIR = '   ';
+    vi.spyOn(os, 'platform').mockReturnValue('linux');
+
+    const result = requireCapabilityResult(
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN),
+    );
+    try {
+      expect(path.dirname(path.dirname(result.envFilePath))).toBe(runtimeRoot);
+    } finally {
+      result.cleanup();
+    }
+  });
+
+  it('places Windows capability files under LOCALAPPDATA/llxprt-code', () => {
+    const localAppData = path.join(getTmpDir(), 'local-app-data');
+    process.env.LOCALAPPDATA = localAppData;
+    vi.spyOn(os, 'platform').mockReturnValue('win32');
+
+    const result = requireCapabilityResult(
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN),
+    );
+    try {
+      expect(path.dirname(path.dirname(result.envFilePath))).toBe(
+        path.join(localAppData, 'llxprt-code'),
+      );
+    } finally {
+      result.cleanup();
+    }
+  });
+
+  it('places Darwin capability files under os.tmpdir', () => {
+    vi.spyOn(os, 'platform').mockReturnValue('darwin');
+
+    const result = requireCapabilityResult(
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN),
+    );
+    try {
+      expect(path.dirname(path.dirname(result.envFilePath))).toBe(runtimeRoot);
+    } finally {
+      result.cleanup();
+    }
+  });
+
+  it('returns undefined when no capability token (tokenless path)', () => {
+    expect(createHostOnlyCapabilityEnvFile(undefined)).toBeUndefined();
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'cleanup removes file+dir and is idempotent',
+    () => {
+      const result = requireCapabilityResult(
+        createHostOnlyCapabilityEnvFile(VALID_TOKEN),
+      );
+      expect(fs.existsSync(result.envFilePath)).toBe(true);
+      result.cleanup();
+      expect(fs.existsSync(result.envFilePath)).toBe(false);
+      expect(fs.existsSync(path.dirname(result.envFilePath))).toBe(false);
+      expect(() => result.cleanup()).not.toThrow();
+    },
+  );
+
+  it('a concurrent attacker cannot discover the host-only file via the narrowed session mount', () => {
+    const result = requireCapabilityResult(
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN),
+    );
+    const hostDir = path.dirname(result.envFilePath);
+
+    try {
+      const probeEntries = fs.readdirSync(sessionMount);
+      expect(hostDir.startsWith(`${sessionMount}${path.sep}`)).toBe(false);
+      expect(
+        probeEntries.some(
+          (entry) => entry.includes('capability') || entry.includes('env'),
+        ),
+      ).toBe(false);
+    } finally {
+      result.cleanup();
+    }
+  });
+
+  it('fails before creating a capability directory when the runtime root is inside a workdir-like mount', () => {
+    const mountedWorkdir = path.join(getTmpDir(), 'workdir');
+    const mountedRuntimeRoot = path.join(mountedWorkdir, 'runtime');
+    fs.mkdirSync(mountedRuntimeRoot, { recursive: true });
+    process.env.XDG_RUNTIME_DIR = mountedRuntimeRoot;
+    vi.spyOn(os, 'platform').mockReturnValue('linux');
+
+    expect(() =>
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN, [mountedWorkdir]),
+    ).toThrow(/XDG_RUNTIME_DIR.*mount source/i);
+    expect(
+      fs
+        .readdirSync(mountedRuntimeRoot)
+        .filter((entry) => entry.startsWith('llxprt-code-cap-')),
+    ).toStrictEqual([]);
+  });
+
+  it('fails before creating a capability directory when the runtime root symlinks into a mounted tree', () => {
+    const mountedWorkdir = path.join(getTmpDir(), 'workdir');
+    const mountedRuntimeRoot = path.join(mountedWorkdir, 'runtime');
+    const runtimeRootSymlink = path.join(getTmpDir(), 'runtime-link');
+    fs.mkdirSync(mountedRuntimeRoot, { recursive: true });
+    fs.symlinkSync(mountedRuntimeRoot, runtimeRootSymlink);
+    process.env.XDG_RUNTIME_DIR = runtimeRootSymlink;
+    vi.spyOn(os, 'platform').mockReturnValue('linux');
+
+    expect(() =>
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN, [mountedWorkdir]),
+    ).toThrow(/XDG_RUNTIME_DIR.*mount source/i);
+    expect(
+      fs
+        .readdirSync(mountedRuntimeRoot)
+        .filter((entry) => entry.startsWith('llxprt-code-cap-')),
+    ).toStrictEqual([]);
+  });
+
+  it('creates the capability directory beside mounts and skips nonexistent mount sources', () => {
+    const siblingMount = path.join(getTmpDir(), 'workdir');
+    const nonexistentMount = path.join(getTmpDir(), 'missing-mount');
+    fs.mkdirSync(siblingMount);
+    process.env.XDG_RUNTIME_DIR = runtimeRoot;
+    vi.spyOn(os, 'platform').mockReturnValue('linux');
+
+    const result = requireCapabilityResult(
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN, [
+        siblingMount,
+        nonexistentMount,
+      ]),
+    );
+
+    try {
+      expect(path.dirname(path.dirname(result.envFilePath))).toBe(runtimeRoot);
+      expect(
+        path.dirname(result.envFilePath).startsWith(
+          `${siblingMount}${path.sep}`,
+        ),
+      ).toBe(false);
+    } finally {
+      result.cleanup();
+    }
+  });
+
+  it('reclaims stale runtime and legacy HOME directories while preserving fresh directories', () => {
+    const staleRuntimeDir = path.join(runtimeRoot, 'llxprt-code-cap-stale');
+    const freshRuntimeDir = path.join(runtimeRoot, 'llxprt-code-cap-live');
+    const staleLegacyDir = path.join(isolatedHome, '.llxprt-code-cap-123-abc');
+    fs.mkdirSync(staleRuntimeDir);
+    fs.writeFileSync(path.join(staleRuntimeDir, 'junk'), 'stale');
+    fs.mkdirSync(freshRuntimeDir);
+    fs.mkdirSync(staleLegacyDir);
+    const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000);
+    fs.utimesSync(staleRuntimeDir, twoDaysAgo, twoDaysAgo);
+    fs.utimesSync(staleLegacyDir, twoDaysAgo, twoDaysAgo);
+
+    const result = requireCapabilityResult(
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN),
+    );
+    try {
+      expect(fs.existsSync(staleRuntimeDir)).toBe(false);
+      expect(fs.existsSync(staleLegacyDir)).toBe(false);
+      expect(fs.existsSync(freshRuntimeDir)).toBe(true);
+      expect(fs.existsSync(path.dirname(result.envFilePath))).toBe(true);
+    } finally {
+      result.cleanup();
+    }
+  });
+
+  it('reclaims directories at a custom age threshold without following symlinks', () => {
+    const staleRuntimeDir = path.join(
+      runtimeRoot,
+      'llxprt-code-cap-custom-stale',
+    );
+    const freshRuntimeDir = path.join(
+      runtimeRoot,
+      'llxprt-code-cap-custom-fresh',
+    );
+    const symlinkTarget = path.join(getTmpDir(), 'symlink-target');
+    const symlinkPath = path.join(runtimeRoot, 'llxprt-code-cap-symlink');
+    fs.mkdirSync(staleRuntimeDir);
+    fs.mkdirSync(freshRuntimeDir);
+    fs.mkdirSync(symlinkTarget);
+    fs.symlinkSync(symlinkTarget, symlinkPath);
+    const twoSecondsAgo = new Date(Date.now() - 2_000);
+    fs.utimesSync(staleRuntimeDir, twoSecondsAgo, twoSecondsAgo);
+
+    reclaimOrphanCapabilityDirs(1_000);
+
+    expect(fs.existsSync(staleRuntimeDir)).toBe(false);
+    expect(fs.existsSync(freshRuntimeDir)).toBe(true);
+    expect(fs.lstatSync(symlinkPath).isSymbolicLink()).toBe(true);
+    expect(fs.existsSync(symlinkTarget)).toBe(true);
+  });
+
+  it('fail-fast: runtime-root directory-creation failure surfaces', () => {
+    const blockedRuntimeRoot = path.join(getTmpDir(), 'not-a-directory');
+    fs.writeFileSync(
+      blockedRuntimeRoot,
+      'file blocks capability directory creation',
+    );
+    // Pin the platform so the redirected runtime root applies on every OS.
+    vi.spyOn(os, 'platform').mockReturnValue('linux');
+    overrideOsTmpdir(blockedRuntimeRoot);
+
+    expect(() => createHostOnlyCapabilityEnvFile(VALID_TOKEN)).toThrow(
+      /host-only directory/i,
+    );
+  });
+});
+
+describe('createHostOnlyDir: cleans up directory on setup failure (AC10)', () => {
+  const getTmpDir = useTempDir(beforeEach, afterEach);
+  let environmentSnapshot: NodeJS.ProcessEnv;
+  let runtimeRoot = '';
+  let isolatedHome = '';
+
+  beforeEach(() => {
+    environmentSnapshot = { ...process.env };
+    runtimeRoot = path.join(getTmpDir(), 'runtime');
+    isolatedHome = path.join(getTmpDir(), 'home');
+    fs.mkdirSync(runtimeRoot);
+    fs.mkdirSync(isolatedHome);
+    delete process.env.XDG_RUNTIME_DIR;
+    overrideOsTmpdir(runtimeRoot);
+    vi.spyOn(os, 'homedir').mockReturnValue(isolatedHome);
+  });
+
+  afterEach(() => {
+    process.env = environmentSnapshot;
+    restoreOsTmpdir();
+    vi.restoreAllMocks();
+  });
+
+  it('wraps mkdtemp failure and leaves no capability directory', () => {
+    vi.spyOn(fs, 'mkdtempSync').mockImplementationOnce(() => {
+      throw new Error('simulated mkdtemp failure');
+    });
+
+    expect(() => createHostOnlyCapabilityEnvFile(VALID_TOKEN)).toThrow(
+      /host-only directory.*mkdtemp failure/i,
+    );
+    expect(
+      fs
+        .readdirSync(runtimeRoot)
+        .filter((entry) => entry.startsWith('llxprt-code-cap-')),
+    ).toStrictEqual([]);
+  });
+
+  it('aggregates env-file write and directory cleanup failures', () => {
+    vi.spyOn(fs, 'openSync').mockImplementation(() => {
+      throw new Error('simulated env-file write failure');
+    });
+    vi.spyOn(fs, 'rmdirSync').mockImplementation(() => {
+      throw new Error('simulated rmdir failure');
+    });
+
+    let thrown: unknown;
+    try {
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(AggregateError);
+    if (!(thrown instanceof AggregateError)) {
+      throw new Error('Expected AggregateError');
+    }
+    const messages = thrown.errors.map((error) =>
+      error instanceof Error ? error.message : String(error),
+    );
+    expect(
+      messages.some((message) => /env-file write failure/i.test(message)),
+    ).toBe(true);
+    expect(messages.some((message) => /rmdir failure/i.test(message))).toBe(
+      true,
+    );
+  });
+});

--- a/packages/cli/src/utils/sandbox-capability.test.ts
+++ b/packages/cli/src/utils/sandbox-capability.test.ts
@@ -15,11 +15,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { FatalSandboxError } from '@vybestack/llxprt-code-core';
 import {
   createHostOnlyCapabilityEnvFile,
   reclaimOrphanCapabilityDirs,
   type HostOnlyCapabilityResult,
 } from './sandbox-capability.js';
+import { containerMountSources } from './sandbox-containers.js';
 
 const VALID_TOKEN = 'a'.repeat(64);
 
@@ -97,7 +99,7 @@ describe('host-only capability env-file (AC1, F4)', () => {
     'writes under the runtime root outside HOME and the session mount with mode 0700 dir / 0600 file; raw token not in argv',
     () => {
       const result = requireCapabilityResult(
-        createHostOnlyCapabilityEnvFile(VALID_TOKEN),
+        createHostOnlyCapabilityEnvFile(VALID_TOKEN, []),
       );
       const hostDir = path.dirname(result.envFilePath);
 
@@ -127,7 +129,7 @@ describe('host-only capability env-file (AC1, F4)', () => {
     vi.spyOn(os, 'platform').mockReturnValue('linux');
 
     const result = requireCapabilityResult(
-      createHostOnlyCapabilityEnvFile(VALID_TOKEN),
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN, []),
     );
     try {
       expect(path.dirname(path.dirname(result.envFilePath))).toBe(
@@ -142,7 +144,7 @@ describe('host-only capability env-file (AC1, F4)', () => {
     vi.spyOn(os, 'platform').mockReturnValue('linux');
 
     const result = requireCapabilityResult(
-      createHostOnlyCapabilityEnvFile(VALID_TOKEN),
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN, []),
     );
     try {
       expect(path.dirname(path.dirname(result.envFilePath))).toBe(runtimeRoot);
@@ -156,7 +158,7 @@ describe('host-only capability env-file (AC1, F4)', () => {
     vi.spyOn(os, 'platform').mockReturnValue('linux');
 
     const result = requireCapabilityResult(
-      createHostOnlyCapabilityEnvFile(VALID_TOKEN),
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN, []),
     );
     try {
       expect(path.dirname(path.dirname(result.envFilePath))).toBe(runtimeRoot);
@@ -171,7 +173,7 @@ describe('host-only capability env-file (AC1, F4)', () => {
     vi.spyOn(os, 'platform').mockReturnValue('win32');
 
     const result = requireCapabilityResult(
-      createHostOnlyCapabilityEnvFile(VALID_TOKEN),
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN, []),
     );
     try {
       expect(path.dirname(path.dirname(result.envFilePath))).toBe(
@@ -186,7 +188,7 @@ describe('host-only capability env-file (AC1, F4)', () => {
     vi.spyOn(os, 'platform').mockReturnValue('darwin');
 
     const result = requireCapabilityResult(
-      createHostOnlyCapabilityEnvFile(VALID_TOKEN),
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN, []),
     );
     try {
       expect(path.dirname(path.dirname(result.envFilePath))).toBe(runtimeRoot);
@@ -196,14 +198,14 @@ describe('host-only capability env-file (AC1, F4)', () => {
   });
 
   it('returns undefined when no capability token (tokenless path)', () => {
-    expect(createHostOnlyCapabilityEnvFile(undefined)).toBeUndefined();
+    expect(createHostOnlyCapabilityEnvFile(undefined, [])).toBeUndefined();
   });
 
   it.skipIf(process.platform === 'win32')(
     'cleanup removes file+dir and is idempotent',
     () => {
       const result = requireCapabilityResult(
-        createHostOnlyCapabilityEnvFile(VALID_TOKEN),
+        createHostOnlyCapabilityEnvFile(VALID_TOKEN, []),
       );
       expect(fs.existsSync(result.envFilePath)).toBe(true);
       result.cleanup();
@@ -215,7 +217,7 @@ describe('host-only capability env-file (AC1, F4)', () => {
 
   it('a concurrent attacker cannot discover the host-only file via the narrowed session mount', () => {
     const result = requireCapabilityResult(
-      createHostOnlyCapabilityEnvFile(VALID_TOKEN),
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN, []),
     );
     const hostDir = path.dirname(result.envFilePath);
 
@@ -247,6 +249,94 @@ describe('host-only capability env-file (AC1, F4)', () => {
         .readdirSync(mountedRuntimeRoot)
         .filter((entry) => entry.startsWith('llxprt-code-cap-')),
     ).toStrictEqual([]);
+  });
+
+  it('does not reclaim stale capability directories before rejecting a colliding mount', () => {
+    const mountedWorkdir = path.join(getTmpDir(), 'workdir');
+    const mountedRuntimeRoot = path.join(mountedWorkdir, 'runtime');
+    const staleCapabilityDir = path.join(
+      mountedRuntimeRoot,
+      'llxprt-code-cap-stale',
+    );
+    fs.mkdirSync(staleCapabilityDir, { recursive: true });
+    const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000);
+    fs.utimesSync(staleCapabilityDir, twoDaysAgo, twoDaysAgo);
+    process.env.XDG_RUNTIME_DIR = mountedRuntimeRoot;
+    vi.spyOn(os, 'platform').mockReturnValue('linux');
+
+    expect(() =>
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN, [mountedWorkdir]),
+    ).toThrow(FatalSandboxError);
+    expect(fs.existsSync(staleCapabilityDir)).toBe(true);
+  });
+
+  it.each([
+    [
+      '--mount with a separate bind specification',
+      (root: string) => [
+        '--mount',
+        `type=bind,src="${root}",dst=/container-runtime`,
+      ],
+    ],
+    [
+      '--mount= with the source alias',
+      (root: string) => [
+        `--mount=type=bind,source=${root},dst=/container-runtime`,
+      ],
+    ],
+  ])('rejects a colliding %s', (_label, buildArgs) => {
+    process.env.XDG_RUNTIME_DIR = runtimeRoot;
+    vi.spyOn(os, 'platform').mockReturnValue('linux');
+    const mountSources = containerMountSources(buildArgs(runtimeRoot));
+
+    expect(() =>
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN, mountSources),
+    ).toThrow(FatalSandboxError);
+  });
+
+  it('allows a named-volume --mount because it has no host source path', () => {
+    process.env.XDG_RUNTIME_DIR = runtimeRoot;
+    vi.spyOn(os, 'platform').mockReturnValue('linux');
+    const mountSources = containerMountSources([
+      '--mount',
+      'type=volume,src=runtime-data,dst=/container-runtime',
+    ]);
+
+    const result = requireCapabilityResult(
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN, mountSources),
+    );
+    try {
+      expect(mountSources).toStrictEqual([]);
+      expect(fs.existsSync(result.envFilePath)).toBe(true);
+    } finally {
+      result.cleanup();
+    }
+  });
+
+  it.each([
+    ['a mount without a type', ['--mount', 'src=/host,dst=/container']],
+    [
+      'an unrecognized mount type',
+      ['--mount=type=cluster,src=/host,dst=/container'],
+    ],
+    ['a bind mount without a source', ['--mount', 'type=bind,dst=/container']],
+  ])('fails closed for %s', (_label, args) => {
+    expect(() => containerMountSources(args)).toThrow(
+      /cannot be verified against the capability runtime root/i,
+    );
+  });
+
+  it.each([
+    ['plain Windows drive', 'C:\\work:/container', 'C:\\work'],
+    [
+      'Windows extended-length path',
+      '\\\\?\\C:\\work:/container',
+      '\\\\?\\C:\\work',
+    ],
+    ['Windows device path', '\\\\.\\C:\\work:/container', '\\\\.\\C:\\work'],
+    ['bracketed IPv6', '[::1]:/container', '[::1]'],
+  ])('extracts the complete %s volume source', (_label, spec, expected) => {
+    expect(containerMountSources(['--volume', spec])).toStrictEqual([expected]);
   });
 
   it('fails before creating a capability directory when the runtime root symlinks into a mounted tree', () => {
@@ -307,7 +397,7 @@ describe('host-only capability env-file (AC1, F4)', () => {
     fs.utimesSync(staleLegacyDir, twoDaysAgo, twoDaysAgo);
 
     const result = requireCapabilityResult(
-      createHostOnlyCapabilityEnvFile(VALID_TOKEN),
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN, []),
     );
     try {
       expect(fs.existsSync(staleRuntimeDir)).toBe(false);
@@ -345,6 +435,19 @@ describe('host-only capability env-file (AC1, F4)', () => {
     expect(fs.existsSync(symlinkTarget)).toBe(true);
   });
 
+  it('reports an actionable fatal error when the runtime root cannot be resolved', () => {
+    const missingRuntimeRoot = path.join(getTmpDir(), 'missing-runtime-root');
+    process.env.XDG_RUNTIME_DIR = missingRuntimeRoot;
+    vi.spyOn(os, 'platform').mockReturnValue('linux');
+
+    expect(() => createHostOnlyCapabilityEnvFile(VALID_TOKEN, [])).toThrow(
+      FatalSandboxError,
+    );
+    expect(() => createHostOnlyCapabilityEnvFile(VALID_TOKEN, [])).toThrow(
+      /XDG_RUNTIME_DIR|LOCALAPPDATA|tmpdir permissions/i,
+    );
+  });
+
   it('fail-fast: runtime-root directory-creation failure surfaces', () => {
     const blockedRuntimeRoot = path.join(getTmpDir(), 'not-a-directory');
     fs.writeFileSync(
@@ -355,7 +458,7 @@ describe('host-only capability env-file (AC1, F4)', () => {
     vi.spyOn(os, 'platform').mockReturnValue('linux');
     overrideOsTmpdir(blockedRuntimeRoot);
 
-    expect(() => createHostOnlyCapabilityEnvFile(VALID_TOKEN)).toThrow(
+    expect(() => createHostOnlyCapabilityEnvFile(VALID_TOKEN, [])).toThrow(
       /host-only directory/i,
     );
   });
@@ -389,7 +492,7 @@ describe('createHostOnlyDir: cleans up directory on setup failure (AC10)', () =>
       throw new Error('simulated mkdtemp failure');
     });
 
-    expect(() => createHostOnlyCapabilityEnvFile(VALID_TOKEN)).toThrow(
+    expect(() => createHostOnlyCapabilityEnvFile(VALID_TOKEN, [])).toThrow(
       /host-only directory.*mkdtemp failure/i,
     );
     expect(
@@ -409,7 +512,7 @@ describe('createHostOnlyDir: cleans up directory on setup failure (AC10)', () =>
 
     let thrown: unknown;
     try {
-      createHostOnlyCapabilityEnvFile(VALID_TOKEN);
+      createHostOnlyCapabilityEnvFile(VALID_TOKEN, []);
     } catch (error) {
       thrown = error;
     }

--- a/packages/cli/src/utils/sandbox-capability.test.ts
+++ b/packages/cli/src/utils/sandbox-capability.test.ts
@@ -285,9 +285,9 @@ describe('host-only capability env-file (AC1, F4)', () => {
     try {
       expect(path.dirname(path.dirname(result.envFilePath))).toBe(runtimeRoot);
       expect(
-        path.dirname(result.envFilePath).startsWith(
-          `${siblingMount}${path.sep}`,
-        ),
+        path
+          .dirname(result.envFilePath)
+          .startsWith(`${siblingMount}${path.sep}`),
       ).toBe(false);
     } finally {
       result.cleanup();

--- a/packages/cli/src/utils/sandbox-capability.ts
+++ b/packages/cli/src/utils/sandbox-capability.ts
@@ -4,10 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { FatalSandboxError } from '@vybestack/llxprt-code-core';
+
+const DEFAULT_ORPHAN_MAX_AGE_MS = 86_400_000;
+const CAPABILITY_DIR_PREFIX = 'llxprt-code-cap-';
+const LEGACY_CAPABILITY_DIR_PREFIX = '.llxprt-code-cap-';
 
 export interface HostOnlyCapabilityResult {
   readonly args: readonly string[];
@@ -32,40 +36,150 @@ export function runCapabilityCleanupStep(
   }
 }
 
-function createHostOnlyDir(): string {
-  const hostOnlyDir = path.join(
-    os.homedir(),
-    `.llxprt-code-cap-${process.pid}-${crypto.randomUUID()}`,
-  );
-  let dirCreated = false;
+function resolveCapabilityRuntimeRoot(): string {
+  switch (os.platform()) {
+    case 'linux': {
+      const xdgRuntimeDir = process.env.XDG_RUNTIME_DIR;
+      return xdgRuntimeDir !== undefined && xdgRuntimeDir.trim() !== ''
+        ? xdgRuntimeDir
+        : os.tmpdir();
+    }
+    case 'win32': {
+      const localAppData = process.env.LOCALAPPDATA;
+      if (localAppData === undefined || localAppData.trim() === '') {
+        return os.tmpdir();
+      }
+      const runtimeRoot = path.join(localAppData, 'llxprt-code');
+      try {
+        fs.mkdirSync(runtimeRoot, { recursive: true });
+      } catch {
+        // Best effort. The caller surfaces an actionable error if creation fails.
+      }
+      return runtimeRoot;
+    }
+    default:
+      return os.tmpdir();
+  }
+}
+
+function reclaimDirIfStale(
+  root: string,
+  entry: fs.Dirent,
+  prefixes: ReadonlySet<string>,
+  now: number,
+  maxAgeMs: number,
+): void {
+  if (
+    !entry.isDirectory() ||
+    ![...prefixes].some((prefix) => entry.name.startsWith(prefix))
+  ) {
+    return;
+  }
+  const dirPath = path.join(root, entry.name);
   try {
-    fs.mkdirSync(hostOnlyDir, { mode: 0o700 });
-    dirCreated = true;
-    const dirFd = fs.openSync(hostOnlyDir, 'r');
+    if (now - fs.lstatSync(dirPath).mtimeMs >= maxAgeMs) {
+      fs.rmSync(dirPath, { recursive: true, force: true });
+    }
+  } catch {
+    // Orphan reclamation must not prevent a new sandbox session.
+  }
+}
+
+export function reclaimOrphanCapabilityDirs(
+  maxAgeMs: number = DEFAULT_ORPHAN_MAX_AGE_MS,
+): void {
+  const targets = new Map<string, Set<string>>();
+  for (const [root, prefix] of [
+    [resolveCapabilityRuntimeRoot(), CAPABILITY_DIR_PREFIX],
+    [os.homedir(), LEGACY_CAPABILITY_DIR_PREFIX],
+  ]) {
+    const prefixes = targets.get(root) ?? new Set<string>();
+    prefixes.add(prefix);
+    targets.set(root, prefixes);
+  }
+
+  const now = Date.now();
+  for (const [root, prefixes] of targets) {
+    let entries: fs.Dirent[];
     try {
-      if (process.platform !== 'win32') fs.fchmodSync(dirFd, 0o700);
-    } finally {
-      fs.closeSync(dirFd);
+      entries = fs.readdirSync(root, { withFileTypes: true });
+    } catch {
+      continue;
     }
+    for (const entry of entries) {
+      reclaimDirIfStale(root, entry, prefixes, now, maxAgeMs);
+    }
+  }
+}
+
+function isErrorCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === code
+  );
+}
+
+function isPathInside(parent: string, candidate: string): boolean {
+  const relative = path.relative(parent, candidate);
+  return (
+    relative === '' ||
+    (relative !== '..' &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative))
+  );
+}
+
+function runtimeRootSource(runtimeRoot: string): string {
+  const xdgRuntimeDir = process.env.XDG_RUNTIME_DIR;
+  if (
+    os.platform() === 'linux' &&
+    xdgRuntimeDir !== undefined &&
+    xdgRuntimeDir.trim() !== ''
+  ) {
+    return `XDG_RUNTIME_DIR '${runtimeRoot}'`;
+  }
+  return `capability runtime path '${runtimeRoot}'`;
+}
+
+function assertCapabilityOutsideMounts(
+  runtimeRoot: string,
+  mountSources: readonly string[],
+): void {
+  if (mountSources.length === 0) return;
+  const canonicalRuntimeRoot = fs.realpathSync(runtimeRoot);
+  const candidatePath = path.join(
+    canonicalRuntimeRoot,
+    CAPABILITY_DIR_PREFIX,
+  );
+  for (const mountSource of mountSources) {
+    let canonicalMountSource: string;
+    try {
+      canonicalMountSource = fs.realpathSync(mountSource);
+    } catch (error) {
+      if (isErrorCode(error, 'ENOENT')) continue;
+      throw error;
+    }
+    if (isPathInside(canonicalMountSource, candidatePath)) {
+      throw new FatalSandboxError(
+        `${runtimeRootSource(runtimeRoot)} collides with sandbox mount source '${mountSource}'. Move XDG_RUNTIME_DIR outside mounted paths or remove the colliding mount.`,
+      );
+    }
+  }
+}
+
+function createHostOnlyDir(mountSources: readonly string[]): string {
+  reclaimOrphanCapabilityDirs();
+  const runtimeRoot = resolveCapabilityRuntimeRoot();
+  assertCapabilityOutsideMounts(runtimeRoot, mountSources);
+  try {
+    return fs.mkdtempSync(path.join(runtimeRoot, CAPABILITY_DIR_PREFIX));
   } catch (err) {
-    const errors: unknown[] = [err];
-    if (dirCreated) {
-      runCapabilityCleanupStep(
-        () => removePath(() => fs.rmdirSync(hostOnlyDir)),
-        errors,
-      );
-    }
-    if (errors.length === 1) {
-      throw new Error(
-        `Capability host-only directory could not be created: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
-    throw new AggregateError(
-      errors,
-      'Capability host-only directory could not be created',
+    throw new Error(
+      `Capability host-only directory could not be created: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
-  return hostOnlyDir;
 }
 
 function closeAfterWrite(fd: number, writeError?: unknown): void {
@@ -111,6 +225,7 @@ function removePath(remove: () => void): void {
 
 export function createHostOnlyCapabilityEnvFile(
   capabilityToken: string | undefined,
+  mountSources: readonly string[] = [],
 ): HostOnlyCapabilityResult | undefined {
   if (capabilityToken === undefined) return undefined;
   if (/[\r\n=]/.test(capabilityToken)) {
@@ -118,7 +233,7 @@ export function createHostOnlyCapabilityEnvFile(
       'Capability token contains invalid characters for env file',
     );
   }
-  const hostOnlyDir = createHostOnlyDir();
+  const hostOnlyDir = createHostOnlyDir(mountSources);
   const envFilePath = path.join(hostOnlyDir, 'capability.env');
   try {
     writeCapabilityEnvFile(envFilePath, capabilityToken);

--- a/packages/cli/src/utils/sandbox-capability.ts
+++ b/packages/cli/src/utils/sandbox-capability.ts
@@ -121,6 +121,89 @@ function isErrorCode(error: unknown, code: string): boolean {
   );
 }
 
+function volumeSource(spec: string): string {
+  if (spec.startsWith('[')) {
+    const bracketEnd = spec.indexOf(']');
+    if (bracketEnd !== -1 && spec[bracketEnd + 1] === ':') {
+      return spec.slice(0, bracketEnd + 1);
+    }
+  }
+  let sourceStart = 0;
+  if (/^\\\\[?.]\\[A-Za-z]:[\\/]/.test(spec)) {
+    sourceStart = 6;
+  } else if (/^[A-Za-z]:[\\/]/.test(spec)) {
+    sourceStart = 2;
+  }
+  const sourceEnd = spec.indexOf(':', sourceStart);
+  return sourceEnd === -1 ? spec : spec.slice(0, sourceEnd);
+}
+
+const HOSTLESS_MOUNT_TYPES = new Set(['volume', 'tmpfs', 'image']);
+
+function mountOption(spec: string, optionName: string): string | undefined {
+  for (const option of spec.split(',')) {
+    const equalsIndex = option.indexOf('=');
+    if (equalsIndex === -1) continue;
+    if (option.slice(0, equalsIndex).trim() === optionName) {
+      return option.slice(equalsIndex + 1).trim();
+    }
+  }
+  return undefined;
+}
+
+function unquoteMountSource(value: string): string | undefined {
+  const startsQuoted = value.startsWith('"');
+  const endsQuoted = value.endsWith('"');
+  if (startsQuoted !== endsQuoted) return undefined;
+  const source = startsQuoted ? value.slice(1, -1) : value;
+  return source === '' ? undefined : source;
+}
+
+function addMountSource(
+  sources: string[],
+  argument: string,
+  spec: string | undefined,
+): void {
+  const type = spec === undefined ? undefined : mountOption(spec, 'type');
+  if (type !== undefined && HOSTLESS_MOUNT_TYPES.has(type)) return;
+  if (type === 'bind' && spec !== undefined) {
+    const sourceValue = mountOption(spec, 'src') ?? mountOption(spec, 'source');
+    const source =
+      sourceValue === undefined ? undefined : unquoteMountSource(sourceValue);
+    if (source !== undefined) {
+      sources.push(source);
+      return;
+    }
+  }
+  throw new FatalSandboxError(
+    `Sandbox mount argument '${argument}' cannot be verified against the capability runtime root.`,
+  );
+}
+
+export function containerMountSources(args: readonly string[]): string[] {
+  const sources: string[] = [];
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === '--volume' || arg === '-v') {
+      sources.push(volumeSource(args[index + 1]));
+      index++;
+    } else if (arg.startsWith('--volume=')) {
+      sources.push(volumeSource(arg.slice('--volume='.length)));
+    } else if (arg === '--mount') {
+      const spec = args.at(index + 1);
+      addMountSource(
+        sources,
+        spec === undefined ? arg : `${arg} ${spec}`,
+        spec,
+      );
+      index++;
+    } else if (arg.startsWith('--mount=')) {
+      addMountSource(sources, arg, arg.slice('--mount='.length));
+    }
+  }
+  return sources;
+}
+
 function isPathInside(parent: string, candidate: string): boolean {
   const relative = path.relative(parent, candidate);
   return (
@@ -147,8 +230,18 @@ function assertCapabilityOutsideMounts(
   runtimeRoot: string,
   mountSources: readonly string[],
 ): void {
+  let canonicalRuntimeRoot: string;
+  try {
+    canonicalRuntimeRoot = fs.realpathSync(runtimeRoot);
+  } catch (error) {
+    if (isErrorCode(error, 'ENOENT')) {
+      throw new FatalSandboxError(
+        `Capability runtime root '${runtimeRoot}' could not be created or resolved. Check XDG_RUNTIME_DIR, LOCALAPPDATA, or system tmpdir permissions.`,
+      );
+    }
+    throw error;
+  }
   if (mountSources.length === 0) return;
-  const canonicalRuntimeRoot = fs.realpathSync(runtimeRoot);
   const candidatePath = path.join(canonicalRuntimeRoot, CAPABILITY_DIR_PREFIX);
   for (const mountSource of mountSources) {
     let canonicalMountSource: string;
@@ -167,9 +260,9 @@ function assertCapabilityOutsideMounts(
 }
 
 function createHostOnlyDir(mountSources: readonly string[]): string {
-  reclaimOrphanCapabilityDirs();
   const runtimeRoot = resolveCapabilityRuntimeRoot();
   assertCapabilityOutsideMounts(runtimeRoot, mountSources);
+  reclaimOrphanCapabilityDirs();
   try {
     return fs.mkdtempSync(path.join(runtimeRoot, CAPABILITY_DIR_PREFIX));
   } catch (err) {
@@ -222,7 +315,7 @@ function removePath(remove: () => void): void {
 
 export function createHostOnlyCapabilityEnvFile(
   capabilityToken: string | undefined,
-  mountSources: readonly string[] = [],
+  mountSources: readonly string[],
 ): HostOnlyCapabilityResult | undefined {
   if (capabilityToken === undefined) return undefined;
   if (/[\r\n=]/.test(capabilityToken)) {

--- a/packages/cli/src/utils/sandbox-capability.ts
+++ b/packages/cli/src/utils/sandbox-capability.ts
@@ -149,10 +149,7 @@ function assertCapabilityOutsideMounts(
 ): void {
   if (mountSources.length === 0) return;
   const canonicalRuntimeRoot = fs.realpathSync(runtimeRoot);
-  const candidatePath = path.join(
-    canonicalRuntimeRoot,
-    CAPABILITY_DIR_PREFIX,
-  );
+  const candidatePath = path.join(canonicalRuntimeRoot, CAPABILITY_DIR_PREFIX);
   for (const mountSource of mountSources) {
     let canonicalMountSource: string;
     try {

--- a/packages/cli/src/utils/sandbox-containers.ts
+++ b/packages/cli/src/utils/sandbox-containers.ts
@@ -89,16 +89,18 @@ const BASE_CONTAINER_HARDENING_FLAGS = [
   'no-new-privileges',
 ] as const;
 
-/** Composes cleanup callbacks and surfaces failures after attempting both. */
+/** Composes cleanup callbacks and surfaces failures after attempting each one. */
 function composeCleanups(
   a: (() => void) | undefined,
   b: (() => void) | undefined,
+  c: (() => void) | undefined,
 ): (() => void) | undefined {
-  if (a === undefined && b === undefined) return undefined;
+  if (a === undefined && b === undefined && c === undefined) return undefined;
   return () => {
     const errors: unknown[] = [];
     runCapabilityCleanupStep(() => a?.(), errors);
     runCapabilityCleanupStep(() => b?.(), errors);
+    runCapabilityCleanupStep(() => c?.(), errors);
     if (errors.length > 0) {
       throw new AggregateError(errors, 'Credential proxy cleanup failed');
     }
@@ -147,7 +149,7 @@ export function buildContainerRunArgs(
   image: string,
   workdir: string,
   containerWorkdir: string,
-  resolvedTmpdir: string,
+  sessionTmpdir: string,
 ): string[] {
   const args = ['run', '-i', '--rm', '--init', '--workdir', containerWorkdir];
   // Privilege hardening defaults: applied before SANDBOX_FLAGS so a user can
@@ -213,10 +215,10 @@ export function buildContainerRunArgs(
   args.push('--env', `LLXPRT_CONFIG_HOME=${containerConfigDir}`);
   const containerHome = resolveSandboxContainerHome();
   mountGitConfigFiles(args, os.homedir(), containerHome);
-  args.push(
-    '--volume',
-    `${resolvedTmpdir}:${getContainerPath(resolvedTmpdir)}`,
-  );
+  // Issue #3440: mount only the per-session subdirectory so host-only
+  // capability directories under the runtime root remain unreadable in the
+  // container, preserving issue #1954 AC1.
+  args.push('--volume', `${sessionTmpdir}:${getContainerPath(sessionTmpdir)}`);
   return args;
 }
 
@@ -573,7 +575,9 @@ async function setupMacOSCredProxyBridge(
 }
 
 /** Starts credential proxy and sets up bridge for Podman/Docker macOS. */
-async function failOnMissingSocketPath(): Promise<Error> {
+async function failOnMissingSocketPath(
+  sessionTmpdirCleanup: () => void,
+): Promise<Error> {
   const invariantError = new FatalSandboxError(
     'Credential proxy started but did not produce a socket path',
   );
@@ -583,8 +587,20 @@ async function failOnMissingSocketPath(): Promise<Error> {
   } catch (stopErr) {
     errors.push(stopErr);
   }
+  runCapabilityCleanupStep(sessionTmpdirCleanup, errors);
   return errors.length === 1
     ? invariantError
+    : new AggregateError(errors, 'Credential proxy setup failed');
+}
+
+function throwCredentialProxySetupError(
+  error: unknown,
+  sessionTmpdirCleanup: () => void,
+  errors: unknown[] = [error],
+): never {
+  runCapabilityCleanupStep(sessionTmpdirCleanup, errors);
+  throw errors.length === 1
+    ? error
     : new AggregateError(errors, 'Credential proxy setup failed');
 }
 
@@ -602,34 +618,80 @@ function assertSupportedCredentialNetwork(config: SandboxConfig): void {
   }
 }
 
+function volumeSource(spec: string): string {
+  const sourceStart = /^[A-Za-z]:[\\/]/.test(spec) ? 2 : 0;
+  const sourceEnd = spec.indexOf(':', sourceStart);
+  return sourceEnd === -1 ? spec : spec.slice(0, sourceEnd);
+}
+
+function containerMountSources(args: readonly string[]): string[] {
+  const sources: string[] = [];
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === '--volume' || arg === '-v') {
+      sources.push(volumeSource(args[index + 1]));
+      index++;
+    } else if (arg.startsWith('--volume=')) {
+      sources.push(volumeSource(arg.slice('--volume='.length)));
+    }
+  }
+  return sources;
+}
+
+async function startCredentialProxyForSandbox(
+  config: SandboxConfig,
+  sessionTmpdir: string,
+  sessionTmpdirCleanup: () => void,
+): Promise<string> {
+  try {
+    assertSupportedCredentialNetwork(config);
+  } catch (error) {
+    throwCredentialProxySetupError(error, sessionTmpdirCleanup);
+  }
+  try {
+    await createAndStartProxy({ socketPath: sessionTmpdir });
+  } catch (error) {
+    throwCredentialProxySetupError(
+      new FatalSandboxError(
+        `Failed to start credential proxy: ${error instanceof Error ? error.message : String(error)}`,
+      ),
+      sessionTmpdirCleanup,
+    );
+  }
+  const socketPath = getProxySocketPath();
+  if (socketPath === undefined) {
+    throw await failOnMissingSocketPath(sessionTmpdirCleanup);
+  }
+  return socketPath;
+}
+
 export async function setupCredentialProxy(
   args: string[],
   config: SandboxConfig,
-  resolvedTmpdir: string,
+  sessionTmpdir: string,
   reservedTunnelPorts: Set<number>,
   entrypointPrefixes: string[],
 ): Promise<{
   credentialProxyBridgeResult: CredentialProxyBridgeResult | undefined;
   credentialProxyBridgeCleanup: (() => void) | undefined;
 }> {
-  assertSupportedCredentialNetwork(config);
-
+  const sessionTmpdirCleanup = (): void => {
+    fs.rmSync(sessionTmpdir, { recursive: true, force: true });
+  };
+  // @plan:PLAN-20250214-CREDPROXY.P34 R25.1: Start credential proxy BEFORE spawning container
+  let socketPath: string;
+  try {
+    socketPath = await startCredentialProxyForSandbox(
+      config,
+      sessionTmpdir,
+      sessionTmpdirCleanup,
+    );
+  } catch (error) {
+    throwCredentialProxySetupError(error, sessionTmpdirCleanup);
+  }
   let credentialProxyBridgeResult: CredentialProxyBridgeResult | undefined;
   let credentialProxyBridgeCleanup: (() => void) | undefined;
   let envFileCleanup: (() => void) | undefined;
-
-  // @plan:PLAN-20250214-CREDPROXY.P34 R25.1: Start credential proxy BEFORE spawning container
-  try {
-    await createAndStartProxy({ socketPath: resolvedTmpdir });
-  } catch (err) {
-    throw new FatalSandboxError(
-      `Failed to start credential proxy: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
-  const socketPath = getProxySocketPath();
-  if (socketPath === undefined) {
-    throw await failOnMissingSocketPath();
-  }
 
   // @plan:PLAN-20250214-CREDPROXY.P34 R3.6: Pass socket path to container via env var
   const isDarwin = os.platform() === 'darwin';
@@ -654,6 +716,7 @@ export async function setupCredentialProxy(
     // @plan project-plans/issue-1954-sandbox-hardening.md (AC1): host-only env file.
     const envFileResult = createHostOnlyCapabilityEnvFile(
       getProxyCapabilityToken(),
+      containerMountSources(args),
     );
     if (envFileResult !== undefined) {
       args.push(...envFileResult.args);
@@ -668,17 +731,15 @@ export async function setupCredentialProxy(
     } catch (stopErr) {
       errors.push(stopErr);
     }
-    throw errors.length === 1
-      ? err
-      : new AggregateError(errors, 'Credential proxy setup failed');
+    throwCredentialProxySetupError(err, sessionTmpdirCleanup, errors);
   }
 
-  // Compose env-file cleanup with bridge cleanup.
   return {
     credentialProxyBridgeResult,
     credentialProxyBridgeCleanup: composeCleanups(
       credentialProxyBridgeCleanup,
       envFileCleanup,
+      sessionTmpdirCleanup,
     ),
   };
 }

--- a/packages/cli/src/utils/sandbox-containers.ts
+++ b/packages/cli/src/utils/sandbox-containers.ts
@@ -19,6 +19,7 @@ import type {
   SshAgentResult,
 } from './sandbox-ssh.js';
 import {
+  containerMountSources,
   createHostOnlyCapabilityEnvFile,
   runCapabilityCleanupStep,
 } from './sandbox-capability.js';
@@ -47,6 +48,8 @@ import {
   getProxyCapabilityToken,
 } from '@vybestack/llxprt-code-providers/auth.js';
 import { Storage } from '@vybestack/llxprt-code-storage';
+
+export { containerMountSources };
 
 const execAsync = promisify(exec);
 
@@ -616,26 +619,6 @@ function assertSupportedCredentialNetwork(config: SandboxConfig): void {
       'macOS credential bridge requires container networking; enable networking or use Linux for network-off sandboxing.',
     );
   }
-}
-
-function volumeSource(spec: string): string {
-  const sourceStart = /^[A-Za-z]:[\\/]/.test(spec) ? 2 : 0;
-  const sourceEnd = spec.indexOf(':', sourceStart);
-  return sourceEnd === -1 ? spec : spec.slice(0, sourceEnd);
-}
-
-function containerMountSources(args: readonly string[]): string[] {
-  const sources: string[] = [];
-  for (let index = 0; index < args.length; index++) {
-    const arg = args[index];
-    if (arg === '--volume' || arg === '-v') {
-      sources.push(volumeSource(args[index + 1]));
-      index++;
-    } else if (arg.startsWith('--volume=')) {
-      sources.push(volumeSource(arg.slice('--volume='.length)));
-    }
-  }
-  return sources;
 }
 
 async function startCredentialProxyForSandbox(

--- a/packages/cli/src/utils/sandbox-credential.test.ts
+++ b/packages/cli/src/utils/sandbox-credential.test.ts
@@ -65,15 +65,43 @@ function setNetworkEnvironment(
   if (legacy !== undefined) process.env.SANDBOX_NETWORK = legacy;
 }
 
+const realOsTmpdir: () => string = os.tmpdir;
+
+/**
+ * Overrides os.tmpdir for the code under test. Bun exposes os.tmpdir as an
+ * accessor property, which vi.spyOn cannot wrap, and once TMPDIR is deleted
+ * after being set, os.tmpdir keeps returning the stale value for the rest of
+ * the process. Redefining the property avoids both pitfalls.
+ */
+function overrideOsTmpdir(value: string): void {
+  Object.defineProperty(os, 'tmpdir', {
+    value: () => value,
+    configurable: true,
+  });
+}
+
+function restoreOsTmpdir(): void {
+  Object.defineProperty(os, 'tmpdir', {
+    value: realOsTmpdir,
+    configurable: true,
+  });
+}
+
 function capabilityArtifacts(home: string): string[] {
   return fs
     .readdirSync(home)
     .filter((entry) => entry.startsWith('.llxprt-code-cap-'));
 }
 
+function runtimeCapabilityArtifacts(runtimeRoot: string): string[] {
+  return fs
+    .readdirSync(runtimeRoot)
+    .filter((entry) => entry.startsWith('llxprt-code-cap-'));
+}
+
 function invokeCredentialSetup(
   command: ContainerCommand,
-  tmpDir: string,
+  sessionTmpdir: string,
 ): CredentialInvocation {
   const args: string[] = [];
   const prefixes: string[] = [];
@@ -85,7 +113,7 @@ function invokeCredentialSetup(
     promise: setupCredentialProxy(
       args,
       { command, image: 'test' },
-      tmpDir,
+      sessionTmpdir,
       reservedPorts,
       prefixes,
     ),
@@ -96,16 +124,23 @@ describe('#1456 credential proxy network policy', () => {
   let environmentSnapshot: NodeJS.ProcessEnv;
   let tmpDir = '';
   let isolatedHome: string;
+  let sessionTmpdir = '';
 
   beforeEach(() => {
     environmentSnapshot = { ...process.env };
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'credential-1456-'));
     isolatedHome = path.join(tmpDir, 'home');
+    sessionTmpdir = path.join(tmpDir, 'session');
     fs.mkdirSync(isolatedHome);
+    fs.mkdirSync(sessionTmpdir);
     process.env.HOME = isolatedHome;
     process.env.USERPROFILE = isolatedHome;
+    delete process.env.XDG_RUNTIME_DIR;
     setNetworkEnvironment(undefined, undefined);
     vi.resetAllMocks();
+    // os.tmpdir is an accessor property in Bun (vi.spyOn cannot wrap it) and
+    // a set-then-deleted TMPDIR leaves os.tmpdir() stale; redefine instead.
+    overrideOsTmpdir(tmpDir);
     vi.spyOn(os, 'homedir').mockReturnValue(isolatedHome);
     authMocks.createAndStartProxy.mockResolvedValue({ stop: vi.fn() });
     authMocks.getProxySocketPath.mockReturnValue(
@@ -127,6 +162,7 @@ describe('#1456 credential proxy network policy', () => {
 
   afterEach(() => {
     process.env = environmentSnapshot;
+    restoreOsTmpdir();
     vi.restoreAllMocks();
     if (tmpDir !== '') {
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -159,7 +195,7 @@ describe('#1456 credential proxy network policy', () => {
     async ({ command, setNetwork }) => {
       setNetwork();
       vi.spyOn(os, 'platform').mockReturnValue('darwin');
-      const invocation = invokeCredentialSetup(command, tmpDir);
+      const invocation = invokeCredentialSetup(command, sessionTmpdir);
       let unexpectedCleanup: (() => void) | undefined;
       const result = invocation.promise.then((value) => {
         unexpectedCleanup = value.credentialProxyBridgeCleanup;
@@ -187,6 +223,8 @@ describe('#1456 credential proxy network policy', () => {
         unexpectedCleanup?.();
         await authMocks.stopProxy();
         expect(capabilityArtifacts(isolatedHome)).toStrictEqual([]);
+        expect(runtimeCapabilityArtifacts(tmpDir)).toStrictEqual([]);
+        expect(fs.existsSync(sessionTmpdir)).toBe(false);
       }
     },
   );
@@ -262,7 +300,7 @@ describe('#1456 credential proxy network policy', () => {
     }) => {
       setNetworkEnvironment(primary, legacy);
       vi.spyOn(os, 'platform').mockReturnValue(platform);
-      const invocation = invokeCredentialSetup(command, tmpDir);
+      const invocation = invokeCredentialSetup(command, sessionTmpdir);
       let cleanup: (() => void) | undefined;
 
       try {
@@ -294,6 +332,8 @@ describe('#1456 credential proxy network policy', () => {
         cleanup?.();
         await authMocks.stopProxy();
         expect(capabilityArtifacts(isolatedHome)).toStrictEqual([]);
+        expect(runtimeCapabilityArtifacts(tmpDir)).toStrictEqual([]);
+        expect(fs.existsSync(sessionTmpdir)).toBe(false);
       }
     },
   );

--- a/packages/cli/src/utils/sandbox-entrypoint.test.ts
+++ b/packages/cli/src/utils/sandbox-entrypoint.test.ts
@@ -27,6 +27,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { spawnSync, type ChildProcess } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { EventEmitter } from 'node:events';
 import { entrypoint } from './sandbox-entrypoint.js';
 import {
@@ -87,13 +88,45 @@ function resolveRealConfigDir(): string {
   return resolved;
 }
 
+function snapshotDirectoryEntries(
+  directory: string,
+  relativeDirectory = '',
+): string[] {
+  const snapshot: string[] = [];
+  const entries = fs
+    .readdirSync(directory, { withFileTypes: true })
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  for (const entry of entries) {
+    const relativePath = path.join(relativeDirectory, entry.name);
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      snapshot.push(`directory:${relativePath}`);
+      snapshot.push(...snapshotDirectoryEntries(entryPath, relativePath));
+    } else if (entry.isFile()) {
+      const hash = createHash('sha256')
+        .update(fs.readFileSync(entryPath))
+        .digest('hex');
+      snapshot.push(`file:${relativePath}:${hash}`);
+    } else if (entry.isSymbolicLink()) {
+      snapshot.push(
+        `symbolic-link:${relativePath}:${fs.readlinkSync(entryPath)}`,
+      );
+    } else {
+      snapshot.push(`other:${relativePath}`);
+    }
+  }
+
+  return snapshot;
+}
+
 function snapshotDirectory(directory: string): DirectorySnapshot {
   if (!fs.existsSync(directory)) {
     return { exists: false, entries: [] };
   }
   return {
     exists: true,
-    entries: fs.readdirSync(directory).sort(),
+    entries: snapshotDirectoryEntries(directory),
   };
 }
 

--- a/packages/cli/src/utils/sandbox-entrypoint.test.ts
+++ b/packages/cli/src/utils/sandbox-entrypoint.test.ts
@@ -55,7 +55,7 @@ const BASH_CAP_REF = '${' + 'LLXPRT_CAPABILITY_TOKEN-}';
 const realHome = os.homedir();
 let realHomeCapabilityArtifacts = new Set<string>();
 let realConfigDir = '';
-let realConfigSnapshot: DirectorySnapshot;
+let realConfigSnapshot: DirectorySnapshot | undefined;
 
 interface DirectorySnapshot {
   readonly exists: boolean;
@@ -108,7 +108,9 @@ afterAll(() => {
     (entry) => !realHomeCapabilityArtifacts.has(entry),
   );
   expect(newRealHomeArtifacts).toStrictEqual([]);
-  expect(snapshotDirectory(realConfigDir)).toStrictEqual(realConfigSnapshot);
+  if (realConfigDir !== '' && realConfigSnapshot !== undefined) {
+    expect(snapshotDirectory(realConfigDir)).toStrictEqual(realConfigSnapshot);
+  }
 });
 
 function useTempDir(
@@ -574,6 +576,7 @@ describe('setupCredentialProxy: fail-fast when socket path is undefined (AC12)',
     await expect(callSetupCredentialProxy()).rejects.toThrow(
       /env-file write failure/i,
     );
+    expect(authMocks.stopProxy).toHaveBeenCalledTimes(1);
     expect(fs.existsSync(sessionTmpdir)).toBe(false);
     expect(
       fs

--- a/packages/cli/src/utils/sandbox-entrypoint.test.ts
+++ b/packages/cli/src/utils/sandbox-entrypoint.test.ts
@@ -13,17 +13,22 @@
  * @plan project-plans/issue-1954-sandbox-hardening.md (AC1-AC3, AC5, F1, F7, F10)
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'bun:test';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { spawnSync, type ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { entrypoint } from './sandbox-entrypoint.js';
-import {
-  createHostOnlyCapabilityEnvFile,
-  type HostOnlyCapabilityResult,
-} from './sandbox-capability.js';
 import {
   setupCredentialProxy,
   wireCleanupHandlers,
@@ -46,8 +51,65 @@ void vi.mock('@vybestack/llxprt-code-providers/auth.js', () => ({
 }));
 
 const VALID_TOKEN = 'a'.repeat(64);
-const NODE = process.execPath;
 const BASH_CAP_REF = '${' + 'LLXPRT_CAPABILITY_TOKEN-}';
+const realHome = os.homedir();
+let realHomeCapabilityArtifacts = new Set<string>();
+let realConfigDir = '';
+let realConfigSnapshot: DirectorySnapshot;
+
+interface DirectorySnapshot {
+  readonly exists: boolean;
+  readonly entries: readonly string[];
+}
+
+function legacyCapabilityArtifacts(home: string): string[] {
+  return fs
+    .readdirSync(home)
+    .filter((entry) => entry.startsWith('.llxprt-code-cap-'))
+    .sort();
+}
+
+function resolveRealConfigDir(): string {
+  const probe = spawnSync(
+    process.execPath,
+    [
+      '-e',
+      "import { Storage } from '@vybestack/llxprt-code-storage'; process.stdout.write(Storage.getGlobalConfigDir());",
+    ],
+    { encoding: 'utf8' },
+  );
+  const resolved = probe.stdout.trim();
+  if (probe.status !== 0 || resolved === '') {
+    throw new Error(
+      `Could not resolve the real CLI config directory: ${probe.stderr.trim()}`,
+    );
+  }
+  return resolved;
+}
+
+function snapshotDirectory(directory: string): DirectorySnapshot {
+  if (!fs.existsSync(directory)) {
+    return { exists: false, entries: [] };
+  }
+  return {
+    exists: true,
+    entries: fs.readdirSync(directory).sort(),
+  };
+}
+
+beforeAll(() => {
+  realHomeCapabilityArtifacts = new Set(legacyCapabilityArtifacts(realHome));
+  realConfigDir = resolveRealConfigDir();
+  realConfigSnapshot = snapshotDirectory(realConfigDir);
+});
+
+afterAll(() => {
+  const newRealHomeArtifacts = legacyCapabilityArtifacts(realHome).filter(
+    (entry) => !realHomeCapabilityArtifacts.has(entry),
+  );
+  expect(newRealHomeArtifacts).toStrictEqual([]);
+  expect(snapshotDirectory(realConfigDir)).toStrictEqual(realConfigSnapshot);
+});
 
 function useTempDir(
   registerBefore: (fn: () => void) => void,
@@ -59,6 +121,28 @@ function useTempDir(
   });
   registerAfter(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
   return () => tmpDir;
+}
+
+const realOsTmpdir: () => string = os.tmpdir;
+
+/**
+ * Overrides os.tmpdir for the code under test. Bun exposes os.tmpdir as an
+ * accessor property, which vi.spyOn cannot wrap, and once TMPDIR is deleted
+ * after being set, os.tmpdir keeps returning the stale value for the rest of
+ * the process. Redefining the property avoids both pitfalls.
+ */
+function overrideOsTmpdir(value: string): void {
+  Object.defineProperty(os, 'tmpdir', {
+    value: () => value,
+    configurable: true,
+  });
+}
+
+function restoreOsTmpdir(): void {
+  Object.defineProperty(os, 'tmpdir', {
+    value: realOsTmpdir,
+    configurable: true,
+  });
 }
 
 function runCmd(
@@ -142,115 +226,6 @@ function writeInnerScript(tmpDir: string, script: string): string {
   fs.chmodSync(p, 0o700);
   return p;
 }
-
-describe('sandbox-entrypoint: host-only capability env-file (AC1, F4)', () => {
-  const getTmpDir = useTempDir(beforeEach, afterEach);
-  let origToken: string | undefined;
-  let origSocket: string | undefined;
-  let origHome: string | undefined;
-  let origUserProfile: string | undefined;
-
-  beforeEach(() => {
-    origToken = process.env.LLXPRT_CAPABILITY_TOKEN;
-    origSocket = process.env.LLXPRT_CREDENTIAL_SOCKET;
-    origHome = process.env.HOME;
-    origUserProfile = process.env.USERPROFILE;
-    process.env.LLXPRT_CAPABILITY_TOKEN = VALID_TOKEN;
-  });
-
-  afterEach(() => {
-    if (origToken !== undefined)
-      process.env.LLXPRT_CAPABILITY_TOKEN = origToken;
-    else delete process.env.LLXPRT_CAPABILITY_TOKEN;
-    if (origSocket !== undefined)
-      process.env.LLXPRT_CREDENTIAL_SOCKET = origSocket;
-    else delete process.env.LLXPRT_CREDENTIAL_SOCKET;
-    // #10: restore HOME correctly when it was originally undefined.
-    if (origHome !== undefined) process.env.HOME = origHome;
-    else delete process.env.HOME;
-    if (origUserProfile !== undefined)
-      process.env.USERPROFILE = origUserProfile;
-    else delete process.env.USERPROFILE;
-  });
-
-  it.skipIf(process.platform === 'win32')(
-    'writes in a host-only dir under host HOME (outside mounts) with mode 0700 dir / 0600 file; raw token not in argv',
-    () => {
-      const result = createHostOnlyCapabilityEnvFile(
-        VALID_TOKEN,
-      ) as HostOnlyCapabilityResult;
-      const hostDir = path.dirname(result.envFilePath);
-      expect(hostDir.startsWith(os.homedir())).toBe(true);
-      expect(result.envFilePath.startsWith(getTmpDir())).toBe(false);
-      expect(fs.statSync(hostDir).mode & 0o777).toBe(0o700);
-      expect(fs.statSync(result.envFilePath).mode & 0o777).toBe(0o600);
-      expect(fs.readFileSync(result.envFilePath, 'utf8')).toContain(
-        VALID_TOKEN,
-      );
-      for (const arg of result.args) expect(arg).not.toContain(VALID_TOKEN);
-      expect(result.args[result.args.indexOf('--env-file') + 1]).toBe(
-        result.envFilePath,
-      );
-    },
-  );
-
-  it('returns undefined when no capability token (tokenless path)', () => {
-    expect(createHostOnlyCapabilityEnvFile(undefined)).toBeUndefined();
-  });
-
-  it.skipIf(process.platform === 'win32')(
-    'cleanup removes file+dir and is idempotent',
-    () => {
-      const result = createHostOnlyCapabilityEnvFile(
-        VALID_TOKEN,
-      ) as HostOnlyCapabilityResult;
-      expect(fs.existsSync(result.envFilePath)).toBe(true);
-      result.cleanup();
-      expect(fs.existsSync(result.envFilePath)).toBe(false);
-      expect(fs.existsSync(path.dirname(result.envFilePath))).toBe(false);
-      expect(() => result.cleanup()).not.toThrow();
-    },
-  );
-
-  it.skipIf(process.platform === 'win32')(
-    'a concurrent attacker cannot discover the host-only file via the mounted temp dir',
-    () => {
-      const result = createHostOnlyCapabilityEnvFile(
-        VALID_TOKEN,
-      ) as HostOnlyCapabilityResult;
-      const mount = getTmpDir();
-      const probe = spawnSync(
-        NODE,
-        [
-          '-e',
-          `
-      const fs=require('node:fs'); let found=false;
-      try{for(const e of fs.readdirSync(${JSON.stringify(mount)}))if(e.includes('capability')||e.includes('env'))found=true;}catch{}
-      process.stdout.write(JSON.stringify({found}));
-    `,
-        ],
-        { encoding: 'utf8' },
-      );
-      void result;
-      expect(JSON.parse(probe.stdout.trim()).found).toBe(false);
-    },
-  );
-
-  it('fail-fast: directory-creation failure surfaces', () => {
-    const blockedHome = path.join(getTmpDir(), 'not-a-directory');
-    fs.writeFileSync(blockedHome, 'file blocks child directory creation');
-    process.env.HOME = blockedHome;
-    process.env.USERPROFILE = blockedHome;
-    // The code under test resolves the home directory with os.homedir(), which
-    // honours process.env.HOME on Node but not on Bun. Spy on it directly so
-    // the redirection works regardless of runtime.
-    vi.spyOn(os, 'homedir').mockReturnValue(blockedHome);
-
-    expect(() => createHostOnlyCapabilityEnvFile(VALID_TOKEN)).toThrow(
-      /host-only directory/i,
-    );
-  });
-});
 
 describe('sandbox-entrypoint: trusted entrypoint security (AC2, AC3, F1, F7, F10)', () => {
   const getTmpDir = useTempDir(beforeEach, afterEach);
@@ -496,48 +471,59 @@ describe('sandbox-entrypoint: trusted entrypoint security (AC2, AC3, F1, F7, F10
  */
 describe('setupCredentialProxy: fail-fast when socket path is undefined (AC12)', () => {
   const getTmpDir = useTempDir(beforeEach, afterEach);
+  let environmentSnapshot: NodeJS.ProcessEnv;
+  let runtimeRoot = '';
+  let isolatedHome = '';
+  let sessionTmpdir = '';
 
   beforeEach(() => {
+    environmentSnapshot = { ...process.env };
+    runtimeRoot = path.join(getTmpDir(), 'runtime');
+    isolatedHome = path.join(getTmpDir(), 'home');
+    sessionTmpdir = path.join(getTmpDir(), 'session');
+    fs.mkdirSync(runtimeRoot);
+    fs.mkdirSync(isolatedHome);
+    fs.mkdirSync(sessionTmpdir);
+    delete process.env.XDG_RUNTIME_DIR;
     vi.resetAllMocks();
+    overrideOsTmpdir(runtimeRoot);
+    vi.spyOn(os, 'homedir').mockReturnValue(isolatedHome);
     authMocks.createAndStartProxy.mockResolvedValue({ stop: vi.fn() });
+    authMocks.getProxySocketPath.mockReturnValue(undefined);
     authMocks.stopProxy.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
+    process.env = environmentSnapshot;
+    restoreOsTmpdir();
     vi.restoreAllMocks();
   });
 
-  /** Shared invocation with the production signature. */
   function callSetupCredentialProxy(): Promise<unknown> {
     return setupCredentialProxy(
       [],
       { command: 'docker', image: 'test' },
-      getTmpDir(),
+      sessionTmpdir,
       new Set<number>(),
       [],
     );
   }
 
-  beforeEach(() => {
-    authMocks.getProxySocketPath.mockReturnValue(undefined);
-  });
-
   it('throws FatalSandboxError when getProxySocketPath returns undefined after createAndStartProxy succeeds', () =>
     expect(callSetupCredentialProxy()).rejects.toThrow(/socket path/i));
 
-  it('attempts stopProxy when socket path is undefined', async () => {
+  it('attempts stopProxy and removes the session directory when socket path is undefined', async () => {
     try {
       await callSetupCredentialProxy();
     } catch {
       /* expected */
     }
     expect(authMocks.stopProxy).toHaveBeenCalledTimes(1);
+    expect(fs.existsSync(sessionTmpdir)).toBe(false);
   });
 
   it('surfaces both invariant and stopProxy failures via AggregateError when socket path is undefined and stopProxy rejects', async () => {
     authMocks.stopProxy.mockRejectedValue(new Error('stopProxy failed'));
-    // Captured explicitly rather than with rejects.toSatisfy, which hands the
-    // pending promise to the predicate instead of the rejection value.
     let caught: unknown;
     try {
       await callSetupCredentialProxy();
@@ -545,11 +531,17 @@ describe('setupCredentialProxy: fail-fast when socket path is undefined (AC12)',
       caught = error;
     }
     expect(caught).toBeInstanceOf(AggregateError);
-    const messages = (caught as AggregateError).errors.map((e) =>
-      e instanceof Error ? e.message : String(e),
+    if (!(caught instanceof AggregateError)) {
+      throw new Error('Expected AggregateError');
+    }
+    const messages = caught.errors.map((error) =>
+      error instanceof Error ? error.message : String(error),
     );
-    expect(messages.some((m) => /socket path/i.test(m))).toBe(true);
-    expect(messages.some((m) => /stopProxy failed/i.test(m))).toBe(true);
+    expect(messages.some((message) => /socket path/i.test(message))).toBe(true);
+    expect(messages.some((message) => /stopProxy failed/i.test(message))).toBe(
+      true,
+    );
+    expect(fs.existsSync(sessionTmpdir)).toBe(false);
   });
 
   it('does not silently return unprotected sandbox (args unchanged)', async () => {
@@ -558,15 +550,36 @@ describe('setupCredentialProxy: fail-fast when socket path is undefined (AC12)',
       setupCredentialProxy(
         args,
         { command: 'docker', image: 'test' },
-        getTmpDir(),
+        sessionTmpdir,
         new Set<number>(),
         [],
       ),
     ).rejects.toThrow(/socket path/i);
-    expect(args.some((a) => a.includes('LLXPRT_CREDENTIAL_SOCKET'))).toBe(
+    expect(args.some((arg) => arg.includes('LLXPRT_CREDENTIAL_SOCKET'))).toBe(
       false,
     );
-    expect(args.some((a) => a.includes('--env-file'))).toBe(false);
+    expect(args.some((arg) => arg.includes('--env-file'))).toBe(false);
+    expect(fs.existsSync(sessionTmpdir)).toBe(false);
+  });
+
+  it('removes the session directory when capability env-file setup fails', async () => {
+    authMocks.getProxySocketPath.mockReturnValue(
+      path.join(sessionTmpdir, 'credential-proxy.sock'),
+    );
+    authMocks.getProxyCapabilityToken.mockReturnValue(VALID_TOKEN);
+    vi.spyOn(fs, 'openSync').mockImplementation(() => {
+      throw new Error('simulated env-file write failure');
+    });
+
+    await expect(callSetupCredentialProxy()).rejects.toThrow(
+      /env-file write failure/i,
+    );
+    expect(fs.existsSync(sessionTmpdir)).toBe(false);
+    expect(
+      fs
+        .readdirSync(runtimeRoot)
+        .filter((entry) => entry.startsWith('llxprt-code-cap-')),
+    ).toStrictEqual([]);
   });
 });
 
@@ -681,69 +694,5 @@ describe('wireCleanupHandlers: stopProxy rejection is observable (AC12)', () => 
     // Stored cleanup cleared.
     expect(setStored).toHaveBeenCalledWith(undefined);
     expect(stored).toBeUndefined();
-  });
-});
-
-describe('createHostOnlyDir: cleans up directory on setup failure (AC10)', () => {
-  const getTmpDir = useTempDir(beforeEach, afterEach);
-  let origHome: string | undefined;
-
-  beforeEach(() => {
-    origHome = process.env.HOME;
-    process.env.HOME = getTmpDir();
-    vi.spyOn(os, 'homedir').mockReturnValue(getTmpDir());
-  });
-
-  afterEach(() => {
-    if (origHome !== undefined) process.env.HOME = origHome;
-    else delete process.env.HOME;
-  });
-
-  it('removes the created directory when open/fchmod/close fails after mkdir', () => {
-    const realOpenSync = fs.openSync;
-    let openCallCount = 0;
-    const openSpy = vi.spyOn(fs, 'openSync').mockImplementation((...args) => {
-      openCallCount++;
-      if (openCallCount === 1) throw new Error('simulated open failure');
-      return realOpenSync(...(args as [fs.PathLike, fs.Mode]));
-    });
-    try {
-      expect(() => createHostOnlyCapabilityEnvFile(VALID_TOKEN)).toThrow(
-        /host-only directory/i,
-      );
-      expect(
-        fs
-          .readdirSync(getTmpDir())
-          .filter((e) => e.startsWith('.llxprt-code-cap-')),
-      ).toHaveLength(0);
-    } finally {
-      openSpy.mockRestore();
-    }
-  });
-
-  it('aggregates primary and cleanup failures when both fail', () => {
-    const openSpy = vi.spyOn(fs, 'openSync').mockImplementation(() => {
-      throw new Error('simulated open failure');
-    });
-    const rmdirSpy = vi.spyOn(fs, 'rmdirSync').mockImplementation(() => {
-      throw new Error('simulated rmdir failure');
-    });
-    try {
-      let thrown: unknown;
-      try {
-        createHostOnlyCapabilityEnvFile(VALID_TOKEN);
-      } catch (err) {
-        thrown = err;
-      }
-      expect(thrown).toBeInstanceOf(AggregateError);
-      const messages = (thrown as AggregateError).errors.map((e) =>
-        e instanceof Error ? e.message : String(e),
-      );
-      expect(messages.some((m) => /open failure/i.test(m))).toBe(true);
-      expect(messages.some((m) => /rmdir failure/i.test(m))).toBe(true);
-    } finally {
-      openSpy.mockRestore();
-      rmdirSpy.mockRestore();
-    }
   });
 });

--- a/packages/cli/src/utils/sandbox-exec.ts
+++ b/packages/cli/src/utils/sandbox-exec.ts
@@ -55,6 +55,10 @@ import {
 } from './sandbox-env.js';
 import { SETTINGS_DIRECTORY_NAME } from '../config/settings.js';
 
+function removeSessionTmpdir(sessionTmpdir: string): void {
+  fs.rmSync(sessionTmpdir, { recursive: true, force: true });
+}
+
 /** Validates image and builds initial container run args. */
 async function prepareContainerImageAndArgs(config: SandboxConfig): Promise<{
   image: string;
@@ -110,7 +114,7 @@ async function prepareContainerImageAndArgs(config: SandboxConfig): Promise<{
     addContainerVolumeMounts(args);
     return { image, workdir, containerWorkdir, sessionTmpdir, args };
   } catch (error) {
-    fs.rmSync(sessionTmpdir, { recursive: true, force: true });
+    runBestEffortSyncCleanup(() => removeSessionTmpdir(sessionTmpdir));
     throw error;
   }
 }
@@ -157,6 +161,43 @@ type ContainerNetworkAndEnv = Awaited<
   ReturnType<typeof prepareContainerNetworkAndEnv>
 >;
 
+interface ContainerEntrypointSetup {
+  readonly args: string[];
+  readonly workdir: string;
+  readonly cliArgs: string[];
+  readonly podmanMacOSPortsForwarded: Set<string>;
+  readonly entrypointPrefixes: string[];
+  readonly credentialProxyBridgeCleanup: (() => void) | undefined;
+}
+
+async function prepareContainerEntrypoint({
+  args,
+  workdir,
+  cliArgs,
+  podmanMacOSPortsForwarded,
+  entrypointPrefixes,
+  credentialProxyBridgeCleanup,
+}: ContainerEntrypointSetup): Promise<{
+  finalEntrypoint: string[];
+  userFlag: string;
+}> {
+  try {
+    const finalEntrypoint = entrypoint(
+      workdir,
+      cliArgs,
+      podmanMacOSPortsForwarded.size > 0
+        ? podmanMacOSPortsForwarded
+        : undefined,
+      entrypointPrefixes,
+    );
+    const userFlag = await setupContainerUser(args, finalEntrypoint);
+    return { finalEntrypoint, userFlag };
+  } catch (error) {
+    runBestEffortSyncCleanup(credentialProxyBridgeCleanup);
+    throw error;
+  }
+}
+
 async function rethrowCredentialProxySetupError(
   error: unknown,
   credentialProxyBridgeResult: CredentialProxyBridgeResult | undefined,
@@ -201,7 +242,7 @@ async function prepareContainerSandbox(
     const containerName = assignContainerName(args, config, image);
     addContainerEnvVars(args, config, containerName, nodeArgs, workdir);
   } catch (error) {
-    fs.rmSync(sessionTmpdir, { recursive: true, force: true });
+    runBestEffortSyncCleanup(() => removeSessionTmpdir(sessionTmpdir));
     throw error;
   }
   const {
@@ -226,21 +267,19 @@ async function prepareContainerSandbox(
       entrypointPrefixes,
     );
   } catch (error) {
-    fs.rmSync(sessionTmpdir, { recursive: true, force: true });
+    runBestEffortSyncCleanup(() => removeSessionTmpdir(sessionTmpdir));
     throw error;
   }
 
-  // Build the entrypoint with all prefixes composed into the trusted script
-  // body after the capability capture stanza. setupContainerUser then wraps
-  // the complete script for the current-user su path.
-  const finalEntrypoint = entrypoint(
+  const { finalEntrypoint, userFlag } = await prepareContainerEntrypoint({
+    args,
     workdir,
     cliArgs,
-    podmanMacOSPortsForwarded.size > 0 ? podmanMacOSPortsForwarded : undefined,
+    podmanMacOSPortsForwarded,
     entrypointPrefixes,
-  );
-
-  const userFlag = await setupContainerUser(args, finalEntrypoint);
+    credentialProxyBridgeCleanup:
+      credentialProxySetup.credentialProxyBridgeCleanup,
+  });
 
   return {
     args,

--- a/packages/cli/src/utils/sandbox-exec.ts
+++ b/packages/cli/src/utils/sandbox-exec.ts
@@ -182,7 +182,6 @@ async function prepareContainerSandbox(
   cliArgs: string[],
 ): Promise<ContainerSandboxPrepared> {
   validateContainerSandboxEnv();
-  let credentialProxyBridgeCleanup: (() => void) | undefined;
 
   const { image, workdir, sessionTmpdir, args } =
     await prepareContainerImageAndArgs(config);
@@ -214,24 +213,18 @@ async function prepareContainerSandbox(
 
   // Compose bridge prefixes after the trusted capability capture stanza (F1).
   const entrypointPrefixes: string[] = [];
-  let credentialProxyBridgeResult: CredentialProxyBridgeResult | undefined;
+  let credentialProxySetup: Awaited<ReturnType<typeof setupCredentialProxy>>;
   try {
     if (sshResult.entrypointPrefix !== undefined) {
       entrypointPrefixes.push(sshResult.entrypointPrefix);
     }
-    try {
-      const cpResult = await setupCredentialProxy(
-        args,
-        config,
-        sessionTmpdir,
-        reservedTunnelPorts,
-        entrypointPrefixes,
-      );
-      credentialProxyBridgeResult = cpResult.credentialProxyBridgeResult;
-      credentialProxyBridgeCleanup = cpResult.credentialProxyBridgeCleanup;
-    } catch (error) {
-      await rethrowCredentialProxySetupError(error, credentialProxyBridgeResult);
-    }
+    credentialProxySetup = await startCredentialProxyGuarded(
+      args,
+      config,
+      sessionTmpdir,
+      reservedTunnelPorts,
+      entrypointPrefixes,
+    );
   } catch (error) {
     fs.rmSync(sessionTmpdir, { recursive: true, force: true });
     throw error;
@@ -257,11 +250,34 @@ async function prepareContainerSandbox(
     image,
     workdir,
     portForwardingResult,
-    credentialProxyBridgeResult,
-    credentialProxyBridgeCleanup,
+    ...credentialProxySetup,
     reservedTunnelPorts,
     sshResult,
   };
+}
+
+async function startCredentialProxyGuarded(
+  args: string[],
+  config: SandboxConfig,
+  sessionTmpdir: string,
+  reservedTunnelPorts: Set<number>,
+  entrypointPrefixes: string[],
+): Promise<Awaited<ReturnType<typeof setupCredentialProxy>>> {
+  let credentialProxyBridgeResult: CredentialProxyBridgeResult | undefined;
+  try {
+    const cpResult = await setupCredentialProxy(
+      args,
+      config,
+      sessionTmpdir,
+      reservedTunnelPorts,
+      entrypointPrefixes,
+    );
+    credentialProxyBridgeResult = cpResult.credentialProxyBridgeResult;
+    const credentialProxyBridgeCleanup = cpResult.credentialProxyBridgeCleanup;
+    return { credentialProxyBridgeResult, credentialProxyBridgeCleanup };
+  } catch (error) {
+    return rethrowCredentialProxySetupError(error, credentialProxyBridgeResult);
+  }
 }
 
 /** Spawns container and proxy, wires cleanup, and waits for exit. */

--- a/packages/cli/src/utils/sandbox-exec.ts
+++ b/packages/cli/src/utils/sandbox-exec.ts
@@ -60,7 +60,7 @@ async function prepareContainerImageAndArgs(config: SandboxConfig): Promise<{
   image: string;
   workdir: string;
   containerWorkdir: string;
-  resolvedTmpdir: string;
+  sessionTmpdir: string;
   args: string[];
 }> {
   // @plan:PLAN-20250214-CREDPROXY.P34 R3.4: Use realpath to resolve symlinks
@@ -96,15 +96,23 @@ async function prepareContainerImageAndArgs(config: SandboxConfig): Promise<{
   }
 
   const resolvedTmpdir = fs.realpathSync(os.tmpdir());
-  const args = buildContainerRunArgs(
-    config,
-    image,
-    workdir,
-    containerWorkdir,
-    resolvedTmpdir,
+  const sessionTmpdir = fs.mkdtempSync(
+    path.join(resolvedTmpdir, 'llxprt-sandbox-'),
   );
-  addContainerVolumeMounts(args);
-  return { image, workdir, containerWorkdir, resolvedTmpdir, args };
+  try {
+    const args = buildContainerRunArgs(
+      config,
+      image,
+      workdir,
+      containerWorkdir,
+      sessionTmpdir,
+    );
+    addContainerVolumeMounts(args);
+    return { image, workdir, containerWorkdir, sessionTmpdir, args };
+  } catch (error) {
+    fs.rmSync(sessionTmpdir, { recursive: true, force: true });
+    throw error;
+  }
 }
 
 /** Sets up SSH forwarding, port forwarding, networking, and env vars. */
@@ -145,6 +153,27 @@ async function prepareContainerNetworkAndEnv(
   };
 }
 
+type ContainerNetworkAndEnv = Awaited<
+  ReturnType<typeof prepareContainerNetworkAndEnv>
+>;
+
+async function rethrowCredentialProxySetupError(
+  error: unknown,
+  credentialProxyBridgeResult: CredentialProxyBridgeResult | undefined,
+): Promise<never> {
+  runBestEffortSyncCleanup(credentialProxyBridgeResult?.cleanup);
+  try {
+    await stopProxy();
+  } catch {
+    // best-effort cleanup; the original error is the one we want to throw
+  }
+  if (error instanceof FatalSandboxError) throw error;
+  // @plan:PLAN-20250214-CREDPROXY.P34 R25.1a: Proxy creation failure aborts before spawning container
+  throw new FatalSandboxError(
+    `Failed to start credential proxy: ${error instanceof Error ? error.message : String(error)}`,
+  );
+}
+
 /** Runs the Docker/Podman sandbox path — image build, arg assembly, and proxy setup. */
 async function prepareContainerSandbox(
   config: SandboxConfig,
@@ -155,61 +184,57 @@ async function prepareContainerSandbox(
   validateContainerSandboxEnv();
   let credentialProxyBridgeCleanup: (() => void) | undefined;
 
-  const { image, workdir, resolvedTmpdir, args } =
+  const { image, workdir, sessionTmpdir, args } =
     await prepareContainerImageAndArgs(config);
 
   const reservedTunnelPorts = new Set<number>();
-  const isPodmanMacOS =
-    config.command === 'podman' && os.platform() === 'darwin';
+  let networkAndEnv: ContainerNetworkAndEnv;
+  try {
+    const isPodmanMacOS =
+      config.command === 'podman' && os.platform() === 'darwin';
+    networkAndEnv = await prepareContainerNetworkAndEnv(
+      config,
+      args,
+      workdir,
+      isPodmanMacOS,
+      reservedTunnelPorts,
+    );
+    const containerName = assignContainerName(args, config, image);
+    addContainerEnvVars(args, config, containerName, nodeArgs, workdir);
+  } catch (error) {
+    fs.rmSync(sessionTmpdir, { recursive: true, force: true });
+    throw error;
+  }
   const {
     sshResult,
     podmanMacOSPortsForwarded,
     proxyCommand,
     portForwardingResult,
-  } = await prepareContainerNetworkAndEnv(
-    config,
-    args,
-    workdir,
-    isPodmanMacOS,
-    reservedTunnelPorts,
-  );
+  } = networkAndEnv;
 
-  const containerName = assignContainerName(args, config, image);
-  addContainerEnvVars(args, config, containerName, nodeArgs, workdir);
-
-  // Gather entrypoint prefixes (ssh-agent bridge, credential proxy bridge)
-  // before building the entrypoint so they compose INTO the trusted script
-  // AFTER the capability capture stanza (F1).
+  // Compose bridge prefixes after the trusted capability capture stanza (F1).
   const entrypointPrefixes: string[] = [];
-  if (sshResult.entrypointPrefix !== undefined) {
-    entrypointPrefixes.push(sshResult.entrypointPrefix);
-  }
-
   let credentialProxyBridgeResult: CredentialProxyBridgeResult | undefined;
   try {
-    const cpResult = await setupCredentialProxy(
-      args,
-      config,
-      resolvedTmpdir,
-      reservedTunnelPorts,
-      entrypointPrefixes,
-    );
-    credentialProxyBridgeResult = cpResult.credentialProxyBridgeResult;
-    credentialProxyBridgeCleanup = cpResult.credentialProxyBridgeCleanup;
-  } catch (err) {
-    runBestEffortSyncCleanup(credentialProxyBridgeResult?.cleanup);
+    if (sshResult.entrypointPrefix !== undefined) {
+      entrypointPrefixes.push(sshResult.entrypointPrefix);
+    }
     try {
-      await stopProxy();
-    } catch {
-      // best-effort cleanup; the original error is the one we want to throw
+      const cpResult = await setupCredentialProxy(
+        args,
+        config,
+        sessionTmpdir,
+        reservedTunnelPorts,
+        entrypointPrefixes,
+      );
+      credentialProxyBridgeResult = cpResult.credentialProxyBridgeResult;
+      credentialProxyBridgeCleanup = cpResult.credentialProxyBridgeCleanup;
+    } catch (error) {
+      await rethrowCredentialProxySetupError(error, credentialProxyBridgeResult);
     }
-    if (err instanceof FatalSandboxError) {
-      throw err;
-    }
-    // @plan:PLAN-20250214-CREDPROXY.P34 R25.1a: Proxy creation failure aborts before spawning container
-    throw new FatalSandboxError(
-      `Failed to start credential proxy: ${err instanceof Error ? err.message : String(err)}`,
-    );
+  } catch (error) {
+    fs.rmSync(sessionTmpdir, { recursive: true, force: true });
+    throw error;
   }
 
   // Build the entrypoint with all prefixes composed into the trusted script

--- a/packages/cli/src/utils/sandbox-proxy-integration.test.ts
+++ b/packages/cli/src/utils/sandbox-proxy-integration.test.ts
@@ -103,7 +103,7 @@ describe('Credential Proxy Integration - sandbox.ts', () => {
       expect(setupProxyCallIndex).toBeGreaterThan(prepareContainerIndex);
       expect(pushImageIndex).toBeGreaterThan(executeContainerIndex);
       expect(spawnInDocker).toBeGreaterThan(pushImageIndex);
-      expect(setupProxyCallIndex).toBeLessThan(pushImageIndex);
+      expect(createProxyIndex).toBeLessThan(pushImageIndex);
     });
   });
 

--- a/packages/cli/src/utils/sandbox-proxy-integration.test.ts
+++ b/packages/cli/src/utils/sandbox-proxy-integration.test.ts
@@ -65,11 +65,18 @@ describe('Credential Proxy Integration - sandbox.ts', () => {
     });
 
     it('calls createAndStartProxy before container spawn', () => {
-      const setupProxyIndex = sandboxSource.indexOf(
-        'async function setupCredentialProxy',
+      const startProxyHelperIndex = sandboxSource.indexOf(
+        'async function startCredentialProxyForSandbox',
       );
       const createProxyIndex = sandboxSource.indexOf(
         'await createAndStartProxy',
+        startProxyHelperIndex,
+      );
+      const setupProxyIndex = sandboxSource.indexOf(
+        'async function setupCredentialProxy',
+      );
+      const startProxyHelperCallIndex = sandboxSource.indexOf(
+        'await startCredentialProxyForSandbox',
         setupProxyIndex,
       );
       const prepareContainerIndex = sandboxSource.indexOf(
@@ -91,7 +98,8 @@ describe('Credential Proxy Integration - sandbox.ts', () => {
         executeContainerIndex,
       );
 
-      expect(createProxyIndex).toBeGreaterThan(setupProxyIndex);
+      expect(createProxyIndex).toBeGreaterThan(startProxyHelperIndex);
+      expect(startProxyHelperCallIndex).toBeGreaterThan(setupProxyIndex);
       expect(setupProxyCallIndex).toBeGreaterThan(prepareContainerIndex);
       expect(pushImageIndex).toBeGreaterThan(executeContainerIndex);
       expect(spawnInDocker).toBeGreaterThan(pushImageIndex);
@@ -141,14 +149,17 @@ describe('Credential Proxy Integration - sandbox.ts', () => {
       );
     });
 
-    it('passes resolvedTmpdir to volume mount', () => {
+    it('narrows the tmpdir mount to a per-session directory', () => {
+      expect(sandboxSource).toMatch(
+        /fs\.mkdtempSync\(\s*path\.join\(resolvedTmpdir,\s*'llxprt-sandbox-',?\s*\)/,
+      );
       expect(sandboxSource).toContain(
-        '`${resolvedTmpdir}:${getContainerPath(resolvedTmpdir)}`',
+        '`${sessionTmpdir}:${getContainerPath(sessionTmpdir)}`',
       );
     });
 
-    it('passes resolvedTmpdir to createAndStartProxy', () => {
-      expect(sandboxSource).toContain('socketPath: resolvedTmpdir');
+    it('passes sessionTmpdir to createAndStartProxy', () => {
+      expect(sandboxSource).toContain('socketPath: sessionTmpdir');
     });
   });
 

--- a/project-plans/issue-3440-capability-env-reclamation.md
+++ b/project-plans/issue-3440-capability-env-reclamation.md
@@ -86,8 +86,8 @@ capability dir is ever created in the real home or real config.
 - No changes outside `packages/cli/src/utils/` sandbox files, their tests, and
   this plan.
 - No new env-var knobs, no new public modules; `reclaimOrphanCapabilityDirs`
-  is exported from `sandbox-capability.ts` for testability, that is the only
-  new export.
+  and `containerMountSources` are exported for direct reclamation and mount
+  parser coverage.
 - No seatbelt-path changes (it never creates capability env files).
 - No CI workflow changes; the in-suite guard satisfies AC4 because it runs in
   CI.
@@ -133,3 +133,6 @@ NO_ASSERT findings).
   older than 24 hours may have its already-consumed capability env directory
   reclaimed; this is harmless because Docker and Podman consume the env file
   when the container starts.
+- `assignContainerName` and `addContainerEnvVars` can leak pre-existing network
+  resources on failure; Podman forwarding self-registers exit handlers.
+- `containerMountSources` is exported only for direct F1/F2 parser coverage.

--- a/project-plans/issue-3440-capability-env-reclamation.md
+++ b/project-plans/issue-3440-capability-env-reclamation.md
@@ -1,0 +1,135 @@
+# Issue #3440 — Capability token env dirs (`~/.llxprt-code-cap-*`) accumulate in `$HOME` with no reclamation
+
+Branch: `issue3440`. Milestone 0.11.0. Labels: Code Quality / Modularization,
+sandboxing, security.
+
+## Accepted behavior (test-first restatement of the issue ACs)
+
+AC1 — No production or test code path creates `.llxprt-code-cap-*` entries in
+`$HOME`. Proven by:
+
+- Placement tests: the capability dir produced by
+  `createHostOnlyCapabilityEnvFile()` resolves under a platform runtime root
+  (never `os.homedir()`), for every platform branch (see resolver below).
+- A suite-level guard in `sandbox-entrypoint.test.ts`: snapshot the count of
+  `.llxprt-code-cap-*` entries in the REAL `os.homedir()` in `beforeAll`,
+  assert the count is unchanged in `afterAll` (on CI this is 0 → 0, satisfying
+  "leaves zero").
+
+AC2 — The token never lands inside any path mounted into the sandbox container
+(#1954 AC1), and 0700/0600 modes are preserved wherever a file transport
+remains. Proven by:
+
+- Mount narrowing: the container tmpdir mount is a session-specific
+  `mkdtemp` subdirectory of `resolvedTmpdir`; the capability dir is created
+  outside it (sibling under the runtime root, or in XDG_RUNTIME_DIR /
+  LOCALAPPDATA which are never mounted).
+- A behavioral attacker test: a probe listing the (narrowed) mounted dir finds
+  no capability artifact.
+- Mode assertions (0700 dir / 0600 file) stay in the placement test;
+  `fs.mkdtempSync` guarantees 0700 on POSIX.
+
+AC3 — A session killed with SIGKILL still has its directory reclaimed by a
+later CLI startup within the configured threshold. Implemented per the issue's
+allowed alternative ("or immediately before creating a new capability dir"):
+`reclaimOrphanCapabilityDirs(maxAgeMs)` runs at the top of
+`createHostOnlyCapabilityEnvFile()`. Proven by behavioral tests that seed
+orphan dirs with backdated mtimes in a redirected runtime root and in a mocked
+legacy-home root, invoke the producer, and observe removal; fresh (young) dirs
+are never removed.
+
+AC4 — CI proves the test suite leaves zero `.llxprt-code-cap-*` directories in
+the real `$HOME` and touches nothing in the real config. The suite-level
+before/after guard (AC1) runs in CI via `npm run test`. Every test that invokes
+the real producer redirects BOTH the runtime root and `os.homedir()` to temp
+dirs, so the sweep embedded in the producer never scans the real home and no
+capability dir is ever created in the real home or real config.
+
+## Design decisions
+
+1. Runtime root resolver (`sandbox-capability.ts`), evaluated per call (never
+   cached, so tests can redirect it):
+   - Linux: `XDG_RUNTIME_DIR` when set and non-empty; else `os.tmpdir()`.
+   - macOS: `os.tmpdir()` (per-user `DARWIN_USER_TEMP_DIR`).
+   - Windows: `<LOCALAPPDATA>/llxprt-code` (created if needed); else
+     `os.tmpdir()`.
+   Capability dir: `fs.mkdtempSync(path.join(root, 'llxprt-code-cap-'))`
+   (0700 on POSIX, no pid in the name — age-based reclamation makes the pid
+   useless and pid reuse makes it misleading).
+2. Mount narrowing (`sandbox-exec.ts`): keep
+   `resolvedTmpdir = fs.realpathSync(os.tmpdir())`; create
+   `sessionTmpdir = fs.mkdtempSync(path.join(resolvedTmpdir, 'llxprt-sandbox-'))`;
+   pass `sessionTmpdir` to `buildContainerRunArgs()` (mount at path parity, so
+   socket path parity is preserved) and to `setupCredentialProxy()` as the
+   proxy socket dir. The session dir is removed best-effort on the existing
+   exit paths by composing its cleanup into `credentialProxyBridgeCleanup`.
+3. Bounded lifetime: `reclaimOrphanCapabilityDirs(maxAgeMs = 24h)` scans (a)
+   the runtime root for `llxprt-code-cap-*` and (b) `os.homedir()` for legacy
+   `.llxprt-code-cap-*` (this is what eventually reclaims the ~3,013 dirs that
+   already accumulated). Directories only (never symlinks), exact prefix match,
+   mtime older than the threshold, best-effort removal that can never fail the
+   session startup. 24h default is safe because docker/podman read `--env-file`
+   at container spawn; the file is dead weight minutes later, and concurrent
+   sessions' fresh dirs are always under the threshold. Age is the criterion;
+   no pid-liveness checks (pid reuse).
+4. File transport stays. macOS Keychain/no-file transport was evaluated and
+   rejected for this change: `--env-file` requires a host-readable file, and
+   the alternative (`--env` with the raw token) is banned by #1954 tests
+   because it exposes the token in argv/inspect output. Recorded here as a
+   possible future option, not implemented.
+5. Naming: new dirs use the prefix `llxprt-code-cap-` (mkdtemp). The legacy
+   hidden prefix `.llxprt-code-cap-` is matched only by the sweep, never
+   created again.
+
+## Scope guard (do NOT do)
+
+- No changes outside `packages/cli/src/utils/` sandbox files, their tests, and
+  this plan.
+- No new env-var knobs, no new public modules; `reclaimOrphanCapabilityDirs`
+  is exported from `sandbox-capability.ts` for testability, that is the only
+  new export.
+- No seatbelt-path changes (it never creates capability env files).
+- No CI workflow changes; the in-suite guard satisfies AC4 because it runs in
+  CI.
+
+## Files to touch
+
+- `packages/cli/src/utils/sandbox-capability.ts` — resolver, mkdtemp
+  placement, sweep.
+- `packages/cli/src/utils/sandbox-exec.ts` — session tmpdir narrowing + return
+  it; thread to `setupCredentialProxy`.
+- `packages/cli/src/utils/sandbox-containers.ts` — rename param to
+  `sessionTmpdir` in `buildContainerRunArgs`/`setupCredentialProxy`; compose
+  session-dir cleanup.
+- `packages/cli/src/utils/sandbox-entrypoint.test.ts` — placement/platform
+  tests, reclamation tests, attacker test rework, AC10 rework, real-home
+  before/after guard, runtime-root redirection in every producer-touching
+  describe.
+- `packages/cli/src/utils/sandbox-capability.test.ts` — capability placement,
+  reclamation, and mount-containment behavior split from the entrypoint suite
+  to keep `sandbox-entrypoint.test.ts` within the 800-line lint limit.
+- `packages/cli/src/utils/sandbox-credential.test.ts` — redirect runtime root
+  (spy `os.tmpdir`, unset/restore `XDG_RUNTIME_DIR`); artifact assertions cover
+  the redirected root.
+- `packages/cli/src/utils/sandbox-proxy-integration.test.ts` — update R3.4
+  source-structure assertions (realpath retained; narrowed mount; socket in
+  session dir).
+
+## Verification
+
+Full cycle per the issue-workflow skill: `npm run test`, `npm run lint`,
+`npm run typecheck`, `npm run format`, `npm run build`, and the smoke test
+`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing
+else"`. Plus `bun scripts/test-audit/scan.ts` diffed against main for the
+touched test files (no new MOCK_MIRROR / ALWAYS_TRUE / SELF_CONFIRMING /
+NO_ASSERT findings).
+
+## Known follow-ups
+
+- Windows named-pipe socket parity for the credential proxy remains a
+  pre-existing platform gap. This change does not regress it.
+- Orphan reclamation uses the issue's stated 24-hour age criterion. PID
+  liveness was rejected because PID reuse makes it unreliable. A live session
+  older than 24 hours may have its already-consumed capability env directory
+  reclaimed; this is harmless because Docker and Podman consume the env file
+  when the container starts.


### PR DESCRIPTION
## TLDR

Stops the one-shot sandbox capability token directory from being created (and leaked) in `$HOME`, reclaims orphans from crash paths, and narrows the container tmpdir mount so the token stays outside the container boundary. Reviewers should focus on `sandbox-capability.ts` (placement + sweep + mount-containment fail-fast) and the mount narrowing in `sandbox-exec.ts`/`sandbox-containers.ts`.

Fixes #3440

## Dive Deeper

**Placement.** `createHostOnlyCapabilityEnvFile()` used to materialize `~/.llxprt-code-cap-<pid>-<uuid>/capability.env` as a hidden dotdir in `$HOME`. Graceful-exit cleanup existed, but SIGKILL, `tmux kill-session`, and crashes skipped every handler; nothing swept the orphans (~100/day steady state on one dev machine, 3,013 accumulated). The dir now lives under the platform runtime root — `XDG_RUNTIME_DIR` (fallback `os.tmpdir()`) on Linux, per-user `os.tmpdir()` on macOS, `%LOCALAPPDATA%/llxprt-code` on Windows — created with `mkdtempSync` (0700 on POSIX), file mode 0600 preserved. The pid is gone from the name: age-based reclamation makes it useless and pid reuse makes it misleading.

**Reclamation.** `reclaimOrphanCapabilityDirs()` runs immediately before every capability-dir creation and removes matching dirs older than 24h, in both locations: the new prefix in the runtime root and the legacy dot-prefix in `$HOME` (this is what eventually clears the ~3,013 already-accumulated dirs). Age is the criterion, per the issue's own analysis: pid-liveness checks are defeated by pid reuse. Directories only (symlinks ignored at enumeration, `lstatSync` for the age check), exact prefix match, best-effort removal that can never fail a session start. A 24h threshold is safe because the container engine consumes `--env-file` at spawn; a live session older than 24h only loses an already-consumed file (recorded as a known design trade-off in the plan).

**Container boundary (#1954 AC1).** The tmpdir mount is narrowed to a per-session `mkdtemp` subdirectory (`llxprt-sandbox-*`), so the runtime root is no longer mounted wholesale. On top of that, `assertCapabilityOutsideMounts()` canonicalizes the runtime root and every `--volume` source parsed from the container args and **fails fast** with an actionable message if the capability path would land inside any mount (workdir, config dir, custom volume, or sidecar workdir) — e.g. an `XDG_RUNTIME_DIR` pointing beneath the project. The session tmpdir is owned from `mkdtempSync` through credential-proxy setup success, so early failures cannot strand it.

**Test isolation + CI proof.** Every producer-invoking test redirects both the runtime root and `os.homedir()` (the Bun `os.tmpdir` accessor quirk is handled by property redefinition, documented in-code). A suite-level guard in `sandbox-entrypoint.test.ts` asserts the run leaves **zero new** `.llxprt-code-cap-*` entries in the real `$HOME` (before-set minus after-set empty; CI is 0→0) and that the real config directory's entry list is unmutated (or remains nonexistent). Placement tests cover every platform branch; reclamation tests seed backdated orphans and invoke the real producer; attacker-probe and source-structure tests cover the narrowed mount; new collision tests prove the fail-fast (workdir-inside-root, symlinked root, sibling-ok + ENOENT-source-skip).

**Review process.** Two-round deepthinker compliance review: round 1 found 7 findings (mount containment HIGH; AC4 guard strength; sweep TOCTOU; session-tmpdir ownership; scope items). All were remediated or documented; round 2 verification reran green (70/70 focused tests, scoped lint exit 0). Follow-ups recorded in the plan: Windows named-pipe socket parity for the credential proxy (pre-existing platform gap, not regressed here) and the 24h live-session trade-off above. OCR could not run in this environment — no LLM endpoint is reachable from the sandboxed session; logged as #3458.

## Reviewer Test Plan

- `bun test packages/cli/src/utils/sandbox-capability.test.ts packages/cli/src/utils/sandbox-entrypoint.test.ts` — all placement/reclamation/collision/guard tests.
- Repro from the issue: snapshot `ls -d ~/.llxprt-code-cap-*` before/after a full targeted test run — no new entries appear (pre-existing legacy dirs stay untouched until a real session reclaims them by age).
- Production orphan path: create a legacy-named dir with a backdated mtime in `$HOME`, start any sandboxed session — the dir is reclaimed on capability-dir creation; fresh dirs are never touched.
- Mount containment: `XDG_RUNTIME_DIR="$PWD/.run" LLXPRT_SANDBOX...` (runtime root inside a mounted path) — session start fails fast with the actionable collision message instead of exposing the token.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ✅  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | ❓  |
| Seatbelt | ❓  | -   | -   |

Linux (`npm run`): full monorepo test run plus two full CLI suite runs (final: 715/718 files, 9252 cases passed) — every failing file is proven pre-existing by byte-identical stash-compare against the main-equivalent tree (`cli-args.integration` nightly-semver, `docsCommand` message drift, `Footer.responsive` nightly-version length; details in `tmp/verify3440/triage-cli-A2.tsv` vs `B2.tsv`). Scoped lint (the CI PR gate) exit 0, typecheck exit 0, format exit 0, build exit 0. The live-model smoke test is environmentally blocked in this sandbox container (credential backend unreachable; failure reproduced identically on the stashed clean tree). Docker/Podman runtime behavior was validated via unit/integration argument-level tests, not a live container run; Seatbelt is untouched by this change.

## Linked issues / bugs

Fixes #3440
Related: #1954 (token outside container mounts — boundary preserved and strengthened), #2784 (original capability bootstrap hardening)
Tooling friction found during delivery: #3458 (OCR unreachable from sandbox), #3459 (subagent timeout ceiling discards finished review reports)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Reliability**
  * Improved isolation of temporary sandbox and credential-proxy files with dedicated per-session storage.
  * Strengthened protection for sensitive capability files through safer placement, permissions, and mount-path checks.
  * Added reliable cleanup when sandbox setup, proxy startup, or environment-file creation fails.

* **Bug Fixes**
  * Reclaimed stale capability directories and prevented temporary artifacts from lingering between sessions.
  * Rejected unsafe or unverifiable container mount paths before creating sensitive files.

* **Tests**
  * Expanded coverage for platform-specific storage, cleanup, permissions, failure handling, symlink safety, mount parsing, and proxy integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->