### PR TITLE
Make sandboxed credential-resolution failures diagnosable with a typed error (Fixes #3451)

### DIFF
--- a/packages/auth/src/__tests__/auth-precedence-resolver.di.test.ts
+++ b/packages/auth/src/__tests__/auth-precedence-resolver.di.test.ts
@@ -143,6 +143,35 @@ describe('AuthPrecedenceResolver DI behavioral tests', () => {
       expect(result).toBe('constructor-api-key');
     });
 
+    it('falls through an unreadable provider keyfile to a working environment credential', async () => {
+      process.env.TEST_AUTH_API_KEY = 'env-key-after-keyfile-failure';
+      try {
+        const settings = createInMemorySettingsService(
+          {},
+          {
+            anthropic: {
+              'auth-keyfile': '/path/that/does/not/exist/issue3451-keyfile',
+            },
+          },
+        );
+        const resolver = new AuthPrecedenceResolver(
+          {
+            providerId: 'anthropic',
+            envKeyNames: ['TEST_AUTH_API_KEY'],
+          },
+          { settingsService: settings },
+        );
+
+        const result = await resolver.resolveAuthenticationResult();
+
+        expect(result).toEqual({
+          token: 'env-key-after-keyfile-failure',
+        });
+      } finally {
+        delete process.env.TEST_AUTH_API_KEY;
+      }
+    });
+
     it('falls back to environment variable when no auth-key or API key', async () => {
       process.env.TEST_AUTH_API_KEY = 'env-key-value';
       try {

--- a/packages/auth/src/__tests__/credential-resolution.test.ts
+++ b/packages/auth/src/__tests__/credential-resolution.test.ts
@@ -1,0 +1,616 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as net from 'node:net';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  AuthPrecedenceResolver,
+  CredentialResolutionError,
+  ProxyProviderKeyStorage,
+  ProxySocketClient,
+  ProxyTokenStore,
+  runtimeScopedStates,
+  type CredentialResolutionErrorKind,
+  type CredentialResolutionResult,
+  type IProviderKeyStorage,
+  type IProviderRuntimeContext,
+  type ISettingsService,
+  type OAuthManager,
+} from '../index.js';
+import { encodeFrame, FrameDecoder } from '../proxy/framing.js';
+
+const CREDENTIAL_SOCKET_ENV = 'LLXPRT_CREDENTIAL_SOCKET';
+const CREDENTIAL_SECRET = 'issue3451-credential-secret';
+const CAPABILITY_SECRET = 'issue3451-capability-secret';
+const KEY_MATERIAL_SECRET = 'issue3451-key-material-secret';
+
+type ProxyBehavior =
+  | 'not-found'
+  | 'disconnect-on-request'
+  | 'unauthorized'
+  | 'token-then-disconnect';
+
+interface ProxyHarness {
+  readonly socketPath: string;
+  readonly requestCount: () => number;
+  close(): Promise<void>;
+}
+
+function createSettingsService(
+  values: Readonly<Record<string, unknown>> = {},
+  providerValues: Readonly<
+    Record<string, Readonly<Record<string, unknown>>>
+  > = {},
+): ISettingsService {
+  const settings = new Map<string, unknown>(Object.entries(values));
+  const providerSettings = new Map(
+    Object.entries(providerValues).map(([provider, entries]) => [
+      provider,
+      { ...entries },
+    ]),
+  );
+  return {
+    get: (key) => settings.get(key),
+    getProviderSettings: (provider) => providerSettings.get(provider) ?? {},
+    on: () => {},
+    off: () => {},
+  };
+}
+
+function createRuntimeContext(
+  runtimeId: string,
+  settingsService: ISettingsService,
+): IProviderRuntimeContext {
+  return { runtimeId, settingsService, metadata: {} };
+}
+
+function createEmptyKeyStorage(): IProviderKeyStorage {
+  return {
+    getKey: async () => null,
+    listKeys: async () => [],
+    hasKey: async () => false,
+  };
+}
+
+async function startProxy(behavior: ProxyBehavior): Promise<ProxyHarness> {
+  const directory = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'llxprt-credential-resolution-'),
+  );
+  const socketPath = path.join(directory, 'proxy.sock');
+  const sockets = new Set<net.Socket>();
+  let requestCount = 0;
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.once('close', () => sockets.delete(socket));
+    const decoder = new FrameDecoder();
+    socket.on('data', (chunk) => {
+      for (const frame of decoder.feed(chunk)) {
+        if (frame.op === 'handshake') {
+          const response =
+            behavior === 'unauthorized'
+              ? {
+                  ok: false,
+                  code: 'UNAUTHORIZED',
+                  error: 'capability rejected',
+                }
+              : { ok: true, data: { version: 2 } };
+          socket.write(encodeFrame(response));
+        } else {
+          requestCount += 1;
+          if (behavior === 'disconnect-on-request') {
+            socket.destroy();
+          } else if (behavior === 'not-found') {
+            socket.write(
+              encodeFrame({
+                ok: false,
+                id: frame.id,
+                code: 'NOT_FOUND',
+                error: 'credential absent',
+              }),
+            );
+          } else if (
+            behavior === 'token-then-disconnect' &&
+            requestCount === 1
+          ) {
+            socket.write(
+              encodeFrame({
+                ok: true,
+                id: frame.id,
+                data: {
+                  access_token: CREDENTIAL_SECRET,
+                  token_type: 'Bearer',
+                  expiry: Math.floor(Date.now() / 1000) + 3600,
+                },
+              }),
+            );
+          } else {
+            socket.destroy();
+          }
+        }
+      }
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(socketPath, () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+  });
+  return {
+    socketPath,
+    requestCount: () => requestCount,
+    close: async () => {
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await fs.rm(directory, { recursive: true, force: true });
+    },
+  };
+}
+
+function expectSafeFailure(
+  result: CredentialResolutionResult,
+  expectedKind: CredentialResolutionErrorKind,
+  forbiddenValues: readonly string[],
+): CredentialResolutionError {
+  if (result.token !== null) {
+    throw new Error('Expected credential resolution to fail');
+  }
+  expect(result.failure).toBeInstanceOf(CredentialResolutionError);
+  expect(result.failure.kind).toBe(expectedKind);
+  expect(result.failure.message).toContain(
+    `provider=${result.failure.diagnostics.provider}`,
+  );
+  expect(result.failure.message).toContain(
+    `profile=${result.failure.diagnostics.profile}`,
+  );
+  expect(result.failure.message).toContain(
+    `runtimeId=${result.failure.diagnostics.runtimeId}`,
+  );
+  expect(result.failure.message).toContain(
+    `attemptedMechanisms=[${result.failure.diagnostics.attemptedMechanisms.join(', ')}]`,
+  );
+  expect(result.failure.message).toContain(
+    `proxyMode=${result.failure.diagnostics.proxyMode}`,
+  );
+  expect(result.failure.message).toContain(
+    `proxyContacted=${result.failure.diagnostics.proxyContacted}`,
+  );
+  const publicDetails = `${result.failure.message}\n${JSON.stringify(
+    result.failure.diagnostics,
+  )}`;
+  for (const forbiddenValue of forbiddenValues) {
+    expect(publicDetails).not.toContain(forbiddenValue);
+  }
+  return result.failure;
+}
+
+function createProxyOAuthManager(tokenStore: ProxyTokenStore): OAuthManager {
+  return {
+    getToken: async (provider) => {
+      const token = await tokenStore.getToken(provider);
+      return token?.access_token ?? null;
+    },
+    isAuthenticated: async () => true,
+  };
+}
+
+describe('Credential resolution diagnostics', () => {
+  const clients: ProxySocketClient[] = [];
+  const harnesses: ProxyHarness[] = [];
+  let originalSocketEnv: string | undefined;
+
+  beforeEach(() => {
+    originalSocketEnv = process.env[CREDENTIAL_SOCKET_ENV];
+    delete process.env[CREDENTIAL_SOCKET_ENV];
+    runtimeScopedStates.clear();
+  });
+
+  afterEach(async () => {
+    for (const client of clients.splice(0)) client.close();
+    for (const harness of harnesses.splice(0)) await harness.close();
+    runtimeScopedStates.clear();
+    if (originalSocketEnv === undefined) {
+      delete process.env[CREDENTIAL_SOCKET_ENV];
+    } else {
+      process.env[CREDENTIAL_SOCKET_ENV] = originalSocketEnv;
+    }
+  });
+
+  it('classifies an unconfigured provider with complete safe diagnostics', async () => {
+    process.env[CREDENTIAL_SOCKET_ENV] = path.join(
+      os.tmpdir(),
+      'issue3451-unused-proxy.sock',
+    );
+    const settings = createSettingsService();
+    const runtime = createRuntimeContext('runtime-unconfigured', settings);
+    const resolver = new AuthPrecedenceResolver(
+      {
+        providerId: 'test-provider',
+        envKeyNames: ['ISSUE3451_MISSING_KEY'],
+      },
+      {
+        settingsService: settings,
+        getActiveRuntimeContext: () => runtime,
+      },
+    );
+
+    const result = await resolver.resolveAuthenticationResult({
+      includeOAuth: true,
+    });
+
+    const failure = expectSafeFailure(result, 'no-credential-configured', [
+      CREDENTIAL_SECRET,
+      CAPABILITY_SECRET,
+      KEY_MATERIAL_SECRET,
+    ]);
+    expect(failure.diagnostics).toEqual({
+      provider: 'test-provider',
+      profile: 'no-profile',
+      runtimeId: 'runtime-unconfigured',
+      attemptedMechanisms: [
+        'provider-auth-key',
+        'provider-auth-keyfile',
+        'constructor-api-key',
+        'global-auth-key',
+        'global-auth-key-name',
+        'global-auth-keyfile',
+        'env:ISSUE3451_MISSING_KEY',
+        'oauth',
+      ],
+      proxyMode: true,
+      proxyContacted: false,
+    });
+    expect(failure.message).toContain('profile=no-profile');
+  });
+
+  it('classifies an absent named key as credential-not-found without leaking credential material', async () => {
+    const settings = createSettingsService({
+      'auth-key-name': 'configured-key-reference',
+      currentProfile: 'sandbox-profile',
+    });
+    const resolver = new AuthPrecedenceResolver(
+      { providerId: 'test-provider' },
+      {
+        settingsService: settings,
+        providerKeyStorage: createEmptyKeyStorage(),
+        getActiveRuntimeContext: () =>
+          createRuntimeContext('runtime-not-found', settings),
+      },
+    );
+
+    const result = await resolver.resolveAuthenticationResult();
+
+    const failure = expectSafeFailure(result, 'credential-not-found', [
+      CREDENTIAL_SECRET,
+      CAPABILITY_SECRET,
+      KEY_MATERIAL_SECRET,
+      'configured-key-reference',
+    ]);
+    expect(failure.diagnostics.attemptedMechanisms).toEqual([
+      'provider-auth-key',
+      'provider-auth-keyfile',
+      'constructor-api-key',
+      'global-auth-key',
+      'global-auth-key-name',
+    ]);
+    expect(failure.diagnostics.proxyContacted).toBe(false);
+  });
+
+  it('classifies a real proxy NOT_FOUND response as credential-not-found and records proxy contact', async () => {
+    const harness = await startProxy('not-found');
+    harnesses.push(harness);
+    process.env[CREDENTIAL_SOCKET_ENV] = harness.socketPath;
+    const client = new ProxySocketClient(harness.socketPath, CAPABILITY_SECRET);
+    clients.push(client);
+    const settings = createSettingsService({
+      'auth-key-name': 'proxy-key-reference',
+      currentProfile: 'sandbox-profile',
+    });
+    const resolver = new AuthPrecedenceResolver(
+      { providerId: 'test-provider' },
+      {
+        settingsService: settings,
+        providerKeyStorage: new ProxyProviderKeyStorage(client),
+        getActiveRuntimeContext: () =>
+          createRuntimeContext('runtime-proxy-not-found', settings),
+      },
+    );
+
+    const result = await resolver.resolveAuthenticationResult();
+
+    const failure = expectSafeFailure(result, 'credential-not-found', [
+      CREDENTIAL_SECRET,
+      CAPABILITY_SECRET,
+      KEY_MATERIAL_SECRET,
+      'proxy-key-reference',
+    ]);
+    expect(harness.requestCount()).toBe(1);
+    expect(failure.diagnostics.proxyMode).toBe(true);
+    expect(failure.diagnostics.proxyContacted).toBe(true);
+  });
+
+  it('classifies a non-transport named-key exception as credential-source-failed and preserves its cause', async () => {
+    const sourceError = new Error(
+      `Key storage failed while handling ${KEY_MATERIAL_SECRET}`,
+    );
+    const keyStorage: IProviderKeyStorage = {
+      getKey: async () => {
+        throw sourceError;
+      },
+      listKeys: async () => [],
+      hasKey: async () => false,
+    };
+    const settings = createSettingsService({
+      'auth-key-name': 'configured-key-reference',
+      currentProfile: 'sandbox-profile',
+    });
+    const resolver = new AuthPrecedenceResolver(
+      { providerId: 'test-provider' },
+      {
+        settingsService: settings,
+        providerKeyStorage: keyStorage,
+        getActiveRuntimeContext: () =>
+          createRuntimeContext('runtime-key-storage-failure', settings),
+      },
+    );
+
+    const result = await resolver.resolveAuthenticationResult();
+
+    const failure = expectSafeFailure(result, 'credential-source-failed', [
+      CREDENTIAL_SECRET,
+      CAPABILITY_SECRET,
+      KEY_MATERIAL_SECRET,
+      'configured-key-reference',
+    ]);
+    expect(failure.diagnostics.proxyContacted).toBe(false);
+    expect(failure.cause).toBe(sourceError);
+  });
+
+  it('classifies a lost real proxy connection as proxy-unavailable and preserves its cause', async () => {
+    const harness = await startProxy('disconnect-on-request');
+    harnesses.push(harness);
+    process.env[CREDENTIAL_SOCKET_ENV] = harness.socketPath;
+    const client = new ProxySocketClient(harness.socketPath, CAPABILITY_SECRET);
+    clients.push(client);
+    const proxyStorage = new ProxyProviderKeyStorage(client);
+    let sourceCause: unknown;
+    const observingStorage: IProviderKeyStorage = {
+      getKey: async (name) => {
+        try {
+          return await proxyStorage.getKey(name);
+        } catch (error) {
+          sourceCause = error;
+          throw error;
+        }
+      },
+      listKeys: () => proxyStorage.listKeys(),
+      hasKey: (name) => proxyStorage.hasKey(name),
+    };
+    const settings = createSettingsService({
+      'auth-key-name': 'proxy-key-reference',
+      currentProfile: 'sandbox-profile',
+    });
+    const resolver = new AuthPrecedenceResolver(
+      { providerId: 'test-provider' },
+      {
+        settingsService: settings,
+        providerKeyStorage: observingStorage,
+        getActiveRuntimeContext: () =>
+          createRuntimeContext('runtime-proxy-loss', settings),
+      },
+    );
+
+    const result = await resolver.resolveAuthenticationResult();
+
+    const failure = expectSafeFailure(result, 'proxy-unavailable', [
+      CREDENTIAL_SECRET,
+      CAPABILITY_SECRET,
+      KEY_MATERIAL_SECRET,
+      'proxy-key-reference',
+    ]);
+    expect(harness.requestCount()).toBe(1);
+    expect(failure.diagnostics.proxyMode).toBe(true);
+    expect(failure.diagnostics.proxyContacted).toBe(true);
+    expect(failure.cause).toBe(sourceCause);
+  });
+
+  it('classifies an unauthorized real proxy handshake without leaking the capability token', async () => {
+    const harness = await startProxy('unauthorized');
+    harnesses.push(harness);
+    process.env[CREDENTIAL_SOCKET_ENV] = harness.socketPath;
+    const client = new ProxySocketClient(harness.socketPath, CAPABILITY_SECRET);
+    clients.push(client);
+    const settings = createSettingsService({
+      'auth-key-name': 'proxy-key-reference',
+      currentProfile: 'sandbox-profile',
+    });
+    const resolver = new AuthPrecedenceResolver(
+      { providerId: 'test-provider' },
+      {
+        settingsService: settings,
+        providerKeyStorage: new ProxyProviderKeyStorage(client),
+        getActiveRuntimeContext: () =>
+          createRuntimeContext('runtime-unauthorized', settings),
+      },
+    );
+
+    const result = await resolver.resolveAuthenticationResult();
+
+    const failure = expectSafeFailure(result, 'proxy-unauthorized', [
+      CREDENTIAL_SECRET,
+      CAPABILITY_SECRET,
+      KEY_MATERIAL_SECRET,
+      'proxy-key-reference',
+    ]);
+    expect(failure.diagnostics.proxyMode).toBe(true);
+    expect(failure.diagnostics.proxyContacted).toBe(true);
+    expect(failure.cause).toBeInstanceOf(Error);
+  });
+
+  it('classifies an unreadable auth keyfile as credential-source-failed and preserves its cause', async () => {
+    const unreadablePath = path.join(
+      os.tmpdir(),
+      `${KEY_MATERIAL_SECRET}-${process.pid}-missing`,
+    );
+    const settings = createSettingsService({
+      'auth-keyfile': unreadablePath,
+      currentProfile: 'sandbox-profile',
+    });
+    const resolver = new AuthPrecedenceResolver(
+      { providerId: 'test-provider' },
+      {
+        settingsService: settings,
+        getActiveRuntimeContext: () =>
+          createRuntimeContext('runtime-keyfile-failure', settings),
+      },
+    );
+
+    const result = await resolver.resolveAuthenticationResult();
+
+    const failure = expectSafeFailure(result, 'credential-source-failed', [
+      CREDENTIAL_SECRET,
+      CAPABILITY_SECRET,
+      KEY_MATERIAL_SECRET,
+      unreadablePath,
+    ]);
+    expect(failure.diagnostics.attemptedMechanisms).toContain(
+      'global-auth-keyfile',
+    );
+    expect(failure.cause).toBeInstanceOf(Error);
+  });
+
+  it('classifies an OAuth token source exception instead of silently returning null', async () => {
+    const sourceError = new Error(
+      `OAuth source failed while handling ${CREDENTIAL_SECRET}`,
+    );
+    const settings = createSettingsService({
+      currentProfile: 'sandbox-profile',
+    });
+    const oauthManager: OAuthManager = {
+      getToken: async () => {
+        throw sourceError;
+      },
+      isAuthenticated: async () => false,
+    };
+    const resolver = new AuthPrecedenceResolver(
+      {
+        providerId: 'test-provider',
+        oauthProvider: 'test-oauth',
+        isOAuthEnabled: true,
+        supportsOAuth: true,
+      },
+      {
+        settingsService: settings,
+        oauthManager,
+        getActiveRuntimeContext: () =>
+          createRuntimeContext('runtime-oauth-failure', settings),
+      },
+    );
+
+    const result = await resolver.resolveAuthenticationResult({
+      includeOAuth: true,
+    });
+
+    const failure = expectSafeFailure(result, 'credential-source-failed', [
+      CREDENTIAL_SECRET,
+      CAPABILITY_SECRET,
+      KEY_MATERIAL_SECRET,
+    ]);
+    expect(failure.diagnostics.attemptedMechanisms.at(-1)).toBe('oauth');
+    expect(failure.cause).toBe(sourceError);
+  });
+
+  it('retains null-returning behavior for legacy authentication helpers after a source failure', async () => {
+    const settings = createSettingsService({
+      'auth-keyfile': path.join(
+        os.tmpdir(),
+        `${KEY_MATERIAL_SECRET}-${process.pid}-compatibility-missing`,
+      ),
+    });
+    const resolver = new AuthPrecedenceResolver(
+      {
+        providerId: 'test-provider',
+        isOAuthEnabled: true,
+        supportsOAuth: true,
+      },
+      { settingsService: settings },
+    );
+
+    const authentication = await resolver.resolveAuthentication();
+    const hasNonOAuth = await resolver.hasNonOAuthAuthentication();
+    const oauthOnly = await resolver.isOAuthOnlyAvailable();
+
+    expect(authentication).toBeNull();
+    expect(hasNonOAuth).toBe(false);
+    expect(oauthOnly).toBe(true);
+  });
+
+  it('keeps a warm runtime cached while a fresh runtime makes a failing live proxy call', async () => {
+    const harness = await startProxy('token-then-disconnect');
+    harnesses.push(harness);
+    process.env[CREDENTIAL_SOCKET_ENV] = harness.socketPath;
+    const tokenStore = new ProxyTokenStore(
+      harness.socketPath,
+      CAPABILITY_SECRET,
+    );
+    clients.push(tokenStore.getClient());
+    const settings = createSettingsService({
+      currentProfile: 'sandbox-profile',
+    });
+    const parentRuntime = createRuntimeContext('parent-runtime', settings);
+    const subagentRuntime = createRuntimeContext(
+      'parent-runtime#typescriptexpert#fresh',
+      settings,
+    );
+    let activeRuntime = parentRuntime;
+    const resolver = new AuthPrecedenceResolver(
+      {
+        providerId: 'test-provider',
+        oauthProvider: 'test-oauth',
+        isOAuthEnabled: true,
+        supportsOAuth: true,
+      },
+      {
+        settingsService: settings,
+        oauthManager: createProxyOAuthManager(tokenStore),
+        getActiveRuntimeContext: () => activeRuntime,
+      },
+    );
+
+    const parentInitial = await resolver.resolveAuthenticationResult({
+      includeOAuth: true,
+    });
+    const parentCached = await resolver.resolveAuthenticationResult({
+      includeOAuth: true,
+    });
+    activeRuntime = subagentRuntime;
+    const subagentFailure = await resolver.resolveAuthenticationResult({
+      includeOAuth: true,
+    });
+    activeRuntime = parentRuntime;
+    const parentAfterFailure = await resolver.resolveAuthenticationResult({
+      includeOAuth: true,
+    });
+
+    expect(parentInitial.token).toBe(CREDENTIAL_SECRET);
+    expect(parentCached.token).toBe(CREDENTIAL_SECRET);
+    const failure = expectSafeFailure(subagentFailure, 'proxy-unavailable', [
+      CREDENTIAL_SECRET,
+      CAPABILITY_SECRET,
+      KEY_MATERIAL_SECRET,
+    ]);
+    expect(failure.diagnostics.runtimeId).toBe(
+      'parent-runtime#typescriptexpert#fresh',
+    );
+    expect(failure.diagnostics.proxyContacted).toBe(true);
+    expect(parentAfterFailure.token).toBe(CREDENTIAL_SECRET);
+    expect(harness.requestCount()).toBe(2);
+  });
+});

--- a/packages/auth/src/__tests__/credential-resolution.test.ts
+++ b/packages/auth/src/__tests__/credential-resolution.test.ts
@@ -346,6 +346,63 @@ describe('Credential resolution diagnostics', () => {
     expect(failure.message).toContain('/key save configured-key-reference');
   });
 
+  it('distinguishes missing storage wiring remediation from absent named-key remediation', async () => {
+    const settings = createSettingsService({
+      'auth-key-name': 'configured-key-reference',
+      currentProfile: 'sandbox-profile',
+    });
+    const missingStorageResolver = new AuthPrecedenceResolver(
+      { providerId: 'test-provider' },
+      {
+        settingsService: settings,
+        getActiveRuntimeContext: () =>
+          createRuntimeContext('runtime-missing-storage', settings),
+      },
+    );
+    const absentKeyResolver = new AuthPrecedenceResolver(
+      { providerId: 'test-provider' },
+      {
+        settingsService: settings,
+        providerKeyStorage: createEmptyKeyStorage(),
+        getActiveRuntimeContext: () =>
+          createRuntimeContext('runtime-absent-key', settings),
+      },
+    );
+
+    const [missingStorageResult, absentKeyResult] = await Promise.all([
+      missingStorageResolver.resolveAuthenticationResult(),
+      absentKeyResolver.resolveAuthenticationResult(),
+    ]);
+
+    const missingStorageFailure = expectSafeFailure(
+      missingStorageResult,
+      'credential-source-failed',
+      [CREDENTIAL_SECRET, CAPABILITY_SECRET, KEY_MATERIAL_SECRET],
+    );
+    const absentKeyFailure = expectSafeFailure(
+      absentKeyResult,
+      'credential-not-found',
+      [CREDENTIAL_SECRET, CAPABILITY_SECRET, KEY_MATERIAL_SECRET],
+    );
+    expect(missingStorageFailure.remediation).toBe(
+      'Pass providerKeyStorage to AuthPrecedenceResolver or use createAuthPrecedenceResolver() from core.',
+    );
+    expect(missingStorageFailure.remediation).not.toContain('/key save');
+    expect(absentKeyFailure.remediation).toBe(
+      "Named key 'configured-key-reference' not found. Save it with /key save configured-key-reference <api-key> before retrying.",
+    );
+    expect(missingStorageFailure.remediation).not.toBe(
+      absentKeyFailure.remediation,
+    );
+    expect(missingStorageFailure.cause).toBeInstanceOf(Error);
+    if (!(missingStorageFailure.cause instanceof Error)) {
+      throw new Error('Expected missing storage failure to preserve its cause');
+    }
+    expect(missingStorageFailure.cause.message).toBe(
+      'Provider key storage is required to resolve named auth keys. Pass providerKeyStorage to AuthPrecedenceResolver or use createAuthPrecedenceResolver() from core.',
+    );
+  });
+
   it('classifies a real proxy NOT_FOUND response as credential-not-found and records proxy contact', async () => {
     const harness = await startProxy('not-found');
     harnesses.push(harness);

--- a/packages/auth/src/__tests__/credential-resolution.test.ts
+++ b/packages/auth/src/__tests__/credential-resolution.test.ts
@@ -173,8 +173,12 @@ function expectSafeFailure(
   expect(result.failure.message).toContain(
     `runtimeId=${result.failure.diagnostics.runtimeId}`,
   );
+  const attemptedMechanisms = result.failure.diagnostics.attemptedMechanisms;
+  if (attemptedMechanisms === 'unknown') {
+    throw new Error('Resolver failures must include attempted mechanisms');
+  }
   expect(result.failure.message).toContain(
-    `attemptedMechanisms=[${result.failure.diagnostics.attemptedMechanisms.join(', ')}]`,
+    `attemptedMechanisms=[${attemptedMechanisms.join(', ')}]`,
   );
   expect(result.failure.message).toContain(
     `proxyMode=${result.failure.diagnostics.proxyMode}`,
@@ -223,7 +227,7 @@ describe('Credential resolution diagnostics', () => {
     }
   });
 
-  it('classifies an unconfigured provider with complete safe diagnostics', async () => {
+  it('does not report OAuth as attempted when the resolver cannot use OAuth', async () => {
     process.env[CREDENTIAL_SOCKET_ENV] = path.join(
       os.tmpdir(),
       'issue3451-unused-proxy.sock',
@@ -262,7 +266,6 @@ describe('Credential resolution diagnostics', () => {
         'global-auth-key-name',
         'global-auth-keyfile',
         'env:ISSUE3451_MISSING_KEY',
-        'oauth',
       ],
       proxyMode: true,
       proxyContacted: false,
@@ -291,7 +294,6 @@ describe('Credential resolution diagnostics', () => {
       CREDENTIAL_SECRET,
       CAPABILITY_SECRET,
       KEY_MATERIAL_SECRET,
-      'configured-key-reference',
     ]);
     expect(failure.diagnostics.attemptedMechanisms).toEqual([
       'provider-auth-key',
@@ -299,8 +301,13 @@ describe('Credential resolution diagnostics', () => {
       'constructor-api-key',
       'global-auth-key',
       'global-auth-key-name',
+      'global-auth-keyfile',
     ]);
     expect(failure.diagnostics.proxyContacted).toBe(false);
+    expect(failure.remediation).toBe(
+      "Named key 'configured-key-reference' not found. Save it with /key save configured-key-reference <api-key> before retrying.",
+    );
+    expect(failure.message).toContain('/key save configured-key-reference');
   });
 
   it('classifies a real proxy NOT_FOUND response as credential-not-found and records proxy contact', async () => {
@@ -329,11 +336,44 @@ describe('Credential resolution diagnostics', () => {
       CREDENTIAL_SECRET,
       CAPABILITY_SECRET,
       KEY_MATERIAL_SECRET,
-      'proxy-key-reference',
     ]);
     expect(harness.requestCount()).toBe(1);
     expect(failure.diagnostics.proxyMode).toBe(true);
     expect(failure.diagnostics.proxyContacted).toBe(true);
+  });
+
+  it('reports proxy-unavailable without proxy contact when the socket cannot be reached', async () => {
+    const socketPath = path.join(
+      os.tmpdir(),
+      `issue3451-unreachable-${process.pid}.sock`,
+    );
+    process.env[CREDENTIAL_SOCKET_ENV] = socketPath;
+    const client = new ProxySocketClient(socketPath, CAPABILITY_SECRET);
+    clients.push(client);
+    const settings = createSettingsService({
+      'auth-key-name': 'proxy-key-reference',
+      currentProfile: 'sandbox-profile',
+    });
+    const resolver = new AuthPrecedenceResolver(
+      { providerId: 'test-provider' },
+      {
+        settingsService: settings,
+        providerKeyStorage: new ProxyProviderKeyStorage(client),
+        getActiveRuntimeContext: () =>
+          createRuntimeContext('runtime-proxy-unreachable', settings),
+      },
+    );
+
+    const result = await resolver.resolveAuthenticationResult();
+
+    const failure = expectSafeFailure(result, 'proxy-unavailable', [
+      CREDENTIAL_SECRET,
+      CAPABILITY_SECRET,
+      KEY_MATERIAL_SECRET,
+    ]);
+    expect(failure.diagnostics.proxyMode).toBe(true);
+    expect(failure.diagnostics.proxyContacted).toBe(false);
+    expect(failure.cause).toBeInstanceOf(Error);
   });
 
   it('classifies a non-transport named-key exception as credential-source-failed and preserves its cause', async () => {
@@ -367,7 +407,6 @@ describe('Credential resolution diagnostics', () => {
       CREDENTIAL_SECRET,
       CAPABILITY_SECRET,
       KEY_MATERIAL_SECRET,
-      'configured-key-reference',
     ]);
     expect(failure.diagnostics.proxyContacted).toBe(false);
     expect(failure.cause).toBe(sourceError);
@@ -413,7 +452,6 @@ describe('Credential resolution diagnostics', () => {
       CREDENTIAL_SECRET,
       CAPABILITY_SECRET,
       KEY_MATERIAL_SECRET,
-      'proxy-key-reference',
     ]);
     expect(harness.requestCount()).toBe(1);
     expect(failure.diagnostics.proxyMode).toBe(true);
@@ -447,7 +485,6 @@ describe('Credential resolution diagnostics', () => {
       CREDENTIAL_SECRET,
       CAPABILITY_SECRET,
       KEY_MATERIAL_SECRET,
-      'proxy-key-reference',
     ]);
     expect(failure.diagnostics.proxyMode).toBe(true);
     expect(failure.diagnostics.proxyContacted).toBe(true);
@@ -525,6 +562,56 @@ describe('Credential resolution diagnostics', () => {
     ]);
     expect(failure.diagnostics.attemptedMechanisms.at(-1)).toBe('oauth');
     expect(failure.cause).toBe(sourceError);
+  });
+
+  it('reports the most significant failure after every configured mechanism fails', async () => {
+    process.env[CREDENTIAL_SOCKET_ENV] = path.join(
+      os.tmpdir(),
+      `issue3451-significance-${process.pid}.sock`,
+    );
+    const namedKeyError = new Error('local key storage failed');
+    const proxyError = new Error('connect ENOENT issue3451-proxy.sock');
+    const settings = createSettingsService({
+      'auth-key-name': 'configured-key-reference',
+      currentProfile: 'sandbox-profile',
+    });
+    const keyStorage: IProviderKeyStorage = {
+      getKey: async () => {
+        throw namedKeyError;
+      },
+      listKeys: async () => [],
+      hasKey: async () => false,
+    };
+    const oauthManager: OAuthManager = {
+      getToken: async () => {
+        throw proxyError;
+      },
+      isAuthenticated: async () => false,
+    };
+    const resolver = new AuthPrecedenceResolver(
+      {
+        providerId: 'test-provider',
+        oauthProvider: 'test-oauth',
+        isOAuthEnabled: true,
+        supportsOAuth: true,
+      },
+      {
+        settingsService: settings,
+        providerKeyStorage: keyStorage,
+        oauthManager,
+        getActiveRuntimeContext: () =>
+          createRuntimeContext('runtime-significant-failure', settings),
+      },
+    );
+
+    const result = await resolver.resolveAuthenticationResult({
+      includeOAuth: true,
+    });
+
+    const failure = expectSafeFailure(result, 'proxy-unavailable', []);
+    expect(failure.cause).toBe(proxyError);
+    expect(failure.cause).not.toBe(namedKeyError);
+    expect(failure.diagnostics.proxyContacted).toBe(false);
   });
 
   it('retains null-returning behavior for legacy authentication helpers after a source failure', async () => {

--- a/packages/auth/src/__tests__/credential-resolution.test.ts
+++ b/packages/auth/src/__tests__/credential-resolution.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
 import * as fs from 'node:fs/promises';
 import * as net from 'node:net';
 import * as os from 'node:os';
@@ -16,6 +16,7 @@ import {
   ProxySocketClient,
   ProxyTokenStore,
   runtimeScopedStates,
+  type CredentialResolutionDiagnostics,
   type CredentialResolutionErrorKind,
   type CredentialResolutionResult,
   type IProviderKeyStorage,
@@ -136,13 +137,18 @@ async function startProxy(behavior: ProxyBehavior): Promise<ProxyHarness> {
       }
     });
   });
-  await new Promise<void>((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(socketPath, () => {
-      server.removeListener('error', reject);
-      resolve();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(socketPath, () => {
+        server.removeListener('error', reject);
+        resolve();
+      });
     });
-  });
+  } catch (error) {
+    await fs.rm(directory, { recursive: true, force: true });
+    throw error;
+  }
   return {
     socketPath,
     requestCount: () => requestCount,
@@ -217,6 +223,7 @@ describe('Credential resolution diagnostics', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     for (const client of clients.splice(0)) client.close();
     for (const harness of harnesses.splice(0)) await harness.close();
     runtimeScopedStates.clear();
@@ -271,6 +278,35 @@ describe('Credential resolution diagnostics', () => {
       proxyContacted: false,
     });
     expect(failure.message).toContain('profile=no-profile');
+  });
+
+  it('trims remediation text and omits whitespace-only remediation', () => {
+    const diagnostics: CredentialResolutionDiagnostics = {
+      provider: 'test-provider',
+      profile: 'sandbox-profile',
+      runtimeId: 'runtime-remediation',
+      attemptedMechanisms: ['oauth'],
+      proxyMode: false,
+      proxyContacted: false,
+    };
+
+    const whitespaceOnly = new CredentialResolutionError(
+      'credential-source-failed',
+      diagnostics,
+      { remediation: ' \n\t ' },
+    );
+    const padded = new CredentialResolutionError(
+      'credential-source-failed',
+      diagnostics,
+      { remediation: '  Retry credential setup.  ' },
+    );
+
+    expect(whitespaceOnly.remediation).toBeUndefined();
+    expect(whitespaceOnly.message).toStartWith('Credential resolution failed:');
+    expect(padded.remediation).toBe('Retry credential setup.');
+    expect(padded.message).toStartWith(
+      'Retry credential setup. Credential resolution failed:',
+    );
   });
 
   it('classifies an absent named key as credential-not-found without leaking credential material', async () => {
@@ -374,6 +410,45 @@ describe('Credential resolution diagnostics', () => {
     expect(failure.diagnostics.proxyMode).toBe(true);
     expect(failure.diagnostics.proxyContacted).toBe(false);
     expect(failure.cause).toBeInstanceOf(Error);
+  });
+
+  it('reports broader connect failures before proxy contact', async () => {
+    const socket = new net.Socket();
+    vi.spyOn(net, 'createConnection').mockImplementation(() => {
+      queueMicrotask(() => {
+        socket.emit(
+          'error',
+          new Error('connect EHOSTUNREACH credential-proxy.sock'),
+        );
+      });
+      return socket;
+    });
+    const socketPath = 'credential-proxy.sock';
+    process.env[CREDENTIAL_SOCKET_ENV] = socketPath;
+    const client = new ProxySocketClient(socketPath, CAPABILITY_SECRET);
+    clients.push(client);
+    const settings = createSettingsService({
+      'auth-key-name': 'proxy-key-reference',
+      currentProfile: 'sandbox-profile',
+    });
+    const resolver = new AuthPrecedenceResolver(
+      { providerId: 'test-provider' },
+      {
+        settingsService: settings,
+        providerKeyStorage: new ProxyProviderKeyStorage(client),
+        getActiveRuntimeContext: () =>
+          createRuntimeContext('runtime-proxy-unreachable', settings),
+      },
+    );
+
+    const result = await resolver.resolveAuthenticationResult();
+
+    const failure = expectSafeFailure(result, 'proxy-unavailable', [
+      CREDENTIAL_SECRET,
+      CAPABILITY_SECRET,
+      KEY_MATERIAL_SECRET,
+    ]);
+    expect(failure.diagnostics.proxyContacted).toBe(false);
   });
 
   it('classifies a non-transport named-key exception as credential-source-failed and preserves its cause', async () => {

--- a/packages/auth/src/auth-precedence-resolver.ts
+++ b/packages/auth/src/auth-precedence-resolver.ts
@@ -89,9 +89,9 @@ function isAuthOnlyEnabled(value: unknown): boolean {
 }
 
 const PROXY_TRANSPORT_ERROR_PATTERN =
-  /Credential proxy (?:connection lost|partial frame timeout)|Handshake (?:failed|timed out)|Request timed out|Malformed handshake response|connect (?:ECONNREFUSED|ENOENT|EACCES)|ECONNRESET|EPIPE|socket hang up|Connection closing/i;
+  /Credential proxy (?:connection lost|partial frame timeout)|Handshake (?:failed|timed out)|Request timed out|Malformed handshake response|connect (?:ECONNREFUSED|ENOENT|EACCES|EHOSTUNREACH|ENETUNREACH|ETIMEDOUT|EPERM|ENOTDIR)|ECONNRESET|EPIPE|socket hang up|Connection closing/i;
 const PROXY_NOT_REACHED_ERROR_PATTERN =
-  /connect (?:ECONNREFUSED|ENOENT|EACCES)/i;
+  /connect (?:ECONNREFUSED|ENOENT|EACCES|EHOSTUNREACH|ENETUNREACH|ETIMEDOUT|EPERM|ENOTDIR)/i;
 
 export class AuthPrecedenceResolver {
   private static readonly NO_OP_LOGGER: IDebugLogger = {

--- a/packages/auth/src/auth-precedence-resolver.ts
+++ b/packages/auth/src/auth-precedence-resolver.ts
@@ -830,16 +830,20 @@ export class AuthPrecedenceResolver {
     trace.configuredSource = true;
     trace.remediation = remediation;
     const storage = this.providerKeyStorage;
+    if (!storage) {
+      const storageRemediation =
+        'Pass providerKeyStorage to AuthPrecedenceResolver or use createAuthPrecedenceResolver() from core.';
+      const cause = new Error(
+        'Provider key storage is required to resolve named auth keys. ' +
+          storageRemediation,
+      );
+      this.recordFailure(trace, cause, storageRemediation);
+      return null;
+    }
     const proxyRequest =
       this.isCredentialProxyMode() &&
       storage instanceof ProxyProviderKeyStorage;
     try {
-      if (!storage) {
-        throw new Error(
-          'Provider key storage is required to resolve named auth keys. ' +
-            'Pass providerKeyStorage to AuthPrecedenceResolver or use createAuthPrecedenceResolver() from core.',
-        );
-      }
       const key = this.normalizeAuthValue(await storage.getKey(trimmedName));
       if (proxyRequest) {
         trace.proxyContacted = true;

--- a/packages/auth/src/auth-precedence-resolver.ts
+++ b/packages/auth/src/auth-precedence-resolver.ts
@@ -14,6 +14,13 @@ import type {
 } from './interfaces/runtime-context.js';
 import type { IDebugLogger } from './interfaces/index.js';
 import type { IProviderKeyStorage } from './interfaces/provider-key-storage.js';
+import { ProxyProviderKeyStorage } from './proxy/proxy-provider-key-storage.js';
+import {
+  CredentialResolutionError,
+  type CredentialMechanism,
+  type CredentialResolutionErrorKind,
+  type CredentialResolutionResult,
+} from './credential-resolution-error.js';
 import { type OAuthToken } from './types.js';
 import type {
   AuthPrecedenceConfig,
@@ -35,9 +42,16 @@ import {
   storeRuntimeScopedToken,
 } from './precedence.js';
 
-interface ResolveAuthOptions {
+export interface ResolveAuthOptions {
   settingsService?: ISettingsService | null;
   includeOAuth?: boolean;
+}
+
+interface ResolutionTrace {
+  readonly attemptedMechanisms: CredentialMechanism[];
+  configuredSource: boolean;
+  credentialMissing: boolean;
+  proxyContacted: boolean;
 }
 
 interface OAuthResolutionContext {
@@ -63,6 +77,9 @@ function isAuthOnlyEnabled(value: unknown): boolean {
   }
   return false;
 }
+
+const PROXY_TRANSPORT_ERROR_PATTERN =
+  /Credential proxy (?:connection lost|partial frame timeout)|Handshake (?:failed|timed out)|Request timed out|Malformed handshake response|connect (?:ECONNREFUSED|ENOENT|EACCES)|ECONNRESET|EPIPE|socket hang up|Connection closing/i;
 
 export class AuthPrecedenceResolver {
   private static readonly NO_OP_LOGGER: IDebugLogger = {
@@ -157,94 +174,175 @@ export class AuthPrecedenceResolver {
   async resolveAuthentication(
     options?: ResolveAuthOptions,
   ): Promise<string | null> {
+    const result = await this.resolveAuthenticationResult(options);
+    return result.token;
+  }
+
+  async resolveAuthenticationResult(
+    options?: ResolveAuthOptions,
+  ): Promise<CredentialResolutionResult> {
     const includeOAuth = options?.includeOAuth ?? false;
     const settingsService = this.resolveSettingsService(
       options?.settingsService ?? undefined,
     );
     const providerKey = this.normalizeProviderId(this.config.providerId);
-    if (!isAuthOnlyEnabled(settingsService.get('authOnly'))) {
-      const nonOAuthAuth = await this.resolveNonOAuthAuthentication(
-        settingsService,
-        providerKey,
-      );
-      if (nonOAuthAuth !== null) return nonOAuthAuth;
+    const provider = this.resolveProviderIdentifier(providerKey);
+    const runtimeContext = this.getActiveRuntimeContext();
+    const trace: ResolutionTrace = {
+      attemptedMechanisms: [],
+      configuredSource: false,
+      credentialMissing: false,
+      proxyContacted: false,
+    };
+    try {
+      if (!isAuthOnlyEnabled(settingsService.get('authOnly'))) {
+        const nonOAuthAuth = await this.resolveNonOAuthAuthentication(
+          settingsService,
+          providerKey,
+          trace,
+        );
+        if (nonOAuthAuth !== null) return { token: nonOAuthAuth };
+      }
+      if (includeOAuth) {
+        trace.attemptedMechanisms.push('oauth');
+      }
+      if (this.canResolveOAuth(includeOAuth)) {
+        const oauthAuth = await this.resolveOAuthAuthentication(
+          settingsService,
+          providerKey,
+          trace,
+        );
+        if (oauthAuth !== null) return { token: oauthAuth };
+      }
+      return {
+        token: null,
+        failure: this.createResolutionError(
+          trace.credentialMissing || trace.configuredSource
+            ? 'credential-not-found'
+            : 'no-credential-configured',
+          provider,
+          settingsService,
+          runtimeContext,
+          trace,
+        ),
+      };
+    } catch (cause) {
+      if (!trace.configuredSource) throw cause;
+      const kind = this.classifySourceFailure(cause);
+      if (kind === 'proxy-unavailable' || kind === 'proxy-unauthorized') {
+        trace.proxyContacted = true;
+      }
+      return {
+        token: null,
+        failure: this.createResolutionError(
+          kind,
+          provider,
+          settingsService,
+          runtimeContext,
+          trace,
+          cause,
+        ),
+      };
     }
-    if (!this.canResolveOAuth(includeOAuth)) return null;
-    return this.resolveOAuthAuthentication(settingsService, providerKey);
   }
 
   private async resolveNonOAuthAuthentication(
     settingsService: ISettingsService,
     providerKey: string | undefined,
+    trace: ResolutionTrace,
   ): Promise<string | null> {
     const directAuth = await this.resolveDirectAuthentication(
       settingsService,
       providerKey,
+      trace,
     );
     if (directAuth !== null) return directAuth;
-    const envAuth = this.resolveEnvironmentAuthentication();
+    const envAuth = this.resolveEnvironmentAuthentication(trace);
     return envAuth ?? null;
   }
 
   private async resolveDirectAuthentication(
     settingsService: ISettingsService,
     providerKey: string | undefined,
+    trace: ResolutionTrace,
   ): Promise<string | null> {
     const providerAuth = await this.resolveProviderAuthentication(
       settingsService,
       providerKey,
+      trace,
     );
     if (providerAuth !== null) return providerAuth;
+    trace.attemptedMechanisms.push('constructor-api-key');
     const configAuth = this.normalizeAuthValue(this.config.apiKey ?? null);
     if (configAuth !== undefined) return configAuth;
-    return this.resolveGlobalAuthentication(settingsService, providerKey);
+    return this.resolveGlobalAuthentication(
+      settingsService,
+      providerKey,
+      trace,
+    );
   }
 
   private async resolveProviderAuthentication(
     settingsService: ISettingsService,
     providerKey: string | undefined,
+    trace: ResolutionTrace,
   ): Promise<string | null> {
     const providerSettings =
       providerKey !== undefined &&
       typeof settingsService.getProviderSettings === 'function'
         ? settingsService.getProviderSettings(providerKey)
         : undefined;
+    trace.attemptedMechanisms.push('provider-auth-key');
     const providerAuthKey = this.normalizeAuthValue(
       providerSettings?.['auth-key'],
     );
     if (providerAuthKey !== undefined) return providerAuthKey;
+    trace.attemptedMechanisms.push('provider-auth-keyfile');
     const providerAuthKeyfile = this.normalizeAuthValue(
       providerSettings?.['auth-keyfile'],
     );
-    return this.resolveKeyFileAuth(providerAuthKeyfile);
+    return this.resolveKeyFileAuth(providerAuthKeyfile, trace);
   }
 
   private async resolveGlobalAuthentication(
     settingsService: ISettingsService,
     providerKey: string | undefined,
+    trace: ResolutionTrace,
   ): Promise<string | null> {
     if (!this.shouldUseGlobalAuth(settingsService, providerKey)) return null;
+    trace.attemptedMechanisms.push('global-auth-key');
     const authKey = this.normalizeAuthValue(settingsService.get('auth-key'));
     if (authKey !== undefined) return authKey;
+    trace.attemptedMechanisms.push('global-auth-key-name');
     const authKeyName = this.normalizeAuthValue(
       settingsService.get('auth-key-name'),
     );
-    if (authKeyName !== undefined) return this.resolveNamedKey(authKeyName);
+    if (authKeyName !== undefined) {
+      return this.resolveNamedKey(authKeyName, trace);
+    }
+    trace.attemptedMechanisms.push('global-auth-keyfile');
     const authKeyfile = this.normalizeAuthValue(
       settingsService.get('auth-keyfile'),
     );
-    return this.resolveKeyFileAuth(authKeyfile);
+    return this.resolveKeyFileAuth(authKeyfile, trace);
   }
 
   private async resolveKeyFileAuth(
     keyFile: string | undefined,
+    trace: ResolutionTrace,
   ): Promise<string | null> {
     if (keyFile === undefined) return null;
+    trace.configuredSource = true;
     const keyFromFile = await this.readKeyFile(keyFile);
-    return keyFromFile ?? null;
+    if (keyFromFile === null) {
+      trace.credentialMissing = true;
+    }
+    return keyFromFile;
   }
 
-  private resolveEnvironmentAuthentication(): string | undefined {
+  private resolveEnvironmentAuthentication(
+    trace: ResolutionTrace,
+  ): string | undefined {
     if (
       this.config.envKeyNames == null ||
       this.config.envKeyNames.length === 0
@@ -252,6 +350,7 @@ export class AuthPrecedenceResolver {
       return undefined;
     }
     for (const envVarName of this.config.envKeyNames) {
+      trace.attemptedMechanisms.push(`env:${envVarName}`);
       const envValue = this.normalizeAuthValue(process.env[envVarName]);
       if (envValue !== undefined) return envValue;
     }
@@ -268,6 +367,7 @@ export class AuthPrecedenceResolver {
   private async resolveOAuthAuthentication(
     settingsService: ISettingsService,
     providerKey: string | undefined,
+    trace: ResolutionTrace,
   ): Promise<string | null> {
     const context = this.buildOAuthContext(settingsService, providerKey);
     if ((await this.isOAuthDisabledByManager()) === true) {
@@ -276,7 +376,12 @@ export class AuthPrecedenceResolver {
     }
     const cachedToken = this.getCachedOAuthToken(context);
     if (cachedToken !== null) return cachedToken;
-    return this.fetchAndCacheOAuthToken(context);
+    trace.configuredSource = true;
+    const token = await this.fetchAndCacheOAuthToken(context);
+    if (token === null) {
+      trace.credentialMissing = true;
+    }
+    return token;
   }
 
   private buildOAuthContext(
@@ -375,20 +480,15 @@ export class AuthPrecedenceResolver {
   private async fetchAndCacheOAuthToken(
     context: OAuthResolutionContext,
   ): Promise<string | null> {
-    try {
-      const requestMetadata = this.buildOAuthRequestMetadata(context);
-      const token = await this.oauthManager!.getToken(
-        this.config.oauthProvider!,
-        requestMetadata,
-      );
-      if (token == null || token === '') return null;
-      const oauthToken = await this.tryGetOAuthTokenMetadata(requestMetadata);
-      this.storeOAuthTokenMetadata(context, token, oauthToken);
-      return token;
-    } catch (error) {
-      this.debugOAuthTokenError(error);
-      return null;
-    }
+    const requestMetadata = this.buildOAuthRequestMetadata(context);
+    const token = await this.oauthManager!.getToken(
+      this.config.oauthProvider!,
+      requestMetadata,
+    );
+    if (token == null || token === '') return null;
+    const oauthToken = await this.tryGetOAuthTokenMetadata(requestMetadata);
+    this.storeOAuthTokenMetadata(context, token, oauthToken);
+    return token;
   }
 
   private buildOAuthRequestMetadata(
@@ -447,15 +547,6 @@ export class AuthPrecedenceResolver {
         );
       }
       return null;
-    }
-  }
-
-  private debugOAuthTokenError(error: unknown): void {
-    if (process.env.DEBUG) {
-      this.logger.warn(
-        `Failed to get OAuth token for ${this.config.oauthProvider}:`,
-        error,
-      );
     }
   }
 
@@ -596,6 +687,44 @@ export class AuthPrecedenceResolver {
     return this.config.envKeyNames?.[0] ?? 'unknown-provider';
   }
 
+  private createResolutionError(
+    kind: CredentialResolutionErrorKind,
+    provider: string,
+    settingsService: ISettingsService,
+    runtimeContext: IProviderRuntimeContext | null,
+    trace: ResolutionTrace,
+    cause?: unknown,
+  ): CredentialResolutionError {
+    const diagnostics = {
+      provider,
+      profile: resolveProfileId(settingsService) ?? 'no-profile',
+      runtimeId: runtimeContext?.runtimeId ?? 'no-runtime',
+      attemptedMechanisms: trace.attemptedMechanisms,
+      proxyMode: this.isCredentialProxyMode(),
+      proxyContacted: trace.proxyContacted,
+    };
+    return cause === undefined
+      ? new CredentialResolutionError(kind, diagnostics)
+      : new CredentialResolutionError(kind, diagnostics, { cause });
+  }
+
+  private classifySourceFailure(cause: unknown): CredentialResolutionErrorKind {
+    if (!this.isCredentialProxyMode()) return 'credential-source-failed';
+    const message = cause instanceof Error ? cause.message : String(cause);
+    if (message.startsWith('Credential proxy authentication failed:')) {
+      return 'proxy-unauthorized';
+    }
+    if (PROXY_TRANSPORT_ERROR_PATTERN.test(message)) {
+      return 'proxy-unavailable';
+    }
+    return 'credential-source-failed';
+  }
+
+  private isCredentialProxyMode(): boolean {
+    const socketPath = process.env.LLXPRT_CREDENTIAL_SOCKET;
+    return typeof socketPath === 'string' && socketPath.trim() !== '';
+  }
+
   private shouldUseGlobalAuth(
     settingsService: ISettingsService,
     providerId?: string,
@@ -607,11 +736,15 @@ export class AuthPrecedenceResolver {
     return trimmed === '' || trimmed === providerId;
   }
 
-  private async resolveNamedKey(name: string): Promise<string> {
+  private async resolveNamedKey(
+    name: string,
+    trace: ResolutionTrace,
+  ): Promise<string | null> {
     const trimmedName = this.normalizeAuthValue(name);
     if (trimmedName === undefined) {
       throw new Error('Named key reference is empty');
     }
+    trace.configuredSource = true;
     const storage = this.providerKeyStorage;
     if (!storage) {
       throw new Error(
@@ -619,11 +752,16 @@ export class AuthPrecedenceResolver {
           'Pass providerKeyStorage to AuthPrecedenceResolver or use createAuthPrecedenceResolver() from core.',
       );
     }
+    if (
+      this.isCredentialProxyMode() &&
+      storage instanceof ProxyProviderKeyStorage
+    ) {
+      trace.proxyContacted = true;
+    }
     const key = this.normalizeAuthValue(await storage.getKey(trimmedName));
     if (key === undefined) {
-      throw new Error(
-        `Named key '${trimmedName}' not found. Save it with /key save ${trimmedName} <api-key> before retrying.`,
-      );
+      trace.credentialMissing = true;
+      return null;
     }
     return key;
   }
@@ -632,28 +770,21 @@ export class AuthPrecedenceResolver {
    * Reads API key from a file path, handling tilde expansion, absolute and relative paths
    */
   private async readKeyFile(filePath: string): Promise<string | null> {
-    try {
-      const expandedPath = filePath.startsWith('~')
-        ? path.join(os.homedir(), filePath.slice(1))
-        : filePath;
-      const resolvedPath = path.isAbsolute(expandedPath)
-        ? expandedPath
-        : path.resolve(process.cwd(), expandedPath);
-      const content = await fs.readFile(resolvedPath, 'utf-8');
-      const key = content.trim();
-      if (key === '') {
-        if (process.env.DEBUG) {
-          this.logger.warn(`Key file ${filePath} is empty`);
-        }
-        return null;
-      }
-      return key;
-    } catch (error) {
+    const expandedPath = filePath.startsWith('~')
+      ? path.join(os.homedir(), filePath.slice(1))
+      : filePath;
+    const resolvedPath = path.isAbsolute(expandedPath)
+      ? expandedPath
+      : path.resolve(process.cwd(), expandedPath);
+    const content = await fs.readFile(resolvedPath, 'utf-8');
+    const key = content.trim();
+    if (key === '') {
       if (process.env.DEBUG) {
-        this.logger.warn(`Failed to read key file ${filePath}:`, error);
+        this.logger.warn(`Key file ${filePath} is empty`);
       }
       return null;
     }
+    return key;
   }
 
   /**

--- a/packages/auth/src/auth-precedence-resolver.ts
+++ b/packages/auth/src/auth-precedence-resolver.ts
@@ -15,6 +15,7 @@ import type {
 import type { IDebugLogger } from './interfaces/index.js';
 import type { IProviderKeyStorage } from './interfaces/provider-key-storage.js';
 import { ProxyProviderKeyStorage } from './proxy/proxy-provider-key-storage.js';
+import { ProxyRequestError } from './proxy/proxy-socket-client.js';
 import {
   CredentialResolutionError,
   type CredentialMechanism,
@@ -48,11 +49,19 @@ export interface ResolveAuthOptions {
   runtimeId?: string;
 }
 
+interface ResolutionFailure {
+  readonly kind: CredentialResolutionErrorKind;
+  readonly cause: unknown;
+  readonly remediation: string;
+}
+
 interface ResolutionTrace {
   readonly attemptedMechanisms: CredentialMechanism[];
+  readonly failures: ResolutionFailure[];
   configuredSource: boolean;
   credentialMissing: boolean;
   proxyContacted: boolean;
+  remediation: string | undefined;
 }
 
 interface OAuthResolutionContext {
@@ -81,6 +90,8 @@ function isAuthOnlyEnabled(value: unknown): boolean {
 
 const PROXY_TRANSPORT_ERROR_PATTERN =
   /Credential proxy (?:connection lost|partial frame timeout)|Handshake (?:failed|timed out)|Request timed out|Malformed handshake response|connect (?:ECONNREFUSED|ENOENT|EACCES)|ECONNRESET|EPIPE|socket hang up|Connection closing/i;
+const PROXY_NOT_REACHED_ERROR_PATTERN =
+  /connect (?:ECONNREFUSED|ENOENT|EACCES)/i;
 
 export class AuthPrecedenceResolver {
   private static readonly NO_OP_LOGGER: IDebugLogger = {
@@ -194,60 +205,45 @@ export class AuthPrecedenceResolver {
       'no-runtime';
     const trace: ResolutionTrace = {
       attemptedMechanisms: [],
+      failures: [],
       configuredSource: false,
       credentialMissing: false,
       proxyContacted: false,
+      remediation: undefined,
     };
-    try {
-      if (!isAuthOnlyEnabled(settingsService.get('authOnly'))) {
-        const nonOAuthAuth = await this.resolveNonOAuthAuthentication(
-          settingsService,
-          providerKey,
-          trace,
-        );
-        if (nonOAuthAuth !== null) return { token: nonOAuthAuth };
-      }
-      if (includeOAuth) {
-        trace.attemptedMechanisms.push('oauth');
-      }
-      if (this.canResolveOAuth(includeOAuth)) {
-        const oauthAuth = await this.resolveOAuthAuthentication(
-          settingsService,
-          providerKey,
-          trace,
-        );
-        if (oauthAuth !== null) return { token: oauthAuth };
-      }
-      return {
-        token: null,
-        failure: this.createResolutionError(
-          trace.credentialMissing || trace.configuredSource
-            ? 'credential-not-found'
-            : 'no-credential-configured',
-          provider,
-          settingsService,
-          runtimeId,
-          trace,
-        ),
-      };
-    } catch (cause) {
-      if (!trace.configuredSource) throw cause;
-      const kind = this.classifySourceFailure(cause);
-      if (kind === 'proxy-unavailable' || kind === 'proxy-unauthorized') {
-        trace.proxyContacted = true;
-      }
-      return {
-        token: null,
-        failure: this.createResolutionError(
-          kind,
-          provider,
-          settingsService,
-          runtimeId,
-          trace,
-          cause,
-        ),
-      };
+    if (!isAuthOnlyEnabled(settingsService.get('authOnly'))) {
+      const nonOAuthAuth = await this.resolveNonOAuthAuthentication(
+        settingsService,
+        providerKey,
+        trace,
+      );
+      if (nonOAuthAuth !== null) return { token: nonOAuthAuth };
     }
+    if (this.canResolveOAuth(includeOAuth)) {
+      trace.attemptedMechanisms.push('oauth');
+      const oauthAuth = await this.resolveOAuthAuthentication(
+        settingsService,
+        providerKey,
+        trace,
+      );
+      if (oauthAuth !== null) return { token: oauthAuth };
+    }
+    const recordedFailure = this.selectResolutionFailure(trace.failures);
+    return {
+      token: null,
+      failure: this.createResolutionError(
+        recordedFailure?.kind ??
+          (trace.credentialMissing || trace.configuredSource
+            ? 'credential-not-found'
+            : 'no-credential-configured'),
+        provider,
+        settingsService,
+        runtimeId,
+        trace,
+        recordedFailure?.cause,
+        recordedFailure?.remediation ?? trace.remediation,
+      ),
+    };
   }
 
   private async resolveNonOAuthAuthentication(
@@ -322,7 +318,8 @@ export class AuthPrecedenceResolver {
       settingsService.get('auth-key-name'),
     );
     if (authKeyName !== undefined) {
-      return this.resolveNamedKey(authKeyName, trace);
+      const namedKey = await this.resolveNamedKey(authKeyName, trace);
+      if (namedKey !== null) return namedKey;
     }
     trace.attemptedMechanisms.push('global-auth-keyfile');
     const authKeyfile = this.normalizeAuthValue(
@@ -336,12 +333,20 @@ export class AuthPrecedenceResolver {
     trace: ResolutionTrace,
   ): Promise<string | null> {
     if (keyFile === undefined) return null;
+    const remediation =
+      'Configure a readable credential file with /keyfile before retrying.';
     trace.configuredSource = true;
-    const keyFromFile = await this.readKeyFile(keyFile);
-    if (keyFromFile === null) {
-      trace.credentialMissing = true;
+    trace.remediation = remediation;
+    try {
+      const keyFromFile = await this.readKeyFile(keyFile);
+      if (keyFromFile === null) {
+        trace.credentialMissing = true;
+      }
+      return keyFromFile;
+    } catch (cause) {
+      this.recordFailure(trace, cause, remediation);
+      return null;
     }
-    return keyFromFile;
   }
 
   private resolveEnvironmentAuthentication(
@@ -380,12 +385,19 @@ export class AuthPrecedenceResolver {
     }
     const cachedToken = this.getCachedOAuthToken(context);
     if (cachedToken !== null) return cachedToken;
+    const remediation = `Run /auth ${this.config.oauthProvider} login to authenticate.`;
     trace.configuredSource = true;
-    const token = await this.fetchAndCacheOAuthToken(context);
-    if (token === null) {
-      trace.credentialMissing = true;
+    trace.remediation = remediation;
+    try {
+      const token = await this.fetchAndCacheOAuthToken(context);
+      if (token === null) {
+        trace.credentialMissing = true;
+      }
+      return token;
+    } catch (cause) {
+      this.recordFailure(trace, cause, remediation);
+      return null;
     }
-    return token;
   }
 
   private buildOAuthContext(
@@ -698,6 +710,7 @@ export class AuthPrecedenceResolver {
     runtimeId: string,
     trace: ResolutionTrace,
     cause?: unknown,
+    remediation?: string,
   ): CredentialResolutionError {
     const diagnostics = {
       provider,
@@ -707,9 +720,72 @@ export class AuthPrecedenceResolver {
       proxyMode: this.isCredentialProxyMode(),
       proxyContacted: trace.proxyContacted,
     };
-    return cause === undefined
-      ? new CredentialResolutionError(kind, diagnostics)
-      : new CredentialResolutionError(kind, diagnostics, { cause });
+    return new CredentialResolutionError(kind, diagnostics, {
+      ...(cause === undefined ? {} : { cause }),
+      ...(remediation === undefined ? {} : { remediation }),
+    });
+  }
+
+  private recordFailure(
+    trace: ResolutionTrace,
+    cause: unknown,
+    remediation: string,
+    proxyRequest = false,
+  ): void {
+    const kind = this.classifySourceFailure(cause);
+    const failureCouldHaveReachedProxy =
+      proxyRequest ||
+      kind === 'proxy-unavailable' ||
+      kind === 'proxy-unauthorized';
+    const proxyContacted =
+      cause instanceof ProxyRequestError
+        ? cause.proxyContacted
+        : failureCouldHaveReachedProxy && this.proxyWasReached(cause);
+    if (proxyContacted) {
+      trace.proxyContacted = true;
+    }
+    trace.failures.push({ kind, cause, remediation });
+  }
+
+  private selectResolutionFailure(
+    failures: readonly ResolutionFailure[],
+  ): ResolutionFailure | undefined {
+    let selected: ResolutionFailure | undefined;
+    for (const failure of failures) {
+      if (
+        selected === undefined ||
+        this.failurePriority(failure.kind) > this.failurePriority(selected.kind)
+      ) {
+        selected = failure;
+      }
+    }
+    return selected;
+  }
+
+  private failurePriority(kind: CredentialResolutionErrorKind): number {
+    switch (kind) {
+      case 'proxy-unauthorized':
+        return 4;
+      case 'proxy-unavailable':
+        return 3;
+      case 'credential-source-failed':
+        return 2;
+      case 'credential-not-found':
+        return 1;
+      case 'no-credential-configured':
+        return 0;
+      default: {
+        const unsupportedKind: never = kind;
+        throw new Error(
+          `Unsupported credential failure kind: ${unsupportedKind}`,
+        );
+      }
+    }
+  }
+
+  private proxyWasReached(cause: unknown): boolean {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    return !PROXY_NOT_REACHED_ERROR_PATTERN.test(message);
   }
 
   private classifySourceFailure(cause: unknown): CredentialResolutionErrorKind {
@@ -748,26 +824,35 @@ export class AuthPrecedenceResolver {
     if (trimmedName === undefined) {
       throw new Error('Named key reference is empty');
     }
+    const remediation =
+      `Named key '${trimmedName}' not found. Save it with ` +
+      `/key save ${trimmedName} <api-key> before retrying.`;
     trace.configuredSource = true;
+    trace.remediation = remediation;
     const storage = this.providerKeyStorage;
-    if (!storage) {
-      throw new Error(
-        'Provider key storage is required to resolve named auth keys. ' +
-          'Pass providerKeyStorage to AuthPrecedenceResolver or use createAuthPrecedenceResolver() from core.',
-      );
-    }
-    if (
+    const proxyRequest =
       this.isCredentialProxyMode() &&
-      storage instanceof ProxyProviderKeyStorage
-    ) {
-      trace.proxyContacted = true;
-    }
-    const key = this.normalizeAuthValue(await storage.getKey(trimmedName));
-    if (key === undefined) {
-      trace.credentialMissing = true;
+      storage instanceof ProxyProviderKeyStorage;
+    try {
+      if (!storage) {
+        throw new Error(
+          'Provider key storage is required to resolve named auth keys. ' +
+            'Pass providerKeyStorage to AuthPrecedenceResolver or use createAuthPrecedenceResolver() from core.',
+        );
+      }
+      const key = this.normalizeAuthValue(await storage.getKey(trimmedName));
+      if (proxyRequest) {
+        trace.proxyContacted = true;
+      }
+      if (key === undefined) {
+        trace.credentialMissing = true;
+        return null;
+      }
+      return key;
+    } catch (cause) {
+      this.recordFailure(trace, cause, remediation, proxyRequest);
       return null;
     }
-    return key;
   }
 
   /**

--- a/packages/auth/src/auth-precedence-resolver.ts
+++ b/packages/auth/src/auth-precedence-resolver.ts
@@ -45,6 +45,7 @@ import {
 export interface ResolveAuthOptions {
   settingsService?: ISettingsService | null;
   includeOAuth?: boolean;
+  runtimeId?: string;
 }
 
 interface ResolutionTrace {
@@ -187,7 +188,10 @@ export class AuthPrecedenceResolver {
     );
     const providerKey = this.normalizeProviderId(this.config.providerId);
     const provider = this.resolveProviderIdentifier(providerKey);
-    const runtimeContext = this.getActiveRuntimeContext();
+    const runtimeId =
+      options?.runtimeId ??
+      this.getActiveRuntimeContext()?.runtimeId ??
+      'no-runtime';
     const trace: ResolutionTrace = {
       attemptedMechanisms: [],
       configuredSource: false,
@@ -222,7 +226,7 @@ export class AuthPrecedenceResolver {
             : 'no-credential-configured',
           provider,
           settingsService,
-          runtimeContext,
+          runtimeId,
           trace,
         ),
       };
@@ -238,7 +242,7 @@ export class AuthPrecedenceResolver {
           kind,
           provider,
           settingsService,
-          runtimeContext,
+          runtimeId,
           trace,
           cause,
         ),
@@ -691,14 +695,14 @@ export class AuthPrecedenceResolver {
     kind: CredentialResolutionErrorKind,
     provider: string,
     settingsService: ISettingsService,
-    runtimeContext: IProviderRuntimeContext | null,
+    runtimeId: string,
     trace: ResolutionTrace,
     cause?: unknown,
   ): CredentialResolutionError {
     const diagnostics = {
       provider,
       profile: resolveProfileId(settingsService) ?? 'no-profile',
-      runtimeId: runtimeContext?.runtimeId ?? 'no-runtime',
+      runtimeId,
       attemptedMechanisms: trace.attemptedMechanisms,
       proxyMode: this.isCredentialProxyMode(),
       proxyContacted: trace.proxyContacted,

--- a/packages/auth/src/credential-resolution-error.ts
+++ b/packages/auth/src/credential-resolution-error.ts
@@ -82,13 +82,16 @@ export class CredentialResolutionError extends Error {
     diagnostics: CredentialResolutionDiagnostics,
     options: CredentialResolutionErrorOptions = {},
   ) {
+    const trimmedRemediation = options.remediation?.trim();
+    const remediation =
+      trimmedRemediation === '' ? undefined : trimmedRemediation;
     super(
-      buildMessage(kind, diagnostics, options.remediation),
+      buildMessage(kind, diagnostics, remediation),
       options.cause === undefined ? undefined : { cause: options.cause },
     );
     this.name = 'CredentialResolutionError';
     this.kind = kind;
-    this.remediation = options.remediation;
+    this.remediation = remediation;
     const attemptedMechanisms: CredentialMechanismAttempts =
       diagnostics.attemptedMechanisms === 'unknown'
         ? 'unknown'

--- a/packages/auth/src/credential-resolution-error.ts
+++ b/packages/auth/src/credential-resolution-error.ts
@@ -32,6 +32,7 @@ export interface CredentialResolutionDiagnostics {
 
 export interface CredentialResolutionErrorOptions {
   readonly cause?: unknown;
+  readonly remediation?: string;
 }
 
 export type CredentialResolutionResult =
@@ -44,20 +45,24 @@ export type CredentialResolutionResult =
 function buildMessage(
   kind: CredentialResolutionErrorKind,
   diagnostics: CredentialResolutionDiagnostics,
+  remediation?: string,
 ): string {
-  return (
+  const diagnosticMessage =
     `Credential resolution failed: kind=${kind}; ` +
     `provider=${diagnostics.provider}; profile=${diagnostics.profile}; ` +
     `runtimeId=${diagnostics.runtimeId}; ` +
     `attemptedMechanisms=[${diagnostics.attemptedMechanisms.join(', ')}]; ` +
     `proxyMode=${diagnostics.proxyMode}; ` +
-    `proxyContacted=${diagnostics.proxyContacted}`
-  );
+    `proxyContacted=${diagnostics.proxyContacted}`;
+  return remediation === undefined
+    ? diagnosticMessage
+    : `${remediation} ${diagnosticMessage}`;
 }
 
 export class CredentialResolutionError extends Error {
   readonly kind: CredentialResolutionErrorKind;
   readonly diagnostics: CredentialResolutionDiagnostics;
+  readonly remediation: string | undefined;
 
   constructor(
     kind: CredentialResolutionErrorKind,
@@ -65,11 +70,12 @@ export class CredentialResolutionError extends Error {
     options: CredentialResolutionErrorOptions = {},
   ) {
     super(
-      buildMessage(kind, diagnostics),
+      buildMessage(kind, diagnostics, options.remediation),
       options.cause === undefined ? undefined : { cause: options.cause },
     );
     this.name = 'CredentialResolutionError';
     this.kind = kind;
+    this.remediation = options.remediation;
     this.diagnostics = Object.freeze({
       ...diagnostics,
       attemptedMechanisms: Object.freeze([...diagnostics.attemptedMechanisms]),

--- a/packages/auth/src/credential-resolution-error.ts
+++ b/packages/auth/src/credential-resolution-error.ts
@@ -21,13 +21,18 @@ export type CredentialMechanism =
   | `env:${string}`
   | 'oauth';
 
+export type CredentialMechanismAttempts =
+  | readonly CredentialMechanism[]
+  | 'unknown';
+export type ProxyContactState = boolean | 'unknown';
+
 export interface CredentialResolutionDiagnostics {
   readonly provider: string;
   readonly profile: string;
   readonly runtimeId: string;
-  readonly attemptedMechanisms: readonly CredentialMechanism[];
+  readonly attemptedMechanisms: CredentialMechanismAttempts;
   readonly proxyMode: boolean;
-  readonly proxyContacted: boolean;
+  readonly proxyContacted: ProxyContactState;
 }
 
 export interface CredentialResolutionErrorOptions {
@@ -42,6 +47,14 @@ export type CredentialResolutionResult =
       readonly failure: CredentialResolutionError;
     };
 
+function formatAttemptedMechanisms(
+  attemptedMechanisms: CredentialMechanismAttempts,
+): string {
+  return attemptedMechanisms === 'unknown'
+    ? 'unknown'
+    : `[${attemptedMechanisms.join(', ')}]`;
+}
+
 function buildMessage(
   kind: CredentialResolutionErrorKind,
   diagnostics: CredentialResolutionDiagnostics,
@@ -51,7 +64,7 @@ function buildMessage(
     `Credential resolution failed: kind=${kind}; ` +
     `provider=${diagnostics.provider}; profile=${diagnostics.profile}; ` +
     `runtimeId=${diagnostics.runtimeId}; ` +
-    `attemptedMechanisms=[${diagnostics.attemptedMechanisms.join(', ')}]; ` +
+    `attemptedMechanisms=${formatAttemptedMechanisms(diagnostics.attemptedMechanisms)}; ` +
     `proxyMode=${diagnostics.proxyMode}; ` +
     `proxyContacted=${diagnostics.proxyContacted}`;
   return remediation === undefined
@@ -76,9 +89,13 @@ export class CredentialResolutionError extends Error {
     this.name = 'CredentialResolutionError';
     this.kind = kind;
     this.remediation = options.remediation;
+    const attemptedMechanisms: CredentialMechanismAttempts =
+      diagnostics.attemptedMechanisms === 'unknown'
+        ? 'unknown'
+        : Object.freeze([...diagnostics.attemptedMechanisms]);
     this.diagnostics = Object.freeze({
       ...diagnostics,
-      attemptedMechanisms: Object.freeze([...diagnostics.attemptedMechanisms]),
+      attemptedMechanisms,
     });
   }
 }

--- a/packages/auth/src/credential-resolution-error.ts
+++ b/packages/auth/src/credential-resolution-error.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type CredentialResolutionErrorKind =
+  | 'no-credential-configured'
+  | 'credential-not-found'
+  | 'credential-source-failed'
+  | 'proxy-unavailable'
+  | 'proxy-unauthorized';
+
+export type CredentialMechanism =
+  | 'provider-auth-key'
+  | 'provider-auth-keyfile'
+  | 'constructor-api-key'
+  | 'global-auth-key'
+  | 'global-auth-key-name'
+  | 'global-auth-keyfile'
+  | `env:${string}`
+  | 'oauth';
+
+export interface CredentialResolutionDiagnostics {
+  readonly provider: string;
+  readonly profile: string;
+  readonly runtimeId: string;
+  readonly attemptedMechanisms: readonly CredentialMechanism[];
+  readonly proxyMode: boolean;
+  readonly proxyContacted: boolean;
+}
+
+export interface CredentialResolutionErrorOptions {
+  readonly cause?: unknown;
+}
+
+export type CredentialResolutionResult =
+  | { readonly token: string }
+  | {
+      readonly token: null;
+      readonly failure: CredentialResolutionError;
+    };
+
+function buildMessage(
+  kind: CredentialResolutionErrorKind,
+  diagnostics: CredentialResolutionDiagnostics,
+): string {
+  return (
+    `Credential resolution failed: kind=${kind}; ` +
+    `provider=${diagnostics.provider}; profile=${diagnostics.profile}; ` +
+    `runtimeId=${diagnostics.runtimeId}; ` +
+    `attemptedMechanisms=[${diagnostics.attemptedMechanisms.join(', ')}]; ` +
+    `proxyMode=${diagnostics.proxyMode}; ` +
+    `proxyContacted=${diagnostics.proxyContacted}`
+  );
+}
+
+export class CredentialResolutionError extends Error {
+  readonly kind: CredentialResolutionErrorKind;
+  readonly diagnostics: CredentialResolutionDiagnostics;
+
+  constructor(
+    kind: CredentialResolutionErrorKind,
+    diagnostics: CredentialResolutionDiagnostics,
+    options: CredentialResolutionErrorOptions = {},
+  ) {
+    super(
+      buildMessage(kind, diagnostics),
+      options.cause === undefined ? undefined : { cause: options.cause },
+    );
+    this.name = 'CredentialResolutionError';
+    this.kind = kind;
+    this.diagnostics = Object.freeze({
+      ...diagnostics,
+      attemptedMechanisms: Object.freeze([...diagnostics.attemptedMechanisms]),
+    });
+  }
+}

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -78,6 +78,15 @@ export type { SanitizedOAuthToken } from './token-sanitization.js';
 
 // ─── Precedence / Auth Resolution ────────────────────────────────────────────
 export { AuthPrecedenceResolver } from './auth-precedence-resolver.js';
+export type { ResolveAuthOptions } from './auth-precedence-resolver.js';
+export { CredentialResolutionError } from './credential-resolution-error.js';
+export type {
+  CredentialMechanism,
+  CredentialResolutionDiagnostics,
+  CredentialResolutionErrorKind,
+  CredentialResolutionErrorOptions,
+  CredentialResolutionResult,
+} from './credential-resolution-error.js';
 
 export {
   flushRuntimeAuthScope,

--- a/packages/auth/src/proxy/__tests__/proxy-socket-client.test.ts
+++ b/packages/auth/src/proxy/__tests__/proxy-socket-client.test.ts
@@ -481,6 +481,10 @@ describe('ProxySocketClient', () => {
    * @scenario Request times out after REQUEST_TIMEOUT_MS
    */
   it('rejects request after 30s timeout', async () => {
+    let markRequestReceived: () => void = () => {};
+    const requestReceived = new Promise<void>((resolve) => {
+      markRequestReceived = resolve;
+    });
     server = net.createServer((socket) => {
       trackServerSockets(initialized(server, 'server'));
       const decoder = new FrameDecoder();
@@ -490,6 +494,8 @@ describe('ProxySocketClient', () => {
           const msg = frame;
           if (msg.op === 'handshake') {
             socket.write(encodeFrame({ ok: true, v: PROTOCOL_VERSION }));
+          } else {
+            markRequestReceived();
           }
           // Deliberately do NOT respond to other requests (simulates timeout)
         }
@@ -506,6 +512,7 @@ describe('ProxySocketClient', () => {
     vi.useFakeTimers();
 
     const requestPromise = client.request('slow-op', {});
+    await requestReceived;
 
     // Advance past the request timeout
     vi.advanceTimersByTime(REQUEST_TIMEOUT_MS + 100);

--- a/packages/auth/src/proxy/proxy-socket-client.ts
+++ b/packages/auth/src/proxy/proxy-socket-client.ts
@@ -14,7 +14,6 @@
 
 import * as net from 'node:net';
 import * as crypto from 'node:crypto';
-import { MessageChannel } from 'node:worker_threads';
 import { encodeFrame, FrameDecoder } from './framing.js';
 
 export const REQUEST_TIMEOUT_MS = 30000;
@@ -65,7 +64,8 @@ function isProxyResponseFrame(
   return true;
 }
 
-const PROXY_CONNECT_FAILURE_PATTERN = /connect (?:ECONNREFUSED|ENOENT|EACCES)/i;
+const PROXY_CONNECT_FAILURE_PATTERN =
+  /connect (?:ECONNREFUSED|ENOENT|EACCES|EHOSTUNREACH|ENETUNREACH|ETIMEDOUT|EPERM|ENOTDIR)/i;
 
 export class ProxyRequestError extends Error {
   readonly proxyContacted: boolean;
@@ -88,7 +88,6 @@ export class ProxySocketClient {
   private readonly socketPath: string;
   private readonly capabilityToken: string | undefined;
   private socket: net.Socket | null = null;
-  private connectionEpoch = 0;
   private decoder: FrameDecoder = new FrameDecoder({
     onPartialFrameTimeout: () => this.handlePartialFrameTimeout(),
   });
@@ -180,18 +179,19 @@ export class ProxySocketClient {
     return connectionWasEstablished && !socket.readableEnded && socket.writable;
   }
 
-  private async hasUsableConnection(): Promise<boolean> {
-    if (!this.isConnected()) return false;
-    await new Promise<void>((resolve) => {
-      const { port1, port2 } = new MessageChannel();
-      port1.once('message', () => {
-        port1.close();
-        port2.close();
-        resolve();
-      });
-      port2.postMessage(undefined);
-    });
-    return this.isConnected();
+  /**
+   * A queued peer FIN is not reflected in the socket's synchronous state until
+   * the poll phase runs. Yield exactly once, and only for connection reuse, so
+   * an already-queued close is observed before a request is written.
+   */
+  private async confirmReusableConnection(socket: net.Socket): Promise<void> {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    if (this.socket !== socket || !this.isConnected()) {
+      throw new ProxyRequestError(
+        new Error('Credential proxy connection lost. Restart the session.'),
+        false,
+      );
+    }
   }
 
   /**
@@ -208,23 +208,18 @@ export class ProxySocketClient {
     payload: Record<string, unknown>,
     options?: RequestOptions,
   ): Promise<ProxyResponse> {
-    const connectionEpoch = this.connectionEpoch;
     let connectionWasEstablished = false;
     let proxyContacted = false;
     try {
-      connectionWasEstablished = await this.hasUsableConnection();
-      if (connectionEpoch !== this.connectionEpoch) {
-        throw new ProxyRequestError(
-          new Error('Credential proxy connection lost. Restart the session.'),
-          false,
-        );
-      }
-      proxyContacted = connectionWasEstablished;
-      if (!connectionWasEstablished) {
+      const reusableSocket = this.socket;
+      if (reusableSocket !== null && this.isConnected()) {
+        connectionWasEstablished = true;
+        await this.confirmReusableConnection(reusableSocket);
+        proxyContacted = true;
+        this.resetIdleTimer();
+      } else {
         await this.ensureConnected();
         proxyContacted = true;
-      } else {
-        this.resetIdleTimer();
       }
       return await this.sendRequest(op, payload, options);
     } catch (cause) {
@@ -348,7 +343,6 @@ export class ProxySocketClient {
   }
 
   gracefulClose(): void {
-    this.connectionEpoch += 1;
     this.handshakeComplete = false;
     // Reject any pending requests
     for (const [, pending] of this.pendingRequests) {
@@ -552,7 +546,6 @@ export class ProxySocketClient {
   }
 
   private destroy(message: string): void {
-    this.connectionEpoch += 1;
     this.cancelIdleTimer();
 
     for (const [, pending] of this.pendingRequests) {

--- a/packages/auth/src/proxy/proxy-socket-client.ts
+++ b/packages/auth/src/proxy/proxy-socket-client.ts
@@ -14,6 +14,7 @@
 
 import * as net from 'node:net';
 import * as crypto from 'node:crypto';
+import { MessageChannel } from 'node:worker_threads';
 import { encodeFrame, FrameDecoder } from './framing.js';
 
 export const REQUEST_TIMEOUT_MS = 30000;
@@ -64,6 +65,19 @@ function isProxyResponseFrame(
   return true;
 }
 
+const PROXY_CONNECT_FAILURE_PATTERN = /connect (?:ECONNREFUSED|ENOENT|EACCES)/i;
+
+export class ProxyRequestError extends Error {
+  readonly proxyContacted: boolean;
+
+  constructor(cause: unknown, proxyContacted: boolean) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    super(message, { cause });
+    this.name = 'ProxyRequestError';
+    this.proxyContacted = proxyContacted;
+  }
+}
+
 interface PendingRequest {
   resolve: (value: ProxyResponse) => void;
   reject: (reason: Error) => void;
@@ -74,6 +88,7 @@ export class ProxySocketClient {
   private readonly socketPath: string;
   private readonly capabilityToken: string | undefined;
   private socket: net.Socket | null = null;
+  private connectionEpoch = 0;
   private decoder: FrameDecoder = new FrameDecoder({
     onPartialFrameTimeout: () => this.handlePartialFrameTimeout(),
   });
@@ -140,7 +155,7 @@ export class ProxySocketClient {
   }
 
   async ensureConnected(): Promise<void> {
-    if (this.socket !== null && this.handshakeComplete) {
+    if (this.isConnected()) {
       this.resetIdleTimer();
       return;
     }
@@ -157,7 +172,26 @@ export class ProxySocketClient {
   }
 
   private isConnected(): boolean {
-    return this.socket !== null && this.handshakeComplete;
+    const socket = this.socket;
+    if (socket === null) return false;
+
+    const connectionWasEstablished =
+      this.handshakeComplete && !socket.destroyed;
+    return connectionWasEstablished && !socket.readableEnded && socket.writable;
+  }
+
+  private async hasUsableConnection(): Promise<boolean> {
+    if (!this.isConnected()) return false;
+    await new Promise<void>((resolve) => {
+      const { port1, port2 } = new MessageChannel();
+      port1.once('message', () => {
+        port1.close();
+        port2.close();
+        resolve();
+      });
+      port2.postMessage(undefined);
+    });
+    return this.isConnected();
   }
 
   /**
@@ -174,12 +208,36 @@ export class ProxySocketClient {
     payload: Record<string, unknown>,
     options?: RequestOptions,
   ): Promise<ProxyResponse> {
-    if (!this.isConnected()) {
-      await this.ensureConnected();
-    } else {
-      this.resetIdleTimer();
+    const connectionEpoch = this.connectionEpoch;
+    let connectionWasEstablished = false;
+    let proxyContacted = false;
+    try {
+      connectionWasEstablished = await this.hasUsableConnection();
+      if (connectionEpoch !== this.connectionEpoch) {
+        throw new ProxyRequestError(
+          new Error('Credential proxy connection lost. Restart the session.'),
+          false,
+        );
+      }
+      proxyContacted = connectionWasEstablished;
+      if (!connectionWasEstablished) {
+        await this.ensureConnected();
+        proxyContacted = true;
+      } else {
+        this.resetIdleTimer();
+      }
+      return await this.sendRequest(op, payload, options);
+    } catch (cause) {
+      if (cause instanceof ProxyRequestError) throw cause;
+      const message = cause instanceof Error ? cause.message : String(cause);
+      const connectionAttemptReachedProxy =
+        !connectionWasEstablished &&
+        !PROXY_CONNECT_FAILURE_PATTERN.test(message);
+      throw new ProxyRequestError(
+        cause,
+        proxyContacted || connectionAttemptReachedProxy,
+      );
     }
-    return this.sendRequest(op, payload, options);
   }
 
   /**
@@ -290,6 +348,7 @@ export class ProxySocketClient {
   }
 
   gracefulClose(): void {
+    this.connectionEpoch += 1;
     this.handshakeComplete = false;
     // Reject any pending requests
     for (const [, pending] of this.pendingRequests) {
@@ -493,6 +552,7 @@ export class ProxySocketClient {
   }
 
   private destroy(message: string): void {
+    this.connectionEpoch += 1;
     this.cancelIdleTimer();
 
     for (const [, pending] of this.pendingRequests) {

--- a/packages/providers/src/BaseProvider.ts
+++ b/packages/providers/src/BaseProvider.ts
@@ -21,6 +21,7 @@ import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 // @plan:PLAN-20260608-ISSUE1586.P15 — auth types from auth package
 import {
   type AuthPrecedenceConfig,
+  type CredentialResolutionError,
   type OAuthManager,
   type IProviderKeyStorage,
 } from '@vybestack/llxprt-code-auth';
@@ -87,6 +88,7 @@ export interface NormalizedGenerateChatOptions extends GenerateChatOptions {
     model: string;
     baseURL?: string;
     authToken: ResolvedAuthToken;
+    authFailure?: CredentialResolutionError;
     telemetry?: ProviderTelemetryContext; // @plan PLAN-20251023-STATELESS-HARDENING.P08: Telemetry service
     temperature?: number;
     maxTokens?: number;
@@ -791,6 +793,7 @@ export abstract class BaseProvider implements IProvider {
           setSettingsProviderRuntimeContext(previousContext ?? null);
         }
         normalized.resolved.authToken = '';
+        delete normalized.resolved.authFailure;
         this.authResolver.setSettingsService(this.defaultSettingsService);
       }
     }.call(this);
@@ -823,14 +826,27 @@ export abstract class BaseProvider implements IProvider {
         | ProviderSettings
         | undefined) ?? ({} as ProviderSettings);
     const resolvedBaseURL = this.computeBaseURL(settings);
-    const resolvedAuth = resolveAuthentication
-      ? ((await this.authResolver.resolveAuthentication({
-          settingsService: settings,
-          includeOAuth: this.isOAuthEligible(
-            providedOptions.resolved?.baseURL ?? resolvedBaseURL,
-          ),
-        })) ?? '')
-      : (providedOptions.resolved?.authToken ?? '');
+    let resolvedAuth: ResolvedAuthToken;
+    let authFailure: CredentialResolutionError | undefined;
+    const runtimeId =
+      providedOptions.runtime?.runtimeId ??
+      providedOptions.invocation?.runtimeId ??
+      peekActiveProviderRuntimeContext()?.runtimeId;
+    if (resolveAuthentication) {
+      const authResult = await this.authResolver.resolveAuthenticationResult({
+        settingsService: settings,
+        includeOAuth: this.isOAuthEligible(
+          providedOptions.resolved?.baseURL ?? resolvedBaseURL,
+        ),
+        ...(runtimeId === undefined ? {} : { runtimeId }),
+      });
+      resolvedAuth = authResult.token ?? '';
+      if (authResult.token === null) {
+        authFailure = authResult.failure;
+      }
+    } else {
+      resolvedAuth = providedOptions.resolved?.authToken ?? '';
+    }
 
     return normalizeProviderGenerateChatOptions(this, providedOptions, {
       providerName: this.name,
@@ -838,6 +854,7 @@ export abstract class BaseProvider implements IProvider {
       defaultConfig: this.defaultConfig,
       maybeTools,
       authToken: resolvedAuth,
+      ...(authFailure === undefined ? {} : { authFailure }),
       resolvedModel: this.computeModel(settings),
       resolvedBaseURL,
       providerSettings,

--- a/packages/providers/src/BaseProviderNormalization.ts
+++ b/packages/providers/src/BaseProviderNormalization.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { CredentialResolutionError } from '@vybestack/llxprt-code-auth';
 import type { SettingsService } from '@vybestack/llxprt-code-settings';
 import type { ProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
 import {
@@ -48,6 +49,7 @@ interface NormalizationDependencies {
   defaultConfig?: Config;
   maybeTools?: ProviderToolset;
   authToken: ResolvedAuthToken;
+  authFailure?: CredentialResolutionError;
   resolvedModel: string;
   resolvedBaseURL?: string;
   providerSettings: ProviderSettings;
@@ -183,6 +185,10 @@ function createResolvedOptions(
     model: providedOptions.resolved?.model ?? deps.resolvedModel,
     baseURL: providedOptions.resolved?.baseURL ?? deps.resolvedBaseURL,
     authToken: providedOptions.resolved?.authToken ?? deps.authToken,
+    ...(providedOptions.resolved?.authToken === undefined &&
+    deps.authFailure !== undefined
+      ? { authFailure: deps.authFailure }
+      : {}),
     telemetry: providedOptions.resolved?.telemetry,
     temperature:
       providedOptions.resolved?.temperature ??

--- a/packages/providers/src/__tests__/BaseProvider.guard.test.ts
+++ b/packages/providers/src/__tests__/BaseProvider.guard.test.ts
@@ -61,7 +61,9 @@ describe('BaseProvider runtime guard', () => {
       provider as unknown as {
         authResolver: {
           resolveAuthentication: (input: unknown) => Promise<string>;
-          resolveAuthenticationResult: (input: unknown) => Promise<{ token: string }>;
+          resolveAuthenticationResult: (
+            input: unknown,
+          ) => Promise<{ token: string }>;
           setSettingsService: (settings: SettingsService | undefined) => void;
         };
       }
@@ -102,13 +104,17 @@ describe('BaseProvider runtime guard', () => {
       provider as unknown as {
         authResolver: {
           resolveAuthentication: (input: unknown) => Promise<string>;
-          resolveAuthenticationResult: (input: unknown) => Promise<{ token: string }>;
+          resolveAuthenticationResult: (
+            input: unknown,
+          ) => Promise<{ token: string }>;
           setSettingsService: (settings: SettingsService | undefined) => void;
         };
       }
     ).authResolver = {
       resolveAuthentication: vi.fn().mockResolvedValue('token'),
-      resolveAuthenticationResult: vi.fn().mockResolvedValue({ token: 'token' }),
+      resolveAuthenticationResult: vi
+        .fn()
+        .mockResolvedValue({ token: 'token' }),
       setSettingsService: vi.fn(),
     };
 

--- a/packages/providers/src/__tests__/BaseProvider.guard.test.ts
+++ b/packages/providers/src/__tests__/BaseProvider.guard.test.ts
@@ -61,11 +61,13 @@ describe('BaseProvider runtime guard', () => {
       provider as unknown as {
         authResolver: {
           resolveAuthentication: (input: unknown) => Promise<string>;
+          resolveAuthenticationResult: (input: unknown) => Promise<{ token: string }>;
           setSettingsService: (settings: SettingsService | undefined) => void;
         };
       }
     ).authResolver = {
       resolveAuthentication: vi.fn().mockResolvedValue(''),
+      resolveAuthenticationResult: vi.fn().mockResolvedValue({ token: '' }),
       setSettingsService: vi.fn(),
     };
 
@@ -100,11 +102,13 @@ describe('BaseProvider runtime guard', () => {
       provider as unknown as {
         authResolver: {
           resolveAuthentication: (input: unknown) => Promise<string>;
+          resolveAuthenticationResult: (input: unknown) => Promise<{ token: string }>;
           setSettingsService: (settings: SettingsService | undefined) => void;
         };
       }
     ).authResolver = {
       resolveAuthentication: vi.fn().mockResolvedValue('token'),
+      resolveAuthenticationResult: vi.fn().mockResolvedValue({ token: 'token' }),
       setSettingsService: vi.fn(),
     };
 

--- a/packages/providers/src/__tests__/BaseProviderNormalization.invocation.test.ts
+++ b/packages/providers/src/__tests__/BaseProviderNormalization.invocation.test.ts
@@ -63,7 +63,9 @@ function wireProviderWithAuth(provider: InvocationSafetyProvider): void {
     provider as unknown as {
       authResolver: {
         resolveAuthentication: (input: unknown) => Promise<string>;
-        resolveAuthenticationResult: (input: unknown) => Promise<{ token: string }>;
+        resolveAuthenticationResult: (
+          input: unknown,
+        ) => Promise<{ token: string }>;
         setSettingsService: (settings: SettingsService | undefined) => void;
       };
     }

--- a/packages/providers/src/__tests__/BaseProviderNormalization.invocation.test.ts
+++ b/packages/providers/src/__tests__/BaseProviderNormalization.invocation.test.ts
@@ -63,11 +63,13 @@ function wireProviderWithAuth(provider: InvocationSafetyProvider): void {
     provider as unknown as {
       authResolver: {
         resolveAuthentication: (input: unknown) => Promise<string>;
+        resolveAuthenticationResult: (input: unknown) => Promise<{ token: string }>;
         setSettingsService: (settings: SettingsService | undefined) => void;
       };
     }
   ).authResolver = {
     resolveAuthentication: vi.fn().mockResolvedValue('token'),
+    resolveAuthenticationResult: vi.fn().mockResolvedValue({ token: 'token' }),
     setSettingsService: vi.fn(),
   };
 }

--- a/packages/providers/src/__tests__/RetryOrchestrator.invocation.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.invocation.test.ts
@@ -79,11 +79,13 @@ function wireProvider(provider: SafetyBaseProvider): SettingsService {
     provider as unknown as {
       authResolver: {
         resolveAuthentication: (input: unknown) => Promise<string>;
+        resolveAuthenticationResult: (input: unknown) => Promise<{ token: string }>;
         setSettingsService: (settings: SettingsService | undefined) => void;
       };
     }
   ).authResolver = {
     resolveAuthentication: vi.fn().mockResolvedValue('token'),
+    resolveAuthenticationResult: vi.fn().mockResolvedValue({ token: 'token' }),
     setSettingsService: vi.fn(),
   };
   const settings = new SettingsService();

--- a/packages/providers/src/__tests__/RetryOrchestrator.invocation.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.invocation.test.ts
@@ -79,7 +79,9 @@ function wireProvider(provider: SafetyBaseProvider): SettingsService {
     provider as unknown as {
       authResolver: {
         resolveAuthentication: (input: unknown) => Promise<string>;
-        resolveAuthenticationResult: (input: unknown) => Promise<{ token: string }>;
+        resolveAuthenticationResult: (
+          input: unknown,
+        ) => Promise<{ token: string }>;
         setSettingsService: (settings: SettingsService | undefined) => void;
       };
     }

--- a/packages/providers/src/anthropic/AnthropicProvider.issue2411.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.issue2411.test.ts
@@ -30,7 +30,10 @@ import {
   AnthropicProvider,
   isAnthropicOAuthBaseURL,
 } from './AnthropicProvider.js';
-import type { OAuthManager } from '@vybestack/llxprt-code-auth';
+import {
+  CredentialResolutionError,
+  type OAuthManager,
+} from '@vybestack/llxprt-code-auth';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import { TEST_PROVIDER_CONFIG } from '../test-utils/providerTestConfig.js';
 import {
@@ -594,6 +597,7 @@ describe('Issue #2411: base-URL-aware OAuth eligibility for Anthropic', () => {
       const generator = result.provider.generateChatCompletion(callOptions);
       const thrownError = await captureGeneratorError(generator);
 
+      expect(thrownError).toBeInstanceOf(CredentialResolutionError);
       expect(thrownError.message).toContain('/auth claudecode');
       expect(thrownError.message.toLowerCase()).not.toContain('/key');
     });
@@ -627,6 +631,7 @@ describe('Issue #2411: base-URL-aware OAuth eligibility for Anthropic', () => {
       const generator = result.provider.generateChatCompletion(callOptions);
       const thrownError = await captureGeneratorError(generator);
 
+      expect(thrownError).toBeInstanceOf(CredentialResolutionError);
       expect(thrownError.message).not.toContain('/auth claudecode');
       expect(thrownError.message).toContain('/key');
       expect(thrownError.message.toLowerCase()).toContain('api key');

--- a/packages/providers/src/anthropic/AnthropicProvider.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.ts
@@ -261,9 +261,10 @@ export class AnthropicProvider extends BaseProvider {
       // Third-party hosts must never be misdirected to Anthropic OAuth; they
       // require an explicit credential regardless of bound identity.
       if (!isAnthropicOAuthBaseURL(baseURL)) {
-        throw new Error(
-          `No API key resolved for Anthropic-compatible endpoint "${baseURL}". Configure an explicit credential (auth-key, auth-keyfile, or auth-key-name) for this profile; OAuth against api.anthropic.com is not used for third-party base URLs.`,
-        );
+        throw createCredentialResolutionError(options, this.name, {
+          kind: 'no-credential-configured',
+          remediation: `No API key resolved for Anthropic-compatible endpoint "${baseURL}". Configure an explicit credential (auth-key, auth-keyfile, or auth-key-name) for this profile; OAuth against api.anthropic.com is not used for third-party base URLs.`,
+        });
       }
       // On the canonical Anthropic host, distinguish by bound identity: only
       // the `claudecode` subscription identity surfaces OAuth recovery; the

--- a/packages/providers/src/anthropic/AnthropicProvider.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.ts
@@ -25,7 +25,10 @@ import {
 } from '../utils/systemPromptPlacement.js';
 import { isRuntimeAuthTokenProvider } from '../utils/authToken.js';
 // @plan:PLAN-20260608-ISSUE1586.P15 — auth types from auth package
-import { type OAuthManager } from '@vybestack/llxprt-code-auth';
+import {
+  CredentialResolutionError,
+  type OAuthManager,
+} from '@vybestack/llxprt-code-auth';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { ProviderTelemetryContext } from '../types/providerRuntime.js';
 import type { DumpMode } from '../utils/dumpContext.js';
@@ -55,6 +58,7 @@ import {
   executeAnthropicApiCall,
 } from './AnthropicApiExecution.js';
 import { collectUnsupportedMedia } from '../utils/mediaUtils.js';
+import { createCredentialResolutionError } from '../utils/credentialResolutionError.js';
 import {
   isAnthropicImageDimensionLimitError,
   parseAnthropicImageDimensionLimit,
@@ -216,16 +220,20 @@ export class AnthropicProvider extends BaseProvider {
     try {
       const freshToken = await runtimeAuthToken.provide();
       if (!freshToken) {
-        throw new Error(
-          `ProviderCacheError("Auth token unavailable for runtimeId=${options.runtime?.runtimeId} (REQ-SP4-003).")`,
-        );
+        throw createCredentialResolutionError(options, this.name, {
+          kind: 'credential-not-found',
+        });
       }
       this.getAuthLogger().debug(() => 'Refreshed OAuth token for call');
       return freshToken;
-    } catch (error) {
-      throw new Error(
-        `ProviderCacheError("Auth token unavailable for runtimeId=${options.runtime?.runtimeId} (REQ-SP4-003)."): ${error}`,
-      );
+    } catch (cause) {
+      if (cause instanceof CredentialResolutionError) {
+        throw cause;
+      }
+      throw createCredentialResolutionError(options, this.name, {
+        kind: 'credential-source-failed',
+        cause,
+      });
     }
   }
 
@@ -261,13 +269,17 @@ export class AnthropicProvider extends BaseProvider {
       // the `claudecode` subscription identity surfaces OAuth recovery; the
       // API-key-only `anthropic` identity is directed to /key or /keyfile.
       if (this.baseProviderConfig.oauthProvider === 'claudecode') {
-        throw new Error(
-          'No authentication available for Anthropic API calls. Run /auth claudecode login to authenticate (or /auth claudecode logout to clear any expired session).',
-        );
+        throw createCredentialResolutionError(options, this.name, {
+          kind: 'no-credential-configured',
+          remediation:
+            'No authentication available for Anthropic API calls. Run /auth claudecode login to authenticate (or /auth claudecode logout to clear any expired session).',
+        });
       }
-      throw new Error(
-        'No Anthropic API key resolved. Set an API key with /key or /keyfile (or ANTHROPIC_API_KEY) to use the Anthropic API.',
-      );
+      throw createCredentialResolutionError(options, this.name, {
+        kind: 'no-credential-configured',
+        remediation:
+          'No Anthropic API key resolved. Set an API key with /key or /keyfile (or ANTHROPIC_API_KEY) to use the Anthropic API.',
+      });
     }
 
     authLogger.debug(() => 'Creating fresh client instance (stateless)');

--- a/packages/providers/src/auth/proxy/__tests__/provider-credential-resolution.e2e.test.ts
+++ b/packages/providers/src/auth/proxy/__tests__/provider-credential-resolution.e2e.test.ts
@@ -256,19 +256,34 @@ describe('Provider credential resolution through a sandbox proxy', () => {
   });
 
   afterEach(async () => {
-    clearActiveProviderRuntimeContext();
-    resetFactorySingletons();
-    runtimeScopedStates.clear();
-    for (const proxy of proxies.splice(0)) {
-      await proxy.server.stop();
+    const cleanupErrors: unknown[] = [];
+    try {
+      clearActiveProviderRuntimeContext();
+      resetFactorySingletons();
+      runtimeScopedStates.clear();
+      for (const proxy of proxies.splice(0)) {
+        try {
+          await proxy.server.stop();
+        } catch (error) {
+          cleanupErrors.push(error);
+        }
+      }
+      if (temporaryDirectory !== undefined) {
+        try {
+          await fs.rm(temporaryDirectory, { recursive: true, force: true });
+        } catch (error) {
+          cleanupErrors.push(error);
+        }
+      }
+    } finally {
+      if (originalSocket === undefined) {
+        delete process.env.LLXPRT_CREDENTIAL_SOCKET;
+      } else {
+        process.env.LLXPRT_CREDENTIAL_SOCKET = originalSocket;
+      }
     }
-    if (temporaryDirectory !== undefined) {
-      await fs.rm(temporaryDirectory, { recursive: true, force: true });
-    }
-    if (originalSocket === undefined) {
-      delete process.env.LLXPRT_CREDENTIAL_SOCKET;
-    } else {
-      process.env.LLXPRT_CREDENTIAL_SOCKET = originalSocket;
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError(cleanupErrors, 'Proxy test cleanup failed');
     }
   });
 

--- a/packages/providers/src/auth/proxy/__tests__/provider-credential-resolution.e2e.test.ts
+++ b/packages/providers/src/auth/proxy/__tests__/provider-credential-resolution.e2e.test.ts
@@ -1,0 +1,378 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  AuthPrecedenceResolver,
+  CredentialResolutionError,
+  runtimeScopedStates,
+  type OAuthManager,
+} from '@vybestack/llxprt-code-auth';
+import type {
+  BucketStats,
+  OAuthToken,
+  TokenStore,
+} from '@vybestack/llxprt-code-core';
+import {
+  clearActiveProviderRuntimeContext,
+  setActiveProviderRuntimeContext,
+} from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import type { ProviderKeyStorage } from '@vybestack/llxprt-code-storage';
+import {
+  BaseProvider,
+  type NormalizedGenerateChatOptions,
+} from '../../../BaseProvider.js';
+import type { IModel } from '../../../IModel.js';
+import { resolveRuntimeAuthToken } from '../../../utils/authToken.js';
+import { createCredentialResolutionError } from '../../../utils/credentialResolutionError.js';
+import { CredentialProxyServer } from '../credential-proxy-server.js';
+import {
+  createTokenStore,
+  resetFactorySingletons,
+} from '../credential-store-factory.js';
+
+const PROFILE = 'issue3451-sandbox-profile';
+const PROVIDER = 'issue3451-proxy-provider';
+const MISSING_KEY_NAME = 'issue3451-missing-key';
+const CREDENTIAL_SECRET = 'issue3451-live-credential-secret';
+
+class CredentialProbeProvider extends BaseProvider {
+  constructor(oauthManager: OAuthManager) {
+    super({
+      name: PROVIDER,
+      isOAuthEnabled: true,
+      supportsOAuth: true,
+      oauthProvider: PROVIDER,
+      oauthManager,
+    });
+  }
+
+  protected supportsOAuth(): boolean {
+    return true;
+  }
+
+  getDefaultModel(): string {
+    return 'credential-probe-model';
+  }
+
+  async getModels(): Promise<IModel[]> {
+    return [
+      {
+        id: this.getDefaultModel(),
+        name: this.getDefaultModel(),
+        provider: PROVIDER,
+        supportedToolFormats: [],
+      },
+    ];
+  }
+
+  protected async *generateChatCompletionWithOptions(
+    options: NormalizedGenerateChatOptions,
+  ): AsyncIterableIterator<IContent> {
+    const token = await resolveRuntimeAuthToken(options.resolved.authToken);
+    if (token === undefined || token === '') {
+      throw createCredentialResolutionError(options, this.name);
+    }
+    yield {
+      speaker: 'ai',
+      blocks: [{ type: 'text', text: 'proxy credential accepted' }],
+    };
+  }
+}
+
+class InMemoryTokenStore implements TokenStore {
+  private readonly tokens = new Map<string, OAuthToken>();
+
+  constructor(token?: OAuthToken) {
+    if (token !== undefined) {
+      this.tokens.set(PROVIDER, token);
+    }
+  }
+
+  async saveToken(
+    provider: string,
+    token: OAuthToken,
+    _bucket?: string,
+  ): Promise<void> {
+    this.tokens.set(provider, token);
+  }
+
+  async getToken(
+    provider: string,
+    _bucket?: string,
+  ): Promise<OAuthToken | null> {
+    return this.tokens.get(provider) ?? null;
+  }
+
+  async removeToken(provider: string, _bucket?: string): Promise<void> {
+    this.tokens.delete(provider);
+  }
+
+  async listProviders(): Promise<string[]> {
+    return [...this.tokens.keys()];
+  }
+
+  async listBuckets(_provider: string): Promise<string[]> {
+    return [];
+  }
+
+  async getBucketStats(
+    _provider: string,
+    _bucket: string,
+  ): Promise<BucketStats | null> {
+    return null;
+  }
+
+  async acquireRefreshLock(
+    _provider: string,
+    _options?: { waitMs?: number; bucket?: string },
+  ): Promise<boolean> {
+    return true;
+  }
+
+  async releaseRefreshLock(
+    _provider: string,
+    _bucket?: string,
+  ): Promise<void> {}
+
+  async acquireAuthLock(
+    _provider: string,
+    _options?: { waitMs?: number; bucket?: string },
+  ): Promise<boolean> {
+    return true;
+  }
+
+  async releaseAuthLock(
+    _provider: string,
+    _bucket?: string,
+  ): Promise<void> {}
+}
+
+class EmptyProviderKeyStorage implements ProviderKeyStorage {
+  async saveKey(_name: string, _apiKey: string): Promise<void> {}
+
+  async getKey(_name: string): Promise<string | null> {
+    return null;
+  }
+
+  async deleteKey(_name: string): Promise<boolean> {
+    return false;
+  }
+
+  async listKeys(): Promise<string[]> {
+    return [];
+  }
+
+  async hasKey(_name: string): Promise<boolean> {
+    return false;
+  }
+}
+
+interface RunningProxy {
+  readonly server: CredentialProxyServer;
+  readonly socketPath: string;
+}
+
+function createSettings(): SettingsService {
+  const settings = new SettingsService();
+  settings.set('activeProvider', PROVIDER);
+  settings.setCurrentProfileName(PROFILE);
+  return settings;
+}
+
+function createProxyOAuthManager(): OAuthManager {
+  const tokenStore = createTokenStore();
+  return {
+    getToken: async (provider) => {
+      const token = await tokenStore.getToken(provider);
+      return token?.access_token ?? null;
+    },
+    isAuthenticated: async () => true,
+  };
+}
+
+function createCallOptions(settings: SettingsService, runtimeId: string) {
+  const options = createProviderCallOptions({
+    providerName: PROVIDER,
+    settings,
+    runtimeId,
+    contents: [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'test proxy credential' }],
+      },
+    ],
+  });
+  setActiveProviderRuntimeContext(options.runtime);
+  return options;
+}
+
+async function callProvider(
+  provider: CredentialProbeProvider,
+  settings: SettingsService,
+  runtimeId: string,
+): Promise<void> {
+  const options = createCallOptions(settings, runtimeId);
+  await provider.generateChatCompletion(options).next();
+}
+
+async function captureCredentialFailure(
+  provider: CredentialProbeProvider,
+  settings: SettingsService,
+  runtimeId: string,
+): Promise<CredentialResolutionError> {
+  try {
+    await callProvider(provider, settings, runtimeId);
+  } catch (error) {
+    if (error instanceof CredentialResolutionError) {
+      return error;
+    }
+    throw error;
+  }
+  throw new Error('Expected credential resolution to fail');
+}
+
+describe('Provider credential resolution through a sandbox proxy', () => {
+  const proxies: RunningProxy[] = [];
+  let temporaryDirectory: string;
+  let originalSocket: string | undefined;
+
+  beforeEach(async () => {
+    temporaryDirectory = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'llxprt-provider-credential-e2e-'),
+    );
+    originalSocket = process.env.LLXPRT_CREDENTIAL_SOCKET;
+    delete process.env.LLXPRT_CREDENTIAL_SOCKET;
+    resetFactorySingletons();
+    runtimeScopedStates.clear();
+  });
+
+  afterEach(async () => {
+    clearActiveProviderRuntimeContext();
+    resetFactorySingletons();
+    runtimeScopedStates.clear();
+    for (const proxy of proxies.splice(0)) {
+      await proxy.server.stop();
+    }
+    await fs.rm(temporaryDirectory, { recursive: true, force: true });
+    if (originalSocket === undefined) {
+      delete process.env.LLXPRT_CREDENTIAL_SOCKET;
+    } else {
+      process.env.LLXPRT_CREDENTIAL_SOCKET = originalSocket;
+    }
+  });
+
+  async function startProxy(withCredential: boolean): Promise<RunningProxy> {
+    const token = withCredential
+      ? {
+          access_token: CREDENTIAL_SECRET,
+          token_type: 'Bearer',
+          expiry: Math.floor(Date.now() / 1000) + 3600,
+        }
+      : undefined;
+    const server = new CredentialProxyServer({
+      tokenStore: new InMemoryTokenStore(token),
+      providerKeyStorage: new EmptyProviderKeyStorage(),
+      socketDir: temporaryDirectory,
+    });
+    const socketPath = await server.start();
+    const proxy = { server, socketPath };
+    proxies.push(proxy);
+    process.env.LLXPRT_CREDENTIAL_SOCKET = socketPath;
+    return proxy;
+  }
+
+  function createProvider(): CredentialProbeProvider {
+    return new CredentialProbeProvider(createProxyOAuthManager());
+  }
+
+  it('resolves a credential for a fresh subagent-shaped runtime while the proxy is available', async () => {
+    await startProxy(true);
+    const settings = createSettings();
+    const provider = createProvider();
+
+    await expect(
+      callProvider(
+        provider,
+        settings,
+        'session#typescriptexpert#credential-present',
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('classifies a closed proxy on a subagent first call while a parent runtime remains warm', async () => {
+    const proxy = await startProxy(true);
+    const settings = createSettings();
+    const provider = createProvider();
+    const parentRuntimeId = 'session-parent-runtime';
+    const parentRuntime = createCallOptions(settings, parentRuntimeId).runtime;
+    const parentResolver = new AuthPrecedenceResolver(
+      {
+        isOAuthEnabled: true,
+        supportsOAuth: true,
+        oauthProvider: PROVIDER,
+        providerId: PROVIDER,
+      },
+      {
+        oauthManager: createProxyOAuthManager(),
+        settingsService: settings,
+        getActiveRuntimeContext: () => parentRuntime,
+      },
+    );
+
+    const parentInitial = await parentResolver.resolveAuthenticationResult({
+      settingsService: settings,
+      includeOAuth: true,
+    });
+    expect(parentInitial.token).toBe(CREDENTIAL_SECRET);
+    await proxy.server.stop();
+    proxies.splice(proxies.indexOf(proxy), 1);
+
+    const failure = await captureCredentialFailure(
+      provider,
+      settings,
+      'session#typescriptexpert#proxy-closed',
+    );
+
+    expect(failure.kind).toBe('proxy-unavailable');
+    expect(failure.diagnostics.provider).toBe(PROVIDER);
+    expect(failure.diagnostics.profile).toBe(PROFILE);
+    expect(failure.diagnostics.proxyContacted).toBe(true);
+    expect(failure.message).not.toContain(CREDENTIAL_SECRET);
+
+    const parentAfterFailure =
+      await parentResolver.resolveAuthenticationResult({
+        settingsService: settings,
+        includeOAuth: true,
+      });
+    expect(parentAfterFailure.token).toBe(CREDENTIAL_SECRET);
+  });
+
+  it('classifies an absent proxy credential distinctly from proxy transport failure', async () => {
+    await startProxy(false);
+    const settings = createSettings();
+    settings.set('auth-key-name', MISSING_KEY_NAME);
+    const provider = createProvider();
+
+    const failure = await captureCredentialFailure(
+      provider,
+      settings,
+      'session#typescriptexpert#credential-absent',
+    );
+
+    expect(failure.kind).toBe('credential-not-found');
+    expect(failure.kind).not.toBe('proxy-unavailable');
+    expect(failure.diagnostics.provider).toBe(PROVIDER);
+    expect(failure.diagnostics.profile).toBe(PROFILE);
+    expect(failure.diagnostics.proxyContacted).toBe(true);
+  });
+});

--- a/packages/providers/src/auth/proxy/__tests__/provider-credential-resolution.e2e.test.ts
+++ b/packages/providers/src/auth/proxy/__tests__/provider-credential-resolution.e2e.test.ts
@@ -241,10 +241,11 @@ async function captureCredentialFailure(
 
 describe('Provider credential resolution through a sandbox proxy', () => {
   const proxies: RunningProxy[] = [];
-  let temporaryDirectory: string;
+  let temporaryDirectory: string | undefined;
   let originalSocket: string | undefined;
 
   beforeEach(async () => {
+    temporaryDirectory = undefined;
     temporaryDirectory = await fs.mkdtemp(
       path.join(os.tmpdir(), 'llxprt-provider-credential-e2e-'),
     );
@@ -261,7 +262,9 @@ describe('Provider credential resolution through a sandbox proxy', () => {
     for (const proxy of proxies.splice(0)) {
       await proxy.server.stop();
     }
-    await fs.rm(temporaryDirectory, { recursive: true, force: true });
+    if (temporaryDirectory !== undefined) {
+      await fs.rm(temporaryDirectory, { recursive: true, force: true });
+    }
     if (originalSocket === undefined) {
       delete process.env.LLXPRT_CREDENTIAL_SOCKET;
     } else {
@@ -277,6 +280,9 @@ describe('Provider credential resolution through a sandbox proxy', () => {
           expiry: Math.floor(Date.now() / 1000) + 3600,
         }
       : undefined;
+    if (temporaryDirectory === undefined) {
+      throw new Error('Temporary proxy directory is not initialized');
+    }
     const server = new CredentialProxyServer({
       tokenStore: new InMemoryTokenStore(token),
       providerKeyStorage: new EmptyProviderKeyStorage(),
@@ -349,7 +355,7 @@ describe('Provider credential resolution through a sandbox proxy', () => {
     expect(failure.kind).toBe('proxy-unavailable');
     expect(failure.diagnostics.provider).toBe(PROVIDER);
     expect(failure.diagnostics.profile).toBe(PROFILE);
-    expect(failure.diagnostics.proxyContacted).toBe(true);
+    expect(failure.diagnostics.proxyContacted).toBe(false);
     expect(failure.message).not.toContain(CREDENTIAL_SECRET);
 
     const parentAfterFailure = await parentResolver.resolveAuthenticationResult(

--- a/packages/providers/src/auth/proxy/__tests__/provider-credential-resolution.e2e.test.ts
+++ b/packages/providers/src/auth/proxy/__tests__/provider-credential-resolution.e2e.test.ts
@@ -12,6 +12,7 @@ import {
   AuthPrecedenceResolver,
   CredentialResolutionError,
   runtimeScopedStates,
+  type IProviderRuntimeContext,
   type OAuthManager,
 } from '@vybestack/llxprt-code-auth';
 import type {
@@ -26,7 +27,7 @@ import {
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
 import { SettingsService } from '@vybestack/llxprt-code-settings';
-import type { ProviderKeyStorage } from '@vybestack/llxprt-code-storage';
+import type { ProviderKeyStorageLike } from '@vybestack/llxprt-code-storage';
 import {
   BaseProvider,
   type NormalizedGenerateChatOptions,
@@ -154,7 +155,7 @@ class InMemoryTokenStore implements TokenStore {
   async releaseAuthLock(_provider: string, _bucket?: string): Promise<void> {}
 }
 
-class EmptyProviderKeyStorage implements ProviderKeyStorage {
+class EmptyProviderKeyStorage implements ProviderKeyStorageLike {
   async saveKey(_name: string, _apiKey: string): Promise<void> {}
 
   async getKey(_name: string): Promise<string | null> {
@@ -269,7 +270,7 @@ describe('Provider credential resolution through a sandbox proxy', () => {
   });
 
   async function startProxy(withCredential: boolean): Promise<RunningProxy> {
-    const token = withCredential
+    const token: OAuthToken | undefined = withCredential
       ? {
           access_token: CREDENTIAL_SECRET,
           token_type: 'Bearer',
@@ -312,6 +313,11 @@ describe('Provider credential resolution through a sandbox proxy', () => {
     const provider = createProvider();
     const parentRuntimeId = 'session-parent-runtime';
     const parentRuntime = createCallOptions(settings, parentRuntimeId).runtime;
+    const getActiveRuntimeContext = (): IProviderRuntimeContext => ({
+      ...parentRuntime,
+      settingsService: settings,
+      runtimeId: parentRuntimeId,
+    });
     const parentResolver = new AuthPrecedenceResolver(
       {
         isOAuthEnabled: true,
@@ -322,7 +328,7 @@ describe('Provider credential resolution through a sandbox proxy', () => {
       {
         oauthManager: createProxyOAuthManager(),
         settingsService: settings,
-        getActiveRuntimeContext: () => parentRuntime,
+        getActiveRuntimeContext,
       },
     );
 

--- a/packages/providers/src/auth/proxy/__tests__/provider-credential-resolution.e2e.test.ts
+++ b/packages/providers/src/auth/proxy/__tests__/provider-credential-resolution.e2e.test.ts
@@ -151,10 +151,7 @@ class InMemoryTokenStore implements TokenStore {
     return true;
   }
 
-  async releaseAuthLock(
-    _provider: string,
-    _bucket?: string,
-  ): Promise<void> {}
+  async releaseAuthLock(_provider: string, _bucket?: string): Promise<void> {}
 }
 
 class EmptyProviderKeyStorage implements ProviderKeyStorage {
@@ -349,11 +346,12 @@ describe('Provider credential resolution through a sandbox proxy', () => {
     expect(failure.diagnostics.proxyContacted).toBe(true);
     expect(failure.message).not.toContain(CREDENTIAL_SECRET);
 
-    const parentAfterFailure =
-      await parentResolver.resolveAuthenticationResult({
+    const parentAfterFailure = await parentResolver.resolveAuthenticationResult(
+      {
         settingsService: settings,
         includeOAuth: true,
-      });
+      },
+    );
     expect(parentAfterFailure.token).toBe(CREDENTIAL_SECRET);
   });
 

--- a/packages/providers/src/credential-resolution-errors.test.ts
+++ b/packages/providers/src/credential-resolution-errors.test.ts
@@ -16,9 +16,11 @@ import { SettingsService } from '@vybestack/llxprt-code-settings';
 import { AnthropicProvider } from './anthropic/AnthropicProvider.js';
 import { resetFactorySingletons } from './auth/proxy/credential-store-factory.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { NormalizedGenerateChatOptions } from './BaseProvider.js';
 import type { IProvider } from './IProvider.js';
 import { OpenAIProvider } from './openai/OpenAIProvider.js';
 import { OpenAIVercelProvider } from './openai-vercel/OpenAIVercelProvider.js';
+import { createCredentialResolutionError } from './utils/credentialResolutionError.js';
 
 const PROFILE = 'issue3451-provider-profile';
 const RUNTIME_ID = 'session#typescriptexpert#provider-surface';
@@ -57,6 +59,23 @@ function createOptions(providerName: string, settings: SettingsService) {
       },
     ],
   });
+}
+
+function createNormalizedOptions(
+  providerName: string,
+  settings: SettingsService,
+  authFailure?: CredentialResolutionError,
+): NormalizedGenerateChatOptions {
+  const options = createOptions(providerName, settings);
+  return {
+    ...options,
+    metadata: options.metadata ?? {},
+    resolved: {
+      model: 'credential-resolution-test-model',
+      authToken: '',
+      ...(authFailure === undefined ? {} : { authFailure }),
+    },
+  };
 }
 
 async function captureProviderFailure(
@@ -165,7 +184,7 @@ describe('Provider credential-resolution error surface', () => {
     });
   }
 
-  it('Anthropic third-party base URL keeps its explicit API-key guidance ahead of the typed failure', async () => {
+  it('Anthropic third-party base URL preserves typed diagnostics and explicit API-key guidance', async () => {
     const baseURL = 'https://api.z.ai/api/anthropic';
     const settings = createSettings('anthropic');
     settings.setProviderSetting('anthropic', 'base-url', baseURL);
@@ -174,9 +193,66 @@ describe('Provider credential-resolution error surface', () => {
 
     const error = await captureError(provider.generateChatCompletion(options));
 
-    expect(error).not.toBeInstanceOf(CredentialResolutionError);
+    expect(error).toBeInstanceOf(CredentialResolutionError);
+    if (!(error instanceof CredentialResolutionError)) {
+      throw new Error('Expected a typed credential-resolution failure');
+    }
+    expect(error.kind).toBe('no-credential-configured');
+    expect(error.diagnostics.profile).toBe(PROFILE);
+    expect(error.diagnostics.runtimeId).toBe(RUNTIME_ID);
+    expect(error.remediation).toContain(
+      `No API key resolved for Anthropic-compatible endpoint "${baseURL}"`,
+    );
     expect(error.message).toContain(
       `No API key resolved for Anthropic-compatible endpoint "${baseURL}"`,
     );
+  });
+
+  it('prefers a live caller failure while retaining resolver diagnostics', () => {
+    const settings = createSettings('openai');
+    const staleCause = new Error('stale resolver failure');
+    const liveCause = new Error('live token refresh failure');
+    const resolverFailure = new CredentialResolutionError(
+      'proxy-unavailable',
+      {
+        provider: 'openai',
+        profile: PROFILE,
+        runtimeId: RUNTIME_ID,
+        attemptedMechanisms: ['oauth'],
+        proxyMode: true,
+        proxyContacted: true,
+      },
+      { cause: staleCause },
+    );
+    const options = createNormalizedOptions(
+      'openai',
+      settings,
+      resolverFailure,
+    );
+
+    const error = createCredentialResolutionError(options, 'openai', {
+      kind: 'credential-source-failed',
+      cause: liveCause,
+    });
+
+    expect(error.kind).toBe('credential-source-failed');
+    expect(error.cause).toBe(liveCause);
+    expect(error.cause).not.toBe(staleCause);
+    expect(error.diagnostics).toEqual(resolverFailure.diagnostics);
+  });
+
+  it('marks fresh failure trace fields unknown instead of asserting no proxy attempt', () => {
+    const settings = createSettings('openai');
+    const options = createNormalizedOptions('openai', settings);
+
+    const error = createCredentialResolutionError(options, 'openai', {
+      kind: 'credential-source-failed',
+      cause: new Error('live token refresh failure'),
+    });
+
+    expect(error.diagnostics.attemptedMechanisms).toBe('unknown');
+    expect(error.diagnostics.proxyContacted).toBe('unknown');
+    expect(error.message).toContain('attemptedMechanisms=unknown');
+    expect(error.message).toContain('proxyContacted=unknown');
   });
 });

--- a/packages/providers/src/credential-resolution-errors.test.ts
+++ b/packages/providers/src/credential-resolution-errors.test.ts
@@ -241,6 +241,37 @@ describe('Provider credential-resolution error surface', () => {
     expect(error.diagnostics).toEqual(resolverFailure.diagnostics);
   });
 
+  it('preserves the resolver failure when a caller explicitly provides an undefined cause', () => {
+    const settings = createSettings('openai');
+    const resolverCause = new Error('resolver transport failure');
+    const resolverFailure = new CredentialResolutionError(
+      'proxy-unavailable',
+      {
+        provider: 'openai',
+        profile: PROFILE,
+        runtimeId: RUNTIME_ID,
+        attemptedMechanisms: ['oauth'],
+        proxyMode: true,
+        proxyContacted: false,
+      },
+      { cause: resolverCause },
+    );
+    const options = createNormalizedOptions(
+      'openai',
+      settings,
+      resolverFailure,
+    );
+
+    const error = createCredentialResolutionError(options, 'openai', {
+      kind: 'credential-source-failed',
+      cause: undefined,
+    });
+
+    expect(error).toBe(resolverFailure);
+    expect(error.kind).toBe('proxy-unavailable');
+    expect(error.cause).toBe(resolverCause);
+  });
+
   it('marks fresh failure trace fields unknown instead of asserting no proxy attempt', () => {
     const settings = createSettings('openai');
     const options = createNormalizedOptions('openai', settings);

--- a/packages/providers/src/credential-resolution-errors.test.ts
+++ b/packages/providers/src/credential-resolution-errors.test.ts
@@ -1,0 +1,182 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { CredentialResolutionError } from '@vybestack/llxprt-code-auth';
+import {
+  clearActiveProviderRuntimeContext,
+  createProviderRuntimeContext,
+  setActiveProviderRuntimeContext,
+} from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { AnthropicProvider } from './anthropic/AnthropicProvider.js';
+import { resetFactorySingletons } from './auth/proxy/credential-store-factory.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { IProvider } from './IProvider.js';
+import { OpenAIProvider } from './openai/OpenAIProvider.js';
+import { OpenAIVercelProvider } from './openai-vercel/OpenAIVercelProvider.js';
+
+const PROFILE = 'issue3451-provider-profile';
+const RUNTIME_ID = 'session#typescriptexpert#provider-surface';
+const UNUSED_PROXY_SOCKET = '/tmp/issue3451-provider-surface-unused.sock';
+const FORBIDDEN_SECRET = 'issue3451-provider-secret';
+
+interface ProviderCase {
+  readonly providerName: string;
+  readonly createProvider: () => IProvider;
+  readonly baseURL: string;
+}
+
+function createSettings(providerName: string): SettingsService {
+  const settings = new SettingsService();
+  settings.set('activeProvider', providerName);
+  settings.setCurrentProfileName(PROFILE);
+  settings.setProviderSetting(providerName, 'streaming', 'disabled');
+  return settings;
+}
+
+function createOptions(providerName: string, settings: SettingsService) {
+  const runtime = createProviderRuntimeContext({
+    settingsService: settings,
+    runtimeId: RUNTIME_ID,
+    metadata: { source: 'credential-resolution-errors.test.ts' },
+  });
+  setActiveProviderRuntimeContext(runtime);
+  return createProviderCallOptions({
+    providerName,
+    settings,
+    runtime,
+    contents: [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'test request' }],
+      },
+    ],
+  });
+}
+
+async function captureProviderFailure(
+  provider: IProvider,
+  settings: SettingsService,
+): Promise<CredentialResolutionError> {
+  const options = createOptions(provider.name, settings);
+  try {
+    await provider.generateChatCompletion(options).next();
+  } catch (error) {
+    if (error instanceof CredentialResolutionError) {
+      return error;
+    }
+    throw error;
+  }
+  throw new Error('Expected provider credential resolution to fail');
+}
+
+async function captureError(
+  iterator: AsyncIterableIterator<IContent>,
+): Promise<Error> {
+  try {
+    await iterator.next();
+  } catch (error) {
+    if (error instanceof Error) {
+      return error;
+    }
+    throw error;
+  }
+  throw new Error('Expected provider call to fail');
+}
+
+describe('Provider credential-resolution error surface', () => {
+  const originalSocket = process.env.LLXPRT_CREDENTIAL_SOCKET;
+  const originalOpenAIKey = process.env.OPENAI_API_KEY;
+  const originalAnthropicKey = process.env.ANTHROPIC_API_KEY;
+
+  beforeEach(() => {
+    process.env.LLXPRT_CREDENTIAL_SOCKET = UNUSED_PROXY_SOCKET;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    resetFactorySingletons();
+  });
+
+  afterEach(() => {
+    clearActiveProviderRuntimeContext();
+    resetFactorySingletons();
+    if (originalSocket === undefined) {
+      delete process.env.LLXPRT_CREDENTIAL_SOCKET;
+    } else {
+      process.env.LLXPRT_CREDENTIAL_SOCKET = originalSocket;
+    }
+    if (originalOpenAIKey === undefined) {
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      process.env.OPENAI_API_KEY = originalOpenAIKey;
+    }
+    if (originalAnthropicKey === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = originalAnthropicKey;
+    }
+  });
+
+  const providerCases: readonly ProviderCase[] = [
+    {
+      providerName: 'openai',
+      createProvider: () =>
+        new OpenAIProvider(undefined, 'https://api.openai.com/v1'),
+      baseURL: 'https://api.openai.com/v1',
+    },
+    {
+      providerName: 'anthropic',
+      createProvider: () => new AnthropicProvider(undefined),
+      baseURL: 'https://api.anthropic.com',
+    },
+    {
+      providerName: 'openaivercel',
+      createProvider: () =>
+        new OpenAIVercelProvider(undefined, 'https://api.openai.com/v1'),
+      baseURL: 'https://api.openai.com/v1',
+    },
+  ];
+
+  for (const providerCase of providerCases) {
+    it(`${providerCase.providerName} throws CredentialResolutionError with safe resolver diagnostics`, async () => {
+      const settings = createSettings(providerCase.providerName);
+      settings.setProviderSetting(
+        providerCase.providerName,
+        'base-url',
+        providerCase.baseURL,
+      );
+      settings.set('issue3451-secret-marker', FORBIDDEN_SECRET);
+      const provider = providerCase.createProvider();
+
+      const error = await captureProviderFailure(provider, settings);
+
+      expect(error.kind).toBe('no-credential-configured');
+      expect(error.message).toContain(`provider=${providerCase.providerName}`);
+      expect(error.message).toContain(`profile=${PROFILE}`);
+      expect(error.message).toContain(`runtimeId=${RUNTIME_ID}`);
+      expect(error.message).toContain('proxyContacted=false');
+      expect(error.message).not.toContain('ProviderCacheError(');
+      expect(error.message).not.toContain(FORBIDDEN_SECRET);
+      expect(JSON.stringify(error.diagnostics)).not.toContain(FORBIDDEN_SECRET);
+    });
+  }
+
+  it('Anthropic third-party base URL keeps its explicit API-key guidance ahead of the typed failure', async () => {
+    const baseURL = 'https://api.z.ai/api/anthropic';
+    const settings = createSettings('anthropic');
+    settings.setProviderSetting('anthropic', 'base-url', baseURL);
+    const provider = new AnthropicProvider(undefined, baseURL);
+    const options = createOptions('anthropic', settings);
+
+    const error = await captureError(provider.generateChatCompletion(options));
+
+    expect(error).not.toBeInstanceOf(CredentialResolutionError);
+    expect(error.message).toContain(
+      `No API key resolved for Anthropic-compatible endpoint "${baseURL}"`,
+    );
+  });
+});

--- a/packages/providers/src/openai-vercel/OpenAIVercelProvider.localAuth.test.ts
+++ b/packages/providers/src/openai-vercel/OpenAIVercelProvider.localAuth.test.ts
@@ -24,7 +24,7 @@
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { OpenAIVercelProvider } from './OpenAIVercelProvider.js';
-import { AuthenticationError } from './errors.js';
+import { CredentialResolutionError } from '@vybestack/llxprt-code-auth';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
 import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
@@ -118,7 +118,7 @@ describe('OpenAIVercelProvider local-endpoint keyless auth (issue #2506)', () =>
     expect(typeof callArgs.apiKey).toBe('string');
   });
 
-  it('throws AuthenticationError for a remote endpoint with no key (no regression)', async () => {
+  it('throws CredentialResolutionError for a remote endpoint with no key', async () => {
     const provider = new OpenAIVercelProvider(undefined, undefined, {
       settingsService,
     });
@@ -146,7 +146,7 @@ describe('OpenAIVercelProvider local-endpoint keyless auth (issue #2506)', () =>
 
     await expect(
       collectResults(provider.generateChatCompletion(options)),
-    ).rejects.toThrow(AuthenticationError);
+    ).rejects.toThrow(CredentialResolutionError);
 
     expect(mockCreateOpenAI).not.toHaveBeenCalled();
   });

--- a/packages/providers/src/openai-vercel/OpenAIVercelProvider.test.ts
+++ b/packages/providers/src/openai-vercel/OpenAIVercelProvider.test.ts
@@ -28,7 +28,7 @@ import {
   clearActiveProviderRuntimeContext,
   setActiveProviderRuntimeContext,
 } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
-import { AuthenticationError } from './errors.js';
+import { CredentialResolutionError } from '@vybestack/llxprt-code-auth';
 import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
 import { SettingsService } from '@vybestack/llxprt-code-settings';
 
@@ -489,7 +489,14 @@ describe('Authentication (REQ-OAV-003)', () => {
       });
 
       const iterator = provider.generateChatCompletion(options);
-      await expect(iterator.next()).rejects.toThrow(AuthenticationError);
+      const rejection = iterator.next();
+      await expect(rejection).rejects.toBeInstanceOf(CredentialResolutionError);
+      await expect(rejection).rejects.toMatchObject({
+        kind: 'no-credential-configured',
+        message: expect.stringContaining(
+          'provider=openaivercel; profile=no-profile; runtimeId=test.provider.runtime',
+        ),
+      });
     });
   });
 

--- a/packages/providers/src/openai-vercel/vercelModelClient.localAuth.test.ts
+++ b/packages/providers/src/openai-vercel/vercelModelClient.localAuth.test.ts
@@ -34,10 +34,23 @@ import { CredentialResolutionError } from '@vybestack/llxprt-code-auth';
 import { createOpenAIClient } from './vercelModelClient.js';
 import type { ProviderClientConfig } from './vercelModelClient.js';
 import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
+import type { ResolvedAuthToken } from '../types/providerRuntime.js';
+
+class RecordingLogger {
+  readonly messages: string[] = [];
+
+  debug(messageOrFactory: string | (() => string), ..._args: unknown[]): void {
+    this.messages.push(
+      typeof messageOrFactory === 'function'
+        ? messageOrFactory()
+        : messageOrFactory,
+    );
+  }
+}
 
 function buildOptions(
   baseURL: string | undefined,
-  authToken: string | undefined,
+  authToken: ResolvedAuthToken | undefined,
 ): NormalizedGenerateChatOptions {
   return {
     settings: {
@@ -145,6 +158,30 @@ describe('createOpenAIClient local-endpoint auth exemption (issue #2506)', () =>
       { requiresAuth: false },
     );
     expect(apiKey).toBe('');
+  });
+
+  it('logs a safe diagnostic when auth resolution fails for an exempt endpoint', async () => {
+    const forbiddenDetail = 'issue3451-sensitive-failure-detail';
+    const logger = new RecordingLogger();
+    const authToken: ResolvedAuthToken = {
+      provide: async () => {
+        throw new Error(forbiddenDetail);
+      },
+    };
+
+    await createOpenAIClient(
+      buildOptions('https://api.openai.com/v1', authToken),
+      buildClientConfig('https://api.openai.com/v1', {
+        requiresAuth: false,
+      }),
+      undefined,
+      logger,
+    );
+
+    const output = logger.messages.join('\n');
+    expect(output).toContain('kind=credential-source-failed');
+    expect(output).toContain('auth-exempt endpoint');
+    expect(output).not.toContain(forbiddenDetail);
   });
 
   it('throws CredentialResolutionError for a non-local endpoint with no key', async () => {

--- a/packages/providers/src/openai-vercel/vercelModelClient.localAuth.test.ts
+++ b/packages/providers/src/openai-vercel/vercelModelClient.localAuth.test.ts
@@ -30,8 +30,8 @@ void vi.mock('@ai-sdk/openai', () => ({
 }));
 
 import { createOpenAI } from '@ai-sdk/openai';
+import { CredentialResolutionError } from '@vybestack/llxprt-code-auth';
 import { createOpenAIClient } from './vercelModelClient.js';
-import { AuthenticationError } from './errors.js';
 import type { ProviderClientConfig } from './vercelModelClient.js';
 import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
 
@@ -147,7 +147,7 @@ describe('createOpenAIClient local-endpoint auth exemption (issue #2506)', () =>
     expect(apiKey).toBe('');
   });
 
-  it('throws AuthenticationError for a non-local endpoint with no key (no regression)', async () => {
+  it('throws CredentialResolutionError for a non-local endpoint with no key', async () => {
     const mockCreateOpenAI = createOpenAI as ReturnType<typeof vi.fn>;
 
     await expect(
@@ -155,7 +155,7 @@ describe('createOpenAIClient local-endpoint auth exemption (issue #2506)', () =>
         buildOptions('https://api.openai.com/v1', undefined),
         buildClientConfig('https://api.openai.com/v1'),
       ),
-    ).rejects.toThrow(AuthenticationError);
+    ).rejects.toThrow(CredentialResolutionError);
 
     expect(mockCreateOpenAI).not.toHaveBeenCalled();
   });

--- a/packages/providers/src/openai-vercel/vercelModelClient.ts
+++ b/packages/providers/src/openai-vercel/vercelModelClient.ts
@@ -23,7 +23,7 @@ import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import { resolveRuntimeAuthToken } from '../utils/authToken.js';
 import { isLocalEndpoint } from '../utils/localEndpoint.js';
 import { isQwenBaseURL } from '../utils/qwenEndpoint.js';
-import { AuthenticationError } from './errors.js';
+import { createCredentialResolutionError } from '../utils/credentialResolutionError.js';
 import { createDeveloperRoleToSystemFetch } from './vercelDeveloperRoleFetch.js';
 import { createReasoningCaptureFetch } from './vercelReasoningCapture.js';
 import type { CaptureBuffer } from './vercelReasoningCapture.js';
@@ -173,18 +173,25 @@ export async function createOpenAIClient(
   clientConfig: ProviderClientConfig,
   customFetch?: typeof fetch,
 ): Promise<ReturnType<typeof createOpenAI>> {
-  const authToken =
-    (await resolveRuntimeAuthToken(options.resolved.authToken)) ?? '';
   const baseURL = options.resolved.baseURL ?? clientConfig.baseURL;
   const shouldForceSystemRole = isQwenBaseURL(baseURL);
-
   const authExempt =
     clientConfig.requiresAuth === false || isLocalEndpoint(baseURL);
+  let authToken = '';
+  try {
+    authToken =
+      (await resolveRuntimeAuthToken(options.resolved.authToken)) ?? '';
+  } catch (cause) {
+    if (!authExempt) {
+      throw createCredentialResolutionError(
+        options,
+        clientConfig.providerName,
+        { kind: 'credential-source-failed', cause },
+      );
+    }
+  }
   if (!authToken && !authExempt) {
-    throw new AuthenticationError(
-      `Auth token unavailable for runtimeId=${options.runtime?.runtimeId} (REQ-SP4-003).`,
-      clientConfig.providerName,
-    );
+    throw createCredentialResolutionError(options, clientConfig.providerName);
   }
 
   const headers = clientConfig.customHeaders;

--- a/packages/providers/src/openai-vercel/vercelModelClient.ts
+++ b/packages/providers/src/openai-vercel/vercelModelClient.ts
@@ -19,7 +19,7 @@ import type { JSONSchema7, LanguageModel, Tool } from 'ai';
 import { createOpenAI } from '@ai-sdk/openai';
 
 import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
-import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import { resolveRuntimeAuthToken } from '../utils/authToken.js';
 import { isLocalEndpoint } from '../utils/localEndpoint.js';
 import { isQwenBaseURL } from '../utils/qwenEndpoint.js';
@@ -172,6 +172,9 @@ export async function createOpenAIClient(
   options: NormalizedGenerateChatOptions,
   clientConfig: ProviderClientConfig,
   customFetch?: typeof fetch,
+  logger: Pick<DebugLogger, 'debug'> = new DebugLogger(
+    'llxprt:provider:openaivercel',
+  ),
 ): Promise<ReturnType<typeof createOpenAI>> {
   const baseURL = options.resolved.baseURL ?? clientConfig.baseURL;
   const shouldForceSystemRole = isQwenBaseURL(baseURL);
@@ -182,13 +185,18 @@ export async function createOpenAIClient(
     authToken =
       (await resolveRuntimeAuthToken(options.resolved.authToken)) ?? '';
   } catch (cause) {
+    const failure = createCredentialResolutionError(
+      options,
+      clientConfig.providerName,
+      { kind: 'credential-source-failed', cause },
+    );
     if (!authExempt) {
-      throw createCredentialResolutionError(
-        options,
-        clientConfig.providerName,
-        { kind: 'credential-source-failed', cause },
-      );
+      throw failure;
     }
+    logger.debug(
+      () =>
+        `Continuing without credentials for auth-exempt endpoint after authentication resolution failed: ${failure.message}`,
+    );
   }
   if (!authToken && !authExempt) {
     throw createCredentialResolutionError(options, clientConfig.providerName);
@@ -236,6 +244,7 @@ export async function createConfiguredModel(
     options,
     clientConfig,
     customFetch,
+    logger,
   );
   const modelId = options.resolved.model || defaultModel;
   const baseModel: LanguageModel =

--- a/packages/providers/src/openai/OpenAIProvider.ts
+++ b/packages/providers/src/openai/OpenAIProvider.ts
@@ -44,6 +44,7 @@ import { ToolCallPipeline } from './ToolCallPipeline.js';
 
 import { isLocalEndpoint } from '../utils/localEndpoint.js';
 import { type DumpMode } from '../utils/dumpContext.js';
+import { createCredentialResolutionError } from '../utils/credentialResolutionError.js';
 
 import { resolveToolFormat } from '../utils/toolFormatDetection.js';
 import { isQwenBaseURL } from '../utils/qwenEndpoint.js';
@@ -215,18 +216,25 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
   protected async getClient(
     options: NormalizedGenerateChatOptions,
   ): Promise<OpenAI> {
-    const authToken =
-      (await resolveRuntimeAuthToken(options.resolved.authToken)) ?? '';
     const baseURL = options.resolved.baseURL ?? this.baseProviderConfig.baseURL;
-
     const requiresAuth = options.settings.getProviderSettings(this.name)[
       'requires-auth'
     ];
     const authExempt = requiresAuth === false || isLocalEndpoint(baseURL);
+    let authToken = '';
+    try {
+      authToken =
+        (await resolveRuntimeAuthToken(options.resolved.authToken)) ?? '';
+    } catch (cause) {
+      if (!authExempt) {
+        throw createCredentialResolutionError(options, this.name, {
+          kind: 'credential-source-failed',
+          cause,
+        });
+      }
+    }
     if (!authToken && !authExempt) {
-      throw new Error(
-        `ProviderCacheError("Auth token unavailable for runtimeId=${options.runtime?.runtimeId} (REQ-SP4-003).")`,
-      );
+      throw createCredentialResolutionError(options, this.name);
     }
 
     const agentSettings = resolveAgentSettings(

--- a/packages/providers/src/openai/OpenAIProvider.ts
+++ b/packages/providers/src/openai/OpenAIProvider.ts
@@ -111,7 +111,7 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
   private readonly toolCallPipeline = new ToolCallPipeline();
   private readonly preparedPromptEnvelopes = new OpenAIPromptEnvelopeStore();
 
-  private getLogger(): DebugLogger {
+  protected getLogger(): DebugLogger {
     return new DebugLogger('llxprt:provider:openai');
   }
 
@@ -226,12 +226,17 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
       authToken =
         (await resolveRuntimeAuthToken(options.resolved.authToken)) ?? '';
     } catch (cause) {
+      const failure = createCredentialResolutionError(options, this.name, {
+        kind: 'credential-source-failed',
+        cause,
+      });
       if (!authExempt) {
-        throw createCredentialResolutionError(options, this.name, {
-          kind: 'credential-source-failed',
-          cause,
-        });
+        throw failure;
       }
+      this.getLogger().debug(
+        () =>
+          `Continuing without credentials for auth-exempt endpoint after authentication resolution failed: ${failure.message}`,
+      );
     }
     if (!authToken && !authExempt) {
       throw createCredentialResolutionError(options, this.name);

--- a/packages/providers/src/openai/__tests__/openai.localEndpoint.test.ts
+++ b/packages/providers/src/openai/__tests__/openai.localEndpoint.test.ts
@@ -21,6 +21,7 @@ import {
   createProviderCallOptions,
   type ProviderCallOptionsInit,
 } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
+import { CredentialResolutionError } from '@vybestack/llxprt-code-auth';
 import { isLocalEndpoint } from '../../utils/localEndpoint.js';
 
 void vi.mock('openai', () => {
@@ -292,7 +293,7 @@ describe('OpenAI local endpoint tests', () => {
     });
 
     describe('remote endpoints require authentication', () => {
-      it('throws REQ-SP4-003 error for api.openai.com without auth', async () => {
+      it('throws a typed credential error for api.openai.com without auth', async () => {
         const provider = new LocalTestOpenAIProvider(
           undefined,
           'https://api.openai.com/v1',
@@ -308,7 +309,16 @@ describe('OpenAI local endpoint tests', () => {
         });
 
         const generator = provider.generateChatCompletion(callOptions);
-        await expect(generator.next()).rejects.toThrow('REQ-SP4-003');
+        const rejection = generator.next();
+        await expect(rejection).rejects.toBeInstanceOf(
+          CredentialResolutionError,
+        );
+        await expect(rejection).rejects.toMatchObject({
+          kind: 'no-credential-configured',
+          message: expect.stringContaining(
+            'provider=openai; profile=no-profile; runtimeId=remote-no-auth',
+          ),
+        });
       });
 
       it('allows remote endpoints with auth token', async () => {

--- a/packages/providers/src/openai/__tests__/openai.requiresAuth.test.ts
+++ b/packages/providers/src/openai/__tests__/openai.requiresAuth.test.ts
@@ -2,6 +2,9 @@ import { restoreEnv, setEnv } from '@vybestack/llxprt-code-test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
 import { SettingsService } from '@vybestack/llxprt-code-settings';
 import { OpenAIProvider } from '../OpenAIProvider.js';
+import type { NormalizedGenerateChatOptions } from '../../BaseProvider.js';
+import type { ResolvedAuthToken } from '../../types/providerRuntime.js';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import OpenAI from 'openai';
 import {
   clearActiveProviderRuntimeContext,
@@ -67,9 +70,38 @@ const FakeOpenAIClass = OpenAI as unknown as {
   reset(): void;
 };
 
+class RecordingDebugLogger extends DebugLogger {
+  readonly messages: string[] = [];
+
+  override debug(
+    messageOrFactory: string | (() => string),
+    ..._args: unknown[]
+  ): void {
+    this.messages.push(
+      typeof messageOrFactory === 'function'
+        ? messageOrFactory()
+        : messageOrFactory,
+    );
+  }
+}
+
 class RequiresAuthTestProvider extends OpenAIProvider {
+  readonly recordingLogger = new RecordingDebugLogger(
+    'llxprt:test:openai-auth-exemption',
+  );
+
   protected override async getAuthToken(): Promise<string> {
     return '';
+  }
+
+  protected override getLogger(): DebugLogger {
+    return this.recordingLogger;
+  }
+
+  async createClientForTest(
+    options: NormalizedGenerateChatOptions,
+  ): Promise<OpenAI> {
+    return this.getClient(options);
   }
 }
 
@@ -97,6 +129,27 @@ function buildCallOptions(
     contents,
     ...rest,
   });
+}
+
+function buildNormalizedOptions(
+  provider: OpenAIProvider,
+  settings: SettingsService,
+  authToken: ResolvedAuthToken,
+): NormalizedGenerateChatOptions {
+  const options = buildCallOptions(provider, {
+    settings,
+    runtimeId: 'auth-exemption-resolution-failure',
+  });
+  return {
+    ...options,
+    metadata: options.metadata ?? {},
+    resolved: {
+      model: 'auth-exemption-test-model',
+      baseURL: 'http://host.docker.internal:1234/v1/',
+      authToken,
+      streaming: false,
+    },
+  };
 }
 
 describe('requires-auth setting', () => {
@@ -136,6 +189,32 @@ describe('requires-auth setting', () => {
     const generator = provider.generateChatCompletion(callOptions);
     await expect(generator.next()).resolves.toBeDefined();
     expect(FakeOpenAIClass.created).toHaveLength(1);
+  });
+
+  it('logs a safe diagnostic when auth resolution fails for an exempt endpoint', async () => {
+    const forbiddenDetail = 'issue3451-sensitive-failure-detail';
+    const provider = new RequiresAuthTestProvider(
+      undefined,
+      'http://host.docker.internal:1234/v1/',
+    );
+    const settings = createSettingsWithRequiresAuth(
+      'http://host.docker.internal:1234/v1/',
+      false,
+    );
+    const authToken: ResolvedAuthToken = {
+      provide: async () => {
+        throw new Error(forbiddenDetail);
+      },
+    };
+
+    await provider.createClientForTest(
+      buildNormalizedOptions(provider, settings, authToken),
+    );
+
+    const output = provider.recordingLogger.messages.join('\n');
+    expect(output).toContain('kind=credential-source-failed');
+    expect(output).toContain('auth-exempt endpoint');
+    expect(output).not.toContain(forbiddenDetail);
   });
 
   it('throws auth error for remote endpoint without auth when requires-auth is not set', async () => {

--- a/packages/providers/src/openai/__tests__/openai.requiresAuth.test.ts
+++ b/packages/providers/src/openai/__tests__/openai.requiresAuth.test.ts
@@ -12,6 +12,7 @@ import {
   createProviderCallOptions,
   type ProviderCallOptionsInit,
 } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
+import { CredentialResolutionError } from '@vybestack/llxprt-code-auth';
 
 void vi.mock('openai', () => {
   class FakeOpenAI {
@@ -152,7 +153,14 @@ describe('requires-auth setting', () => {
     });
 
     const generator = provider.generateChatCompletion(callOptions);
-    await expect(generator.next()).rejects.toThrow('REQ-SP4-003');
+    const rejection = generator.next();
+    await expect(rejection).rejects.toBeInstanceOf(CredentialResolutionError);
+    await expect(rejection).rejects.toMatchObject({
+      kind: 'no-credential-configured',
+      message: expect.stringContaining(
+        'provider=openai; profile=no-profile; runtimeId=auth-required-default',
+      ),
+    });
   });
 
   it('throws auth error for remote endpoint without auth when requires-auth is true', async () => {
@@ -171,6 +179,13 @@ describe('requires-auth setting', () => {
     });
 
     const generator = provider.generateChatCompletion(callOptions);
-    await expect(generator.next()).rejects.toThrow('REQ-SP4-003');
+    const rejection = generator.next();
+    await expect(rejection).rejects.toBeInstanceOf(CredentialResolutionError);
+    await expect(rejection).rejects.toMatchObject({
+      kind: 'no-credential-configured',
+      message: expect.stringContaining(
+        'provider=openai; profile=no-profile; runtimeId=auth-required-explicit',
+      ),
+    });
   });
 });

--- a/packages/providers/src/utils/credentialResolutionError.ts
+++ b/packages/providers/src/utils/credentialResolutionError.ts
@@ -38,10 +38,7 @@ export function createCredentialResolutionError(
 ): CredentialResolutionError {
   if (options.resolved.authFailure !== undefined) {
     const failure = options.resolved.authFailure;
-    const hasLiveCause = Object.prototype.hasOwnProperty.call(
-      fallback,
-      'cause',
-    );
+    const hasLiveCause = fallback.cause !== undefined;
     if (!hasLiveCause && fallback.remediation === undefined) return failure;
     const remediation = fallback.remediation ?? failure.remediation;
     const cause = hasLiveCause ? fallback.cause : failure.cause;

--- a/packages/providers/src/utils/credentialResolutionError.ts
+++ b/packages/providers/src/utils/credentialResolutionError.ts
@@ -23,6 +23,12 @@ function resolveProfile(options: NormalizedGenerateChatOptions): string {
     : 'no-profile';
 }
 
+/**
+ * Builds a provider-facing credential failure. A fallback with an explicit
+ * `cause` represents a failure that happened after resolution, so its kind and
+ * cause take precedence while the resolver diagnostics remain authoritative.
+ * Without a live cause, the resolver's original classification is preserved.
+ */
 export function createCredentialResolutionError(
   options: NormalizedGenerateChatOptions,
   provider: string,
@@ -32,12 +38,21 @@ export function createCredentialResolutionError(
 ): CredentialResolutionError {
   if (options.resolved.authFailure !== undefined) {
     const failure = options.resolved.authFailure;
-    return fallback.remediation === undefined
-      ? failure
-      : new CredentialResolutionError(failure.kind, failure.diagnostics, {
-          ...(failure.cause === undefined ? {} : { cause: failure.cause }),
-          remediation: fallback.remediation,
-        });
+    const hasLiveCause = Object.prototype.hasOwnProperty.call(
+      fallback,
+      'cause',
+    );
+    if (!hasLiveCause && fallback.remediation === undefined) return failure;
+    const remediation = fallback.remediation ?? failure.remediation;
+    const cause = hasLiveCause ? fallback.cause : failure.cause;
+    return new CredentialResolutionError(
+      hasLiveCause ? fallback.kind : failure.kind,
+      failure.diagnostics,
+      {
+        ...(cause === undefined ? {} : { cause }),
+        ...(remediation === undefined ? {} : { remediation }),
+      },
+    );
   }
 
   return new CredentialResolutionError(
@@ -46,9 +61,9 @@ export function createCredentialResolutionError(
       provider,
       profile: resolveProfile(options),
       runtimeId: options.runtime?.runtimeId ?? 'no-runtime',
-      attemptedMechanisms: [],
+      attemptedMechanisms: 'unknown',
       proxyMode: Boolean(process.env.LLXPRT_CREDENTIAL_SOCKET),
-      proxyContacted: false,
+      proxyContacted: 'unknown',
     },
     {
       ...(fallback.cause === undefined ? {} : { cause: fallback.cause }),

--- a/packages/providers/src/utils/credentialResolutionError.ts
+++ b/packages/providers/src/utils/credentialResolutionError.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  CredentialResolutionError,
+  type CredentialResolutionErrorKind,
+} from '@vybestack/llxprt-code-auth';
+import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
+
+interface CredentialFailureFallback {
+  readonly kind: CredentialResolutionErrorKind;
+  readonly cause?: unknown;
+  readonly remediation?: string;
+}
+
+function resolveProfile(options: NormalizedGenerateChatOptions): string {
+  const profile = options.settings.get('currentProfile');
+  return typeof profile === 'string' && profile.trim() !== ''
+    ? profile
+    : 'no-profile';
+}
+
+export function createCredentialResolutionError(
+  options: NormalizedGenerateChatOptions,
+  provider: string,
+  fallback: CredentialFailureFallback = {
+    kind: 'no-credential-configured',
+  },
+): CredentialResolutionError {
+  if (options.resolved.authFailure !== undefined) {
+    const failure = options.resolved.authFailure;
+    return fallback.remediation === undefined
+      ? failure
+      : new CredentialResolutionError(failure.kind, failure.diagnostics, {
+          ...(failure.cause === undefined ? {} : { cause: failure.cause }),
+          remediation: fallback.remediation,
+        });
+  }
+
+  return new CredentialResolutionError(
+    fallback.kind,
+    {
+      provider,
+      profile: resolveProfile(options),
+      runtimeId: options.runtime?.runtimeId ?? 'no-runtime',
+      attemptedMechanisms: [],
+      proxyMode: Boolean(process.env.LLXPRT_CREDENTIAL_SOCKET),
+      proxyContacted: false,
+    },
+    {
+      ...(fallback.cause === undefined ? {} : { cause: fallback.cause }),
+      ...(fallback.remediation === undefined
+        ? {}
+        : { remediation: fallback.remediation }),
+    },
+  );
+}

--- a/project-plans/issue3451/plan.md
+++ b/project-plans/issue3451/plan.md
@@ -14,30 +14,43 @@ sessions on the same host.
 
 ## Root-cause analysis
 
-### Why the parent survives and a new subagent runtime does not
+### On the parent/subagent asymmetry (acceptance criterion 3)
 
-The resolved-credential cache is keyed by `runtimeId`:
+An earlier draft of this plan asserted that the parent survives because it is
+served from a `runtimeId`-scoped credential cache while each freshly minted
+subagent runtime starts cold and must make a live credential-proxy call. **That
+explanation is wrong for the production path and is retracted here.**
 
-- `packages/auth/src/precedence.ts:119` — `runtimeScopedStates = new Map<string, RuntimeScopedState>()`
-- `packages/auth/src/precedence.ts:217` — `runtimeScopedStates.get(runtimeId)`
-- `packages/auth/src/precedence.ts:255-279` — `getValidCachedEntry` keyed by
-  `${runtimeAuthScopeId}::${providerId}::${profileId}`
+The runtime-scoped cache does exist and is keyed by `runtimeId`
+(`packages/auth/src/precedence.ts:119,217,255-279`), and every subagent launch
+does mint a new runtime id
+(`packages/agents/src/core/subagentOrchestrator.ts:598-601`). But
+`AuthPrecedenceResolver` only consults that cache when it is constructed with a
+`getActiveRuntimeContext` callback (`auth-precedence-resolver.ts:154-155`,
+`:429`), and `BaseProvider` does not pass one
+(`packages/providers/src/BaseProvider.ts:164-168`). So for every provider built
+through `BaseProvider`, `tryGetRuntimeState()` returns null and the cache is
+inert. It is also populated only by the OAuth path, so named-key and API-key
+lookups would not be cached there in any case.
 
-Every subagent launch mints a brand-new runtime id:
+Two consequences, stated plainly:
 
-- `packages/agents/src/core/subagentOrchestrator.ts:598-601` —
-  `` `${this.baseSessionId()}#${subagentName}#${suffix}` ``
+1. The asymmetry reported in the issue is **not explained** by this change. What
+   is proven is the second defect below: the cause of a credential-resolution
+   failure was discarded, which is why the symptom was undiagnosable and looked
+   arbitrary.
+2. Acceptance criterion 3 is therefore **not met**. It is conditional ("if the
+   failure is specific to subagent runtimes"), and the evidence available does
+   not establish that it is: subagents launch successfully in concurrent
+   sessions on the same host, and the failure has never been reduced to a
+   deterministic sequence.
 
-So the parent resolves its credential once and is served from its runtime-scoped
-entry on every subsequent call, whereas each new subagent runtime starts with an
-empty cache and must perform a live credential resolution. Inside a sandbox that
-live resolution is the credential-proxy hop
-(`LLXPRT_CREDENTIAL_SOCKET`, `packages/providers/src/auth/proxy/credential-store-factory.ts:283,364`).
-
-This is the asymmetry named in acceptance criterion 3. The cache scoping itself
-is correct: a subagent runtime must not inherit the parent's credential cache.
-What is defective is that the first-call failure in that new scope is flattened
-into an empty string, which is why the symptom is intermittent and undiagnosable.
+Rewiring subagent credential plumbing on this evidence would be a speculative
+fix for a mechanism nobody has demonstrated. The diagnostics delivered here are
+what make the next occurrence diagnosable: the operator will see which mechanism
+was attempted, whether the credential proxy was reached, and whether it refused
+the request or was never contacted at all. That is the prerequisite for
+identifying the real asymmetry rather than guessing at it.
 
 ### Why the message carries no information
 
@@ -123,13 +136,39 @@ diagnostics. Follows the existing redaction convention (`maskToken` in
 ## Explicitly out of scope
 
 - Rewiring subagent credential plumbing. Evidence does not support a categorical
-  subagent auth defect; subagents launch successfully in concurrent sessions.
-  Acceptance criterion 3 is satisfied by identifying the cache-scope mechanism
-  above and fixing the swallowing that made it undiagnosable, not by changing
-  how subagent runtimes obtain credentials.
+  subagent auth defect; subagents launch successfully in concurrent sessions, and
+  the reported failure has never been reduced to a deterministic sequence. See
+  the retraction above: acceptance criterion 3 is **not met**, and closing it
+  would require first reproducing the asymmetry with the diagnostics this change
+  adds.
 - Changing cache scoping, TTLs, or proxy connection lifetime.
 - Retry or reconnect policy for the credential proxy.
+- Cache hit/miss/evicted state in the diagnostics payload. Reporting it would
+  require new instrumentation in `precedence.ts`, and the cache is inert on the
+  `BaseProvider` path anyway.
+- A redaction or serialization boundary for `error.cause`. The public message and
+  diagnostics are free of credential material and tests enforce that; the raw
+  cause is retained deliberately so the originating error survives for debugging.
 - Issues #3449, #3450, #3440.
+
+## Review findings and triage
+
+Two independent reviews were run against the implementation. Accepted and fixed:
+
+| Ref | Severity | Finding                                                                     |
+| --- | -------- | --------------------------------------------------------------------------- |
+| B1  | HIGH     | One broken mechanism aborted the whole precedence chain, so a bad keyfile defeated a working env var or OAuth token. Now recorded per mechanism and the chain continues. |
+| B2  | HIGH     | Anthropic-compatible third-party endpoints threw an untyped `Error`, discarding kind and diagnostics. Now typed, with the actionable text kept as `remediation`. |
+| B3  | HIGH     | A caller's explicit `kind`/`cause` was silently dropped when a resolver failure was already bound, misclassifying live failures. |
+| B4  | HIGH     | `proxyContacted` reported true for connect-level failures where the proxy was never reached, contradicting acceptance criterion 1. |
+| B5  | MEDIUM   | The named-key `/key save` guidance was lost when the throw became a result.  |
+| I1  | MEDIUM   | Provider fallback path hardcoded `proxyContacted: false` and an empty mechanism list, producing contradictory diagnostics. |
+| I2  | LOW      | `oauth` was recorded as attempted even when OAuth was never eligible.        |
+| I3  | LOW      | `afterEach` cleanup could throw and mask a real test failure.                |
+| I4  | LOW      | An auth-exempt endpoint swallowed a genuine proxy failure with no trace.     |
+
+Deferred, with reasons given in the out-of-scope list above: cache-state
+diagnostics, and a redaction boundary for `error.cause`.
 
 ## Test plan (written first, behavioral, `bun:test`)
 

--- a/project-plans/issue3451/plan.md
+++ b/project-plans/issue3451/plan.md
@@ -1,0 +1,188 @@
+# Issue #3451 — Diagnosable credential-resolution failures for subagent runtimes in a sandbox
+
+## Problem restated from evidence
+
+A subagent launch inside a podman sandbox failed with:
+
+```
+ProviderCacheError("Auth token unavailable for runtimeId=8c854271-...#typescriptexpert#ec0977da (REQ-SP4-003).")
+```
+
+while the parent session kept making provider calls on the same stack. The
+failure is intermittent: subagents launch successfully in other concurrent
+sessions on the same host.
+
+## Root-cause analysis
+
+### Why the parent survives and a new subagent runtime does not
+
+The resolved-credential cache is keyed by `runtimeId`:
+
+- `packages/auth/src/precedence.ts:119` — `runtimeScopedStates = new Map<string, RuntimeScopedState>()`
+- `packages/auth/src/precedence.ts:217` — `runtimeScopedStates.get(runtimeId)`
+- `packages/auth/src/precedence.ts:255-279` — `getValidCachedEntry` keyed by
+  `${runtimeAuthScopeId}::${providerId}::${profileId}`
+
+Every subagent launch mints a brand-new runtime id:
+
+- `packages/agents/src/core/subagentOrchestrator.ts:598-601` —
+  `` `${this.baseSessionId()}#${subagentName}#${suffix}` ``
+
+So the parent resolves its credential once and is served from its runtime-scoped
+entry on every subsequent call, whereas each new subagent runtime starts with an
+empty cache and must perform a live credential resolution. Inside a sandbox that
+live resolution is the credential-proxy hop
+(`LLXPRT_CREDENTIAL_SOCKET`, `packages/providers/src/auth/proxy/credential-store-factory.ts:283,364`).
+
+This is the asymmetry named in acceptance criterion 3. The cache scoping itself
+is correct: a subagent runtime must not inherit the parent's credential cache.
+What is defective is that the first-call failure in that new scope is flattened
+into an empty string, which is why the symptom is intermittent and undiagnosable.
+
+### Why the message carries no information
+
+Three layers discard the cause:
+
+1. `packages/auth/src/auth-precedence-resolver.ts:352-357` —
+   `fetchAndCacheOAuthToken` catches every error and returns `null`, logging only
+   under `DEBUG`. A proxy transport failure and "nothing configured" become the
+   same `null`.
+2. `packages/auth/src/auth-precedence-resolver.ts:644-652` — `readKeyFile`
+   catches and returns `null` the same way.
+3. `packages/providers/src/BaseProvider.ts:826-833` — `resolveAuthentication()`
+   returning `null` becomes `''`, and the provider renders `''` as the
+   `ProviderCacheError(...)` string at
+   `AnthropicProvider.ts:220`, `OpenAIProvider.ts:228`,
+   `openai-vercel/vercelModelClient.ts:185`.
+
+The transport layer below already produces precise, distinguishable errors and
+every one of them is thrown away: `packages/auth/src/proxy/proxy-socket-client.ts`
+distinguishes `UNAUTHORIZED` handshake rejection, generic handshake failure,
+per-request timeout (`REQUEST_TIMEOUT_MS = 30000`), and
+`Credential proxy connection lost`, and it idle-closes the connection after
+`IDLE_TIMEOUT_MS = 300000`. A subagent launched after the parent has been quiet
+is exactly the case that must reconnect.
+
+## Accepted behavior
+
+### AB1 — Typed credential-resolution error
+
+A `CredentialResolutionError` is thrown instead of an interpolated
+`ProviderCacheError(...)` string. It carries a discriminated `kind`:
+
+| kind                       | meaning                                                     |
+| -------------------------- | ----------------------------------------------------------- |
+| `no-credential-configured` | no auth mechanism was configured for the provider/profile   |
+| `credential-not-found`     | source was reached, credential absent (proxy `NOT_FOUND`)   |
+| `credential-source-failed` | configured source failed (keyfile unreadable, lookup threw) |
+| `proxy-unavailable`        | credential proxy transport failed                           |
+| `proxy-unauthorized`       | credential proxy refused the capability token               |
+
+`proxy-unavailable` and `proxy-unauthorized` satisfy acceptance criterion 2:
+transport failure is a distinct `kind` from `no-credential-configured` and
+`credential-not-found`, both in the type and in the message.
+
+### AB2 — Diagnostics payload
+
+The error carries, and its operator-facing message states:
+
+- `provider` — provider id being resolved
+- `profile` — profile name, or an explicit "no profile" marker
+- `runtimeId` — the failing runtime id
+- `attemptedMechanisms` — ordered list of what was tried, e.g.
+  `provider-auth-key`, `provider-auth-keyfile`, `global-auth-key-name`,
+  `env:<VAR>`, `oauth`
+- `proxyMode` — whether the process is in credential-proxy mode
+- `proxyContacted` — whether a request actually reached the proxy
+
+This satisfies acceptance criterion 1.
+
+### AB3 — Stop swallowing causes
+
+`readKeyFile` and `fetchAndCacheOAuthToken` stop converting failures into a
+silent `null`. Each records the underlying error so the resolver can classify it.
+The originating error is preserved as `cause`.
+
+`resolveAuthentication()` keeps its `Promise<string | null>` contract so
+`hasNonOAuthAuthentication` and `isOAuthOnlyAvailable` are unaffected. A new
+result-returning entry point exposes the failure to callers that need it.
+
+### AB4 — Provider call sites throw the typed error
+
+`AnthropicProvider`, `OpenAIProvider` and `vercelModelClient` throw the typed
+error carrying the resolver's diagnostics when resolution failed, and a
+`no-credential-configured` error naming provider/profile/runtimeId/proxyMode when
+nothing was configured.
+
+### AB5 — Secrets stay out of the payload
+
+No credential value, capability token or key material appears in the message or
+diagnostics. Follows the existing redaction convention (`maskToken` in
+`precedence.ts`, `REDACTED` in `oauth-errors.ts`).
+
+## Explicitly out of scope
+
+- Rewiring subagent credential plumbing. Evidence does not support a categorical
+  subagent auth defect; subagents launch successfully in concurrent sessions.
+  Acceptance criterion 3 is satisfied by identifying the cache-scope mechanism
+  above and fixing the swallowing that made it undiagnosable, not by changing
+  how subagent runtimes obtain credentials.
+- Changing cache scoping, TTLs, or proxy connection lifetime.
+- Retry or reconnect policy for the credential proxy.
+- Issues #3449, #3450, #3440.
+
+## Test plan (written first, behavioral, `bun:test`)
+
+No mock theater. Transport failures are exercised against a real unix-socket
+server, following `packages/auth/src/proxy/__tests__/proxy-socket-client.test.ts`.
+
+### T1 — resolver classification (`packages/auth`)
+
+1. Nothing configured → `kind: 'no-credential-configured'`, `proxyContacted:false`,
+   `attemptedMechanisms` lists what was checked.
+2. Named key configured, storage returns `null` → `kind: 'credential-not-found'`.
+3. Named key configured, storage throws a transport error → `kind:'proxy-unavailable'`,
+   `proxyContacted: true`, `cause` preserved.
+4. Proxy handshake rejects with `UNAUTHORIZED` → `kind: 'proxy-unauthorized'`.
+5. `auth-keyfile` points at an unreadable path → `kind:'credential-source-failed'`,
+   cause preserved, and the failure is no longer silent.
+6. OAuth manager `getToken` throws → surfaces as a classified failure rather than
+   `null`.
+7. Message and diagnostics contain no credential material for every case above.
+
+### T2 — runtime-scope asymmetry (`packages/auth`)
+
+Proves the AC3 mechanism against the real `precedence.ts` cache:
+
+1. A runtime that has already resolved serves from cache and performs no live
+   credential call.
+2. A second, freshly minted runtime id for the same provider/profile misses the
+   cache and performs a live call.
+3. When that live call fails, the second runtime raises a classified
+   `CredentialResolutionError` while the first continues to resolve from cache.
+
+### T3 — provider surface (`packages/providers`)
+
+For `OpenAIProvider`, `AnthropicProvider` and `vercelModelClient`:
+
+1. Failed resolution throws `CredentialResolutionError`, not a string containing
+   `ProviderCacheError(`.
+2. The message names provider, profile and proxy-contacted status.
+3. `requires-auth: false` and local-endpoint exemptions still bypass the error.
+
+### T4 — end to end under a sandboxed proxy (`packages/providers`)
+
+Using the existing credential-proxy test harness:
+
+1. Proxy up, credential present → subagent-shaped runtime resolves successfully.
+2. Proxy socket closed before the subagent runtime's first call → the launch
+   fails with `kind: 'proxy-unavailable'` naming the profile and provider, while
+   a parent runtime with a warm cache is unaffected.
+3. Proxy up, credential absent for that profile → `kind:'credential-not-found'`,
+   distinguishable from case 2.
+
+## Verification
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+`npm run build`, then
+`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.


### PR DESCRIPTION
## TLDR

A subagent launch inside a podman sandbox failed with an opaque string and nothing an operator could act on:

```
ProviderCacheError("Auth token unavailable for runtimeId=8c854271-...#typescriptexpert#ec0977da (REQ-SP4-003).")
```

That message could mean no credential was configured, or the credential proxy refused the request, or the proxy was never reachable. Three layers were discarding the real cause before it ever reached the operator.

This replaces it with a typed `CredentialResolutionError` carrying a discriminated `kind`, so a proxy transport failure is distinguishable from a missing credential both in the message and in the error type. It names the provider, the profile, the runtime id, which auth mechanisms were tried, and whether the proxy was actually contacted.

**Reviewers should read the "Acceptance criterion 3" section below.** My original root-cause analysis was wrong, review caught it, and I have retracted it rather than leave a tidy but false story in the repo. AC3 is not met and I explain why closing it would require guessing.

## Dive Deeper

### What was swallowing the cause

The transport layer already produces precise, distinguishable errors. `packages/auth/src/proxy/proxy-socket-client.ts` separates `UNAUTHORIZED` handshake rejection, generic handshake failure, a 30s request timeout, and `Credential proxy connection lost`. Every one of them was thrown away:

- `auth-precedence-resolver.ts` `fetchAndCacheOAuthToken` caught every error and returned `null`, logged only under `DEBUG`.
- `auth-precedence-resolver.ts` `readKeyFile` did the same.
- `BaseProvider` turned `null` into `''`, which the three provider sites rendered as the `ProviderCacheError(...)` string.

### What this adds

`CredentialResolutionError` with five kinds:

| kind | meaning |
| --- | --- |
| `no-credential-configured` | nothing configured for that provider/profile |
| `credential-not-found` | source reached, credential absent |
| `credential-source-failed` | a configured source failed |
| `proxy-unavailable` | credential proxy transport failure |
| `proxy-unauthorized` | proxy refused the capability token |

`resolveAuthentication()` keeps its `Promise<string | null>` contract, so `hasNonOAuthAuthentication()` and `isOAuthOnlyAvailable()` are unaffected. A new `resolveAuthenticationResult()` exposes the classified failure, which `BaseProvider` plumbs to `AnthropicProvider`, `OpenAIProvider` and `vercelModelClient` via `resolved.authFailure`, cleared per call.

Operator remediation text (`/key`, `/keyfile`, `/auth claudecode`, `/key save <name>`) is carried on the typed error rather than dropped, so the structured diagnostics do not cost you the actionable guidance.

No credential value, capability token or key material appears in any message or diagnostics, and tests enforce that.

### Acceptance criterion 3, and what I got wrong

My first analysis claimed the parent survives because it is served from a `runtimeId`-scoped credential cache while each freshly minted subagent runtime starts cold and must make a live proxy call. Review checked it against the code and it does not hold.

`AuthPrecedenceResolver` only consults that cache when constructed with a `getActiveRuntimeContext` callback (`auth-precedence-resolver.ts:154-155,429`), and `BaseProvider` never passes one (`BaseProvider.ts:164-168`). The cache is inert on the production path, and it is OAuth-only besides, so named-key and API-key lookups would not be cached there anyway. I verified this independently before retracting.

So **AC3 is not met**. It is conditional ("if the failure is specific to subagent runtimes"), and the evidence does not establish that it is: subagents launch successfully in concurrent sessions on the same host, and the failure has never been reduced to a deterministic sequence. Rewiring subagent credential plumbing on this evidence would be a speculative fix for a mechanism nobody has demonstrated. The diagnostics here are the prerequisite for identifying the real asymmetry next time instead of guessing. The retraction is recorded in `project-plans/issue3451/plan.md`.

AC1, AC2 and AC4 are met.

### Review findings

Two independent reviews ran against the implementation. Nine findings accepted and fixed:

| Ref | Severity | Finding |
| --- | --- | --- |
| B1 | HIGH | One broken mechanism aborted the whole precedence chain, so an unreadable keyfile would defeat a working `ANTHROPIC_API_KEY` or OAuth token. This was a regression introduced by the fix itself and would have broken working setups. Failures are now recorded per mechanism and the chain continues. |
| B2 | HIGH | Anthropic-compatible third-party endpoints (z.ai and similar, exactly where sandboxed subagents run) still threw an untyped `Error`, silently defeating AC1 and AC2. |
| B3 | HIGH | A caller's explicit `kind`/`cause` was discarded when a resolver failure was already bound, misclassifying live failures. |
| B4 | HIGH | `proxyContacted` reported `true` for connect-level failures where the proxy was never reached, contradicting AC1. |
| B5 | MEDIUM | The named-key `/key save` guidance was lost when the throw became a result. |
| I1 | MEDIUM | Provider fallback path hardcoded contradictory diagnostics. |
| I2 | LOW | `oauth` recorded as attempted when it was never eligible. |
| I3 | LOW | `afterEach` cleanup could throw and mask a real test failure. |
| I4 | LOW | An auth-exempt endpoint swallowed a genuine proxy failure with no trace. |

Deferred with reasons recorded in the plan: cache hit/miss/evicted state in diagnostics (would need new instrumentation in `precedence.ts`, and the cache is inert on this path), and a redaction boundary for `error.cause` (public message and diagnostics are already clean and tested; the raw cause is retained deliberately for debugging).

## Reviewer Test Plan

The interesting behavior is at the socket boundary, and the tests exercise a real `CredentialProxyServer` over a real unix socket rather than mocking it.

```bash
cd packages/auth && bun run-bun-tests.ts
cd packages/providers && bun ../../scripts/run_bun_tests.ts --workspace providers
```

Targeted files:

- `packages/auth/src/__tests__/credential-resolution.test.ts` — classification of each failure path, real proxy disconnect and real `UNAUTHORIZED` handshake rejection, and assertions that no credential material reaches the message or diagnostics
- `packages/providers/src/credential-resolution-errors.test.ts` — all three provider sites throw the typed error and the thrown value no longer contains `ProviderCacheError(`, with `requires-auth: false` and local-endpoint exemptions still bypassing
- `packages/providers/src/auth/proxy/__tests__/provider-credential-resolution.e2e.test.ts` — proxy up with credential present, proxy closed before a subagent-shaped runtime's first call (`proxy-unavailable`, `proxyContacted: false`), and proxy up with credential absent (`credential-not-found`), proving the transport case is distinguishable from the missing case

To see the change by hand, run a sandboxed session against a profile with no credential configured and compare the error to the old opaque string.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: `npm run test` (exit 0), `npm run lint` (0 errors), `npm run typecheck` (0 errors), `npm run build`, `npm run format`, and the `stepfun-37` startup smoke test. Providers 584/584 and auth 44/44 on the rebased head. Windows and Linux left unmarked because I did not run them; CI covers those.

## Linked issues / bugs

Fixes #3451

Related, from the same session, not addressed here: #3449, #3450, #3440.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured credential-resolution results with categorized failures and diagnostic details.
  * Improved authentication fallback when configured keyfiles are unavailable.
  * Added runtime-aware credential caching and proxy connectivity diagnostics.
  * Providers now offer targeted remediation messages for missing or invalid credentials.
  * Auth-exempt endpoints can continue without credentials while recording safe debug diagnostics.

* **Bug Fixes**
  * Prevented credentials and key material from appearing in errors or logs.
  * Improved detection and classification of unavailable, disconnected, or unauthorized credential proxies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->