### PR TITLE
Make Lint (Javascript) green on dev/0.12.0: strip peer flags, apply prettier, fix jest lint rules (Fixes #3484, #3487, #3489)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -863,29 +863,15 @@ export default tseslint.config(
           ],
         },
       ],
-      // 'warn', deliberately, and not a lowering of the bar. The harm this
-      // rule is named for -- a test that may not assert -- is caught by
-      // jest/no-conditional-expect above, which is 'error' and currently
-      // reports zero violations. This rule is the broader one: it flags any
-      // conditional lexically inside a test, so it also catches branching in
-      // mock implementations, array callbacks and polling loops, which is
-      // ordinary code that happens to live in an it().
-      //
-      // Measured over the tree: of 785 reports, 36 wrapped an actual expect(),
-      // and exactly ONE made a test pass vacuously
-      // (chatSession.media-history.test.ts, where `?? []` let an assertion
-      // about a second request succeed when no second request existed). That
-      // one is fixed. The rest are worth cleaning up as the files are touched,
-      // which a warning supports and a red build does not.
-      'jest/no-conditional-in-test': 'warn',
+      // 'off' since #3489 (option 4): the 785-report measurement and the
+      // history of the warn choice live in 376bf0105 and #3489.
+      'jest/no-conditional-in-test': 'off', // eslint-policy-allow-off: #2970/#3489 harmful subset enforced by jest/no-conditional-expect at error; 781 remaining reports tracked in #3129
       'jest/prefer-strict-equal': 'error',
-      // 'warn' for a mechanical reason: the remaining reports are hooks
-      // registered from shared lifecycle helper functions. They are correctly
-      // scoped at runtime -- the helper is called inside a describe -- but the
-      // rule only sees that they are not lexically nested, and unlike
-      // no-standalone-expect it has no additionalTestBlockFunctions option to
-      // declare them. Satisfying it would mean inlining shared setup into
-      // every describe, duplicating it for no behavioural gain.
+      // Hooks registered from shared lifecycle helpers are wrapped in a
+      // per-file root describe (see #3489), so the helper stays defined
+      // once and every hook is lexically inside a describe. The rule stays
+      // on so every file, including new ones, must nest hooks inside a
+      // describe.
       'jest/require-top-level-describe': 'warn',
       'jest/valid-expect': 'error',
       // vitest/no-import-node-test → no-restricted-imports banning node:test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1043,7 +1043,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1092,7 +1091,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -3502,7 +3500,6 @@
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3587,7 +3584,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4536,7 +4532,6 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5480,7 +5475,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6199,7 +6193,6 @@
       "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -9523,7 +9516,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -10741,7 +10733,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.4.tgz",
       "integrity": "sha512-AGEwKIyRMHRv1t8Wjwa3LHxQ61X5CqrdFT+4BRNTpqS5aJNnpl5WLjADb7vFlJzI/8uK7T5QLVApCMQKNa3LgQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -11037,7 +11028,6 @@
       "resolved": "https://registry.npmjs.org/@jrichman/ink/-/ink-6.4.8.tgz",
       "integrity": "sha512-v0thcXIKl9hqF/1w4HqA6MKxIcMoWSP3YtEZIAA+eeJngXpN5lGnMkb6rllB7FnOdwyEyYaFTcu1ZVr4/JZpWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.2.1",
         "ansi-escapes": "^7.0.0",
@@ -14270,7 +14260,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14281,7 +14270,6 @@
       "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
@@ -16365,8 +16353,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "devOptional": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/turndown": {
       "version": "7.2.4",
@@ -16521,7 +16508,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17431,7 +17417,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/packages/agents/src/api/__tests__/providerActivation.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/providerActivation.behavior.test.ts
@@ -148,7 +148,7 @@ describe('ProviderActivationIntent / executeProviderActivation (#2374)', () => {
       const chunks: string[] = [];
       for await (const chunk of active!.generateChatCompletion([])) {
         const text = chunk.blocks
-          .map((block) => (blockTextOrEmpty(block)))
+          .map((block) => blockTextOrEmpty(block))
           .join('');
         chunks.push(text);
       }

--- a/packages/agents/src/api/__tests__/sessionControl.concurrency.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/sessionControl.concurrency.behavior.test.ts
@@ -492,9 +492,7 @@ describe('SessionControl concurrency + atomicity (issue #1604 A1/A2/A3) @plan:PL
 
       expect(thrown).toBeInstanceOf(AggregateError);
       expect(
-        (thrown as AggregateError).errors.map((error) =>
-          errorMessage(error),
-        ),
+        (thrown as AggregateError).errors.map((error) => errorMessage(error)),
       ).toStrictEqual(['clear failed', 'resubscribe failed']);
       await control.dispose();
     });

--- a/packages/agents/src/core/promptEnvelopeSendSeam.test.ts
+++ b/packages/agents/src/core/promptEnvelopeSendSeam.test.ts
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { assertInstanceOf, errorMessage } from '@vybestack/llxprt-code-test-utils';
+import {
+  assertInstanceOf,
+  errorMessage,
+} from '@vybestack/llxprt-code-test-utils';
 import { describe, expect, it } from 'bun:test';
 import type { RuntimeGenerateChatOptions } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProviderChat.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
@@ -344,11 +347,10 @@ describe('preparePromptEnvelopeAfterEnforcement', () => {
       AggregateError,
       'Expected aggregate cleanup failure',
     );
-    expect(
-      thrown.errors.map((error) =>
-        errorMessage(error),
-      ),
-    ).toStrictEqual(['first cleanup failed', 'second cleanup failed']);
+    expect(thrown.errors.map((error) => errorMessage(error))).toStrictEqual([
+      'first cleanup failed',
+      'second cleanup failed',
+    ]);
   });
 
   it('prepares a fresh projection after releasing the prior projection for the same contents', async () => {

--- a/packages/cli/src/config/__tests__/profileBootstrap.parseBoundary.test.ts
+++ b/packages/cli/src/config/__tests__/profileBootstrap.parseBoundary.test.ts
@@ -67,9 +67,9 @@ describe('parseInlineProfile — same content as the on-disk parse boundary (#26
       // invisible temp-directory leaks. process.emitWarning rather than
       // console.* because the repo bans console statements.
       process.emitWarning(
-        `parseBoundary test: failed to remove ${tempDir}: ${
-          errorMessage(error)
-        }`,
+        `parseBoundary test: failed to remove ${tempDir}: ${errorMessage(
+          error,
+        )}`,
       );
     }
   });

--- a/packages/cli/src/config/sandboxEnvGuard.behavior.test.ts
+++ b/packages/cli/src/config/sandboxEnvGuard.behavior.test.ts
@@ -32,438 +32,452 @@ void vi.mock('command-exists', () => ({
 
 const { loadSandboxConfig } = await import('./sandboxConfig.js');
 
-const CONFIG = { command: 'docker', image: 'test' } as const;
-const SENTINEL = 'sentinel-2958-ambient-key';
-const NEWLINE = String.fromCharCode(10);
-const AMBIENT_API_KEY_VAR = 'GEMINI_API_KEY';
+describe('sandbox-env-guard', () => {
+  const CONFIG = { command: 'docker', image: 'test' } as const;
+  const SENTINEL = 'sentinel-2958-ambient-key';
+  const NEWLINE = String.fromCharCode(10);
+  const AMBIENT_API_KEY_VAR = 'GEMINI_API_KEY';
 
-/**
- * The launcher controls a repository `.env` must never be able to set. Written
- * out independently of the production set so the suite states the security
- * requirement rather than mirroring the implementation.
- */
-const LAUNCHER_ENV_VARS = [
-  'SANDBOX_FLAGS',
-  'SANDBOX_ENV',
-  'LLXPRT_SANDBOX_MOUNTS',
-  'SANDBOX_MOUNTS',
-  'LLXPRT_SANDBOX',
-  'SANDBOX',
-  'LLXPRT_SANDBOX_IMAGE',
-  'BUILD_SANDBOX',
-  'SEATBELT_PROFILE',
-  'LLXPRT_SANDBOX_NETWORK',
-  'SANDBOX_NETWORK',
-  'LLXPRT_SANDBOX_PROXY_COMMAND',
-  'LLXPRT_SANDBOX_CPUS',
-  'SANDBOX_CPUS',
-  'LLXPRT_SANDBOX_MEMORY',
-  'SANDBOX_MEMORY',
-  'LLXPRT_SANDBOX_PIDS',
-  'SANDBOX_PIDS',
-  'SANDBOX_PORTS',
-  'LLXPRT_SANDBOX_SSH_AGENT',
-  'SANDBOX_SSH_AGENT',
-  'SANDBOX_SET_UID_GID',
-  'LLXPRT_CONFIG_HOME',
-  'LLXPRT_DATA_HOME',
-  'LLXPRT_CACHE_HOME',
-  'LLXPRT_LOG_HOME',
-] as const;
+  /**
+   * The launcher controls a repository `.env` must never be able to set. Written
+   * out independently of the production set so the suite states the security
+   * requirement rather than mirroring the implementation.
+   */
+  const LAUNCHER_ENV_VARS = [
+    'SANDBOX_FLAGS',
+    'SANDBOX_ENV',
+    'LLXPRT_SANDBOX_MOUNTS',
+    'SANDBOX_MOUNTS',
+    'LLXPRT_SANDBOX',
+    'SANDBOX',
+    'LLXPRT_SANDBOX_IMAGE',
+    'BUILD_SANDBOX',
+    'SEATBELT_PROFILE',
+    'LLXPRT_SANDBOX_NETWORK',
+    'SANDBOX_NETWORK',
+    'LLXPRT_SANDBOX_PROXY_COMMAND',
+    'LLXPRT_SANDBOX_CPUS',
+    'SANDBOX_CPUS',
+    'LLXPRT_SANDBOX_MEMORY',
+    'SANDBOX_MEMORY',
+    'LLXPRT_SANDBOX_PIDS',
+    'SANDBOX_PIDS',
+    'SANDBOX_PORTS',
+    'LLXPRT_SANDBOX_SSH_AGENT',
+    'SANDBOX_SSH_AGENT',
+    'SANDBOX_SET_UID_GID',
+    'LLXPRT_CONFIG_HOME',
+    'LLXPRT_DATA_HOME',
+    'LLXPRT_CACHE_HOME',
+    'LLXPRT_LOG_HOME',
+  ] as const;
 
-/**
- * The storage roots double as the test harness's isolation mechanism: the
- * repo-root preload points them at a per-process temp directory so nothing
- * touches the developer's real config. The per-test reset must leave them
- * alone, or every case in this file would resolve Storage against the real
- * user directories. Individual tests still clear one deliberately.
- */
-const STORAGE_ROOT_ENV_VARS = new Set<string>([
-  'LLXPRT_CONFIG_HOME',
-  'LLXPRT_DATA_HOME',
-  'LLXPRT_CACHE_HOME',
-  'LLXPRT_LOG_HOME',
-]);
+  /**
+   * The storage roots double as the test harness's isolation mechanism: the
+   * repo-root preload points them at a per-process temp directory so nothing
+   * touches the developer's real config. The per-test reset must leave them
+   * alone, or every case in this file would resolve Storage against the real
+   * user directories. Individual tests still clear one deliberately.
+   */
+  const STORAGE_ROOT_ENV_VARS = new Set<string>([
+    'LLXPRT_CONFIG_HOME',
+    'LLXPRT_DATA_HOME',
+    'LLXPRT_CACHE_HOME',
+    'LLXPRT_LOG_HOME',
+  ]);
 
-let originalCwd = '';
-let originalEnv: NodeJS.ProcessEnv;
-let tempDirs: string[] = [];
+  let originalCwd = '';
+  let originalEnv: NodeJS.ProcessEnv;
+  let tempDirs: string[] = [];
 
-function makeTempDir(prefix: string): string {
-  const dir = fs.realpathSync(
-    fs.mkdtempSync(path.join(os.tmpdir(), `issue-2958-${prefix}`)),
-  );
-  tempDirs.push(dir);
-  return dir;
-}
-
-function useRepoSandboxHarness(): void {
-  beforeEach(() => {
-    originalCwd = process.cwd();
-    originalEnv = { ...process.env };
-    tempDirs = [];
-    for (const key of LAUNCHER_ENV_VARS) {
-      if (!STORAGE_ROOT_ENV_VARS.has(key)) delete process.env[key];
-    }
-    delete process.env.GEMINI_API_KEY;
-    delete process.env.MY_PROJECT_VAR;
-    process.chdir(makeTempDir('repo-'));
-  });
-
-  afterEach(() => {
-    process.chdir(originalCwd);
-    for (const dir of tempDirs.splice(0)) {
-      fs.rmSync(dir, { recursive: true, force: true });
-    }
-    for (const key of Object.keys(process.env)) {
-      delete process.env[key];
-    }
-    for (const [key, value] of Object.entries(originalEnv)) {
-      if (value !== undefined) process.env[key] = value;
-    }
-  });
-}
-
-function writeDotEnv(relativePath: string, content: string): void {
-  const absolutePath = path.join(process.cwd(), relativePath);
-  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
-  fs.writeFileSync(absolutePath, content);
-}
-
-function runArgs(): string[] {
-  return buildContainerRunArgs(
-    CONFIG,
-    'sandbox:0.11.0',
-    process.cwd(),
-    '/workspace',
-    process.cwd(),
-  );
-}
-
-interface StartupProbeResult {
-  readonly env: Record<string, string | null>;
-  readonly sentinelInArgs: boolean;
-}
-
-/**
- * Runs the real startup order — the settings loader, then the loader
- * `loadCliConfig` calls — in a child process whose storage roots are UNSET,
- * which is the normal production state and the state the config-root poisoning
- * bypass needs. It cannot be reproduced in-process: the suite's isolation
- * preload sets those roots, and clearing them there would drop the test onto
- * the developer's real configuration. The child is isolated instead by pointing
- * HOME at a temp directory before it starts, so every platform default it
- * computes lands under that directory.
- */
-function runRealStartupSequence(repoDir: string): StartupProbeResult {
-  const configDir = path.dirname(fileURLToPath(import.meta.url));
-  const importPath = (relative: string): string =>
-    JSON.stringify(path.join(configDir, relative));
-  const probePath = path.join(repoDir, 'startup-probe.ts');
-  fs.writeFileSync(
-    probePath,
-    [
-      `import { loadEnvironment as loadFromSettings } from ${importPath('settings.js')};`,
-      `import { loadEnvironment as loadFromEnvLoader } from ${importPath('environmentLoader.js')};`,
-      `import { buildContainerRunArgs } from ${importPath('../utils/sandbox-containers.js')};`,
-      `loadFromSettings({});`,
-      `loadFromEnvLoader();`,
-      `const args = buildContainerRunArgs({ command: 'docker', image: 'test' }, 'sandbox:0.11.0', process.cwd(), '/workspace', process.cwd());`,
-      `const reported = ${JSON.stringify(LAUNCHER_ENV_VARS)};`,
-      `const env = Object.fromEntries(reported.map((k) => [k, process.env[k] ?? null]));`,
-      `console.log(JSON.stringify({`,
-      `  env,`,
-      `  sentinelInArgs: args.join(' ').includes(${JSON.stringify(SENTINEL)}),`,
-      `}));`,
-    ].join(NEWLINE),
-  );
-
-  const result = spawnSync(process.execPath, [probePath], {
-    cwd: repoDir,
-    encoding: 'utf8',
-    env: {
-      PATH: process.env.PATH ?? '',
-      HOME: makeTempDir('home-'),
-      // Computed key: a literal Gemini-prefixed object property would trip the
-      // provider-agnostic naming guard in packages/agents.
-      [AMBIENT_API_KEY_VAR]: SENTINEL,
-    },
-  });
-  if (result.status !== 0) {
-    throw new Error(`startup probe failed: ${result.stderr}`);
+  function makeTempDir(prefix: string): string {
+    const dir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), `issue-2958-${prefix}`)),
+    );
+    tempDirs.push(dir);
+    return dir;
   }
-  return JSON.parse(result.stdout.trim()) as StartupProbeResult;
-}
 
-describe('sandboxEnvGuard', () => {
-  describe('a repo .env cannot set sandbox launcher variables', () => {
-    useRepoSandboxHarness();
-
-    it('T1 (AC1, AC4): SANDBOX_FLAGS from a repo .env never carries the ambient API key into the run args', () => {
-      process.env.GEMINI_API_KEY = SENTINEL;
-      writeDotEnv('.env', 'SANDBOX_FLAGS=--env GEMINI_API_KEY=$GEMINI_API_KEY');
-
-      loadEnvironment();
-
-      expect(process.env.SANDBOX_FLAGS).toBeUndefined();
-      expect(runArgs().join(' ')).not.toContain(SENTINEL);
+  function useRepoSandboxHarness(): void {
+    beforeEach(() => {
+      originalCwd = process.cwd();
+      originalEnv = { ...process.env };
+      tempDirs = [];
+      for (const key of LAUNCHER_ENV_VARS) {
+        if (!STORAGE_ROOT_ENV_VARS.has(key)) delete process.env[key];
+      }
+      delete process.env.GEMINI_API_KEY;
+      delete process.env.MY_PROJECT_VAR;
+      process.chdir(makeTempDir('repo-'));
     });
 
-    it('T2 (AC2): SANDBOX_ENV from a repo .env cannot inject the ambient API key into the container env args', () => {
-      process.env.GEMINI_API_KEY = SENTINEL;
-      writeDotEnv('.env', 'SANDBOX_ENV=STOLEN=$GEMINI_API_KEY');
-
-      loadEnvironment();
-
-      const args: string[] = [];
-      addContainerEnvVars(args, CONFIG, 'test-container', [], '/workspace');
-      expect(args.join(' ')).not.toContain(SENTINEL);
-    });
-
-    it('T3 (AC2): mount variables from a repo .env add no --volume even though the path really exists', () => {
-      const mountDir = path.join(process.cwd(), 'real-mount-dir');
-      fs.mkdirSync(mountDir);
-      writeDotEnv(
-        '.env',
-        `LLXPRT_SANDBOX_MOUNTS=${mountDir}\nSANDBOX_MOUNTS=${mountDir}\n`,
-      );
-
-      loadEnvironment();
-
-      const args: string[] = [];
-      addContainerVolumeMounts(args);
-      expect(args.join(' ')).not.toContain('real-mount-dir');
-    });
-
-    it('T4: a repo .llxprt/.env is repo-controlled too and cannot set SANDBOX_FLAGS', () => {
-      process.env.GEMINI_API_KEY = SENTINEL;
-      writeDotEnv(
-        '.llxprt/.env',
-        'SANDBOX_FLAGS=--env GEMINI_API_KEY=$GEMINI_API_KEY',
-      );
-
-      loadEnvironment();
-
-      expect(process.env.SANDBOX_FLAGS).toBeUndefined();
-      expect(runArgs().join(' ')).not.toContain(SENTINEL);
-    });
-
-    it('T10: a repo .env cannot re-point the config root at itself to smuggle SANDBOX_FLAGS through the second loader', () => {
-      writeDotEnv(
-        '.env',
-        `LLXPRT_CONFIG_HOME=${process.cwd()}\nSANDBOX_FLAGS=--env STOLEN=$GEMINI_API_KEY\n`,
-      );
-
-      const result = runRealStartupSequence(process.cwd());
-
-      expect(result.env.LLXPRT_CONFIG_HOME).toBeNull();
-      expect(result.env.SANDBOX_FLAGS).toBeNull();
-      expect(result.sentinelInArgs).toBe(false);
-    });
-
-    it('T13: SANDBOX_FLAGS the Bun runtime pre-loads from a repo .env never reaches the run args', () => {
-      writeDotEnv('.env', 'SANDBOX_FLAGS=--env GEMINI_API_KEY=$GEMINI_API_KEY');
-
-      const result = runRealStartupSequence(process.cwd());
-
-      expect(result.env.SANDBOX_FLAGS).toBeNull();
-      expect(result.sentinelInArgs).toBe(false);
-    });
-
-    it('T14: a launcher control named only in a repo .env.local is dropped too', () => {
-      writeDotEnv('.env', 'MY_PROJECT_VAR=hello-2958');
-      writeDotEnv('.env.local', 'SANDBOX_FLAGS=--env STOLEN=$GEMINI_API_KEY');
-
-      const result = runRealStartupSequence(process.cwd());
-
-      expect(result.env.SANDBOX_FLAGS).toBeNull();
-      expect(result.sentinelInArgs).toBe(false);
-    });
-
-    it('T17: a launcher control in a repo .env.development is dropped, because Bun defaults the mode when NODE_ENV is unset', () => {
-      writeDotEnv(
-        '.env.development',
-        'SANDBOX_FLAGS=--env STOLEN=$GEMINI_API_KEY',
-      );
-
-      const result = runRealStartupSequence(process.cwd());
-
-      expect(result.env.SANDBOX_FLAGS).toBeNull();
-      expect(result.sentinelInArgs).toBe(false);
-    });
-
-    it('T18: a launcher control in a repo .env.development.local is dropped too', () => {
-      writeDotEnv(
-        '.env.development.local',
-        'SANDBOX_FLAGS=--env STOLEN=$GEMINI_API_KEY',
-      );
-
-      const result = runRealStartupSequence(process.cwd());
-
-      expect(result.env.SANDBOX_FLAGS).toBeNull();
-      expect(result.sentinelInArgs).toBe(false);
-    });
-
-    it('T15: a repo .llxprt/.env does not shadow the runtime scrub of the sibling .env', () => {
-      writeDotEnv('.llxprt/.env', 'MY_PROJECT_VAR=hello-2958');
-      writeDotEnv('.env', 'SANDBOX_FLAGS=--env STOLEN=$GEMINI_API_KEY');
-
-      const result = runRealStartupSequence(process.cwd());
-
-      expect(result.env.SANDBOX_FLAGS).toBeNull();
-      expect(result.sentinelInArgs).toBe(false);
-    });
-
-    it('T16: a repo .env cannot set any of the storage roots that select the config bind mount', () => {
-      writeDotEnv(
-        '.env',
-        [...STORAGE_ROOT_ENV_VARS]
-          .map((rootVar) => `${rootVar}=${process.cwd()}`)
-          .join(NEWLINE),
-      );
-
-      const result = runRealStartupSequence(process.cwd());
-
-      for (const rootVar of STORAGE_ROOT_ENV_VARS) {
-        expect(result.env[rootVar]).toBeNull();
+    afterEach(() => {
+      process.chdir(originalCwd);
+      for (const dir of tempDirs.splice(0)) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+      for (const key of Object.keys(process.env)) {
+        delete process.env[key];
+      }
+      for (const [key, value] of Object.entries(originalEnv)) {
+        if (value !== undefined) process.env[key] = value;
       }
     });
+  }
 
-    it('T11: a lower-cased launcher key in a repo .env is blocked (Windows env names are case-insensitive)', () => {
-      writeDotEnv('.env', 'sandbox_flags=--cap-add=NET_ADMIN');
+  function writeDotEnv(relativePath: string, content: string): void {
+    const absolutePath = path.join(process.cwd(), relativePath);
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    fs.writeFileSync(absolutePath, content);
+  }
 
-      loadEnvironment();
+  function runArgs(): string[] {
+    return buildContainerRunArgs(
+      CONFIG,
+      'sandbox:0.11.0',
+      process.cwd(),
+      '/workspace',
+      process.cwd(),
+    );
+  }
 
-      expect(process.env.SANDBOX_FLAGS).toBeUndefined();
-      expect(process.env['sandbox_flags']).toBeUndefined();
+  interface StartupProbeResult {
+    readonly env: Record<string, string | null>;
+    readonly sentinelInArgs: boolean;
+  }
+
+  /**
+   * Runs the real startup order — the settings loader, then the loader
+   * `loadCliConfig` calls — in a child process whose storage roots are UNSET,
+   * which is the normal production state and the state the config-root poisoning
+   * bypass needs. It cannot be reproduced in-process: the suite's isolation
+   * preload sets those roots, and clearing them there would drop the test onto
+   * the developer's real configuration. The child is isolated instead by pointing
+   * HOME at a temp directory before it starts, so every platform default it
+   * computes lands under that directory.
+   */
+  function runRealStartupSequence(repoDir: string): StartupProbeResult {
+    const configDir = path.dirname(fileURLToPath(import.meta.url));
+    const importPath = (relative: string): string =>
+      JSON.stringify(path.join(configDir, relative));
+    const probePath = path.join(repoDir, 'startup-probe.ts');
+    fs.writeFileSync(
+      probePath,
+      [
+        `import { loadEnvironment as loadFromSettings } from ${importPath('settings.js')};`,
+        `import { loadEnvironment as loadFromEnvLoader } from ${importPath('environmentLoader.js')};`,
+        `import { buildContainerRunArgs } from ${importPath('../utils/sandbox-containers.js')};`,
+        `loadFromSettings({});`,
+        `loadFromEnvLoader();`,
+        `const args = buildContainerRunArgs({ command: 'docker', image: 'test' }, 'sandbox:0.11.0', process.cwd(), '/workspace', process.cwd());`,
+        `const reported = ${JSON.stringify(LAUNCHER_ENV_VARS)};`,
+        `const env = Object.fromEntries(reported.map((k) => [k, process.env[k] ?? null]));`,
+        `console.log(JSON.stringify({`,
+        `  env,`,
+        `  sentinelInArgs: args.join(' ').includes(${JSON.stringify(SENTINEL)}),`,
+        `}));`,
+      ].join(NEWLINE),
+    );
+
+    const result = spawnSync(process.execPath, [probePath], {
+      cwd: repoDir,
+      encoding: 'utf8',
+      env: {
+        PATH: process.env.PATH ?? '',
+        HOME: makeTempDir('home-'),
+        // Computed key: a literal Gemini-prefixed object property would trip the
+        // provider-agnostic naming guard in packages/agents.
+        [AMBIENT_API_KEY_VAR]: SENTINEL,
+      },
     });
+    if (result.status !== 0) {
+      throw new Error(`startup probe failed: ${result.stderr}`);
+    }
+    return JSON.parse(result.stdout.trim()) as StartupProbeResult;
+  }
 
-    for (const launcherVar of LAUNCHER_ENV_VARS) {
-      if (STORAGE_ROOT_ENV_VARS.has(launcherVar)) continue;
-      it(`blocks ${launcherVar} set by a repo .env`, () => {
-        writeDotEnv('.env', `${launcherVar}=repo-supplied-value`);
+  describe('sandboxEnvGuard', () => {
+    describe('a repo .env cannot set sandbox launcher variables', () => {
+      useRepoSandboxHarness();
+
+      it('T1 (AC1, AC4): SANDBOX_FLAGS from a repo .env never carries the ambient API key into the run args', () => {
+        process.env.GEMINI_API_KEY = SENTINEL;
+        writeDotEnv(
+          '.env',
+          'SANDBOX_FLAGS=--env GEMINI_API_KEY=$GEMINI_API_KEY',
+        );
 
         loadEnvironment();
 
-        expect(process.env[launcherVar]).toBeUndefined();
+        expect(process.env.SANDBOX_FLAGS).toBeUndefined();
+        expect(runArgs().join(' ')).not.toContain(SENTINEL);
       });
-    }
 
-    it('T9 (AC5): excludedProjectEnvVars: [] does not switch the guard off', () => {
-      writeDotEnv('.env', 'SANDBOX_FLAGS=--cap-add=NET_ADMIN');
-      const settings: Settings = { excludedProjectEnvVars: [] };
+      it('T2 (AC2): SANDBOX_ENV from a repo .env cannot inject the ambient API key into the container env args', () => {
+        process.env.GEMINI_API_KEY = SENTINEL;
+        writeDotEnv('.env', 'SANDBOX_ENV=STOLEN=$GEMINI_API_KEY');
 
-      loadEnvironmentFromSettings(settings);
+        loadEnvironment();
 
-      expect(process.env.SANDBOX_FLAGS).toBeUndefined();
-    });
-
-    it('T7: a repo .env key that is not a launcher control still loads', () => {
-      writeDotEnv('.env', 'MY_PROJECT_VAR=hello-2958');
-
-      loadEnvironment();
-
-      expect(process.env.MY_PROJECT_VAR).toBe('hello-2958');
-    });
-  });
-
-  describe('user-supplied sandbox launcher variables keep working', () => {
-    useRepoSandboxHarness();
-
-    it('T5 (AC3): a shell-exported SANDBOX_FLAGS survives and reaches the run args', () => {
-      process.env.SANDBOX_FLAGS = '--cap-add=NET_ADMIN';
-      writeDotEnv('.env', 'MY_PROJECT_VAR=hello-2958');
-
-      loadEnvironment();
-
-      expect(process.env.SANDBOX_FLAGS).toBe('--cap-add=NET_ADMIN');
-      expect(runArgs().join(' ')).toContain('--cap-add=NET_ADMIN');
-    });
-
-    it('T5b: a repo .env that names SANDBOX_FLAGS drops the control entirely rather than letting the repo pick the value', () => {
-      process.env.SANDBOX_FLAGS = '--cap-add=NET_ADMIN';
-      writeDotEnv('.env', 'SANDBOX_FLAGS=--env GEMINI_API_KEY=$GEMINI_API_KEY');
-
-      loadEnvironment();
-
-      expect(process.env.SANDBOX_FLAGS).toBeUndefined();
-      expect(runArgs().join(' ')).not.toContain('GEMINI_API_KEY');
-    });
-
-    it('T12 (AC3): a sandbox profile still supplies SANDBOX_FLAGS and mounts after a hostile repo .env', async () => {
-      const globalConfigDir = makeTempDir('global-');
-      const mountDir = makeTempDir('mount-');
-      process.env.LLXPRT_CONFIG_HOME = globalConfigDir;
-      fs.mkdirSync(path.join(globalConfigDir, 'sandboxes'), {
-        recursive: true,
+        const args: string[] = [];
+        addContainerEnvVars(args, CONFIG, 'test-container', [], '/workspace');
+        expect(args.join(' ')).not.toContain(SENTINEL);
       });
-      fs.writeFileSync(
-        path.join(globalConfigDir, 'sandboxes', 'issue2958.json'),
-        JSON.stringify({
-          engine: 'docker',
-          image: 'sandbox:0.11.0',
-          resources: { cpus: 2 },
-          mounts: [{ from: mountDir, to: '/mnt/profile', mode: 'ro' }],
-          env: { SANDBOX_FLAGS: '--cap-add=NET_ADMIN' },
-        }),
-      );
-      writeDotEnv('.env', 'SANDBOX_FLAGS=--env GEMINI_API_KEY=$GEMINI_API_KEY');
 
-      loadEnvironment();
-      await loadSandboxConfig(
-        { sandbox: true },
-        { sandboxProfileLoad: 'issue2958', sandboxEngine: 'docker' },
-      );
+      it('T3 (AC2): mount variables from a repo .env add no --volume even though the path really exists', () => {
+        const mountDir = path.join(process.cwd(), 'real-mount-dir');
+        fs.mkdirSync(mountDir);
+        writeDotEnv(
+          '.env',
+          `LLXPRT_SANDBOX_MOUNTS=${mountDir}\nSANDBOX_MOUNTS=${mountDir}\n`,
+        );
 
-      const args = runArgs();
-      addContainerVolumeMounts(args);
-      const joined = args.join(' ');
-      expect(joined).toContain('--cap-add=NET_ADMIN');
-      expect(joined).toContain('/mnt/profile');
-      expect(joined).not.toContain('GEMINI_API_KEY');
+        loadEnvironment();
+
+        const args: string[] = [];
+        addContainerVolumeMounts(args);
+        expect(args.join(' ')).not.toContain('real-mount-dir');
+      });
+
+      it('T4: a repo .llxprt/.env is repo-controlled too and cannot set SANDBOX_FLAGS', () => {
+        process.env.GEMINI_API_KEY = SENTINEL;
+        writeDotEnv(
+          '.llxprt/.env',
+          'SANDBOX_FLAGS=--env GEMINI_API_KEY=$GEMINI_API_KEY',
+        );
+
+        loadEnvironment();
+
+        expect(process.env.SANDBOX_FLAGS).toBeUndefined();
+        expect(runArgs().join(' ')).not.toContain(SENTINEL);
+      });
+
+      it('T10: a repo .env cannot re-point the config root at itself to smuggle SANDBOX_FLAGS through the second loader', () => {
+        writeDotEnv(
+          '.env',
+          `LLXPRT_CONFIG_HOME=${process.cwd()}\nSANDBOX_FLAGS=--env STOLEN=$GEMINI_API_KEY\n`,
+        );
+
+        const result = runRealStartupSequence(process.cwd());
+
+        expect(result.env.LLXPRT_CONFIG_HOME).toBeNull();
+        expect(result.env.SANDBOX_FLAGS).toBeNull();
+        expect(result.sentinelInArgs).toBe(false);
+      });
+
+      it('T13: SANDBOX_FLAGS the Bun runtime pre-loads from a repo .env never reaches the run args', () => {
+        writeDotEnv(
+          '.env',
+          'SANDBOX_FLAGS=--env GEMINI_API_KEY=$GEMINI_API_KEY',
+        );
+
+        const result = runRealStartupSequence(process.cwd());
+
+        expect(result.env.SANDBOX_FLAGS).toBeNull();
+        expect(result.sentinelInArgs).toBe(false);
+      });
+
+      it('T14: a launcher control named only in a repo .env.local is dropped too', () => {
+        writeDotEnv('.env', 'MY_PROJECT_VAR=hello-2958');
+        writeDotEnv('.env.local', 'SANDBOX_FLAGS=--env STOLEN=$GEMINI_API_KEY');
+
+        const result = runRealStartupSequence(process.cwd());
+
+        expect(result.env.SANDBOX_FLAGS).toBeNull();
+        expect(result.sentinelInArgs).toBe(false);
+      });
+
+      it('T17: a launcher control in a repo .env.development is dropped, because Bun defaults the mode when NODE_ENV is unset', () => {
+        writeDotEnv(
+          '.env.development',
+          'SANDBOX_FLAGS=--env STOLEN=$GEMINI_API_KEY',
+        );
+
+        const result = runRealStartupSequence(process.cwd());
+
+        expect(result.env.SANDBOX_FLAGS).toBeNull();
+        expect(result.sentinelInArgs).toBe(false);
+      });
+
+      it('T18: a launcher control in a repo .env.development.local is dropped too', () => {
+        writeDotEnv(
+          '.env.development.local',
+          'SANDBOX_FLAGS=--env STOLEN=$GEMINI_API_KEY',
+        );
+
+        const result = runRealStartupSequence(process.cwd());
+
+        expect(result.env.SANDBOX_FLAGS).toBeNull();
+        expect(result.sentinelInArgs).toBe(false);
+      });
+
+      it('T15: a repo .llxprt/.env does not shadow the runtime scrub of the sibling .env', () => {
+        writeDotEnv('.llxprt/.env', 'MY_PROJECT_VAR=hello-2958');
+        writeDotEnv('.env', 'SANDBOX_FLAGS=--env STOLEN=$GEMINI_API_KEY');
+
+        const result = runRealStartupSequence(process.cwd());
+
+        expect(result.env.SANDBOX_FLAGS).toBeNull();
+        expect(result.sentinelInArgs).toBe(false);
+      });
+
+      it('T16: a repo .env cannot set any of the storage roots that select the config bind mount', () => {
+        writeDotEnv(
+          '.env',
+          [...STORAGE_ROOT_ENV_VARS]
+            .map((rootVar) => `${rootVar}=${process.cwd()}`)
+            .join(NEWLINE),
+        );
+
+        const result = runRealStartupSequence(process.cwd());
+
+        for (const rootVar of STORAGE_ROOT_ENV_VARS) {
+          expect(result.env[rootVar]).toBeNull();
+        }
+      });
+
+      it('T11: a lower-cased launcher key in a repo .env is blocked (Windows env names are case-insensitive)', () => {
+        writeDotEnv('.env', 'sandbox_flags=--cap-add=NET_ADMIN');
+
+        loadEnvironment();
+
+        expect(process.env.SANDBOX_FLAGS).toBeUndefined();
+        expect(process.env['sandbox_flags']).toBeUndefined();
+      });
+
+      for (const launcherVar of LAUNCHER_ENV_VARS) {
+        if (STORAGE_ROOT_ENV_VARS.has(launcherVar)) continue;
+        it(`blocks ${launcherVar} set by a repo .env`, () => {
+          writeDotEnv('.env', `${launcherVar}=repo-supplied-value`);
+
+          loadEnvironment();
+
+          expect(process.env[launcherVar]).toBeUndefined();
+        });
+      }
+
+      it('T9 (AC5): excludedProjectEnvVars: [] does not switch the guard off', () => {
+        writeDotEnv('.env', 'SANDBOX_FLAGS=--cap-add=NET_ADMIN');
+        const settings: Settings = { excludedProjectEnvVars: [] };
+
+        loadEnvironmentFromSettings(settings);
+
+        expect(process.env.SANDBOX_FLAGS).toBeUndefined();
+      });
+
+      it('T7: a repo .env key that is not a launcher control still loads', () => {
+        writeDotEnv('.env', 'MY_PROJECT_VAR=hello-2958');
+
+        loadEnvironment();
+
+        expect(process.env.MY_PROJECT_VAR).toBe('hello-2958');
+      });
     });
 
-    it('T8: an env file at the global config root may still set SANDBOX_FLAGS', () => {
-      const globalConfigDir = makeTempDir('global-');
-      process.env.LLXPRT_CONFIG_HOME = globalConfigDir;
-      fs.writeFileSync(
-        path.join(globalConfigDir, '.env'),
-        'SANDBOX_FLAGS=--cap-add=NET_ADMIN',
-      );
+    describe('user-supplied sandbox launcher variables keep working', () => {
+      useRepoSandboxHarness();
 
-      loadEnvironment();
+      it('T5 (AC3): a shell-exported SANDBOX_FLAGS survives and reaches the run args', () => {
+        process.env.SANDBOX_FLAGS = '--cap-add=NET_ADMIN';
+        writeDotEnv('.env', 'MY_PROJECT_VAR=hello-2958');
 
-      expect(process.env.SANDBOX_FLAGS).toBe('--cap-add=NET_ADMIN');
-      expect(runArgs().join(' ')).toContain('--cap-add=NET_ADMIN');
+        loadEnvironment();
+
+        expect(process.env.SANDBOX_FLAGS).toBe('--cap-add=NET_ADMIN');
+        expect(runArgs().join(' ')).toContain('--cap-add=NET_ADMIN');
+      });
+
+      it('T5b: a repo .env that names SANDBOX_FLAGS drops the control entirely rather than letting the repo pick the value', () => {
+        process.env.SANDBOX_FLAGS = '--cap-add=NET_ADMIN';
+        writeDotEnv(
+          '.env',
+          'SANDBOX_FLAGS=--env GEMINI_API_KEY=$GEMINI_API_KEY',
+        );
+
+        loadEnvironment();
+
+        expect(process.env.SANDBOX_FLAGS).toBeUndefined();
+        expect(runArgs().join(' ')).not.toContain('GEMINI_API_KEY');
+      });
+
+      it('T12 (AC3): a sandbox profile still supplies SANDBOX_FLAGS and mounts after a hostile repo .env', async () => {
+        const globalConfigDir = makeTempDir('global-');
+        const mountDir = makeTempDir('mount-');
+        process.env.LLXPRT_CONFIG_HOME = globalConfigDir;
+        fs.mkdirSync(path.join(globalConfigDir, 'sandboxes'), {
+          recursive: true,
+        });
+        fs.writeFileSync(
+          path.join(globalConfigDir, 'sandboxes', 'issue2958.json'),
+          JSON.stringify({
+            engine: 'docker',
+            image: 'sandbox:0.11.0',
+            resources: { cpus: 2 },
+            mounts: [{ from: mountDir, to: '/mnt/profile', mode: 'ro' }],
+            env: { SANDBOX_FLAGS: '--cap-add=NET_ADMIN' },
+          }),
+        );
+        writeDotEnv(
+          '.env',
+          'SANDBOX_FLAGS=--env GEMINI_API_KEY=$GEMINI_API_KEY',
+        );
+
+        loadEnvironment();
+        await loadSandboxConfig(
+          { sandbox: true },
+          { sandboxProfileLoad: 'issue2958', sandboxEngine: 'docker' },
+        );
+
+        const args = runArgs();
+        addContainerVolumeMounts(args);
+        const joined = args.join(' ');
+        expect(joined).toContain('--cap-add=NET_ADMIN');
+        expect(joined).toContain('/mnt/profile');
+        expect(joined).not.toContain('GEMINI_API_KEY');
+      });
+
+      it('T8: an env file at the global config root may still set SANDBOX_FLAGS', () => {
+        const globalConfigDir = makeTempDir('global-');
+        process.env.LLXPRT_CONFIG_HOME = globalConfigDir;
+        fs.writeFileSync(
+          path.join(globalConfigDir, '.env'),
+          'SANDBOX_FLAGS=--cap-add=NET_ADMIN',
+        );
+
+        loadEnvironment();
+
+        expect(process.env.SANDBOX_FLAGS).toBe('--cap-add=NET_ADMIN');
+        expect(runArgs().join(' ')).toContain('--cap-add=NET_ADMIN');
+      });
     });
-  });
 
-  describe('isUserGlobalEnvFile', () => {
-    useRepoSandboxHarness();
+    describe('isUserGlobalEnvFile', () => {
+      useRepoSandboxHarness();
 
-    it('trusts the env file at the global config root but not a sibling directory', () => {
-      const globalConfigDir = path.join(process.cwd(), 'config-root');
-      process.env.LLXPRT_CONFIG_HOME = globalConfigDir;
+      it('trusts the env file at the global config root but not a sibling directory', () => {
+        const globalConfigDir = path.join(process.cwd(), 'config-root');
+        process.env.LLXPRT_CONFIG_HOME = globalConfigDir;
 
-      expect(isUserGlobalEnvFile(path.join(globalConfigDir, '.env'))).toBe(
-        true,
-      );
-      expect(
-        isUserGlobalEnvFile(path.join(`${globalConfigDir}-evil`, '.env')),
-      ).toBe(false);
-    });
+        expect(isUserGlobalEnvFile(path.join(globalConfigDir, '.env'))).toBe(
+          true,
+        );
+        expect(
+          isUserGlobalEnvFile(path.join(`${globalConfigDir}-evil`, '.env')),
+        ).toBe(false);
+      });
 
-    it('does not trust a repository checked out underneath the global config root', () => {
-      const globalConfigDir = path.join(process.cwd(), 'config-root');
-      process.env.LLXPRT_CONFIG_HOME = globalConfigDir;
+      it('does not trust a repository checked out underneath the global config root', () => {
+        const globalConfigDir = path.join(process.cwd(), 'config-root');
+        process.env.LLXPRT_CONFIG_HOME = globalConfigDir;
 
-      expect(
-        isUserGlobalEnvFile(path.join(globalConfigDir, 'some-repo', '.env')),
-      ).toBe(false);
-    });
+        expect(
+          isUserGlobalEnvFile(path.join(globalConfigDir, 'some-repo', '.env')),
+        ).toBe(false);
+      });
 
-    it('trusts the env file at the home root', () => {
-      expect(isUserGlobalEnvFile(path.join(os.homedir(), '.env'))).toBe(true);
+      it('trusts the env file at the home root', () => {
+        expect(isUserGlobalEnvFile(path.join(os.homedir(), '.env'))).toBe(true);
+      });
     });
   });
 });

--- a/packages/cli/src/config/welcomeConfig.test.ts
+++ b/packages/cli/src/config/welcomeConfig.test.ts
@@ -20,218 +20,237 @@ import {
 } from './welcomeConfig.js';
 import { USER_SETTINGS_DIR } from './paths.js';
 
-const WELCOME_CONFIG_ENV = 'LLXPRT_CODE_WELCOME_CONFIG_PATH';
+describe('welcome-config', () => {
+  const WELCOME_CONFIG_ENV = 'LLXPRT_CODE_WELCOME_CONFIG_PATH';
 
-interface PersistedWelcomeConfig {
-  welcomeCompleted: boolean;
-  completedAt?: string;
-  skipped?: boolean;
-}
-
-function isPersistedWelcomeConfig(
-  value: unknown,
-): value is PersistedWelcomeConfig {
-  if (typeof value !== 'object' || value === null) return false;
-  const candidate = value as Record<string, unknown>;
-  if (typeof candidate.welcomeCompleted !== 'boolean') return false;
-  if ('completedAt' in candidate && typeof candidate.completedAt !== 'string') {
-    return false;
+  interface PersistedWelcomeConfig {
+    welcomeCompleted: boolean;
+    completedAt?: string;
+    skipped?: boolean;
   }
-  if ('skipped' in candidate && typeof candidate.skipped !== 'boolean') {
-    return false;
-  }
-  return true;
-}
 
-function readWelcomeConfig(configPath: string): PersistedWelcomeConfig {
-  const onDisk: unknown = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-  if (!isPersistedWelcomeConfig(onDisk)) {
-    throw new Error(`Malformed welcome config at ${configPath}`);
-  }
-  return onDisk;
-}
-
-/**
- * Shared temp-config lifecycle. Registers beforeEach/afterEach that point the
- * welcome config at a throwaway path under the OS temp dir, so no test ever
- * touches the real user settings dir, and restores the environment afterwards.
- * Returns a lazy accessor for the config path configured for the current test.
- */
-function useTempWelcomeConfig(): () => string {
-  let configDir: string | undefined;
-  let originalEnv: string | undefined;
-  let configPath = '';
-
-  beforeEach(() => {
-    originalEnv = process.env[WELCOME_CONFIG_ENV];
-    configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'welcome-config-'));
-    configPath = path.join(configDir, WELCOME_CONFIG_FILENAME);
-    process.env[WELCOME_CONFIG_ENV] = configPath;
-    resetWelcomeConfigForTesting();
-  });
-
-  afterEach(() => {
-    if (originalEnv === undefined) {
-      delete process.env[WELCOME_CONFIG_ENV];
-    } else {
-      process.env[WELCOME_CONFIG_ENV] = originalEnv;
+  function isPersistedWelcomeConfig(
+    value: unknown,
+  ): value is PersistedWelcomeConfig {
+    if (typeof value !== 'object' || value === null) return false;
+    const candidate = value as Record<string, unknown>;
+    if (typeof candidate.welcomeCompleted !== 'boolean') return false;
+    if (
+      'completedAt' in candidate &&
+      typeof candidate.completedAt !== 'string'
+    ) {
+      return false;
     }
-    resetWelcomeConfigForTesting();
-    if (configDir) {
-      fs.rmSync(configDir, { recursive: true, force: true });
-      configDir = undefined;
+    if ('skipped' in candidate && typeof candidate.skipped !== 'boolean') {
+      return false;
     }
-  });
+    return true;
+  }
 
-  return () => configPath;
-}
+  function readWelcomeConfig(configPath: string): PersistedWelcomeConfig {
+    const onDisk: unknown = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    if (!isPersistedWelcomeConfig(onDisk)) {
+      throw new Error(`Malformed welcome config at ${configPath}`);
+    }
+    return onDisk;
+  }
 
-describe('welcomeConfig', () => {
-  describe('getWelcomeConfigPath', () => {
-    const getConfigPath = useTempWelcomeConfig();
+  /**
+   * Shared temp-config lifecycle. Registers beforeEach/afterEach that point the
+   * welcome config at a throwaway path under the OS temp dir, so no test ever
+   * touches the real user settings dir, and restores the environment afterwards.
+   * Returns a lazy accessor for the config path configured for the current test.
+   */
+  function useTempWelcomeConfig(): () => string {
+    let configDir: string | undefined;
+    let originalEnv: string | undefined;
+    let configPath = '';
 
-    it('returns the environment override verbatim when the override is set', () => {
-      expect(getWelcomeConfigPath()).toBe(getConfigPath());
-    });
-
-    it('falls back to the user settings dir when the override is unset', () => {
-      delete process.env[WELCOME_CONFIG_ENV];
-      resetWelcomeConfigForTesting();
-      expect(getWelcomeConfigPath()).toBe(
-        path.join(USER_SETTINGS_DIR, WELCOME_CONFIG_FILENAME),
-      );
-    });
-  });
-
-  describe('loadWelcomeConfig', () => {
-    const getConfigPath = useTempWelcomeConfig();
-
-    it('returns welcomeCompleted false when no file exists on disk', () => {
-      expect(loadWelcomeConfig()).toStrictEqual({ welcomeCompleted: false });
-      expect(isWelcomeCompleted()).toBe(false);
-    });
-
-    it('reports onboarding complete when the file says welcomeCompleted true', () => {
-      fs.writeFileSync(getConfigPath(), '{"welcomeCompleted": true}', 'utf-8');
-      resetWelcomeConfigForTesting();
-      expect(isWelcomeCompleted()).toBe(true);
-    });
-
-    it('falls back to welcomeCompleted false instead of throwing on malformed JSON', () => {
-      fs.writeFileSync(getConfigPath(), '{ not json', 'utf-8');
-      resetWelcomeConfigForTesting();
-      expect(loadWelcomeConfig()).toStrictEqual({ welcomeCompleted: false });
-      expect(isWelcomeCompleted()).toBe(false);
-      // Repeated reads without a cache reset must keep returning the default
-      // rather than re-parsing (or caching) the corrupt file into something else.
-      expect(loadWelcomeConfig()).toStrictEqual({ welcomeCompleted: false });
-      expect(isWelcomeCompleted()).toBe(false);
-    });
-
-    it('recovers once the malformed file is replaced and the cache is reset', () => {
-      fs.writeFileSync(getConfigPath(), '{ not json', 'utf-8');
-      resetWelcomeConfigForTesting();
-      expect(isWelcomeCompleted()).toBe(false);
-      fs.writeFileSync(getConfigPath(), '{"welcomeCompleted": true}', 'utf-8');
-      resetWelcomeConfigForTesting();
-      expect(isWelcomeCompleted()).toBe(true);
-    });
-  });
-
-  describe('saveWelcomeConfig', () => {
-    const getConfigPath = useTempWelcomeConfig();
-
-    it('creates a missing parent directory and writes the file', () => {
-      const configPath = path.join(
-        getConfigPath(),
-        'nested',
-        'dir',
-        'welcomeConfig.json',
-      );
+    beforeEach(() => {
+      originalEnv = process.env[WELCOME_CONFIG_ENV];
+      configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'welcome-config-'));
+      configPath = path.join(configDir, WELCOME_CONFIG_FILENAME);
       process.env[WELCOME_CONFIG_ENV] = configPath;
       resetWelcomeConfigForTesting();
-      saveWelcomeConfig({ welcomeCompleted: true });
-      expect(fs.existsSync(configPath)).toBe(true);
-      expect(loadWelcomeConfig()).toStrictEqual({ welcomeCompleted: true });
     });
 
-    it.skipIf(process.platform === 'win32')(
-      'writes the file with owner-only permissions',
-      () => {
-        saveWelcomeConfig({ welcomeCompleted: true });
-        const mode = fs.statSync(getConfigPath()).mode & 0o777;
-        expect(mode).toBe(0o600);
-      },
-    );
-
-    it('round-trips the exact JSON that was saved', () => {
-      saveWelcomeConfig({
-        welcomeCompleted: true,
-        skipped: true,
-        completedAt: '2026-01-02T03:04:05.000Z',
-      });
-      expect(
-        JSON.parse(fs.readFileSync(getConfigPath(), 'utf-8')),
-      ).toStrictEqual({
-        welcomeCompleted: true,
-        skipped: true,
-        completedAt: '2026-01-02T03:04:05.000Z',
-      });
-    });
-
-    it('does not throw when the config path is unwritable', () => {
-      const configPath = getConfigPath();
-      fs.mkdirSync(configPath);
-      expect(() => saveWelcomeConfig({ welcomeCompleted: true })).not.toThrow();
-    });
-  });
-
-  describe('markWelcomeCompleted', () => {
-    const getConfigPath = useTempWelcomeConfig();
-
-    it('persists welcomeCompleted and skipped true with a strict ISO completion time', () => {
-      markWelcomeCompleted(true);
-      const onDisk = readWelcomeConfig(getConfigPath());
-      expect(onDisk.welcomeCompleted).toBe(true);
-      expect(onDisk.skipped).toBe(true);
-      expect(onDisk.completedAt).toBeDefined();
-      assertDefined(
-        onDisk.completedAt,
-        'completedAt must be present for a skipped completion',
-      );
-      expect(new Date(onDisk.completedAt).toISOString()).toBe(
-        onDisk.completedAt,
-      );
-    });
-
-    it('persists skipped false with a strict ISO completion time', () => {
-      markWelcomeCompleted(false);
-      const onDisk = readWelcomeConfig(getConfigPath());
-      expect(onDisk.welcomeCompleted).toBe(true);
-      expect(onDisk.skipped).toBe(false);
-      expect(onDisk.completedAt).toBeDefined();
-      assertDefined(
-        onDisk.completedAt,
-        'completedAt must be present for a non-skipped completion',
-      );
-      expect(new Date(onDisk.completedAt).toISOString()).toBe(
-        onDisk.completedAt,
-      );
-    });
-  });
-
-  describe('welcome config caching', () => {
-    const getConfigPath = useTempWelcomeConfig();
-
-    it('returns the cached value until the cache is reset', () => {
-      // The first and second reads assert the same value on purpose: the second
-      // one comes AFTER an out-of-band rewrite, so an unchanged result is the
-      // evidence that the process-lifetime cache is being served.
-      expect(loadWelcomeConfig()).toStrictEqual({ welcomeCompleted: false });
-      fs.writeFileSync(getConfigPath(), '{"welcomeCompleted": true}', 'utf-8');
-      expect(loadWelcomeConfig()).toStrictEqual({ welcomeCompleted: false });
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env[WELCOME_CONFIG_ENV];
+      } else {
+        process.env[WELCOME_CONFIG_ENV] = originalEnv;
+      }
       resetWelcomeConfigForTesting();
-      expect(loadWelcomeConfig()).toStrictEqual({ welcomeCompleted: true });
+      if (configDir) {
+        fs.rmSync(configDir, { recursive: true, force: true });
+        configDir = undefined;
+      }
+    });
+
+    return () => configPath;
+  }
+
+  describe('welcomeConfig', () => {
+    describe('getWelcomeConfigPath', () => {
+      const getConfigPath = useTempWelcomeConfig();
+
+      it('returns the environment override verbatim when the override is set', () => {
+        expect(getWelcomeConfigPath()).toBe(getConfigPath());
+      });
+
+      it('falls back to the user settings dir when the override is unset', () => {
+        delete process.env[WELCOME_CONFIG_ENV];
+        resetWelcomeConfigForTesting();
+        expect(getWelcomeConfigPath()).toBe(
+          path.join(USER_SETTINGS_DIR, WELCOME_CONFIG_FILENAME),
+        );
+      });
+    });
+
+    describe('loadWelcomeConfig', () => {
+      const getConfigPath = useTempWelcomeConfig();
+
+      it('returns welcomeCompleted false when no file exists on disk', () => {
+        expect(loadWelcomeConfig()).toStrictEqual({ welcomeCompleted: false });
+        expect(isWelcomeCompleted()).toBe(false);
+      });
+
+      it('reports onboarding complete when the file says welcomeCompleted true', () => {
+        fs.writeFileSync(
+          getConfigPath(),
+          '{"welcomeCompleted": true}',
+          'utf-8',
+        );
+        resetWelcomeConfigForTesting();
+        expect(isWelcomeCompleted()).toBe(true);
+      });
+
+      it('falls back to welcomeCompleted false instead of throwing on malformed JSON', () => {
+        fs.writeFileSync(getConfigPath(), '{ not json', 'utf-8');
+        resetWelcomeConfigForTesting();
+        expect(loadWelcomeConfig()).toStrictEqual({ welcomeCompleted: false });
+        expect(isWelcomeCompleted()).toBe(false);
+        // Repeated reads without a cache reset must keep returning the default
+        // rather than re-parsing (or caching) the corrupt file into something else.
+        expect(loadWelcomeConfig()).toStrictEqual({ welcomeCompleted: false });
+        expect(isWelcomeCompleted()).toBe(false);
+      });
+
+      it('recovers once the malformed file is replaced and the cache is reset', () => {
+        fs.writeFileSync(getConfigPath(), '{ not json', 'utf-8');
+        resetWelcomeConfigForTesting();
+        expect(isWelcomeCompleted()).toBe(false);
+        fs.writeFileSync(
+          getConfigPath(),
+          '{"welcomeCompleted": true}',
+          'utf-8',
+        );
+        resetWelcomeConfigForTesting();
+        expect(isWelcomeCompleted()).toBe(true);
+      });
+    });
+
+    describe('saveWelcomeConfig', () => {
+      const getConfigPath = useTempWelcomeConfig();
+
+      it('creates a missing parent directory and writes the file', () => {
+        const configPath = path.join(
+          getConfigPath(),
+          'nested',
+          'dir',
+          'welcomeConfig.json',
+        );
+        process.env[WELCOME_CONFIG_ENV] = configPath;
+        resetWelcomeConfigForTesting();
+        saveWelcomeConfig({ welcomeCompleted: true });
+        expect(fs.existsSync(configPath)).toBe(true);
+        expect(loadWelcomeConfig()).toStrictEqual({ welcomeCompleted: true });
+      });
+
+      it.skipIf(process.platform === 'win32')(
+        'writes the file with owner-only permissions',
+        () => {
+          saveWelcomeConfig({ welcomeCompleted: true });
+          const mode = fs.statSync(getConfigPath()).mode & 0o777;
+          expect(mode).toBe(0o600);
+        },
+      );
+
+      it('round-trips the exact JSON that was saved', () => {
+        saveWelcomeConfig({
+          welcomeCompleted: true,
+          skipped: true,
+          completedAt: '2026-01-02T03:04:05.000Z',
+        });
+        expect(
+          JSON.parse(fs.readFileSync(getConfigPath(), 'utf-8')),
+        ).toStrictEqual({
+          welcomeCompleted: true,
+          skipped: true,
+          completedAt: '2026-01-02T03:04:05.000Z',
+        });
+      });
+
+      it('does not throw when the config path is unwritable', () => {
+        const configPath = getConfigPath();
+        fs.mkdirSync(configPath);
+        expect(() =>
+          saveWelcomeConfig({ welcomeCompleted: true }),
+        ).not.toThrow();
+      });
+    });
+
+    describe('markWelcomeCompleted', () => {
+      const getConfigPath = useTempWelcomeConfig();
+
+      it('persists welcomeCompleted and skipped true with a strict ISO completion time', () => {
+        markWelcomeCompleted(true);
+        const onDisk = readWelcomeConfig(getConfigPath());
+        expect(onDisk.welcomeCompleted).toBe(true);
+        expect(onDisk.skipped).toBe(true);
+        expect(onDisk.completedAt).toBeDefined();
+        assertDefined(
+          onDisk.completedAt,
+          'completedAt must be present for a skipped completion',
+        );
+        expect(new Date(onDisk.completedAt).toISOString()).toBe(
+          onDisk.completedAt,
+        );
+      });
+
+      it('persists skipped false with a strict ISO completion time', () => {
+        markWelcomeCompleted(false);
+        const onDisk = readWelcomeConfig(getConfigPath());
+        expect(onDisk.welcomeCompleted).toBe(true);
+        expect(onDisk.skipped).toBe(false);
+        expect(onDisk.completedAt).toBeDefined();
+        assertDefined(
+          onDisk.completedAt,
+          'completedAt must be present for a non-skipped completion',
+        );
+        expect(new Date(onDisk.completedAt).toISOString()).toBe(
+          onDisk.completedAt,
+        );
+      });
+    });
+
+    describe('welcome config caching', () => {
+      const getConfigPath = useTempWelcomeConfig();
+
+      it('returns the cached value until the cache is reset', () => {
+        // The first and second reads assert the same value on purpose: the second
+        // one comes AFTER an out-of-band rewrite, so an unchanged result is the
+        // evidence that the process-lifetime cache is being served.
+        expect(loadWelcomeConfig()).toStrictEqual({ welcomeCompleted: false });
+        fs.writeFileSync(
+          getConfigPath(),
+          '{"welcomeCompleted": true}',
+          'utf-8',
+        );
+        expect(loadWelcomeConfig()).toStrictEqual({ welcomeCompleted: false });
+        resetWelcomeConfigForTesting();
+        expect(loadWelcomeConfig()).toStrictEqual({ welcomeCompleted: true });
+      });
     });
   });
 });

--- a/packages/cli/src/ui/components/ProfileCreateWizard/validation.test.ts
+++ b/packages/cli/src/ui/components/ProfileCreateWizard/validation.test.ts
@@ -32,30 +32,30 @@ import {
   validateProfileName,
 } from './validation.js';
 
-/**
- * Shared temp-dir lifecycle. Registers beforeEach/afterEach that provision a
- * throwaway directory under the OS temp dir and always remove it afterwards.
- * Returns a lazy accessor for the directory path for the current test.
- */
-function useTempDir(): () => string {
-  let dir: string | undefined;
-
-  beforeEach(() => {
-    dir = fs.mkdtempSync(path.join(osTmpdir(), 'wizard-keyfile-'));
-  });
-
-  afterEach(() => {
-    homeDirOverride = undefined;
-    if (dir) {
-      fs.rmSync(dir, { recursive: true, force: true });
-      dir = undefined;
-    }
-  });
-
-  return () => dir as string;
-}
-
 describe('validation', () => {
+  /**
+   * Shared temp-dir lifecycle. Registers beforeEach/afterEach that provision a
+   * throwaway directory under the OS temp dir and always remove it afterwards.
+   * Returns a lazy accessor for the directory path for the current test.
+   */
+  function useTempDir(): () => string {
+    let dir: string | undefined;
+
+    beforeEach(() => {
+      dir = fs.mkdtempSync(path.join(osTmpdir(), 'wizard-keyfile-'));
+    });
+
+    afterEach(() => {
+      homeDirOverride = undefined;
+      if (dir) {
+        fs.rmSync(dir, { recursive: true, force: true });
+        dir = undefined;
+      }
+    });
+
+    return () => dir as string;
+  }
+
   describe('validateBaseUrl', () => {
     it('rejects empty and whitespace-only URLs with the required message', () => {
       for (const url of ['', '   ']) {

--- a/packages/core/src/recording/RecordingIntegration.lifecycle.test.ts
+++ b/packages/core/src/recording/RecordingIntegration.lifecycle.test.ts
@@ -29,7 +29,10 @@
  * These tests are expected to fail against the Phase 12 stub implementation.
  */
 
-import { assertDefined, blockTextOrEmpty } from '@vybestack/llxprt-code-test-utils';
+import {
+  assertDefined,
+  blockTextOrEmpty,
+} from '@vybestack/llxprt-code-test-utils';
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';

--- a/packages/core/src/recording/rewindChronology.integration.test.ts
+++ b/packages/core/src/recording/rewindChronology.integration.test.ts
@@ -43,365 +43,371 @@ import {
   type DensityResultMetadata,
 } from '../core/compression/types.js';
 
-const PROJECT_HASH = 'rewind-chronology-hash';
+describe('rewind-chronology', () => {
+  const PROJECT_HASH = 'rewind-chronology-hash';
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
 
-function makeContent(
-  text: string,
-  speaker: IContent['speaker'] = 'human',
-): IContent {
-  return { speaker, blocks: [{ type: 'text', text }] };
-}
-
-function makeDensityMetadata(): DensityResultMetadata {
-  return {
-    readWritePairsPruned: 0,
-    fileDeduplicationsPruned: 0,
-    recencyPruned: 0,
-  };
-}
-
-function makeDensityResult(
-  removals: readonly number[],
-  replacements: ReadonlyMap<number, IContent> = new Map(),
-): DensityResult {
-  return { removals, replacements, metadata: makeDensityMetadata() };
-}
-
-/**
- * Project the first text block, or '' for a blockless or non-text entry.
- * The length check precedes the index because `blocks[0]` is not typed as
- * possibly-undefined, so an `undefined` guard trips no-unnecessary-condition.
- */
-function textOf(content: IContent): string {
-  if (content.blocks.length === 0) {
-    return '';
+  function makeContent(
+    text: string,
+    speaker: IContent['speaker'] = 'human',
+  ): IContent {
+    return { speaker, blocks: [{ type: 'text', text }] };
   }
-  const block = content.blocks[0];
-  return block.type === 'text' ? block.text : '';
-}
 
-function textsOf(history: readonly IContent[]): string[] {
-  return history.map(textOf);
-}
-
-function seqsOf(history: readonly IContent[]): Array<number | undefined> {
-  return history.map((item) => item.metadata?.chronology?.seq);
-}
-
-function requireReplaySuccess(
-  result: Awaited<ReturnType<typeof replaySession>>,
-): asserts result is Extract<
-  Awaited<ReturnType<typeof replaySession>>,
-  { ok: true }
-> {
-  if (!result.ok) throw new Error(`Expected replay success: ${result.error}`);
-}
-
-function requireMutationSuccess<T extends { ok: boolean }>(
-  result: T,
-): asserts result is T & { ok: true } {
-  if (!result.ok) throw new Error('Expected history mutation success');
-}
-
-/**
- * Registers the temp-dir lifecycle hooks and returns a lazy accessor for the
- * chats directory.
- */
-function useChatsDir(): () => string {
-  let dir = '';
-  beforeEach(async () => {
-    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'rewind-chronology-'));
-    await fs.mkdir(path.join(dir, 'chats'), { recursive: true });
-  });
-  afterEach(async () => {
-    await fs.rm(dir, { recursive: true, force: true });
-  });
-  return () => path.join(dir, 'chats');
-}
-
-function makeConfig(chatsDir: string): SessionRecordingServiceConfig {
-  return {
-    sessionId: crypto.randomUUID(),
-    projectHash: PROJECT_HASH,
-    chatsDir,
-    workspaceDirs: ['/test/workspace'],
-    provider: 'anthropic',
-    model: 'claude-4',
-  };
-}
-
-/**
- * A live session: a real HistoryService whose additions are journalled by a
- * real SessionRecordingService through the real RecordingIntegration bridge.
- */
-interface LiveSession {
-  readonly history: HistoryService;
-  readonly recording: SessionRecordingService;
-}
-
-function startSession(chatsDir: string): LiveSession {
-  const recording = new SessionRecordingService(makeConfig(chatsDir));
-  const history = new HistoryService();
-  new RecordingIntegration(recording).subscribeToHistory(history);
-  return { history, recording };
-}
-
-async function addTurns(
-  session: LiveSession,
-  entries: readonly IContent[],
-): Promise<void> {
-  for (const entry of entries) {
-    session.history.add(entry);
+  function makeDensityMetadata(): DensityResultMetadata {
+    return {
+      readWritePairsPruned: 0,
+      fileDeduplicationsPruned: 0,
+      recencyPruned: 0,
+    };
   }
-  await session.history.waitForTokenUpdates();
-  await session.recording.flush();
-}
 
-/** Replay the session file from disk after closing the recording. */
-async function replayFromDisk(
-  session: LiveSession,
-): Promise<readonly IContent[]> {
-  const filePath = session.recording.getFilePath();
-  expect(filePath).not.toBeNull();
-  await session.recording.dispose();
-  const replay = await replaySession(filePath as string, PROJECT_HASH);
-  requireReplaySuccess(replay);
-  return replay.history;
-}
+  function makeDensityResult(
+    removals: readonly number[],
+    replacements: ReadonlyMap<number, IContent> = new Map(),
+  ): DensityResult {
+    return { removals, replacements, metadata: makeDensityMetadata() };
+  }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+  /**
+   * Project the first text block, or '' for a blockless or non-text entry.
+   * The length check precedes the index because `blocks[0]` is not typed as
+   * possibly-undefined, so an `undefined` guard trips no-unnecessary-condition.
+   */
+  function textOf(content: IContent): string {
+    if (content.blocks.length === 0) {
+      return '';
+    }
+    const block = content.blocks[0];
+    return block.type === 'text' ? block.text : '';
+  }
 
-describe('rewindChronology', () => {
-  describe('rewind survives density divergence @issue:2934', () => {
-    const chatsDir = useChatsDir();
+  function textsOf(history: readonly IContent[]): string[] {
+    return history.map(textOf);
+  }
 
-    it('restore keeps the removed turns removed after replay', async () => {
-      const session = startSession(chatsDir());
-      // Turn 3 owns a tool result that density will prune from live history.
-      // Nothing before the restore cut is pruned, so a correct replay reproduces
-      // the live post-restore history exactly.
-      await addTurns(session, [
-        makeContent('Q1', 'human'),
-        makeContent('A1', 'ai'),
-        makeContent('Q2', 'human'),
-        makeContent('A2', 'ai'),
-        makeContent('Q3', 'human'),
-        makeContent('A3', 'ai'),
-        makeContent('T3', 'tool'),
-        makeContent('A3-followup', 'ai'),
-      ]);
+  function seqsOf(history: readonly IContent[]): Array<number | undefined> {
+    return history.map((item) => item.metadata?.chronology?.seq);
+  }
 
-      // Density prunes the tool result inside the most recent turn. The journal
-      // learns nothing about it, so live history is now one item shorter.
-      await session.history.applyDensityResult(makeDensityResult([6]));
-      await session.history.waitForTokenUpdates();
-      expect(textsOf(session.history.getAll())).toStrictEqual([
-        'Q1',
-        'A1',
-        'Q2',
-        'A2',
-        'Q3',
-        'A3',
-        'A3-followup',
-      ]);
+  function requireReplaySuccess(
+    result: Awaited<ReturnType<typeof replaySession>>,
+  ): asserts result is Extract<
+    Awaited<ReturnType<typeof replaySession>>,
+    { ok: true }
+  > {
+    if (!result.ok) throw new Error(`Expected replay success: ${result.error}`);
+  }
 
-      const live = [...session.history.getAll()];
-      const result = await new HistoryMutationService().restore(
-        live,
-        1,
-        session.recording,
-      );
-      requireMutationSuccess(result);
-      expect(textsOf(result.remainingHistory)).toStrictEqual([
-        'Q1',
-        'A1',
-        'Q2',
-        'A2',
-      ]);
+  function requireMutationSuccess<T extends { ok: boolean }>(
+    result: T,
+  ): asserts result is T & { ok: true } {
+    if (!result.ok) throw new Error('Expected history mutation success');
+  }
 
-      const replayed = await replayFromDisk(session);
-
-      expect(textsOf(replayed)).toStrictEqual(textsOf(result.remainingHistory));
-      expect(textsOf(replayed)).not.toContain('Q3');
+  /**
+   * Registers the temp-dir lifecycle hooks and returns a lazy accessor for the
+   * chats directory.
+   */
+  function useChatsDir(): () => string {
+    let dir = '';
+    beforeEach(async () => {
+      dir = await fs.mkdtemp(path.join(os.tmpdir(), 'rewind-chronology-'));
+      await fs.mkdir(path.join(dir, 'chats'), { recursive: true });
     });
-
-    it('clear does not resurrect cleared turns after replay', async () => {
-      const session = startSession(chatsDir());
-      await addTurns(session, [
-        makeContent('Q1', 'human'),
-        makeContent('A1', 'ai'),
-        makeContent('T1', 'tool'),
-        makeContent('Q2', 'human'),
-        makeContent('A2', 'ai'),
-        makeContent('T2', 'tool'),
-        makeContent('Q3', 'human'),
-      ]);
-
-      // Density prunes a tool result that belongs to a turn the clear removes.
-      await session.history.applyDensityResult(makeDensityResult([5]));
-      await session.history.waitForTokenUpdates();
-
-      const live = [...session.history.getAll()];
-      const result = await new HistoryMutationService().clear(
-        live,
-        session.recording,
-      );
-      requireMutationSuccess(result);
-      expect(textsOf(result.remainingHistory)).toStrictEqual([
-        'Q1',
-        'A1',
-        'T1',
-      ]);
-
-      const replayed = await replayFromDisk(session);
-
-      expect(textsOf(replayed)).toStrictEqual(textsOf(result.remainingHistory));
-      expect(textsOf(replayed)).not.toContain('Q2');
-      expect(textsOf(replayed)).not.toContain('Q3');
+    afterEach(async () => {
+      await fs.rm(dir, { recursive: true, force: true });
     });
+    return () => path.join(dir, 'chats');
+  }
 
-    it('token total after replay matches the token total after the live restore', async () => {
-      const session = startSession(chatsDir());
-      await addTurns(session, [
-        makeContent('first question', 'human'),
-        makeContent('first answer', 'ai'),
-        makeContent('second question', 'human'),
-        makeContent('second answer', 'ai'),
-        makeContent('third question', 'human'),
-        makeContent('third answer', 'ai'),
-        makeContent('a tool result that density will prune', 'tool'),
-        makeContent('third answer continued', 'ai'),
-      ]);
+  function makeConfig(chatsDir: string): SessionRecordingServiceConfig {
+    return {
+      sessionId: crypto.randomUUID(),
+      projectHash: PROJECT_HASH,
+      chatsDir,
+      workspaceDirs: ['/test/workspace'],
+      provider: 'anthropic',
+      model: 'claude-4',
+    };
+  }
 
-      await session.history.applyDensityResult(makeDensityResult([6]));
-      await session.history.waitForTokenUpdates();
+  /**
+   * A live session: a real HistoryService whose additions are journalled by a
+   * real SessionRecordingService through the real RecordingIntegration bridge.
+   */
+  interface LiveSession {
+    readonly history: HistoryService;
+    readonly recording: SessionRecordingService;
+  }
 
-      const live = [...session.history.getAll()];
-      const result = await new HistoryMutationService().restore(
-        live,
-        1,
-        session.recording,
-      );
-      requireMutationSuccess(result);
+  function startSession(chatsDir: string): LiveSession {
+    const recording = new SessionRecordingService(makeConfig(chatsDir));
+    const history = new HistoryService();
+    new RecordingIntegration(recording).subscribeToHistory(history);
+    return { history, recording };
+  }
 
-      const replayed = await replayFromDisk(session);
+  async function addTurns(
+    session: LiveSession,
+    entries: readonly IContent[],
+  ): Promise<void> {
+    for (const entry of entries) {
+      session.history.add(entry);
+    }
+    await session.history.waitForTokenUpdates();
+    await session.recording.flush();
+  }
 
-      const estimator = new HistoryService();
-      const liveTokens = await estimator.estimateTokensForContents([
-        ...result.remainingHistory,
-      ]);
-      const replayedTokens = await estimator.estimateTokensForContents([
-        ...replayed,
-      ]);
+  /** Replay the session file from disk after closing the recording. */
+  async function replayFromDisk(
+    session: LiveSession,
+  ): Promise<readonly IContent[]> {
+    const filePath = session.recording.getFilePath();
+    expect(filePath).not.toBeNull();
+    await session.recording.dispose();
+    const replay = await replaySession(filePath as string, PROJECT_HASH);
+    requireReplaySuccess(replay);
+    return replay.history;
+  }
 
-      expect(liveTokens).toBeGreaterThan(0);
-      expect(replayedTokens).toBe(liveTokens);
-    });
+  // ---------------------------------------------------------------------------
+  // Tests
+  // ---------------------------------------------------------------------------
 
-    it('keeps the cut aligned when density replaced an item before the cut', async () => {
-      const session = startSession(chatsDir());
-      await addTurns(session, [
-        makeContent('Q1', 'human'),
-        makeContent('A1', 'ai'),
-        makeContent('T1', 'tool'),
-        makeContent('Q2', 'human'),
-        makeContent('A2', 'ai'),
-      ]);
+  describe('rewindChronology', () => {
+    describe('rewind survives density divergence @issue:2934', () => {
+      const chatsDir = useChatsDir();
 
-      // A truncating replacement inherits the replaced item's chronology marker,
-      // and a removal after the cut shortens live history.
-      const truncated = makeContent('T1 (truncated)', 'tool');
-      await session.history.applyDensityResult(
-        makeDensityResult([4], new Map([[2, truncated]])),
-      );
-      await session.history.waitForTokenUpdates();
+      it('restore keeps the removed turns removed after replay', async () => {
+        const session = startSession(chatsDir());
+        // Turn 3 owns a tool result that density will prune from live history.
+        // Nothing before the restore cut is pruned, so a correct replay reproduces
+        // the live post-restore history exactly.
+        await addTurns(session, [
+          makeContent('Q1', 'human'),
+          makeContent('A1', 'ai'),
+          makeContent('Q2', 'human'),
+          makeContent('A2', 'ai'),
+          makeContent('Q3', 'human'),
+          makeContent('A3', 'ai'),
+          makeContent('T3', 'tool'),
+          makeContent('A3-followup', 'ai'),
+        ]);
 
-      const live = [...session.history.getAll()];
-      const result = await new HistoryMutationService().clear(
-        live,
-        session.recording,
-      );
-      requireMutationSuccess(result);
-      expect(textsOf(result.remainingHistory)).toStrictEqual([
-        'Q1',
-        'A1',
-        'T1 (truncated)',
-      ]);
+        // Density prunes the tool result inside the most recent turn. The journal
+        // learns nothing about it, so live history is now one item shorter.
+        await session.history.applyDensityResult(makeDensityResult([6]));
+        await session.history.waitForTokenUpdates();
+        expect(textsOf(session.history.getAll())).toStrictEqual([
+          'Q1',
+          'A1',
+          'Q2',
+          'A2',
+          'Q3',
+          'A3',
+          'A3-followup',
+        ]);
 
-      const replayed = await replayFromDisk(session);
+        const live = [...session.history.getAll()];
+        const result = await new HistoryMutationService().restore(
+          live,
+          1,
+          session.recording,
+        );
+        requireMutationSuccess(result);
+        expect(textsOf(result.remainingHistory)).toStrictEqual([
+          'Q1',
+          'A1',
+          'Q2',
+          'A2',
+        ]);
 
-      // The journal never learned about the truncation (issue #1393), so the
-      // replayed tool result still carries its original text. What must hold is
-      // that the cut landed on the same chronology positions.
-      expect(seqsOf(replayed)).toStrictEqual(seqsOf(result.remainingHistory));
-      expect(textsOf(replayed)).not.toContain('Q2');
-    });
+        const replayed = await replayFromDisk(session);
 
-    it('restoring more turns than exist empties the replayed history', async () => {
-      const session = startSession(chatsDir());
-      await addTurns(session, [
-        makeContent('Q1', 'human'),
-        makeContent('A1', 'ai'),
-        makeContent('T1', 'tool'),
-        makeContent('Q2', 'human'),
-      ]);
+        expect(textsOf(replayed)).toStrictEqual(
+          textsOf(result.remainingHistory),
+        );
+        expect(textsOf(replayed)).not.toContain('Q3');
+      });
 
-      await session.history.applyDensityResult(makeDensityResult([2]));
-      await session.history.waitForTokenUpdates();
+      it('clear does not resurrect cleared turns after replay', async () => {
+        const session = startSession(chatsDir());
+        await addTurns(session, [
+          makeContent('Q1', 'human'),
+          makeContent('A1', 'ai'),
+          makeContent('T1', 'tool'),
+          makeContent('Q2', 'human'),
+          makeContent('A2', 'ai'),
+          makeContent('T2', 'tool'),
+          makeContent('Q3', 'human'),
+        ]);
 
-      const live = [...session.history.getAll()];
-      const result = await new HistoryMutationService().restore(
-        live,
-        5,
-        session.recording,
-      );
-      requireMutationSuccess(result);
-      expect(result.remainingHistory).toStrictEqual([]);
+        // Density prunes a tool result that belongs to a turn the clear removes.
+        await session.history.applyDensityResult(makeDensityResult([5]));
+        await session.history.waitForTokenUpdates();
 
-      const replayed = await replayFromDisk(session);
-      expect(replayed).toStrictEqual([]);
-    });
+        const live = [...session.history.getAll()];
+        const result = await new HistoryMutationService().clear(
+          live,
+          session.recording,
+        );
+        requireMutationSuccess(result);
+        expect(textsOf(result.remainingHistory)).toStrictEqual([
+          'Q1',
+          'A1',
+          'T1',
+        ]);
 
-    it('records no cut marker when the cut item carries no chronology marker', async () => {
-      const recording = new SessionRecordingService(makeConfig(chatsDir()));
-      // Unmarked history: recorded directly, never passed through HistoryService,
-      // so no chronology marker was ever stamped.
-      const history: IContent[] = [
-        makeContent('Q1', 'human'),
-        makeContent('A1', 'ai'),
-        makeContent('Q2', 'human'),
-        makeContent('A2', 'ai'),
-      ];
-      for (const entry of history) recording.recordContent(entry);
-      await recording.flush();
+        const replayed = await replayFromDisk(session);
 
-      const result = await new HistoryMutationService().restore(
-        history,
-        1,
-        recording,
-      );
-      requireMutationSuccess(result);
+        expect(textsOf(replayed)).toStrictEqual(
+          textsOf(result.remainingHistory),
+        );
+        expect(textsOf(replayed)).not.toContain('Q2');
+        expect(textsOf(replayed)).not.toContain('Q3');
+      });
 
-      const filePath = recording.getFilePath();
-      expect(filePath).not.toBeNull();
-      await recording.dispose();
+      it('token total after replay matches the token total after the live restore', async () => {
+        const session = startSession(chatsDir());
+        await addTurns(session, [
+          makeContent('first question', 'human'),
+          makeContent('first answer', 'ai'),
+          makeContent('second question', 'human'),
+          makeContent('second answer', 'ai'),
+          makeContent('third question', 'human'),
+          makeContent('third answer', 'ai'),
+          makeContent('a tool result that density will prune', 'tool'),
+          makeContent('third answer continued', 'ai'),
+        ]);
 
-      const raw = await fs.readFile(filePath as string, 'utf8');
-      const rewindLines = raw
-        .split('\n')
-        .filter((line) => line.includes('"type":"rewind"'));
-      expect(rewindLines).toHaveLength(1);
-      expect(rewindLines[0]).not.toContain('cutSeq');
+        await session.history.applyDensityResult(makeDensityResult([6]));
+        await session.history.waitForTokenUpdates();
 
-      const replay = await replaySession(filePath as string, PROJECT_HASH);
-      requireReplaySuccess(replay);
-      expect(textsOf(replay.history)).toStrictEqual(['Q1', 'A1']);
+        const live = [...session.history.getAll()];
+        const result = await new HistoryMutationService().restore(
+          live,
+          1,
+          session.recording,
+        );
+        requireMutationSuccess(result);
+
+        const replayed = await replayFromDisk(session);
+
+        const estimator = new HistoryService();
+        const liveTokens = await estimator.estimateTokensForContents([
+          ...result.remainingHistory,
+        ]);
+        const replayedTokens = await estimator.estimateTokensForContents([
+          ...replayed,
+        ]);
+
+        expect(liveTokens).toBeGreaterThan(0);
+        expect(replayedTokens).toBe(liveTokens);
+      });
+
+      it('keeps the cut aligned when density replaced an item before the cut', async () => {
+        const session = startSession(chatsDir());
+        await addTurns(session, [
+          makeContent('Q1', 'human'),
+          makeContent('A1', 'ai'),
+          makeContent('T1', 'tool'),
+          makeContent('Q2', 'human'),
+          makeContent('A2', 'ai'),
+        ]);
+
+        // A truncating replacement inherits the replaced item's chronology marker,
+        // and a removal after the cut shortens live history.
+        const truncated = makeContent('T1 (truncated)', 'tool');
+        await session.history.applyDensityResult(
+          makeDensityResult([4], new Map([[2, truncated]])),
+        );
+        await session.history.waitForTokenUpdates();
+
+        const live = [...session.history.getAll()];
+        const result = await new HistoryMutationService().clear(
+          live,
+          session.recording,
+        );
+        requireMutationSuccess(result);
+        expect(textsOf(result.remainingHistory)).toStrictEqual([
+          'Q1',
+          'A1',
+          'T1 (truncated)',
+        ]);
+
+        const replayed = await replayFromDisk(session);
+
+        // The journal never learned about the truncation (issue #1393), so the
+        // replayed tool result still carries its original text. What must hold is
+        // that the cut landed on the same chronology positions.
+        expect(seqsOf(replayed)).toStrictEqual(seqsOf(result.remainingHistory));
+        expect(textsOf(replayed)).not.toContain('Q2');
+      });
+
+      it('restoring more turns than exist empties the replayed history', async () => {
+        const session = startSession(chatsDir());
+        await addTurns(session, [
+          makeContent('Q1', 'human'),
+          makeContent('A1', 'ai'),
+          makeContent('T1', 'tool'),
+          makeContent('Q2', 'human'),
+        ]);
+
+        await session.history.applyDensityResult(makeDensityResult([2]));
+        await session.history.waitForTokenUpdates();
+
+        const live = [...session.history.getAll()];
+        const result = await new HistoryMutationService().restore(
+          live,
+          5,
+          session.recording,
+        );
+        requireMutationSuccess(result);
+        expect(result.remainingHistory).toStrictEqual([]);
+
+        const replayed = await replayFromDisk(session);
+        expect(replayed).toStrictEqual([]);
+      });
+
+      it('records no cut marker when the cut item carries no chronology marker', async () => {
+        const recording = new SessionRecordingService(makeConfig(chatsDir()));
+        // Unmarked history: recorded directly, never passed through HistoryService,
+        // so no chronology marker was ever stamped.
+        const history: IContent[] = [
+          makeContent('Q1', 'human'),
+          makeContent('A1', 'ai'),
+          makeContent('Q2', 'human'),
+          makeContent('A2', 'ai'),
+        ];
+        for (const entry of history) recording.recordContent(entry);
+        await recording.flush();
+
+        const result = await new HistoryMutationService().restore(
+          history,
+          1,
+          recording,
+        );
+        requireMutationSuccess(result);
+
+        const filePath = recording.getFilePath();
+        expect(filePath).not.toBeNull();
+        await recording.dispose();
+
+        const raw = await fs.readFile(filePath as string, 'utf8');
+        const rewindLines = raw
+          .split('\n')
+          .filter((line) => line.includes('"type":"rewind"'));
+        expect(rewindLines).toHaveLength(1);
+        expect(rewindLines[0]).not.toContain('cutSeq');
+
+        const replay = await replaySession(filePath as string, PROJECT_HASH);
+        requireReplaySuccess(replay);
+        expect(textsOf(replay.history)).toStrictEqual(['Q1', 'A1']);
+      });
     });
   });
 });

--- a/packages/core/src/storage/local-media-store-locking.test.ts
+++ b/packages/core/src/storage/local-media-store-locking.test.ts
@@ -32,498 +32,506 @@ import {
   type MediaReferenceBlock,
 } from '../services/history/IContent.js';
 
-function useTempDirectory(): () => string {
-  let directory = '';
-  beforeEach(async () => {
-    directory = await mkdtemp(join(tmpdir(), 'llxprt-media-store-'));
-  });
-  afterEach(async () => {
-    if (directory !== '') {
-      await chmod(directory, 0o700).catch(() => undefined);
-      await rm(directory, { recursive: true, force: true });
-    }
-  });
-  return () => directory;
-}
-
-function bytes(...values: number[]): Uint8Array {
-  return new Uint8Array(values);
-}
-
-function admitInput(payload: Uint8Array) {
-  return {
-    bytes: payload,
-    mimeType: 'image/png',
-    semanticMetadata: { detail: 'high', nested: { page: 2 } },
-  };
-}
-
-async function capturedError(work: Promise<unknown>): Promise<Error> {
-  try {
-    await work;
-  } catch (error) {
-    if (error instanceof Error) {
-      return error;
-    }
-    throw new Error('Expected an Error instance');
-  }
-  throw new Error('Expected operation to reject');
-}
-
-interface ChildResult {
-  readonly exitCode: number;
-  readonly stdout: string;
-  readonly stderr: string;
-}
-
-function childCommand(
-  mode: string,
-  rootDirectory: string,
-  quotaBytes: number,
-  payload: string,
-  ...additionalArguments: readonly string[]
-): string[] {
-  return [
-    process.execPath,
-    join(import.meta.dir, 'local-media-store-child.ts'),
-    mode,
-    rootDirectory,
-    String(quotaBytes),
-    payload,
-    ...additionalArguments,
-  ];
-}
-
-async function runChild(command: string[]): Promise<ChildResult> {
-  const child = Bun.spawn(command, { stdout: 'pipe', stderr: 'pipe' });
-  try {
-    const [exitCode, stdout, stderr] = await Promise.all([
-      child.exited,
-      new Response(child.stdout).text(),
-      new Response(child.stderr).text(),
-    ]);
-    return { exitCode, stdout, stderr };
-  } finally {
-    if (child.exitCode === null) child.kill('SIGKILL');
-    await child.exited;
-  }
-}
-
-async function waitForPath(path: string, directory: string): Promise<void> {
-  if (await Bun.file(path).exists()) return;
-  const controller = new AbortController();
-  const events = watch(directory, { signal: controller.signal });
-  try {
-    if (await Bun.file(path).exists()) return;
-    for await (const _event of events) {
-      if (await Bun.file(path).exists()) return;
-    }
-    throw new Error(`Filesystem watch ended before ${path} appeared`);
-  } finally {
-    controller.abort();
-  }
-}
-
-async function waitForMtimeAfterEpoch(
-  path: string,
-  directory: string,
-): Promise<void> {
-  if ((await stat(path)).mtimeMs > 0) return;
-  const controller = new AbortController();
-  const events = watch(directory, { signal: controller.signal });
-  try {
-    if ((await stat(path)).mtimeMs > 0) return;
-    for await (const _event of events) {
-      if ((await stat(path)).mtimeMs > 0) return;
-    }
-    throw new Error(`Filesystem watch ended before ${path} was renewed`);
-  } finally {
-    controller.abort();
-  }
-}
-
-function parseChildReference(serialized: string): MediaReferenceBlock {
-  const parsed: unknown = JSON.parse(serialized.trim());
-  if (!isMediaReferenceBlock(parsed)) {
-    throw new Error('Child returned malformed media reference');
-  }
-  return parsed;
-}
-
 describe('local-media-store-locking', () => {
-  describe('LocalMediaStore quota enforcement', () => {
-    const tempDirectory = useTempDirectory();
-
-    it('rejects a non-empty object when quota is zero', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 0,
-      });
-
-      const error = await capturedError(store.admit(admitInput(bytes(1))));
-
-      expect(error.message).toContain('quota');
+  function useTempDirectory(): () => string {
+    let directory = '';
+    beforeEach(async () => {
+      directory = await mkdtemp(join(tmpdir(), 'llxprt-media-store-'));
     });
-
-    it('admits an object exactly at quota', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-      });
-
-      const reference = await store.admit(admitInput(bytes(1, 2, 3)));
-
-      expect(reference.byteLength).toBe(3);
-    });
-
-    it('rejects an object one byte over quota', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 2,
-      });
-
-      const error = await capturedError(
-        store.admit(admitInput(bytes(1, 2, 3))),
-      );
-
-      expect(error.message).toContain('quota');
-    });
-
-    it('includes pre-existing stored objects in aggregate quota usage', async () => {
-      const firstStore = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 4,
-      });
-      await firstStore.admit(admitInput(bytes(1, 2, 3)));
-      const reopenedStore = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 4,
-      });
-
-      const error = await capturedError(
-        reopenedStore.admit(admitInput(bytes(4, 5))),
-      );
-
-      expect(error.message).toContain('quota');
-      expect(await reopenedStore.getStoredByteLength()).toBe(3);
-    });
-
-    it('allows a duplicate when the spool is already at quota', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-      });
-      const first = await store.admit(admitInput(bytes(1, 2, 3)));
-
-      const duplicate = await store.admit(admitInput(bytes(1, 2, 3)));
-
-      expect(duplicate.contentId).toBe(first.contentId);
-      expect(await store.getStoredByteLength()).toBe(3);
-    });
-    it('enforces quota atomically across independent store instances admitting different objects', async () => {
-      const firstStore = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 4,
-      });
-      const secondStore = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 4,
-      });
-
-      const outcomes = await Promise.allSettled([
-        firstStore.admit(admitInput(bytes(1, 2, 3))),
-        secondStore.admit(admitInput(bytes(4, 5, 6))),
-      ]);
-
-      expect(
-        outcomes.filter((outcome) => outcome.status === 'fulfilled'),
-      ).toHaveLength(1);
-      expect(
-        outcomes.filter((outcome) => outcome.status === 'rejected'),
-      ).toHaveLength(1);
-      expect(await firstStore.getStoredByteLength()).toBe(3);
-    });
-
-    it('deduplicates concurrent admission across independent store instances', async () => {
-      const firstStore = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-      });
-      const secondStore = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-      });
-      const input = admitInput(bytes(7, 8, 9));
-
-      const [first, second] = await Promise.all([
-        firstStore.admit(input),
-        secondStore.admit(input),
-      ]);
-
-      expect(first.contentId).toBe(second.contentId);
-      expect(await firstStore.getStoredByteLength()).toBe(3);
-      expect(await secondStore.readVerified(second)).toStrictEqual(input.bytes);
-    });
-
-    it('deduplicates the same blob across concurrent child processes', async () => {
-      const command = childCommand('admit', tempDirectory(), 3, '31,32,33');
-
-      const [first, second] = await Promise.all([
-        runChild(command),
-        runChild(command),
-      ]);
-      if (first.exitCode !== 0) throw new Error(first.stderr);
-      if (second.exitCode !== 0) throw new Error(second.stderr);
-      const firstReference = parseChildReference(first.stdout);
-      const secondReference = parseChildReference(second.stdout);
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-      });
-
-      expect(firstReference.contentId).toBe(secondReference.contentId);
-      expect(await store.getStoredByteLength()).toBe(3);
-    });
-
-    it('serializes quota contention across child processes admitting different blobs', async () => {
-      const [first, second] = await Promise.all([
-        runChild(childCommand('admit', tempDirectory(), 3, '41,42,43')),
-        runChild(childCommand('admit', tempDirectory(), 3, '51,52,53')),
-      ]);
-      const successes = [first, second].filter(
-        (result) => result.exitCode === 0,
-      );
-      const failures = [first, second].filter(
-        (result) => result.exitCode !== 0,
-      );
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-      });
-
-      expect(successes).toHaveLength(1);
-      expect(failures).toHaveLength(1);
-      expect(failures[0]?.stderr).toContain('quota');
-      expect(await store.getStoredByteLength()).toBe(3);
-    });
-
-    it('fails before publication when quota state exceeds its finite scan bound', async () => {
-      const objectDirectory = join(tempDirectory(), 'objects', 'sha256');
-      await mkdir(objectDirectory, { recursive: true });
-      const existingDigests = ['first', 'second'].map((label) =>
-        createHash('sha256').update(label).digest('hex'),
-      );
-      await Promise.all(
-        existingDigests.map((digest) =>
-          writeFile(join(objectDirectory, digest), bytes(1), { mode: 0o600 }),
-        ),
-      );
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 10,
-        quotaScanMaxEntries: 1,
-      });
-      const payload = bytes(7, 8, 9);
-      const digest = createHash('sha256').update(payload).digest('hex');
-
-      await expect(store.admit(admitInput(payload))).rejects.toThrow(
-        /quota state.*bound/i,
-      );
-
-      expect(await Bun.file(join(objectDirectory, digest)).exists()).toBe(
-        false,
-      );
-      expect(await readdir(objectDirectory)).toHaveLength(2);
-    });
-
-    it('does not remove a replacement holder after partial lock initialization fails', async () => {
-      const lockPath = join(tempDirectory(), 'locks', 'store.lock');
-      const displacedPath = join(tempDirectory(), 'locks', 'displaced.lock');
-      const replacementOwner = '{"token":"replacement-holder"}';
-      let failInitialization = true;
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-        fileOperations: {
-          link: publishLink,
-          syncDirectory: async (path) => {
-            if (path.endsWith(join('locks')) && failInitialization) {
-              failInitialization = false;
-              await rename(lockPath, displacedPath);
-              await writeFile(lockPath, replacementOwner, {
-                flag: 'wx',
-                mode: 0o600,
-              });
-              throw new Error('induced lock initialization failure');
-            }
-          },
-        },
-      });
-
-      await expect(store.admit(admitInput(bytes(1, 2, 3)))).rejects.toThrow(
-        'induced lock initialization failure',
-      );
-
-      expect(await readFile(lockPath, 'utf8')).toBe(replacementOwner);
-    });
-
-    it('aggregates lock initialization and owned-path cleanup failures', async () => {
-      let lockDirectorySyncs = 0;
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-        fileOperations: {
-          link: publishLink,
-          syncDirectory: async (path) => {
-            if (!path.endsWith(join('locks'))) return;
-            lockDirectorySyncs += 1;
-            throw new Error(
-              lockDirectorySyncs === 1
-                ? 'induced lock initialization failure'
-                : 'induced lock cleanup failure',
-            );
-          },
-        },
-      });
-
-      const error = await capturedError(
-        store.admit(admitInput(bytes(1, 2, 3))),
-      );
-
-      assertInstanceOf(
-        error.cause,
-        AggregateError,
-        'Expected aggregated lock initialization failures',
-      );
-      expect(
-        error.cause.errors.map((failure) => errorMessage(failure)),
-      ).toStrictEqual([
-        'induced lock initialization failure',
-        'induced lock cleanup failure',
-      ]);
-      expect(
-        await Bun.file(join(tempDirectory(), 'locks', 'store.lock')).exists(),
-      ).toBe(false);
-    });
-
-    it('refuses to release a lock whose inode has an active takeover claim', async () => {
-      const payload = bytes(1, 2, 3);
-      const contentId = `sha256:${createHash('sha256').update(payload).digest('hex')}`;
-      const lockPath = join(tempDirectory(), 'locks', 'store.lock');
-      const claimPath = join(
-        tempDirectory(),
-        'locks',
-        'store.lock.test.takeover',
-      );
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-      });
-
-      try {
-        await expect(
-          store.admitObjectsTransaction(
-            [
-              {
-                object: {
-                  contentId,
-                  mimeType: 'image/png',
-                  byteLength: payload.byteLength,
-                  normalizedBase64Length: 4,
-                },
-                bytes: payload,
-              },
-            ],
-            async () => {
-              await publishLink(lockPath, claimPath);
-            },
-          ),
-        ).rejects.toThrow(/ownership changed/i);
-        expect(await Bun.file(lockPath).exists()).toBe(true);
-      } finally {
-        await rm(claimPath, { force: true });
-        await rm(lockPath, { force: true });
+    afterEach(async () => {
+      if (directory !== '') {
+        await chmod(directory, 0o700).catch(() => undefined);
+        await rm(directory, { recursive: true, force: true });
       }
     });
+    return () => directory;
+  }
 
-    it('recovers a store lock abandoned by a crashed child process', async () => {
-      const crashed = await runChild(
-        childCommand('lock-crash', tempDirectory(), 3, '81,82,83'),
-      );
-      if (crashed.exitCode !== 0) throw new Error(crashed.stderr);
-      const epoch = new Date(0);
-      await utimes(join(tempDirectory(), 'locks', 'store.lock'), epoch, epoch);
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-        lockTimeoutMs: 2_000,
-        staleLockMs: 30,
+  function bytes(...values: number[]): Uint8Array {
+    return new Uint8Array(values);
+  }
+
+  function admitInput(payload: Uint8Array) {
+    return {
+      bytes: payload,
+      mimeType: 'image/png',
+      semanticMetadata: { detail: 'high', nested: { page: 2 } },
+    };
+  }
+
+  async function capturedError(work: Promise<unknown>): Promise<Error> {
+    try {
+      await work;
+    } catch (error) {
+      if (error instanceof Error) {
+        return error;
+      }
+      throw new Error('Expected an Error instance');
+    }
+    throw new Error('Expected operation to reject');
+  }
+
+  interface ChildResult {
+    readonly exitCode: number;
+    readonly stdout: string;
+    readonly stderr: string;
+  }
+
+  function childCommand(
+    mode: string,
+    rootDirectory: string,
+    quotaBytes: number,
+    payload: string,
+    ...additionalArguments: readonly string[]
+  ): string[] {
+    return [
+      process.execPath,
+      join(import.meta.dir, 'local-media-store-child.ts'),
+      mode,
+      rootDirectory,
+      String(quotaBytes),
+      payload,
+      ...additionalArguments,
+    ];
+  }
+
+  async function runChild(command: string[]): Promise<ChildResult> {
+    const child = Bun.spawn(command, { stdout: 'pipe', stderr: 'pipe' });
+    try {
+      const [exitCode, stdout, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+      ]);
+      return { exitCode, stdout, stderr };
+    } finally {
+      if (child.exitCode === null) child.kill('SIGKILL');
+      await child.exited;
+    }
+  }
+
+  async function waitForPath(path: string, directory: string): Promise<void> {
+    if (await Bun.file(path).exists()) return;
+    const controller = new AbortController();
+    const events = watch(directory, { signal: controller.signal });
+    try {
+      if (await Bun.file(path).exists()) return;
+      for await (const _event of events) {
+        if (await Bun.file(path).exists()) return;
+      }
+      throw new Error(`Filesystem watch ended before ${path} appeared`);
+    } finally {
+      controller.abort();
+    }
+  }
+
+  async function waitForMtimeAfterEpoch(
+    path: string,
+    directory: string,
+  ): Promise<void> {
+    if ((await stat(path)).mtimeMs > 0) return;
+    const controller = new AbortController();
+    const events = watch(directory, { signal: controller.signal });
+    try {
+      if ((await stat(path)).mtimeMs > 0) return;
+      for await (const _event of events) {
+        if ((await stat(path)).mtimeMs > 0) return;
+      }
+      throw new Error(`Filesystem watch ended before ${path} was renewed`);
+    } finally {
+      controller.abort();
+    }
+  }
+
+  function parseChildReference(serialized: string): MediaReferenceBlock {
+    const parsed: unknown = JSON.parse(serialized.trim());
+    if (!isMediaReferenceBlock(parsed)) {
+      throw new Error('Child returned malformed media reference');
+    }
+    return parsed;
+  }
+
+  describe('local-media-store-locking', () => {
+    describe('LocalMediaStore quota enforcement', () => {
+      const tempDirectory = useTempDirectory();
+
+      it('rejects a non-empty object when quota is zero', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 0,
+        });
+
+        const error = await capturedError(store.admit(admitInput(bytes(1))));
+
+        expect(error.message).toContain('quota');
       });
 
-      const reference = await store.admit(admitInput(bytes(81, 82, 83)));
+      it('admits an object exactly at quota', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
 
-      expect(await store.readVerified(reference)).toStrictEqual(
-        bytes(81, 82, 83),
-      );
-    });
+        const reference = await store.admit(admitInput(bytes(1, 2, 3)));
 
-    it('keeps a live slow publisher exclusive after a deterministic heartbeat barrier', async () => {
-      const readyPath = join(tempDirectory(), 'slow-publisher-ready');
-      const releasePath = join(tempDirectory(), 'release-slow-publisher');
-      const lockDirectory = join(tempDirectory(), 'locks');
-      const lockPath = join(lockDirectory, 'store.lock');
-      const child = Bun.spawn(
-        childCommand(
-          'hold-publish',
-          tempDirectory(),
-          3,
-          '91,92,93',
-          readyPath,
-          releasePath,
-        ),
-        { stdout: 'pipe', stderr: 'pipe' },
-      );
-      try {
-        await Promise.race([
-          waitForPath(readyPath, tempDirectory()),
-          child.exited.then(async () => {
-            if (!(await Bun.file(readyPath).exists())) {
-              throw new Error(await new Response(child.stderr).text());
-            }
-          }),
+        expect(reference.byteLength).toBe(3);
+      });
+
+      it('rejects an object one byte over quota', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 2,
+        });
+
+        const error = await capturedError(
+          store.admit(admitInput(bytes(1, 2, 3))),
+        );
+
+        expect(error.message).toContain('quota');
+      });
+
+      it('includes pre-existing stored objects in aggregate quota usage', async () => {
+        const firstStore = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 4,
+        });
+        await firstStore.admit(admitInput(bytes(1, 2, 3)));
+        const reopenedStore = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 4,
+        });
+
+        const error = await capturedError(
+          reopenedStore.admit(admitInput(bytes(4, 5))),
+        );
+
+        expect(error.message).toContain('quota');
+        expect(await reopenedStore.getStoredByteLength()).toBe(3);
+      });
+
+      it('allows a duplicate when the spool is already at quota', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
+        const first = await store.admit(admitInput(bytes(1, 2, 3)));
+
+        const duplicate = await store.admit(admitInput(bytes(1, 2, 3)));
+
+        expect(duplicate.contentId).toBe(first.contentId);
+        expect(await store.getStoredByteLength()).toBe(3);
+      });
+      it('enforces quota atomically across independent store instances admitting different objects', async () => {
+        const firstStore = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 4,
+        });
+        const secondStore = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 4,
+        });
+
+        const outcomes = await Promise.allSettled([
+          firstStore.admit(admitInput(bytes(1, 2, 3))),
+          secondStore.admit(admitInput(bytes(4, 5, 6))),
         ]);
+
+        expect(
+          outcomes.filter((outcome) => outcome.status === 'fulfilled'),
+        ).toHaveLength(1);
+        expect(
+          outcomes.filter((outcome) => outcome.status === 'rejected'),
+        ).toHaveLength(1);
+        expect(await firstStore.getStoredByteLength()).toBe(3);
+      });
+
+      it('deduplicates concurrent admission across independent store instances', async () => {
+        const firstStore = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
+        const secondStore = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
+        const input = admitInput(bytes(7, 8, 9));
+
+        const [first, second] = await Promise.all([
+          firstStore.admit(input),
+          secondStore.admit(input),
+        ]);
+
+        expect(first.contentId).toBe(second.contentId);
+        expect(await firstStore.getStoredByteLength()).toBe(3);
+        expect(await secondStore.readVerified(second)).toStrictEqual(
+          input.bytes,
+        );
+      });
+
+      it('deduplicates the same blob across concurrent child processes', async () => {
+        const command = childCommand('admit', tempDirectory(), 3, '31,32,33');
+
+        const [first, second] = await Promise.all([
+          runChild(command),
+          runChild(command),
+        ]);
+        if (first.exitCode !== 0) throw new Error(first.stderr);
+        if (second.exitCode !== 0) throw new Error(second.stderr);
+        const firstReference = parseChildReference(first.stdout);
+        const secondReference = parseChildReference(second.stdout);
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
+
+        expect(firstReference.contentId).toBe(secondReference.contentId);
+        expect(await store.getStoredByteLength()).toBe(3);
+      });
+
+      it('serializes quota contention across child processes admitting different blobs', async () => {
+        const [first, second] = await Promise.all([
+          runChild(childCommand('admit', tempDirectory(), 3, '41,42,43')),
+          runChild(childCommand('admit', tempDirectory(), 3, '51,52,53')),
+        ]);
+        const successes = [first, second].filter(
+          (result) => result.exitCode === 0,
+        );
+        const failures = [first, second].filter(
+          (result) => result.exitCode !== 0,
+        );
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
+
+        expect(successes).toHaveLength(1);
+        expect(failures).toHaveLength(1);
+        expect(failures[0]?.stderr).toContain('quota');
+        expect(await store.getStoredByteLength()).toBe(3);
+      });
+
+      it('fails before publication when quota state exceeds its finite scan bound', async () => {
+        const objectDirectory = join(tempDirectory(), 'objects', 'sha256');
+        await mkdir(objectDirectory, { recursive: true });
+        const existingDigests = ['first', 'second'].map((label) =>
+          createHash('sha256').update(label).digest('hex'),
+        );
+        await Promise.all(
+          existingDigests.map((digest) =>
+            writeFile(join(objectDirectory, digest), bytes(1), { mode: 0o600 }),
+          ),
+        );
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 10,
+          quotaScanMaxEntries: 1,
+        });
+        const payload = bytes(7, 8, 9);
+        const digest = createHash('sha256').update(payload).digest('hex');
+
+        await expect(store.admit(admitInput(payload))).rejects.toThrow(
+          /quota state.*bound/i,
+        );
+
+        expect(await Bun.file(join(objectDirectory, digest)).exists()).toBe(
+          false,
+        );
+        expect(await readdir(objectDirectory)).toHaveLength(2);
+      });
+
+      it('does not remove a replacement holder after partial lock initialization fails', async () => {
+        const lockPath = join(tempDirectory(), 'locks', 'store.lock');
+        const displacedPath = join(tempDirectory(), 'locks', 'displaced.lock');
+        const replacementOwner = '{"token":"replacement-holder"}';
+        let failInitialization = true;
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+          fileOperations: {
+            link: publishLink,
+            syncDirectory: async (path) => {
+              if (path.endsWith(join('locks')) && failInitialization) {
+                failInitialization = false;
+                await rename(lockPath, displacedPath);
+                await writeFile(lockPath, replacementOwner, {
+                  flag: 'wx',
+                  mode: 0o600,
+                });
+                throw new Error('induced lock initialization failure');
+              }
+            },
+          },
+        });
+
+        await expect(store.admit(admitInput(bytes(1, 2, 3)))).rejects.toThrow(
+          'induced lock initialization failure',
+        );
+
+        expect(await readFile(lockPath, 'utf8')).toBe(replacementOwner);
+      });
+
+      it('aggregates lock initialization and owned-path cleanup failures', async () => {
+        let lockDirectorySyncs = 0;
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+          fileOperations: {
+            link: publishLink,
+            syncDirectory: async (path) => {
+              if (!path.endsWith(join('locks'))) return;
+              lockDirectorySyncs += 1;
+              throw new Error(
+                lockDirectorySyncs === 1
+                  ? 'induced lock initialization failure'
+                  : 'induced lock cleanup failure',
+              );
+            },
+          },
+        });
+
+        const error = await capturedError(
+          store.admit(admitInput(bytes(1, 2, 3))),
+        );
+
+        assertInstanceOf(
+          error.cause,
+          AggregateError,
+          'Expected aggregated lock initialization failures',
+        );
+        expect(
+          error.cause.errors.map((failure) => errorMessage(failure)),
+        ).toStrictEqual([
+          'induced lock initialization failure',
+          'induced lock cleanup failure',
+        ]);
+        expect(
+          await Bun.file(join(tempDirectory(), 'locks', 'store.lock')).exists(),
+        ).toBe(false);
+      });
+
+      it('refuses to release a lock whose inode has an active takeover claim', async () => {
+        const payload = bytes(1, 2, 3);
+        const contentId = `sha256:${createHash('sha256').update(payload).digest('hex')}`;
+        const lockPath = join(tempDirectory(), 'locks', 'store.lock');
+        const claimPath = join(
+          tempDirectory(),
+          'locks',
+          'store.lock.test.takeover',
+        );
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
+
+        try {
+          await expect(
+            store.admitObjectsTransaction(
+              [
+                {
+                  object: {
+                    contentId,
+                    mimeType: 'image/png',
+                    byteLength: payload.byteLength,
+                    normalizedBase64Length: 4,
+                  },
+                  bytes: payload,
+                },
+              ],
+              async () => {
+                await publishLink(lockPath, claimPath);
+              },
+            ),
+          ).rejects.toThrow(/ownership changed/i);
+          expect(await Bun.file(lockPath).exists()).toBe(true);
+        } finally {
+          await rm(claimPath, { force: true });
+          await rm(lockPath, { force: true });
+        }
+      });
+
+      it('recovers a store lock abandoned by a crashed child process', async () => {
+        const crashed = await runChild(
+          childCommand('lock-crash', tempDirectory(), 3, '81,82,83'),
+        );
+        if (crashed.exitCode !== 0) throw new Error(crashed.stderr);
         const epoch = new Date(0);
-        await utimes(lockPath, epoch, epoch);
-        await waitForMtimeAfterEpoch(lockPath, lockDirectory);
-        const contender = new LocalMediaStore({
+        await utimes(
+          join(tempDirectory(), 'locks', 'store.lock'),
+          epoch,
+          epoch,
+        );
+        const store = new LocalMediaStore({
           rootDirectory: tempDirectory(),
           quotaBytes: 3,
           lockTimeoutMs: 2_000,
           staleLockMs: 30,
         });
 
-        const reclamation = contender.reclaimUnreferenced(
-          new Set(),
-          Date.now(),
-        );
-        await writeFile(releasePath, 'release', { flag: 'wx' });
-        const [exitCode, result, stdout, stderr] = await Promise.all([
-          child.exited,
-          reclamation,
-          new Response(child.stdout).text(),
-          new Response(child.stderr).text(),
-        ]);
-        if (exitCode !== 0) throw new Error(stderr);
-        const reference = parseChildReference(stdout);
+        const reference = await store.admit(admitInput(bytes(81, 82, 83)));
 
-        expect(result.temporaryFilesRemoved).toBe(0);
-        expect(await contender.readVerified(reference)).toStrictEqual(
-          bytes(91, 92, 93),
+        expect(await store.readVerified(reference)).toStrictEqual(
+          bytes(81, 82, 83),
         );
-      } finally {
-        if (child.exitCode === null) child.kill('SIGKILL');
-        await child.exited;
-      }
+      });
+
+      it('keeps a live slow publisher exclusive after a deterministic heartbeat barrier', async () => {
+        const readyPath = join(tempDirectory(), 'slow-publisher-ready');
+        const releasePath = join(tempDirectory(), 'release-slow-publisher');
+        const lockDirectory = join(tempDirectory(), 'locks');
+        const lockPath = join(lockDirectory, 'store.lock');
+        const child = Bun.spawn(
+          childCommand(
+            'hold-publish',
+            tempDirectory(),
+            3,
+            '91,92,93',
+            readyPath,
+            releasePath,
+          ),
+          { stdout: 'pipe', stderr: 'pipe' },
+        );
+        try {
+          await Promise.race([
+            waitForPath(readyPath, tempDirectory()),
+            child.exited.then(async () => {
+              if (!(await Bun.file(readyPath).exists())) {
+                throw new Error(await new Response(child.stderr).text());
+              }
+            }),
+          ]);
+          const epoch = new Date(0);
+          await utimes(lockPath, epoch, epoch);
+          await waitForMtimeAfterEpoch(lockPath, lockDirectory);
+          const contender = new LocalMediaStore({
+            rootDirectory: tempDirectory(),
+            quotaBytes: 3,
+            lockTimeoutMs: 2_000,
+            staleLockMs: 30,
+          });
+
+          const reclamation = contender.reclaimUnreferenced(
+            new Set(),
+            Date.now(),
+          );
+          await writeFile(releasePath, 'release', { flag: 'wx' });
+          const [exitCode, result, stdout, stderr] = await Promise.all([
+            child.exited,
+            reclamation,
+            new Response(child.stdout).text(),
+            new Response(child.stderr).text(),
+          ]);
+          if (exitCode !== 0) throw new Error(stderr);
+          const reference = parseChildReference(stdout);
+
+          expect(result.temporaryFilesRemoved).toBe(0);
+          expect(await contender.readVerified(reference)).toStrictEqual(
+            bytes(91, 92, 93),
+          );
+        } finally {
+          if (child.exitCode === null) child.kill('SIGKILL');
+          await child.exited;
+        }
+      });
     });
   });
 });

--- a/packages/core/src/storage/local-media-store-verification.test.ts
+++ b/packages/core/src/storage/local-media-store-verification.test.ts
@@ -41,734 +41,745 @@ import {
   type MediaReferenceBlock,
 } from '../services/history/IContent.js';
 
-function useTempDirectory(): () => string {
-  let directory = '';
-  beforeEach(async () => {
-    directory = await mkdtemp(join(tmpdir(), 'llxprt-media-store-'));
-  });
-  afterEach(async () => {
-    if (directory !== '') {
-      await chmod(directory, 0o700).catch(() => undefined);
-      await rm(directory, { recursive: true, force: true });
-    }
-  });
-  return () => directory;
-}
+describe('local-media-store-verification', () => {
+  function useTempDirectory(): () => string {
+    let directory = '';
+    beforeEach(async () => {
+      directory = await mkdtemp(join(tmpdir(), 'llxprt-media-store-'));
+    });
+    afterEach(async () => {
+      if (directory !== '') {
+        await chmod(directory, 0o700).catch(() => undefined);
+        await rm(directory, { recursive: true, force: true });
+      }
+    });
+    return () => directory;
+  }
 
-async function allFiles(directory: string): Promise<readonly string[]> {
-  const result: string[] = [];
-  async function visit(current: string): Promise<void> {
-    const entries = await readdir(current, { withFileTypes: true });
-    for (const entry of entries) {
-      const path = join(current, entry.name);
-      if (entry.isDirectory()) {
-        await visit(path);
-      } else {
-        result.push(path);
+  async function allFiles(directory: string): Promise<readonly string[]> {
+    const result: string[] = [];
+    async function visit(current: string): Promise<void> {
+      const entries = await readdir(current, { withFileTypes: true });
+      for (const entry of entries) {
+        const path = join(current, entry.name);
+        if (entry.isDirectory()) {
+          await visit(path);
+        } else {
+          result.push(path);
+        }
       }
     }
+    await visit(directory);
+    return result;
   }
-  await visit(directory);
-  return result;
-}
 
-async function storedObjectPath(
-  root: string,
-  reference: MediaReferenceBlock,
-): Promise<string> {
-  const digest = reference.contentId.slice('sha256:'.length);
-  const files = await allFiles(root);
-  const matches = files.filter((path) => path.endsWith(digest));
-  if (matches.length !== 1) {
-    throw new Error(`Expected one stored object for ${reference.contentId}`);
-  }
-  return matches[0];
-}
-
-function bytes(...values: number[]): Uint8Array {
-  return new Uint8Array(values);
-}
-
-function admitInput(payload: Uint8Array) {
-  return {
-    bytes: payload,
-    mimeType: 'image/png',
-    semanticMetadata: { detail: 'high', nested: { page: 2 } },
-  };
-}
-
-async function capturedError(work: Promise<unknown>): Promise<Error> {
-  try {
-    await work;
-  } catch (error) {
-    if (error instanceof Error) {
-      return error;
+  async function storedObjectPath(
+    root: string,
+    reference: MediaReferenceBlock,
+  ): Promise<string> {
+    const digest = reference.contentId.slice('sha256:'.length);
+    const files = await allFiles(root);
+    const matches = files.filter((path) => path.endsWith(digest));
+    if (matches.length !== 1) {
+      throw new Error(`Expected one stored object for ${reference.contentId}`);
     }
-    throw new Error('Expected an Error instance');
+    return matches[0];
   }
-  throw new Error('Expected operation to reject');
-}
 
-interface ChildResult {
-  readonly exitCode: number;
-  readonly stdout: string;
-  readonly stderr: string;
-}
-
-function childCommand(
-  mode: string,
-  rootDirectory: string,
-  quotaBytes: number,
-  payload: string,
-  ...additionalArguments: readonly string[]
-): string[] {
-  return [
-    process.execPath,
-    join(import.meta.dir, 'local-media-store-child.ts'),
-    mode,
-    rootDirectory,
-    String(quotaBytes),
-    payload,
-    ...additionalArguments,
-  ];
-}
-
-async function runChild(command: string[]): Promise<ChildResult> {
-  const child = Bun.spawn(command, { stdout: 'pipe', stderr: 'pipe' });
-  try {
-    const [exitCode, stdout, stderr] = await Promise.all([
-      child.exited,
-      new Response(child.stdout).text(),
-      new Response(child.stderr).text(),
-    ]);
-    return { exitCode, stdout, stderr };
-  } finally {
-    if (child.exitCode === null) child.kill('SIGKILL');
-    await child.exited;
+  function bytes(...values: number[]): Uint8Array {
+    return new Uint8Array(values);
   }
-}
-async function waitForPath(path: string, directory: string): Promise<void> {
-  if (await Bun.file(path).exists()) return;
-  const controller = new AbortController();
-  const events = watch(directory, { signal: controller.signal });
-  try {
-    if (await Bun.file(path).exists()) return;
-    for await (const _event of events) {
-      if (await Bun.file(path).exists()) return;
+
+  function admitInput(payload: Uint8Array) {
+    return {
+      bytes: payload,
+      mimeType: 'image/png',
+      semanticMetadata: { detail: 'high', nested: { page: 2 } },
+    };
+  }
+
+  async function capturedError(work: Promise<unknown>): Promise<Error> {
+    try {
+      await work;
+    } catch (error) {
+      if (error instanceof Error) {
+        return error;
+      }
+      throw new Error('Expected an Error instance');
     }
-    throw new Error(`Filesystem watch ended before ${path} appeared`);
-  } finally {
-    controller.abort();
+    throw new Error('Expected operation to reject');
   }
-}
 
-async function waitForMtimeAfterEpoch(
-  path: string,
-  directory: string,
-): Promise<void> {
-  if ((await stat(path)).mtimeMs > 0) return;
-  const controller = new AbortController();
-  const events = watch(directory, { signal: controller.signal });
-  try {
-    if ((await stat(path)).mtimeMs > 0) return;
-    for await (const _event of events) {
-      if ((await stat(path)).mtimeMs > 0) return;
-    }
-    throw new Error(`Filesystem watch ended before ${path} was renewed`);
-  } finally {
-    controller.abort();
+  interface ChildResult {
+    readonly exitCode: number;
+    readonly stdout: string;
+    readonly stderr: string;
   }
-}
 
-function parseChildReference(serialized: string): MediaReferenceBlock {
-  const parsed: unknown = JSON.parse(serialized.trim());
-  if (!isMediaReferenceBlock(parsed)) {
-    throw new Error('Child returned malformed media reference');
+  function childCommand(
+    mode: string,
+    rootDirectory: string,
+    quotaBytes: number,
+    payload: string,
+    ...additionalArguments: readonly string[]
+  ): string[] {
+    return [
+      process.execPath,
+      join(import.meta.dir, 'local-media-store-child.ts'),
+      mode,
+      rootDirectory,
+      String(quotaBytes),
+      payload,
+      ...additionalArguments,
+    ];
   }
-  return parsed;
-}
 
-class ReclamationReadHarness extends LocalMediaStorePersistence {
-  async scanObjectDirectory(): Promise<void> {
-    await this.scanReclamationCandidates(new Set(), Date.now());
-  }
-}
-
-describe('local-media-store-verification', () => {
-  describe('LocalMediaStore verified reads', () => {
-    const tempDirectory = useTempDirectory();
-
-    it('distinguishes a missing object and carries content identity and operation', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-      });
-      const reference = await store.admit(admitInput(bytes(1, 2, 3)));
-      await rm(await storedObjectPath(tempDirectory(), reference));
-
-      const error = await capturedError(store.readVerified(reference));
-
-      expect(error).toBeInstanceOf(MediaObjectMissingError);
-      expect(error).toBeInstanceOf(MediaStoreError);
-      assertInstanceOf(error, MediaStoreError, 'Expected MediaStoreError');
-      expect(error.contentId).toBe(reference.contentId);
-      expect(error.operation).toBe('read verified');
-    });
-
-    it('distinguishes corrupt length from a hash mismatch', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-      });
-      const reference = await store.admit(admitInput(bytes(1, 2, 3)));
-      await writeFile(
-        await storedObjectPath(tempDirectory(), reference),
-        bytes(9),
-      );
-
-      const error = await capturedError(store.readVerified(reference));
-
-      expect(error).toBeInstanceOf(MediaObjectCorruptError);
-      expect(error.message).toContain(reference.contentId);
-    });
-
-    it('distinguishes same-length hash-mismatched bytes', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-      });
-      const reference = await store.admit(admitInput(bytes(1, 2, 3)));
-      await writeFile(
-        await storedObjectPath(tempDirectory(), reference),
-        bytes(3, 2, 1),
-      );
-
-      const error = await capturedError(store.readVerified(reference));
-
-      expect(error).toBeInstanceOf(MediaObjectHashMismatchError);
-      expect(error.message).toContain(reference.contentId);
-    });
-
-    it('rejects a non-file object as corrupt', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-      });
-      const reference = await store.admit(admitInput(bytes(1, 2, 3)));
-      const path = await storedObjectPath(tempDirectory(), reference);
-      await rm(path);
-      await Bun.write(join(path, 'nested'), 'not an object file');
-
-      const error = await capturedError(store.readVerified(reference));
-
-      expect(error).toBeInstanceOf(MediaObjectCorruptError);
-    });
-
-    it('reports malformed runtime references through the media-store error contract', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-      });
-      const invocation: unknown = Reflect.apply(store.readVerified, store, [
-        undefined,
+  async function runChild(command: string[]): Promise<ChildResult> {
+    const child = Bun.spawn(command, { stdout: 'pipe', stderr: 'pipe' });
+    try {
+      const [exitCode, stdout, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
       ]);
-      assertInstanceOf(
-        invocation,
-        Promise,
-        'Expected readVerified to return a promise',
-      );
+      return { exitCode, stdout, stderr };
+    } finally {
+      if (child.exitCode === null) child.kill('SIGKILL');
+      await child.exited;
+    }
+  }
+  async function waitForPath(path: string, directory: string): Promise<void> {
+    if (await Bun.file(path).exists()) return;
+    const controller = new AbortController();
+    const events = watch(directory, { signal: controller.signal });
+    try {
+      if (await Bun.file(path).exists()) return;
+      for await (const _event of events) {
+        if (await Bun.file(path).exists()) return;
+      }
+      throw new Error(`Filesystem watch ended before ${path} appeared`);
+    } finally {
+      controller.abort();
+    }
+  }
 
-      const error = await capturedError(invocation);
+  async function waitForMtimeAfterEpoch(
+    path: string,
+    directory: string,
+  ): Promise<void> {
+    if ((await stat(path)).mtimeMs > 0) return;
+    const controller = new AbortController();
+    const events = watch(directory, { signal: controller.signal });
+    try {
+      if ((await stat(path)).mtimeMs > 0) return;
+      for await (const _event of events) {
+        if ((await stat(path)).mtimeMs > 0) return;
+      }
+      throw new Error(`Filesystem watch ended before ${path} was renewed`);
+    } finally {
+      controller.abort();
+    }
+  }
 
-      expect(error).toBeInstanceOf(MediaObjectCorruptError);
-    });
+  function parseChildReference(serialized: string): MediaReferenceBlock {
+    const parsed: unknown = JSON.parse(serialized.trim());
+    if (!isMediaReferenceBlock(parsed)) {
+      throw new Error('Child returned malformed media reference');
+    }
+    return parsed;
+  }
 
-    it('attributes object-directory read failures to reclamation', async () => {
-      await mkdir(join(tempDirectory(), 'objects'), { recursive: true });
-      await writeFile(
-        join(tempDirectory(), 'objects', 'sha256'),
-        'not a directory',
-      );
-      const harness = new ReclamationReadHarness({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
+  class ReclamationReadHarness extends LocalMediaStorePersistence {
+    async scanObjectDirectory(): Promise<void> {
+      await this.scanReclamationCandidates(new Set(), Date.now());
+    }
+  }
+
+  describe('local-media-store-verification', () => {
+    describe('LocalMediaStore verified reads', () => {
+      const tempDirectory = useTempDirectory();
+
+      it('distinguishes a missing object and carries content identity and operation', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
+        const reference = await store.admit(admitInput(bytes(1, 2, 3)));
+        await rm(await storedObjectPath(tempDirectory(), reference));
+
+        const error = await capturedError(store.readVerified(reference));
+
+        expect(error).toBeInstanceOf(MediaObjectMissingError);
+        expect(error).toBeInstanceOf(MediaStoreError);
+        assertInstanceOf(error, MediaStoreError, 'Expected MediaStoreError');
+        expect(error.contentId).toBe(reference.contentId);
+        expect(error.operation).toBe('read verified');
       });
 
-      const error = await capturedError(harness.scanObjectDirectory());
-
-      expect(error).toBeInstanceOf(MediaStoreError);
-      assertInstanceOf(error, MediaStoreError, 'Expected MediaStoreError');
-      expect(error.operation).toBe('reclaim media');
-    });
-  });
-
-  describe('LocalMediaStore ownership reservations', () => {
-    const tempDirectory = useTempDirectory();
-
-    it('reserves and releases explicit owners without changing spool usage', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-      });
-      const reference = await store.admit(admitInput(bytes(1, 2, 3)));
-
-      await store.reserve(reference, 'in-flight:request-1');
-      const reserved = await store.hasReservations(reference.contentId);
-      await store.release(reference.contentId, 'in-flight:request-1');
-
-      expect(reserved).toBe(true);
-      expect(await store.hasReservations(reference.contentId)).toBe(false);
-      expect(await store.getStoredByteLength()).toBe(3);
-    });
-
-    it('fails reservation of missing content with identity and operation context', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-      });
-      const contentId = `sha256:${createHash('sha256').update('missing').digest('hex')}`;
-      const missingReference: MediaReferenceBlock = {
-        type: 'media',
-        encoding: 'reference',
-        mimeType: 'image/png',
-        contentId,
-        originalContentId: contentId,
-        selectedContentId: contentId,
-        originalObject: {
-          contentId,
-          mimeType: 'image/png',
-          byteLength: 1,
-          normalizedBase64Length: 4,
-        },
-        selectedObject: {
-          contentId,
-          mimeType: 'image/png',
-          byteLength: 1,
-          normalizedBase64Length: 4,
-        },
-        transformation: {
-          policyId: 'identity',
-          policyVersion: 1,
-          parameters: {},
-        },
-        byteLength: 1,
-        normalizedBase64Length: 4,
-        semanticMetadata: {},
-      };
-
-      const error = await capturedError(
-        store.reserve(missingReference, 'persisted:session-1'),
-      );
-
-      expect(error).toBeInstanceOf(MediaObjectMissingError);
-      assertInstanceOf(error, MediaStoreError, 'Expected MediaStoreError');
-      expect(error.contentId).toBe(contentId);
-      expect(error.operation).toBe('reserve reference');
-    });
-
-    it('uses owner identity rather than exposing it as a path segment', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-      });
-      const reference = await store.admit(admitInput(bytes(1, 2, 3)));
-      const ownerId = '../../outside';
-
-      await store.reserve(reference, ownerId);
-
-      expect(
-        (await allFiles(tempDirectory())).some((path) =>
-          path.includes(ownerId),
-        ),
-      ).toBe(false);
-      await expect(
-        access(join(tempDirectory(), '..', 'outside'), constants.F_OK),
-      ).rejects.toThrow('ENOENT');
-    });
-
-    it('recovers stale ownership after a reserving process exits', async () => {
-      const child = await runChild(
-        childCommand('reserve-crash', tempDirectory(), 3, '61,62,63'),
-      );
-      if (child.exitCode !== 0) throw new Error(child.stderr);
-      const reference = parseChildReference(child.stdout);
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-        reservationLeaseMs: 30,
-      });
-      const instancePath = (await allFiles(tempDirectory())).find((path) =>
-        path.includes(join('instances')),
-      );
-      assertDefined(instancePath, 'Expected an instance lease');
-      const epoch = new Date(0);
-      await utimes(instancePath, epoch, epoch);
-
-      const result = await store.reclaimUnreferenced(new Set(), Date.now());
-
-      expect(result.objectsRemoved).toBe(1);
-      await expect(
-        stat(
-          join(
-            store.rootDirectory,
-            'objects',
-            'sha256',
-            reference.contentId.slice('sha256:'.length),
-          ),
-        ),
-      ).rejects.toMatchObject({ code: 'ENOENT' });
-    });
-
-    it('does not reclaim a live blob owned by another process', async () => {
-      const readyPath = join(tempDirectory(), 'child-ready.json');
-      const child = Bun.spawn(
-        childCommand('reserve-live', tempDirectory(), 3, '71,72,73', readyPath),
-        { stdout: 'pipe', stderr: 'pipe' },
-      );
-      try {
-        await Promise.race([
-          waitForPath(readyPath, tempDirectory()),
-          child.exited.then(async () => {
-            if (!(await Bun.file(readyPath).exists())) {
-              throw new Error(await new Response(child.stderr).text());
-            }
-          }),
-        ]);
-        const reference = parseChildReference(
-          await readFile(readyPath, 'utf8'),
+      it('distinguishes corrupt length from a hash mismatch', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
+        const reference = await store.admit(admitInput(bytes(1, 2, 3)));
+        await writeFile(
+          await storedObjectPath(tempDirectory(), reference),
+          bytes(9),
         );
-        const instanceDirectory = join(tempDirectory(), 'instances');
+
+        const error = await capturedError(store.readVerified(reference));
+
+        expect(error).toBeInstanceOf(MediaObjectCorruptError);
+        expect(error.message).toContain(reference.contentId);
+      });
+
+      it('distinguishes same-length hash-mismatched bytes', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
+        const reference = await store.admit(admitInput(bytes(1, 2, 3)));
+        await writeFile(
+          await storedObjectPath(tempDirectory(), reference),
+          bytes(3, 2, 1),
+        );
+
+        const error = await capturedError(store.readVerified(reference));
+
+        expect(error).toBeInstanceOf(MediaObjectHashMismatchError);
+        expect(error.message).toContain(reference.contentId);
+      });
+
+      it('rejects a non-file object as corrupt', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
+        const reference = await store.admit(admitInput(bytes(1, 2, 3)));
+        const path = await storedObjectPath(tempDirectory(), reference);
+        await rm(path);
+        await Bun.write(join(path, 'nested'), 'not an object file');
+
+        const error = await capturedError(store.readVerified(reference));
+
+        expect(error).toBeInstanceOf(MediaObjectCorruptError);
+      });
+
+      it('reports malformed runtime references through the media-store error contract', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
+        const invocation: unknown = Reflect.apply(store.readVerified, store, [
+          undefined,
+        ]);
+        assertInstanceOf(
+          invocation,
+          Promise,
+          'Expected readVerified to return a promise',
+        );
+
+        const error = await capturedError(invocation);
+
+        expect(error).toBeInstanceOf(MediaObjectCorruptError);
+      });
+
+      it('attributes object-directory read failures to reclamation', async () => {
+        await mkdir(join(tempDirectory(), 'objects'), { recursive: true });
+        await writeFile(
+          join(tempDirectory(), 'objects', 'sha256'),
+          'not a directory',
+        );
+        const harness = new ReclamationReadHarness({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
+
+        const error = await capturedError(harness.scanObjectDirectory());
+
+        expect(error).toBeInstanceOf(MediaStoreError);
+        assertInstanceOf(error, MediaStoreError, 'Expected MediaStoreError');
+        expect(error.operation).toBe('reclaim media');
+      });
+    });
+
+    describe('LocalMediaStore ownership reservations', () => {
+      const tempDirectory = useTempDirectory();
+
+      it('reserves and releases explicit owners without changing spool usage', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
+        const reference = await store.admit(admitInput(bytes(1, 2, 3)));
+
+        await store.reserve(reference, 'in-flight:request-1');
+        const reserved = await store.hasReservations(reference.contentId);
+        await store.release(reference.contentId, 'in-flight:request-1');
+
+        expect(reserved).toBe(true);
+        expect(await store.hasReservations(reference.contentId)).toBe(false);
+        expect(await store.getStoredByteLength()).toBe(3);
+      });
+
+      it('fails reservation of missing content with identity and operation context', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
+        const contentId = `sha256:${createHash('sha256').update('missing').digest('hex')}`;
+        const missingReference: MediaReferenceBlock = {
+          type: 'media',
+          encoding: 'reference',
+          mimeType: 'image/png',
+          contentId,
+          originalContentId: contentId,
+          selectedContentId: contentId,
+          originalObject: {
+            contentId,
+            mimeType: 'image/png',
+            byteLength: 1,
+            normalizedBase64Length: 4,
+          },
+          selectedObject: {
+            contentId,
+            mimeType: 'image/png',
+            byteLength: 1,
+            normalizedBase64Length: 4,
+          },
+          transformation: {
+            policyId: 'identity',
+            policyVersion: 1,
+            parameters: {},
+          },
+          byteLength: 1,
+          normalizedBase64Length: 4,
+          semanticMetadata: {},
+        };
+
+        const error = await capturedError(
+          store.reserve(missingReference, 'persisted:session-1'),
+        );
+
+        expect(error).toBeInstanceOf(MediaObjectMissingError);
+        assertInstanceOf(error, MediaStoreError, 'Expected MediaStoreError');
+        expect(error.contentId).toBe(contentId);
+        expect(error.operation).toBe('reserve reference');
+      });
+
+      it('uses owner identity rather than exposing it as a path segment', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
+        const reference = await store.admit(admitInput(bytes(1, 2, 3)));
+        const ownerId = '../../outside';
+
+        await store.reserve(reference, ownerId);
+
+        expect(
+          (await allFiles(tempDirectory())).some((path) =>
+            path.includes(ownerId),
+          ),
+        ).toBe(false);
+        await expect(
+          access(join(tempDirectory(), '..', 'outside'), constants.F_OK),
+        ).rejects.toThrow('ENOENT');
+      });
+
+      it('recovers stale ownership after a reserving process exits', async () => {
+        const child = await runChild(
+          childCommand('reserve-crash', tempDirectory(), 3, '61,62,63'),
+        );
+        if (child.exitCode !== 0) throw new Error(child.stderr);
+        const reference = parseChildReference(child.stdout);
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+          reservationLeaseMs: 30,
+        });
         const instancePath = (await allFiles(tempDirectory())).find((path) =>
           path.includes(join('instances')),
         );
         assertDefined(instancePath, 'Expected an instance lease');
         const epoch = new Date(0);
         await utimes(instancePath, epoch, epoch);
-        await waitForMtimeAfterEpoch(instancePath, instanceDirectory);
+
+        const result = await store.reclaimUnreferenced(new Set(), Date.now());
+
+        expect(result.objectsRemoved).toBe(1);
+        await expect(
+          stat(
+            join(
+              store.rootDirectory,
+              'objects',
+              'sha256',
+              reference.contentId.slice('sha256:'.length),
+            ),
+          ),
+        ).rejects.toMatchObject({ code: 'ENOENT' });
+      });
+
+      it('does not reclaim a live blob owned by another process', async () => {
+        const readyPath = join(tempDirectory(), 'child-ready.json');
+        const child = Bun.spawn(
+          childCommand(
+            'reserve-live',
+            tempDirectory(),
+            3,
+            '71,72,73',
+            readyPath,
+          ),
+          { stdout: 'pipe', stderr: 'pipe' },
+        );
+        try {
+          await Promise.race([
+            waitForPath(readyPath, tempDirectory()),
+            child.exited.then(async () => {
+              if (!(await Bun.file(readyPath).exists())) {
+                throw new Error(await new Response(child.stderr).text());
+              }
+            }),
+          ]);
+          const reference = parseChildReference(
+            await readFile(readyPath, 'utf8'),
+          );
+          const instanceDirectory = join(tempDirectory(), 'instances');
+          const instancePath = (await allFiles(tempDirectory())).find((path) =>
+            path.includes(join('instances')),
+          );
+          assertDefined(instancePath, 'Expected an instance lease');
+          const epoch = new Date(0);
+          await utimes(instancePath, epoch, epoch);
+          await waitForMtimeAfterEpoch(instancePath, instanceDirectory);
+          const store = new LocalMediaStore({
+            rootDirectory: tempDirectory(),
+            quotaBytes: 3,
+            reservationLeaseMs: 30,
+          });
+
+          const whileLive = await store.reclaimUnreferenced(
+            new Set(),
+            Date.now(),
+          );
+          child.kill('SIGKILL');
+          await child.exited;
+          await utimes(instancePath, epoch, epoch);
+          const afterCrash = await store.reclaimUnreferenced(
+            new Set(),
+            Date.now(),
+          );
+
+          expect(whileLive.objectsRemoved).toBe(0);
+          expect(afterCrash.objectsRemoved).toBe(1);
+          await expect(store.readVerified(reference)).rejects.toBeInstanceOf(
+            MediaObjectMissingError,
+          );
+        } finally {
+          if (child.exitCode === null) child.kill('SIGKILL');
+          await child.exited;
+        }
+      });
+
+      it('treats repeated reservation and release by one owner as idempotent', async () => {
         const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
+        const reference = await store.admit(admitInput(bytes(1, 2, 3)));
+
+        await store.reserve(reference, 'request:stable-owner');
+        await store.reserve(reference, 'request:stable-owner');
+        await store.release(reference.contentId, 'request:stable-owner');
+        await store.release(reference.contentId, 'request:stable-owner');
+
+        expect(await store.hasReservations(reference.contentId)).toBe(false);
+      });
+
+      it('atomically replaces reservation records with restrictive permissions', async () => {
+        let replacementStarted = (): void => undefined;
+        const started = new Promise<void>((resolve) => {
+          replacementStarted = resolve;
+        });
+        let allowReplacement = (): void => undefined;
+        const allowed = new Promise<void>((resolve) => {
+          allowReplacement = resolve;
+        });
+        let blockReplacement = false;
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+          fileOperations: {
+            link,
+            rename: async (sourcePath, destinationPath) => {
+              if (blockReplacement) {
+                replacementStarted();
+                await allowed;
+              }
+              await rename(sourcePath, destinationPath);
+            },
+          },
+        });
+        const reference = await store.admit(admitInput(bytes(1, 2, 3)));
+        await store.reserve(reference, 'request:atomic-replacement');
+        const reservationPath = (await allFiles(tempDirectory())).find((path) =>
+          path.includes(join('references', 'sha256')),
+        );
+        assertDefined(reservationPath, 'Expected a durable reservation record');
+        const existing: unknown = JSON.parse(
+          await readFile(reservationPath, 'utf8'),
+        );
+        if (typeof existing !== 'object' || existing === null) {
+          throw new Error('Expected a reservation object');
+        }
+        Reflect.set(existing, 'expiresAt', 0);
+        Reflect.set(existing, 'instanceId', 'expired-instance');
+        await writeFile(reservationPath, JSON.stringify(existing));
+        blockReplacement = true;
+
+        const replacement = store.reserve(
+          reference,
+          'request:atomic-replacement',
+        );
+        await started;
+        let visibleDuringReplacement: string;
+        try {
+          visibleDuringReplacement = await readFile(reservationPath, 'utf8');
+        } finally {
+          allowReplacement();
+        }
+        await replacement;
+
+        expect(visibleDuringReplacement).toBe(JSON.stringify(existing));
+        const reservationMode = (await stat(reservationPath)).mode & 0o777;
+        expect(process.platform === 'win32' || reservationMode === 0o600).toBe(
+          true,
+        );
+      });
+
+      it('fails conservatively for a malformed present instance lease and later reclaims a valid stale lease', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+          reservationLeaseMs: 30_000,
+        });
+        const reference = await store.admit(admitInput(bytes(1, 2, 3)));
+        await store.reserve(reference, 'request:malformed-live-lease');
+        const files = await allFiles(tempDirectory());
+        const reservationPath = files.find((path) =>
+          path.includes(join('references', 'sha256')),
+        );
+        assertDefined(reservationPath, 'Expected a reservation record');
+        await store.close();
+        const externalInstanceId = 'external-live-instance';
+        const instancePath = join(
+          tempDirectory(),
+          'instances',
+          externalInstanceId,
+        );
+        const reservation: unknown = JSON.parse(
+          await readFile(reservationPath, 'utf8'),
+        );
+        if (typeof reservation !== 'object' || reservation === null) {
+          throw new Error('Expected a reservation object');
+        }
+        Reflect.set(reservation, 'expiresAt', 0);
+        Reflect.set(reservation, 'instanceId', externalInstanceId);
+        await writeFile(reservationPath, JSON.stringify(reservation));
+        await writeFile(instancePath, '{');
+        const scanner = new LocalMediaStore({
           rootDirectory: tempDirectory(),
           quotaBytes: 3,
           reservationLeaseMs: 30,
         });
 
-        const whileLive = await store.reclaimUnreferenced(
-          new Set(),
-          Date.now(),
-        );
-        child.kill('SIGKILL');
-        await child.exited;
-        await utimes(instancePath, epoch, epoch);
-        const afterCrash = await store.reclaimUnreferenced(
-          new Set(),
-          Date.now(),
-        );
+        await expect(
+          scanner.hasReservations(reference.contentId),
+        ).rejects.toThrow(/owner lease/i);
+        expect(await Bun.file(reservationPath).exists()).toBe(true);
 
-        expect(whileLive.objectsRemoved).toBe(0);
-        expect(afterCrash.objectsRemoved).toBe(1);
-        await expect(store.readVerified(reference)).rejects.toBeInstanceOf(
+        await writeFile(
+          instancePath,
+          JSON.stringify({
+            version: 1,
+            instanceId: externalInstanceId,
+            token: 'external-token',
+            createdAt: 0,
+          }),
+        );
+        const epoch = new Date(0);
+        await utimes(instancePath, epoch, epoch);
+        expect(await scanner.hasReservations(reference.contentId)).toBe(false);
+        expect(await Bun.file(reservationPath).exists()).toBe(false);
+      });
+
+      it('rejects owner identities containing control characters', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
+        const reference = await store.admit(admitInput(bytes(1, 2, 3)));
+
+        await expect(
+          store.reserve(reference, 'request\u0000owner'),
+        ).rejects.toThrow(/owner id/i);
+
+        expect(await store.hasReservations(reference.contentId)).toBe(false);
+      });
+
+      it('expires a dead instance reservation even when its pid has been reused', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+          reservationLeaseMs: 30,
+        });
+        const reference = await store.admit(admitInput(bytes(1, 2, 3)));
+        await store.reserve(reference, 'request:expired-instance');
+        const reservationPath = (await allFiles(tempDirectory())).find((path) =>
+          path.includes(join('references', 'sha256')),
+        );
+        assertDefined(reservationPath, 'Expected a durable reservation record');
+        const record: unknown = JSON.parse(
+          await readFile(reservationPath, 'utf8'),
+        );
+        if (typeof record !== 'object' || record === null) {
+          throw new Error('Expected a reservation object');
+        }
+        Reflect.set(record, 'instanceId', 'dead-instance');
+        Reflect.set(record, 'pid', process.pid);
+        Reflect.set(record, 'expiresAt', 0);
+        await writeFile(reservationPath, JSON.stringify(record));
+
+        const result = await store.reclaimUnreferenced(new Set(), Date.now());
+
+        expect(result.objectsRemoved).toBe(1);
+      });
+
+      it('removes a torn reservation instead of wedging reclamation', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
+        const reference = await store.admit(admitInput(bytes(1, 2, 3)));
+        await store.reserve(reference, 'request:torn-record');
+        const reservationPath = (await allFiles(tempDirectory())).find((path) =>
+          path.includes(join('references', 'sha256')),
+        );
+        assertDefined(reservationPath, 'Expected a durable reservation record');
+        await writeFile(reservationPath, '{');
+
+        const result = await store.reclaimUnreferenced(new Set(), Date.now());
+
+        expect(result.objectsRemoved).toBe(1);
+        expect(await store.hasReservations(reference.contentId)).toBe(false);
+      });
+
+      it('allows verified reads and admission during a slow multi-object reclamation scan', async () => {
+        const initialStore = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 12,
+        });
+        const first = await initialStore.admit(admitInput(bytes(1, 2, 3)));
+        await initialStore.admit(admitInput(bytes(4, 5, 6)));
+        await initialStore.admit(admitInput(bytes(7, 8, 9)));
+        const objectPaths = (await allFiles(tempDirectory())).filter((path) =>
+          path.includes(join('objects', 'sha256')),
+        );
+        const creationTimes = await Promise.all(
+          objectPaths.map(async (path) => (await stat(path)).ctimeMs),
+        );
+        const latestCreationTime = Math.max(...creationTimes);
+        while (Date.now() <= latestCreationTime) {
+          await new Promise<void>((resolve) => setImmediate(resolve));
+        }
+        let releaseScan = (): void => undefined;
+        const scanRelease = new Promise<void>((resolve) => {
+          releaseScan = resolve;
+        });
+        let markScanBlocked = (): void => undefined;
+        const scanBlocked = new Promise<void>((resolve) => {
+          markScanBlocked = resolve;
+        });
+        let inspected = 0;
+        const scanner = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 12,
+          fileOperations: {
+            link,
+            inspectReclamationCandidate: async () => {
+              inspected += 1;
+              if (inspected === 2) {
+                markScanBlocked();
+                await scanRelease;
+              }
+            },
+          },
+        });
+        const contender = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 12,
+        });
+        const reclamation = scanner.reclaimUnreferenced(new Set(), Date.now());
+        await scanBlocked;
+
+        const concurrentWork = Promise.all([
+          contender.readVerified(first),
+          contender.admit(admitInput(bytes(10, 11, 12))),
+        ]);
+        try {
+          await concurrentWork;
+        } finally {
+          releaseScan();
+        }
+        const [verified, admitted] = await concurrentWork;
+        const result = await reclamation;
+
+        expect(verified).toStrictEqual(bytes(1, 2, 3));
+        expect(await contender.readVerified(admitted)).toStrictEqual(
+          bytes(10, 11, 12),
+        );
+        expect(result.objectsRemoved).toBe(3);
+      });
+
+      it('isolates malformed reservation entries while preserving a valid live reservation', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 6,
+        });
+        const reclaimable = await store.admit(admitInput(bytes(1, 2, 3)));
+        const live = await store.admit(admitInput(bytes(4, 5, 6)));
+        await store.reserve(live, 'request:live-corruption-control');
+        const reservationDirectory = join(
+          tempDirectory(),
+          'references',
+          'sha256',
+          reclaimable.contentId.slice('sha256:'.length),
+        );
+        await mkdir(reservationDirectory, { recursive: true });
+        const digestName = (label: string): string =>
+          createHash('sha256').update(label).digest('hex');
+        await Promise.all([
+          writeFile(join(reservationDirectory, 'malformed-name'), '{}'),
+          mkdir(join(reservationDirectory, digestName('non-file-entry'))),
+          writeFile(
+            join(reservationDirectory, digestName('invalid-json')),
+            '{',
+          ),
+          writeFile(
+            join(reservationDirectory, digestName('schema-invalid')),
+            JSON.stringify({ version: 1 }),
+          ),
+        ]);
+
+        const result = await store.reclaimUnreferenced(new Set(), Date.now());
+
+        expect(result.objectsRemoved).toBe(1);
+        await expect(store.readVerified(reclaimable)).rejects.toBeInstanceOf(
           MediaObjectMissingError,
         );
-      } finally {
-        if (child.exitCode === null) child.kill('SIGKILL');
-        await child.exited;
-      }
-    });
-
-    it('treats repeated reservation and release by one owner as idempotent', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
+        expect(await store.readVerified(live)).toStrictEqual(bytes(4, 5, 6));
+        expect(await store.hasReservations(live.contentId)).toBe(true);
       });
-      const reference = await store.admit(admitInput(bytes(1, 2, 3)));
-
-      await store.reserve(reference, 'request:stable-owner');
-      await store.reserve(reference, 'request:stable-owner');
-      await store.release(reference.contentId, 'request:stable-owner');
-      await store.release(reference.contentId, 'request:stable-owner');
-
-      expect(await store.hasReservations(reference.contentId)).toBe(false);
-    });
-
-    it('atomically replaces reservation records with restrictive permissions', async () => {
-      let replacementStarted = (): void => undefined;
-      const started = new Promise<void>((resolve) => {
-        replacementStarted = resolve;
-      });
-      let allowReplacement = (): void => undefined;
-      const allowed = new Promise<void>((resolve) => {
-        allowReplacement = resolve;
-      });
-      let blockReplacement = false;
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-        fileOperations: {
-          link,
-          rename: async (sourcePath, destinationPath) => {
-            if (blockReplacement) {
-              replacementStarted();
-              await allowed;
-            }
-            await rename(sourcePath, destinationPath);
-          },
-        },
-      });
-      const reference = await store.admit(admitInput(bytes(1, 2, 3)));
-      await store.reserve(reference, 'request:atomic-replacement');
-      const reservationPath = (await allFiles(tempDirectory())).find((path) =>
-        path.includes(join('references', 'sha256')),
-      );
-      assertDefined(reservationPath, 'Expected a durable reservation record');
-      const existing: unknown = JSON.parse(
-        await readFile(reservationPath, 'utf8'),
-      );
-      if (typeof existing !== 'object' || existing === null) {
-        throw new Error('Expected a reservation object');
-      }
-      Reflect.set(existing, 'expiresAt', 0);
-      Reflect.set(existing, 'instanceId', 'expired-instance');
-      await writeFile(reservationPath, JSON.stringify(existing));
-      blockReplacement = true;
-
-      const replacement = store.reserve(
-        reference,
-        'request:atomic-replacement',
-      );
-      await started;
-      let visibleDuringReplacement: string;
-      try {
-        visibleDuringReplacement = await readFile(reservationPath, 'utf8');
-      } finally {
-        allowReplacement();
-      }
-      await replacement;
-
-      expect(visibleDuringReplacement).toBe(JSON.stringify(existing));
-      const reservationMode = (await stat(reservationPath)).mode & 0o777;
-      expect(process.platform === 'win32' || reservationMode === 0o600).toBe(
-        true,
-      );
-    });
-
-    it('fails conservatively for a malformed present instance lease and later reclaims a valid stale lease', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-        reservationLeaseMs: 30_000,
-      });
-      const reference = await store.admit(admitInput(bytes(1, 2, 3)));
-      await store.reserve(reference, 'request:malformed-live-lease');
-      const files = await allFiles(tempDirectory());
-      const reservationPath = files.find((path) =>
-        path.includes(join('references', 'sha256')),
-      );
-      assertDefined(reservationPath, 'Expected a reservation record');
-      await store.close();
-      const externalInstanceId = 'external-live-instance';
-      const instancePath = join(
-        tempDirectory(),
-        'instances',
-        externalInstanceId,
-      );
-      const reservation: unknown = JSON.parse(
-        await readFile(reservationPath, 'utf8'),
-      );
-      if (typeof reservation !== 'object' || reservation === null) {
-        throw new Error('Expected a reservation object');
-      }
-      Reflect.set(reservation, 'expiresAt', 0);
-      Reflect.set(reservation, 'instanceId', externalInstanceId);
-      await writeFile(reservationPath, JSON.stringify(reservation));
-      await writeFile(instancePath, '{');
-      const scanner = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-        reservationLeaseMs: 30,
-      });
-
-      await expect(
-        scanner.hasReservations(reference.contentId),
-      ).rejects.toThrow(/owner lease/i);
-      expect(await Bun.file(reservationPath).exists()).toBe(true);
-
-      await writeFile(
-        instancePath,
-        JSON.stringify({
-          version: 1,
-          instanceId: externalInstanceId,
-          token: 'external-token',
-          createdAt: 0,
-        }),
-      );
-      const epoch = new Date(0);
-      await utimes(instancePath, epoch, epoch);
-      expect(await scanner.hasReservations(reference.contentId)).toBe(false);
-      expect(await Bun.file(reservationPath).exists()).toBe(false);
-    });
-
-    it('rejects owner identities containing control characters', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-      });
-      const reference = await store.admit(admitInput(bytes(1, 2, 3)));
-
-      await expect(
-        store.reserve(reference, 'request\u0000owner'),
-      ).rejects.toThrow(/owner id/i);
-
-      expect(await store.hasReservations(reference.contentId)).toBe(false);
-    });
-
-    it('expires a dead instance reservation even when its pid has been reused', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-        reservationLeaseMs: 30,
-      });
-      const reference = await store.admit(admitInput(bytes(1, 2, 3)));
-      await store.reserve(reference, 'request:expired-instance');
-      const reservationPath = (await allFiles(tempDirectory())).find((path) =>
-        path.includes(join('references', 'sha256')),
-      );
-      assertDefined(reservationPath, 'Expected a durable reservation record');
-      const record: unknown = JSON.parse(
-        await readFile(reservationPath, 'utf8'),
-      );
-      if (typeof record !== 'object' || record === null) {
-        throw new Error('Expected a reservation object');
-      }
-      Reflect.set(record, 'instanceId', 'dead-instance');
-      Reflect.set(record, 'pid', process.pid);
-      Reflect.set(record, 'expiresAt', 0);
-      await writeFile(reservationPath, JSON.stringify(record));
-
-      const result = await store.reclaimUnreferenced(new Set(), Date.now());
-
-      expect(result.objectsRemoved).toBe(1);
-    });
-
-    it('removes a torn reservation instead of wedging reclamation', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-      });
-      const reference = await store.admit(admitInput(bytes(1, 2, 3)));
-      await store.reserve(reference, 'request:torn-record');
-      const reservationPath = (await allFiles(tempDirectory())).find((path) =>
-        path.includes(join('references', 'sha256')),
-      );
-      assertDefined(reservationPath, 'Expected a durable reservation record');
-      await writeFile(reservationPath, '{');
-
-      const result = await store.reclaimUnreferenced(new Set(), Date.now());
-
-      expect(result.objectsRemoved).toBe(1);
-      expect(await store.hasReservations(reference.contentId)).toBe(false);
-    });
-
-    it('allows verified reads and admission during a slow multi-object reclamation scan', async () => {
-      const initialStore = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 12,
-      });
-      const first = await initialStore.admit(admitInput(bytes(1, 2, 3)));
-      await initialStore.admit(admitInput(bytes(4, 5, 6)));
-      await initialStore.admit(admitInput(bytes(7, 8, 9)));
-      const objectPaths = (await allFiles(tempDirectory())).filter((path) =>
-        path.includes(join('objects', 'sha256')),
-      );
-      const creationTimes = await Promise.all(
-        objectPaths.map(async (path) => (await stat(path)).ctimeMs),
-      );
-      const latestCreationTime = Math.max(...creationTimes);
-      while (Date.now() <= latestCreationTime) {
-        await new Promise<void>((resolve) => setImmediate(resolve));
-      }
-      let releaseScan = (): void => undefined;
-      const scanRelease = new Promise<void>((resolve) => {
-        releaseScan = resolve;
-      });
-      let markScanBlocked = (): void => undefined;
-      const scanBlocked = new Promise<void>((resolve) => {
-        markScanBlocked = resolve;
-      });
-      let inspected = 0;
-      const scanner = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 12,
-        fileOperations: {
-          link,
-          inspectReclamationCandidate: async () => {
-            inspected += 1;
-            if (inspected === 2) {
-              markScanBlocked();
-              await scanRelease;
-            }
-          },
-        },
-      });
-      const contender = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 12,
-      });
-      const reclamation = scanner.reclaimUnreferenced(new Set(), Date.now());
-      await scanBlocked;
-
-      const concurrentWork = Promise.all([
-        contender.readVerified(first),
-        contender.admit(admitInput(bytes(10, 11, 12))),
-      ]);
-      try {
-        await concurrentWork;
-      } finally {
-        releaseScan();
-      }
-      const [verified, admitted] = await concurrentWork;
-      const result = await reclamation;
-
-      expect(verified).toStrictEqual(bytes(1, 2, 3));
-      expect(await contender.readVerified(admitted)).toStrictEqual(
-        bytes(10, 11, 12),
-      );
-      expect(result.objectsRemoved).toBe(3);
-    });
-
-    it('isolates malformed reservation entries while preserving a valid live reservation', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 6,
-      });
-      const reclaimable = await store.admit(admitInput(bytes(1, 2, 3)));
-      const live = await store.admit(admitInput(bytes(4, 5, 6)));
-      await store.reserve(live, 'request:live-corruption-control');
-      const reservationDirectory = join(
-        tempDirectory(),
-        'references',
-        'sha256',
-        reclaimable.contentId.slice('sha256:'.length),
-      );
-      await mkdir(reservationDirectory, { recursive: true });
-      const digestName = (label: string): string =>
-        createHash('sha256').update(label).digest('hex');
-      await Promise.all([
-        writeFile(join(reservationDirectory, 'malformed-name'), '{}'),
-        mkdir(join(reservationDirectory, digestName('non-file-entry'))),
-        writeFile(join(reservationDirectory, digestName('invalid-json')), '{'),
-        writeFile(
-          join(reservationDirectory, digestName('schema-invalid')),
-          JSON.stringify({ version: 1 }),
-        ),
-      ]);
-
-      const result = await store.reclaimUnreferenced(new Set(), Date.now());
-
-      expect(result.objectsRemoved).toBe(1);
-      await expect(store.readVerified(reclaimable)).rejects.toBeInstanceOf(
-        MediaObjectMissingError,
-      );
-      expect(await store.readVerified(live)).toStrictEqual(bytes(4, 5, 6));
-      expect(await store.hasReservations(live.contentId)).toBe(true);
     });
   });
 });

--- a/packages/core/src/storage/local-media-store.test.ts
+++ b/packages/core/src/storage/local-media-store.test.ts
@@ -32,694 +32,708 @@ import type {
   MediaReferenceBlock,
 } from '../services/history/IContent.js';
 
-function useTempDirectory(): () => string {
-  let directory = '';
-  beforeEach(async () => {
-    directory = await mkdtemp(join(tmpdir(), 'llxprt-media-store-'));
-  });
-  afterEach(async () => {
-    if (directory !== '') {
-      await chmod(directory, 0o700).catch(() => undefined);
-      await rm(directory, { recursive: true, force: true });
-    }
-  });
-  return () => directory;
-}
+describe('local-media-store', () => {
+  function useTempDirectory(): () => string {
+    let directory = '';
+    beforeEach(async () => {
+      directory = await mkdtemp(join(tmpdir(), 'llxprt-media-store-'));
+    });
+    afterEach(async () => {
+      if (directory !== '') {
+        await chmod(directory, 0o700).catch(() => undefined);
+        await rm(directory, { recursive: true, force: true });
+      }
+    });
+    return () => directory;
+  }
 
-async function allFiles(directory: string): Promise<readonly string[]> {
-  const result: string[] = [];
-  async function visit(current: string): Promise<void> {
-    const entries = await readdir(current, { withFileTypes: true });
-    for (const entry of entries) {
-      const path = join(current, entry.name);
-      if (entry.isDirectory()) {
-        await visit(path);
-      } else {
-        result.push(path);
+  async function allFiles(directory: string): Promise<readonly string[]> {
+    const result: string[] = [];
+    async function visit(current: string): Promise<void> {
+      const entries = await readdir(current, { withFileTypes: true });
+      for (const entry of entries) {
+        const path = join(current, entry.name);
+        if (entry.isDirectory()) {
+          await visit(path);
+        } else {
+          result.push(path);
+        }
       }
     }
+    await visit(directory);
+    return result;
   }
-  await visit(directory);
-  return result;
-}
 
-async function storedObjectPath(
-  root: string,
-  reference: MediaReferenceBlock,
-): Promise<string> {
-  const digest = reference.contentId.slice('sha256:'.length);
-  const files = await allFiles(root);
-  const matches = files.filter((path) => path.endsWith(digest));
-  if (matches.length !== 1) {
-    throw new Error(`Expected one stored object for ${reference.contentId}`);
-  }
-  return matches[0];
-}
-
-function bytes(...values: number[]): Uint8Array {
-  return new Uint8Array(values);
-}
-
-function testStore(rootDirectory: string): LocalMediaStore {
-  return new LocalMediaStore({ rootDirectory, quotaBytes: 10 });
-}
-
-function admitInput(payload: Uint8Array) {
-  return {
-    bytes: payload,
-    mimeType: 'image/png',
-    semanticMetadata: { detail: 'high', nested: { page: 2 } },
-  };
-}
-
-async function capturedError(work: Promise<unknown>): Promise<Error> {
-  try {
-    await work;
-  } catch (error) {
-    if (error instanceof Error) {
-      return error;
+  async function storedObjectPath(
+    root: string,
+    reference: MediaReferenceBlock,
+  ): Promise<string> {
+    const digest = reference.contentId.slice('sha256:'.length);
+    const files = await allFiles(root);
+    const matches = files.filter((path) => path.endsWith(digest));
+    if (matches.length !== 1) {
+      throw new Error(`Expected one stored object for ${reference.contentId}`);
     }
-    throw new Error('Expected an Error instance');
+    return matches[0];
   }
-  throw new Error('Expected operation to reject');
-}
 
-interface ChildResult {
-  readonly exitCode: number;
-  readonly stdout: string;
-  readonly stderr: string;
-}
-
-function childCommand(
-  mode: string,
-  rootDirectory: string,
-  quotaBytes: number,
-  payload: string,
-  ...additionalArguments: readonly string[]
-): string[] {
-  return [
-    process.execPath,
-    join(import.meta.dir, 'local-media-store-child.ts'),
-    mode,
-    rootDirectory,
-    String(quotaBytes),
-    payload,
-    ...additionalArguments,
-  ];
-}
-
-async function runChild(command: string[]): Promise<ChildResult> {
-  const child = Bun.spawn(command, { stdout: 'pipe', stderr: 'pipe' });
-  try {
-    const [exitCode, stdout, stderr] = await Promise.all([
-      child.exited,
-      new Response(child.stdout).text(),
-      new Response(child.stderr).text(),
-    ]);
-    return { exitCode, stdout, stderr };
-  } finally {
-    if (child.exitCode === null) child.kill('SIGKILL');
-    await child.exited;
+  function bytes(...values: number[]): Uint8Array {
+    return new Uint8Array(values);
   }
-}
 
-describe('local-media-store', () => {
-  describe('LocalMediaStore admission', () => {
-    const tempDirectory = useTempDirectory();
+  function testStore(rootDirectory: string): LocalMediaStore {
+    return new LocalMediaStore({ rootDirectory, quotaBytes: 10 });
+  }
 
-    it('stores exact bytes and returns complete immutable metadata', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 4,
-      });
-      const payload = bytes(0, 1, 2, 3);
+  function admitInput(payload: Uint8Array) {
+    return {
+      bytes: payload,
+      mimeType: 'image/png',
+      semanticMetadata: { detail: 'high', nested: { page: 2 } },
+    };
+  }
 
-      const reference = await store.admit({
-        ...admitInput(payload),
-        knownByteLength: 4,
-        dimensions: { width: 640, height: 480 },
-        providerFileIds: { openai: 'file-123' },
-      });
-      payload[0] = 99;
+  async function capturedError(work: Promise<unknown>): Promise<Error> {
+    try {
+      await work;
+    } catch (error) {
+      if (error instanceof Error) {
+        return error;
+      }
+      throw new Error('Expected an Error instance');
+    }
+    throw new Error('Expected operation to reject');
+  }
 
-      expect(reference).toStrictEqual({
-        type: 'media',
-        encoding: 'reference',
-        mimeType: 'image/png',
-        contentId:
-          'sha256:054edec1d0211f624fed0cbca9d4f9400b0e491c43742af2c5b0abebf0c990d8',
-        originalContentId:
-          'sha256:054edec1d0211f624fed0cbca9d4f9400b0e491c43742af2c5b0abebf0c990d8',
-        selectedContentId:
-          'sha256:054edec1d0211f624fed0cbca9d4f9400b0e491c43742af2c5b0abebf0c990d8',
-        originalObject: {
+  interface ChildResult {
+    readonly exitCode: number;
+    readonly stdout: string;
+    readonly stderr: string;
+  }
+
+  function childCommand(
+    mode: string,
+    rootDirectory: string,
+    quotaBytes: number,
+    payload: string,
+    ...additionalArguments: readonly string[]
+  ): string[] {
+    return [
+      process.execPath,
+      join(import.meta.dir, 'local-media-store-child.ts'),
+      mode,
+      rootDirectory,
+      String(quotaBytes),
+      payload,
+      ...additionalArguments,
+    ];
+  }
+
+  async function runChild(command: string[]): Promise<ChildResult> {
+    const child = Bun.spawn(command, { stdout: 'pipe', stderr: 'pipe' });
+    try {
+      const [exitCode, stdout, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+      ]);
+      return { exitCode, stdout, stderr };
+    } finally {
+      if (child.exitCode === null) child.kill('SIGKILL');
+      await child.exited;
+    }
+  }
+
+  describe('local-media-store', () => {
+    describe('LocalMediaStore admission', () => {
+      const tempDirectory = useTempDirectory();
+
+      it('stores exact bytes and returns complete immutable metadata', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 4,
+        });
+        const payload = bytes(0, 1, 2, 3);
+
+        const reference = await store.admit({
+          ...admitInput(payload),
+          knownByteLength: 4,
+          dimensions: { width: 640, height: 480 },
+          providerFileIds: { openai: 'file-123' },
+        });
+        payload[0] = 99;
+
+        expect(reference).toStrictEqual({
+          type: 'media',
+          encoding: 'reference',
+          mimeType: 'image/png',
           contentId:
             'sha256:054edec1d0211f624fed0cbca9d4f9400b0e491c43742af2c5b0abebf0c990d8',
-          mimeType: 'image/png',
+          originalContentId:
+            'sha256:054edec1d0211f624fed0cbca9d4f9400b0e491c43742af2c5b0abebf0c990d8',
+          selectedContentId:
+            'sha256:054edec1d0211f624fed0cbca9d4f9400b0e491c43742af2c5b0abebf0c990d8',
+          originalObject: {
+            contentId:
+              'sha256:054edec1d0211f624fed0cbca9d4f9400b0e491c43742af2c5b0abebf0c990d8',
+            mimeType: 'image/png',
+            byteLength: 4,
+            normalizedBase64Length: 8,
+            dimensions: { width: 640, height: 480 },
+          },
+          selectedObject: {
+            contentId:
+              'sha256:054edec1d0211f624fed0cbca9d4f9400b0e491c43742af2c5b0abebf0c990d8',
+            mimeType: 'image/png',
+            byteLength: 4,
+            normalizedBase64Length: 8,
+            dimensions: { width: 640, height: 480 },
+          },
+          transformation: {
+            policyId: 'identity',
+            policyVersion: 1,
+            parameters: {},
+          },
           byteLength: 4,
           normalizedBase64Length: 8,
           dimensions: { width: 640, height: 480 },
-        },
-        selectedObject: {
-          contentId:
-            'sha256:054edec1d0211f624fed0cbca9d4f9400b0e491c43742af2c5b0abebf0c990d8',
-          mimeType: 'image/png',
-          byteLength: 4,
-          normalizedBase64Length: 8,
-          dimensions: { width: 640, height: 480 },
-        },
-        transformation: {
-          policyId: 'identity',
-          policyVersion: 1,
-          parameters: {},
-        },
-        byteLength: 4,
-        normalizedBase64Length: 8,
-        dimensions: { width: 640, height: 480 },
-        semanticMetadata: { detail: 'high', nested: { page: 2 } },
-        providerFileIds: { openai: 'file-123' },
-      });
-      expect(await store.readVerified(reference)).toStrictEqual(
-        bytes(0, 1, 2, 3),
-      );
-      expect(Object.isFrozen(reference.semanticMetadata)).toBe(true);
-      expect(Object.isFrozen(reference.semanticMetadata['nested'])).toBe(true);
-      expect(Object.isFrozen(reference.providerFileIds)).toBe(true);
-      expect(
-        (await storedObjectPath(tempDirectory(), reference)).startsWith(
-          tempDirectory(),
-        ),
-      ).toBe(true);
-    });
-
-    it('stores and verifies original and selected derived objects with stable policy identity', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 16,
-      });
-      const originalBytes = bytes(1, 2, 3, 4);
-      const selectedBytes = bytes(9, 8, 7);
-
-      const reference = await store.admit({
-        bytes: selectedBytes,
-        mimeType: 'image/webp',
-        dimensions: { width: 20, height: 10 },
-        original: {
-          bytes: originalBytes,
-          mimeType: 'image/png',
-          dimensions: { width: 200, height: 100 },
-        },
-        transformation: {
-          policyId: 'image-resize',
-          policyVersion: 1,
-          parameters: { maxLongEdge: 20 },
-        },
-        semanticMetadata: { detail: 'high' },
+          semanticMetadata: { detail: 'high', nested: { page: 2 } },
+          providerFileIds: { openai: 'file-123' },
+        });
+        expect(await store.readVerified(reference)).toStrictEqual(
+          bytes(0, 1, 2, 3),
+        );
+        expect(Object.isFrozen(reference.semanticMetadata)).toBe(true);
+        expect(Object.isFrozen(reference.semanticMetadata['nested'])).toBe(
+          true,
+        );
+        expect(Object.isFrozen(reference.providerFileIds)).toBe(true);
+        expect(
+          (await storedObjectPath(tempDirectory(), reference)).startsWith(
+            tempDirectory(),
+          ),
+        ).toBe(true);
       });
 
-      expect(reference).toMatchObject({
-        mimeType: 'image/webp',
-        byteLength: 3,
-        transformation: {
-          policyId: 'image-resize',
-          policyVersion: 1,
-          parameters: { maxLongEdge: 20 },
-        },
-        originalObject: {
-          mimeType: 'image/png',
-          byteLength: 4,
-          dimensions: { width: 200, height: 100 },
-        },
-        selectedObject: {
+      it('stores and verifies original and selected derived objects with stable policy identity', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 16,
+        });
+        const originalBytes = bytes(1, 2, 3, 4);
+        const selectedBytes = bytes(9, 8, 7);
+
+        const reference = await store.admit({
+          bytes: selectedBytes,
+          mimeType: 'image/webp',
+          dimensions: { width: 20, height: 10 },
+          original: {
+            bytes: originalBytes,
+            mimeType: 'image/png',
+            dimensions: { width: 200, height: 100 },
+          },
+          transformation: {
+            policyId: 'image-resize',
+            policyVersion: 1,
+            parameters: { maxLongEdge: 20 },
+          },
+          semanticMetadata: { detail: 'high' },
+        });
+
+        expect(reference).toMatchObject({
           mimeType: 'image/webp',
           byteLength: 3,
-          dimensions: { width: 20, height: 10 },
-        },
-      });
-      expect(reference.originalContentId).not.toBe(reference.selectedContentId);
-      expect(
-        await store.readObjectVerified(reference.originalObject),
-      ).toStrictEqual(originalBytes);
-      expect(await store.readVerified(reference)).toStrictEqual(selectedBytes);
-      expect(await store.getStoredByteLength()).toBe(7);
-    });
-
-    it('rejects known-size quota failure before invoking the byte source', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 2,
-      });
-      const payload = bytes(1, 2, 3);
-      const contentId = `sha256:${createHash('sha256').update(payload).digest('hex')}`;
-      let sourceRead = false;
-
-      const work = store.admitKnown(
-        {
-          contentId,
-          knownByteLength: payload.byteLength,
-          mimeType: 'image/png',
-          semanticMetadata: {},
-        },
-        async () => {
-          sourceRead = true;
-          return payload;
-        },
-      );
-
-      await expect(work).rejects.toThrow('quota');
-      expect(sourceRead).toBe(false);
-    });
-
-    it('snapshots a known byte source while the cross-process lock is not held', async () => {
-      const payload = bytes(1, 2, 3);
-      const contentId = `sha256:${createHash('sha256').update(payload).digest('hex')}`;
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: payload.byteLength,
-      });
-      let lockVisibleDuringRead = true;
-
-      const reference = await store.admitKnown(
-        {
-          contentId,
-          knownByteLength: payload.byteLength,
-          mimeType: 'image/png',
-          semanticMetadata: {},
-        },
-        async () => {
-          lockVisibleDuringRead = await Bun.file(
-            join(tempDirectory(), 'locks', 'store.lock'),
-          ).exists();
-          return payload;
-        },
-      );
-
-      expect(lockVisibleDuringRead).toBe(false);
-      expect(await store.readVerified(reference)).toStrictEqual(payload);
-    });
-
-    it('deduplicates identical content without charging it twice', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-      });
-
-      const first = await store.admit(admitInput(bytes(1, 2, 3)));
-      const second = await store.admit(admitInput(bytes(1, 2, 3)));
-
-      expect(second.contentId).toBe(first.contentId);
-      expect(await store.getStoredByteLength()).toBe(3);
-    });
-
-    it('stores distinct bytes as distinct content', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 6,
-      });
-
-      const first = await store.admit(admitInput(bytes(1, 2, 3)));
-      const second = await store.admit(admitInput(bytes(1, 2, 4)));
-
-      expect(second.contentId).not.toBe(first.contentId);
-      expect(await store.getStoredByteLength()).toBe(6);
-    });
-
-    it('admits one concurrent copy of identical content without partial data', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 4,
-      });
-      const input = admitInput(bytes(7, 8, 9, 10));
-
-      const references = await Promise.all(
-        Array.from({ length: 20 }, () => store.admit(input)),
-      );
-
-      expect(
-        new Set(references.map((reference) => reference.contentId)).size,
-      ).toBe(1);
-      expect(await store.getStoredByteLength()).toBe(4);
-      expect(await store.readVerified(references[0])).toStrictEqual(
-        input.bytes,
-      );
-    });
-
-    it('uses restrictive directory and file permissions where supported', async () => {
-      if (process.platform === 'win32') {
-        return;
-      }
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-      });
-
-      const reference = await store.admit(admitInput(bytes(1, 2, 3)));
-      const objectPath = await storedObjectPath(tempDirectory(), reference);
-
-      expect((await stat(tempDirectory())).mode & 0o777).toBe(0o700);
-      expect((await stat(objectPath)).mode & 0o777).toBe(0o600);
-    });
-
-    it('cleans temporary files after successful admission', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-      });
-
-      await store.admit(admitInput(bytes(1, 2, 3)));
-
-      expect(
-        (await allFiles(tempDirectory())).some((path) => path.endsWith('.tmp')),
-      ).toBe(false);
-    });
-
-    it('cleans temporary files when atomic commit fails', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-        fileOperations: {
-          link: async () => {
-            throw new Error('induced link failure');
+          transformation: {
+            policyId: 'image-resize',
+            policyVersion: 1,
+            parameters: { maxLongEdge: 20 },
           },
-        },
-      });
-
-      const error = await capturedError(
-        store.admit(admitInput(bytes(1, 2, 3))),
-      );
-
-      expect(error).toBeInstanceOf(MediaStoreError);
-      expect(error.message).toContain('commit');
-      expect(
-        (await allFiles(tempDirectory())).some((path) => path.endsWith('.tmp')),
-      ).toBe(false);
-    });
-    it('rolls back a newly published object when post-publication commit fails', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-        fileOperations: {
-          link: async (sourcePath, destinationPath) => {
-            await publishLink(sourcePath, destinationPath);
-            throw new Error('induced post-publication failure');
+          originalObject: {
+            mimeType: 'image/png',
+            byteLength: 4,
+            dimensions: { width: 200, height: 100 },
           },
-        },
-      });
-
-      const error = await capturedError(
-        store.admit(admitInput(bytes(1, 2, 3))),
-      );
-
-      expect(error).toBeInstanceOf(MediaStoreError);
-      expect(await store.getStoredByteLength()).toBe(0);
-    });
-
-    it('does not roll back an object published concurrently by another owner', async () => {
-      const payload = bytes(1, 2, 3);
-      const contentId = `sha256:${createHash('sha256').update(payload).digest('hex')}`;
-      const object = {
-        contentId,
-        mimeType: 'image/png',
-        byteLength: payload.byteLength,
-        normalizedBase64Length: 4,
-      };
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-        fileOperations: {
-          link: async (sourcePath, destinationPath) => {
-            await publishLink(sourcePath, destinationPath);
-            await publishLink(sourcePath, destinationPath);
+          selectedObject: {
+            mimeType: 'image/webp',
+            byteLength: 3,
+            dimensions: { width: 20, height: 10 },
           },
-        },
+        });
+        expect(reference.originalContentId).not.toBe(
+          reference.selectedContentId,
+        );
+        expect(
+          await store.readObjectVerified(reference.originalObject),
+        ).toStrictEqual(originalBytes);
+        expect(await store.readVerified(reference)).toStrictEqual(
+          selectedBytes,
+        );
+        expect(await store.getStoredByteLength()).toBe(7);
       });
 
-      await expect(
-        store.admitObjectsTransaction([{ object, bytes: payload }], () =>
-          Promise.reject(new Error('durable history publication failed')),
-        ),
-      ).rejects.toThrow('durable history publication failed');
+      it('rejects known-size quota failure before invoking the byte source', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 2,
+        });
+        const payload = bytes(1, 2, 3);
+        const contentId = `sha256:${createHash('sha256').update(payload).digest('hex')}`;
+        let sourceRead = false;
 
-      expect(await store.readObjectVerified(object)).toStrictEqual(payload);
-      expect(await store.getStoredByteLength()).toBe(payload.byteLength);
-    });
-
-    it('rolls back a newly published known object when verification fails', async () => {
-      const payload = bytes(4, 5, 6);
-      const contentId = `sha256:${createHash('sha256').update(payload).digest('hex')}`;
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 3,
-        fileOperations: {
-          link: async (sourcePath, destinationPath) => {
-            await publishLink(sourcePath, destinationPath);
-            await writeFile(destinationPath, bytes(9, 9, 9));
-          },
-        },
-      });
-
-      await expect(
-        store.admitKnown(
+        const work = store.admitKnown(
           {
             contentId,
             knownByteLength: payload.byteLength,
             mimeType: 'image/png',
             semanticMetadata: {},
           },
-          () => Promise.resolve(payload),
-        ),
-      ).rejects.toBeInstanceOf(MediaObjectHashMismatchError);
+          async () => {
+            sourceRead = true;
+            return payload;
+          },
+        );
 
-      expect(await store.getStoredByteLength()).toBe(0);
-    });
-
-    it('rejects a symlink source without publishing its target', async () => {
-      const payload = bytes(7, 8, 9);
-      const contentId = `sha256:${createHash('sha256').update(payload).digest('hex')}`;
-      const sourceTarget = join(tempDirectory(), 'source-target');
-      const sourceLink = join(tempDirectory(), 'source-link');
-      await writeFile(sourceTarget, payload);
-      await symlink(sourceTarget, sourceLink);
-      const store = new LocalMediaStore({
-        rootDirectory: join(tempDirectory(), 'store'),
-        quotaBytes: payload.byteLength,
+        await expect(work).rejects.toThrow('quota');
+        expect(sourceRead).toBe(false);
       });
 
-      await expect(
-        store.stageObjectFiles([
+      it('snapshots a known byte source while the cross-process lock is not held', async () => {
+        const payload = bytes(1, 2, 3);
+        const contentId = `sha256:${createHash('sha256').update(payload).digest('hex')}`;
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: payload.byteLength,
+        });
+        let lockVisibleDuringRead = true;
+
+        const reference = await store.admitKnown(
           {
-            object: {
+            contentId,
+            knownByteLength: payload.byteLength,
+            mimeType: 'image/png',
+            semanticMetadata: {},
+          },
+          async () => {
+            lockVisibleDuringRead = await Bun.file(
+              join(tempDirectory(), 'locks', 'store.lock'),
+            ).exists();
+            return payload;
+          },
+        );
+
+        expect(lockVisibleDuringRead).toBe(false);
+        expect(await store.readVerified(reference)).toStrictEqual(payload);
+      });
+
+      it('deduplicates identical content without charging it twice', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
+
+        const first = await store.admit(admitInput(bytes(1, 2, 3)));
+        const second = await store.admit(admitInput(bytes(1, 2, 3)));
+
+        expect(second.contentId).toBe(first.contentId);
+        expect(await store.getStoredByteLength()).toBe(3);
+      });
+
+      it('stores distinct bytes as distinct content', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 6,
+        });
+
+        const first = await store.admit(admitInput(bytes(1, 2, 3)));
+        const second = await store.admit(admitInput(bytes(1, 2, 4)));
+
+        expect(second.contentId).not.toBe(first.contentId);
+        expect(await store.getStoredByteLength()).toBe(6);
+      });
+
+      it('admits one concurrent copy of identical content without partial data', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 4,
+        });
+        const input = admitInput(bytes(7, 8, 9, 10));
+
+        const references = await Promise.all(
+          Array.from({ length: 20 }, () => store.admit(input)),
+        );
+
+        expect(
+          new Set(references.map((reference) => reference.contentId)).size,
+        ).toBe(1);
+        expect(await store.getStoredByteLength()).toBe(4);
+        expect(await store.readVerified(references[0])).toStrictEqual(
+          input.bytes,
+        );
+      });
+
+      it('uses restrictive directory and file permissions where supported', async () => {
+        if (process.platform === 'win32') {
+          return;
+        }
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
+
+        const reference = await store.admit(admitInput(bytes(1, 2, 3)));
+        const objectPath = await storedObjectPath(tempDirectory(), reference);
+
+        expect((await stat(tempDirectory())).mode & 0o777).toBe(0o700);
+        expect((await stat(objectPath)).mode & 0o777).toBe(0o600);
+      });
+
+      it('cleans temporary files after successful admission', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+        });
+
+        await store.admit(admitInput(bytes(1, 2, 3)));
+
+        expect(
+          (await allFiles(tempDirectory())).some((path) =>
+            path.endsWith('.tmp'),
+          ),
+        ).toBe(false);
+      });
+
+      it('cleans temporary files when atomic commit fails', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+          fileOperations: {
+            link: async () => {
+              throw new Error('induced link failure');
+            },
+          },
+        });
+
+        const error = await capturedError(
+          store.admit(admitInput(bytes(1, 2, 3))),
+        );
+
+        expect(error).toBeInstanceOf(MediaStoreError);
+        expect(error.message).toContain('commit');
+        expect(
+          (await allFiles(tempDirectory())).some((path) =>
+            path.endsWith('.tmp'),
+          ),
+        ).toBe(false);
+      });
+      it('rolls back a newly published object when post-publication commit fails', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+          fileOperations: {
+            link: async (sourcePath, destinationPath) => {
+              await publishLink(sourcePath, destinationPath);
+              throw new Error('induced post-publication failure');
+            },
+          },
+        });
+
+        const error = await capturedError(
+          store.admit(admitInput(bytes(1, 2, 3))),
+        );
+
+        expect(error).toBeInstanceOf(MediaStoreError);
+        expect(await store.getStoredByteLength()).toBe(0);
+      });
+
+      it('does not roll back an object published concurrently by another owner', async () => {
+        const payload = bytes(1, 2, 3);
+        const contentId = `sha256:${createHash('sha256').update(payload).digest('hex')}`;
+        const object = {
+          contentId,
+          mimeType: 'image/png',
+          byteLength: payload.byteLength,
+          normalizedBase64Length: 4,
+        };
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+          fileOperations: {
+            link: async (sourcePath, destinationPath) => {
+              await publishLink(sourcePath, destinationPath);
+              await publishLink(sourcePath, destinationPath);
+            },
+          },
+        });
+
+        await expect(
+          store.admitObjectsTransaction([{ object, bytes: payload }], () =>
+            Promise.reject(new Error('durable history publication failed')),
+          ),
+        ).rejects.toThrow('durable history publication failed');
+
+        expect(await store.readObjectVerified(object)).toStrictEqual(payload);
+        expect(await store.getStoredByteLength()).toBe(payload.byteLength);
+      });
+
+      it('rolls back a newly published known object when verification fails', async () => {
+        const payload = bytes(4, 5, 6);
+        const contentId = `sha256:${createHash('sha256').update(payload).digest('hex')}`;
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 3,
+          fileOperations: {
+            link: async (sourcePath, destinationPath) => {
+              await publishLink(sourcePath, destinationPath);
+              await writeFile(destinationPath, bytes(9, 9, 9));
+            },
+          },
+        });
+
+        await expect(
+          store.admitKnown(
+            {
+              contentId,
+              knownByteLength: payload.byteLength,
+              mimeType: 'image/png',
+              semanticMetadata: {},
+            },
+            () => Promise.resolve(payload),
+          ),
+        ).rejects.toBeInstanceOf(MediaObjectHashMismatchError);
+
+        expect(await store.getStoredByteLength()).toBe(0);
+      });
+
+      it('rejects a symlink source without publishing its target', async () => {
+        const payload = bytes(7, 8, 9);
+        const contentId = `sha256:${createHash('sha256').update(payload).digest('hex')}`;
+        const sourceTarget = join(tempDirectory(), 'source-target');
+        const sourceLink = join(tempDirectory(), 'source-link');
+        await writeFile(sourceTarget, payload);
+        await symlink(sourceTarget, sourceLink);
+        const store = new LocalMediaStore({
+          rootDirectory: join(tempDirectory(), 'store'),
+          quotaBytes: payload.byteLength,
+        });
+
+        await expect(
+          store.stageObjectFiles([
+            {
+              object: {
+                contentId,
+                mimeType: 'image/png',
+                byteLength: payload.byteLength,
+                normalizedBase64Length: 4,
+              },
+              sourcePath: sourceLink,
+            },
+          ]),
+        ).rejects.toThrow(/symbolic link|regular file/i);
+
+        expect(await store.getStoredByteLength()).toBe(0);
+      });
+
+      it('rejects a symlink root without changing its target permissions', async () => {
+        if (process.platform === 'win32') return;
+        const target = join(tempDirectory(), 'target');
+        const rootLink = join(tempDirectory(), 'store-link');
+        await mkdir(target, { mode: 0o755 });
+        await symlink(target, rootLink);
+        const store = new LocalMediaStore({
+          rootDirectory: rootLink,
+          quotaBytes: 3,
+        });
+
+        await expect(store.admit(admitInput(bytes(1, 2, 3)))).rejects.toThrow(
+          /symbolic link/i,
+        );
+
+        expect((await stat(target)).mode & 0o777).toBe(0o755);
+      });
+
+      it('never follows an object-path symlink during deduplicated publication', async () => {
+        if (process.platform === 'win32') return;
+        const payload = bytes(10, 11, 12);
+        const externalTarget = join(tempDirectory(), 'external-target');
+        await writeFile(externalTarget, payload, { mode: 0o640 });
+        const store = new LocalMediaStore({
+          rootDirectory: join(tempDirectory(), 'store'),
+          quotaBytes: payload.byteLength,
+          fileOperations: {
+            link: async (sourcePath, destinationPath) => {
+              await symlink(externalTarget, destinationPath);
+              await publishLink(sourcePath, destinationPath);
+            },
+          },
+        });
+
+        await expect(store.admit(admitInput(payload))).rejects.toBeInstanceOf(
+          MediaObjectCorruptError,
+        );
+
+        expect((await stat(externalTarget)).mode & 0o777).toBe(0o640);
+        expect([...(await readFile(externalTarget))]).toStrictEqual([
+          ...payload,
+        ]);
+      });
+    });
+
+    describe('LocalMediaStore child byte parsing', () => {
+      const tempDirectory = useTempDirectory();
+
+      it('rejects empty and non-decimal byte tokens', async () => {
+        const results = await Promise.all([
+          runChild(childCommand('admit', tempDirectory(), 6, '1,,2')),
+          runChild(childCommand('admit', tempDirectory(), 6, '0x10')),
+        ]);
+
+        expect(results.map((result) => result.exitCode === 0)).toStrictEqual([
+          false,
+          false,
+        ]);
+        expect(
+          results.every((result) => result.stderr.includes('Invalid bytes')),
+        ).toBe(true);
+      });
+    });
+
+    describe('LocalMediaStore input validation', () => {
+      const tempDirectory = useTempDirectory();
+
+      it('rejects invalid quotas at construction', () => {
+        const invalid = [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY];
+
+        const failures = invalid.map(() => false);
+        invalid.forEach((quotaBytes, index) => {
+          try {
+            new LocalMediaStore({ rootDirectory: tempDirectory(), quotaBytes });
+          } catch (error) {
+            failures[index] = error instanceof MediaStoreError;
+          }
+        });
+
+        expect(failures).toStrictEqual([true, true, true, true]);
+      });
+
+      it('rejects empty bytes', async () => {
+        const store = testStore(tempDirectory());
+
+        const error = await capturedError(store.admit(admitInput(bytes())));
+
+        expect(error.message).toContain('empty');
+      });
+
+      it('rejects invalid MIME types', async () => {
+        const store = testStore(tempDirectory());
+
+        const error = await capturedError(
+          store.admit({ ...admitInput(bytes(1)), mimeType: 'not a mime' }),
+        );
+
+        expect(error.message).toContain('MIME');
+      });
+
+      it('rejects malformed dimensions', async () => {
+        const store = testStore(tempDirectory());
+        const malformed = JSON.parse('{"width":0,"height":12}');
+
+        const error = await capturedError(
+          store.admit({ ...admitInput(bytes(1)), dimensions: malformed }),
+        );
+
+        expect(error.message).toContain('dimensions');
+      });
+
+      it('rejects invalid semantic metadata', async () => {
+        const store = testStore(tempDirectory());
+        const invalidMetadata = { score: Number.NaN };
+
+        const error = await capturedError(
+          store.admit({
+            ...admitInput(bytes(1)),
+            semanticMetadata: invalidMetadata,
+          }),
+        );
+
+        expect(error.message).toContain('semantic metadata');
+      });
+
+      it('rejects semantic metadata beyond the recursion bound with its media location', async () => {
+        const store = testStore(tempDirectory());
+        const mediaBytes = bytes(1);
+        const contentId = `sha256:${createHash('sha256').update(mediaBytes).digest('hex')}`;
+        let nested: MediaSemanticMetadataValue = 'leaf';
+        for (let depth = 0; depth < 66; depth += 1) {
+          nested = [nested];
+        }
+        const semanticMetadata: MediaSemanticMetadata = { pipeline: nested };
+
+        const error = await capturedError(
+          store.admit({
+            ...admitInput(mediaBytes),
+            semanticMetadata,
+          }),
+        );
+
+        expect(error.message).toContain('semanticMetadata.pipeline');
+        expect(error.message).toMatch(/maximum depth 64/i);
+        expect(error.message).toContain(contentId);
+      });
+
+      it('rejects invalid provider file metadata', async () => {
+        const store = testStore(tempDirectory());
+        const invalid = JSON.parse('{"openai":""}');
+
+        const error = await capturedError(
+          store.admit({ ...admitInput(bytes(1)), providerFileIds: invalid }),
+        );
+
+        expect(error.message).toContain('provider file IDs');
+      });
+
+      it('rejects a known size inconsistent with actual bytes', async () => {
+        const store = testStore(tempDirectory());
+
+        const error = await capturedError(
+          store.admit({ ...admitInput(bytes(1, 2)), knownByteLength: 3 }),
+        );
+
+        expect(error.message).toContain('known byte length');
+      });
+
+      it('rejects invalid known sizes', async () => {
+        const store = testStore(tempDirectory());
+
+        const error = await capturedError(
+          store.admit({ ...admitInput(bytes(1)), knownByteLength: -1 }),
+        );
+
+        expect(error.message).toContain('known byte length');
+      });
+
+      it('rejects conflicting dimensions for one content-addressed object', async () => {
+        const store = testStore(tempDirectory());
+        const contentId = `sha256:${createHash('sha256').update(bytes(1)).digest('hex')}`;
+
+        await expect(
+          store.preflightObjects([
+            {
               contentId,
               mimeType: 'image/png',
-              byteLength: payload.byteLength,
+              byteLength: 1,
               normalizedBase64Length: 4,
+              dimensions: { width: 10, height: 20 },
             },
-            sourcePath: sourceLink,
-          },
-        ]),
-      ).rejects.toThrow(/symbolic link|regular file/i);
-
-      expect(await store.getStoredByteLength()).toBe(0);
-    });
-
-    it('rejects a symlink root without changing its target permissions', async () => {
-      if (process.platform === 'win32') return;
-      const target = join(tempDirectory(), 'target');
-      const rootLink = join(tempDirectory(), 'store-link');
-      await mkdir(target, { mode: 0o755 });
-      await symlink(target, rootLink);
-      const store = new LocalMediaStore({
-        rootDirectory: rootLink,
-        quotaBytes: 3,
+            {
+              contentId,
+              mimeType: 'image/png',
+              byteLength: 1,
+              normalizedBase64Length: 4,
+              dimensions: { width: 20, height: 10 },
+            },
+          ]),
+        ).rejects.toThrow('Conflicting stored object metadata');
       });
-
-      await expect(store.admit(admitInput(bytes(1, 2, 3)))).rejects.toThrow(
-        /symbolic link/i,
-      );
-
-      expect((await stat(target)).mode & 0o777).toBe(0o755);
-    });
-
-    it('never follows an object-path symlink during deduplicated publication', async () => {
-      if (process.platform === 'win32') return;
-      const payload = bytes(10, 11, 12);
-      const externalTarget = join(tempDirectory(), 'external-target');
-      await writeFile(externalTarget, payload, { mode: 0o640 });
-      const store = new LocalMediaStore({
-        rootDirectory: join(tempDirectory(), 'store'),
-        quotaBytes: payload.byteLength,
-        fileOperations: {
-          link: async (sourcePath, destinationPath) => {
-            await symlink(externalTarget, destinationPath);
-            await publishLink(sourcePath, destinationPath);
-          },
-        },
-      });
-
-      await expect(store.admit(admitInput(payload))).rejects.toBeInstanceOf(
-        MediaObjectCorruptError,
-      );
-
-      expect((await stat(externalTarget)).mode & 0o777).toBe(0o640);
-      expect([...(await readFile(externalTarget))]).toStrictEqual([...payload]);
-    });
-  });
-
-  describe('LocalMediaStore child byte parsing', () => {
-    const tempDirectory = useTempDirectory();
-
-    it('rejects empty and non-decimal byte tokens', async () => {
-      const results = await Promise.all([
-        runChild(childCommand('admit', tempDirectory(), 6, '1,,2')),
-        runChild(childCommand('admit', tempDirectory(), 6, '0x10')),
-      ]);
-
-      expect(results.map((result) => result.exitCode === 0)).toStrictEqual([
-        false,
-        false,
-      ]);
-      expect(
-        results.every((result) => result.stderr.includes('Invalid bytes')),
-      ).toBe(true);
-    });
-  });
-
-  describe('LocalMediaStore input validation', () => {
-    const tempDirectory = useTempDirectory();
-
-    it('rejects invalid quotas at construction', () => {
-      const invalid = [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY];
-
-      const failures = invalid.map(() => false);
-      invalid.forEach((quotaBytes, index) => {
-        try {
-          new LocalMediaStore({ rootDirectory: tempDirectory(), quotaBytes });
-        } catch (error) {
-          failures[index] = error instanceof MediaStoreError;
-        }
-      });
-
-      expect(failures).toStrictEqual([true, true, true, true]);
-    });
-
-    it('rejects empty bytes', async () => {
-      const store = testStore(tempDirectory());
-
-      const error = await capturedError(store.admit(admitInput(bytes())));
-
-      expect(error.message).toContain('empty');
-    });
-
-    it('rejects invalid MIME types', async () => {
-      const store = testStore(tempDirectory());
-
-      const error = await capturedError(
-        store.admit({ ...admitInput(bytes(1)), mimeType: 'not a mime' }),
-      );
-
-      expect(error.message).toContain('MIME');
-    });
-
-    it('rejects malformed dimensions', async () => {
-      const store = testStore(tempDirectory());
-      const malformed = JSON.parse('{"width":0,"height":12}');
-
-      const error = await capturedError(
-        store.admit({ ...admitInput(bytes(1)), dimensions: malformed }),
-      );
-
-      expect(error.message).toContain('dimensions');
-    });
-
-    it('rejects invalid semantic metadata', async () => {
-      const store = testStore(tempDirectory());
-      const invalidMetadata = { score: Number.NaN };
-
-      const error = await capturedError(
-        store.admit({
-          ...admitInput(bytes(1)),
-          semanticMetadata: invalidMetadata,
-        }),
-      );
-
-      expect(error.message).toContain('semantic metadata');
-    });
-
-    it('rejects semantic metadata beyond the recursion bound with its media location', async () => {
-      const store = testStore(tempDirectory());
-      const mediaBytes = bytes(1);
-      const contentId = `sha256:${createHash('sha256').update(mediaBytes).digest('hex')}`;
-      let nested: MediaSemanticMetadataValue = 'leaf';
-      for (let depth = 0; depth < 66; depth += 1) {
-        nested = [nested];
-      }
-      const semanticMetadata: MediaSemanticMetadata = { pipeline: nested };
-
-      const error = await capturedError(
-        store.admit({
-          ...admitInput(mediaBytes),
-          semanticMetadata,
-        }),
-      );
-
-      expect(error.message).toContain('semanticMetadata.pipeline');
-      expect(error.message).toMatch(/maximum depth 64/i);
-      expect(error.message).toContain(contentId);
-    });
-
-    it('rejects invalid provider file metadata', async () => {
-      const store = testStore(tempDirectory());
-      const invalid = JSON.parse('{"openai":""}');
-
-      const error = await capturedError(
-        store.admit({ ...admitInput(bytes(1)), providerFileIds: invalid }),
-      );
-
-      expect(error.message).toContain('provider file IDs');
-    });
-
-    it('rejects a known size inconsistent with actual bytes', async () => {
-      const store = testStore(tempDirectory());
-
-      const error = await capturedError(
-        store.admit({ ...admitInput(bytes(1, 2)), knownByteLength: 3 }),
-      );
-
-      expect(error.message).toContain('known byte length');
-    });
-
-    it('rejects invalid known sizes', async () => {
-      const store = testStore(tempDirectory());
-
-      const error = await capturedError(
-        store.admit({ ...admitInput(bytes(1)), knownByteLength: -1 }),
-      );
-
-      expect(error.message).toContain('known byte length');
-    });
-
-    it('rejects conflicting dimensions for one content-addressed object', async () => {
-      const store = testStore(tempDirectory());
-      const contentId = `sha256:${createHash('sha256').update(bytes(1)).digest('hex')}`;
-
-      await expect(
-        store.preflightObjects([
-          {
-            contentId,
-            mimeType: 'image/png',
-            byteLength: 1,
-            normalizedBase64Length: 4,
-            dimensions: { width: 10, height: 20 },
-          },
-          {
-            contentId,
-            mimeType: 'image/png',
-            byteLength: 1,
-            normalizedBase64Length: 4,
-            dimensions: { width: 20, height: 10 },
-          },
-        ]),
-      ).rejects.toThrow('Conflicting stored object metadata');
     });
   });
 });

--- a/packages/core/src/storage/media-admission-service.test.ts
+++ b/packages/core/src/storage/media-admission-service.test.ts
@@ -17,453 +17,421 @@ import type {
 import { LocalMediaStore } from './local-media-store.js';
 import { MediaAdmissionService } from './media-admission-service.js';
 
-const PNG_BASE64 =
-  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Zl1sAAAAASUVORK5CYII=';
-
-function useTempDirectory(): () => string {
-  let directory = '';
-  beforeEach(async () => {
-    directory = await mkdtemp(join(tmpdir(), 'llxprt-media-admission-'));
-  });
-  afterEach(async () => {
-    await rm(directory, { recursive: true, force: true });
-  });
-  return () => directory;
-}
-
-function imageContent(data = PNG_BASE64): IContent {
-  return {
-    speaker: 'human',
-    blocks: [
-      { type: 'text', text: 'inspect this image' },
-      {
-        type: 'media',
-        mimeType: 'image/png',
-        encoding: 'base64',
-        data,
-        caption: 'one pixel',
-        filename: 'pixel.png',
-        providerMetadata: { detail: 'high' },
-      },
-    ],
-    metadata: { turnId: 'turn-7' },
-  };
-}
-
 describe('media-admission-service', () => {
-  describe('MediaAdmissionService', () => {
-    const tempDirectory = useTempDirectory();
+  const PNG_BASE64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Zl1sAAAAASUVORK5CYII=';
 
-    it('admits base64 image bytes before adding immutable references to history', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1024,
-      });
-      const admission = new MediaAdmissionService(store);
-      const history = new HistoryService();
-
-      await admission.addToHistory(history, imageContent(), {
-        turnId: 'turn-7',
-        source: 'clipboard',
-      });
-
-      const stored = history.getAll()[0];
-      expect(stored.blocks[1]).toMatchObject({
-        type: 'media',
-        encoding: 'reference',
-        mimeType: 'image/png',
-        dimensions: { width: 1, height: 1 },
-        caption: 'one pixel',
-        filename: 'pixel.png',
-        providerMetadata: { detail: 'high' },
-      });
-      expect(JSON.stringify(stored)).not.toContain(PNG_BASE64);
+  function useTempDirectory(): () => string {
+    let directory = '';
+    beforeEach(async () => {
+      directory = await mkdtemp(join(tmpdir(), 'llxprt-media-admission-'));
     });
-
-    it('releases the exact reservations created for admitted contents', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1024,
-      });
-      const admission = new MediaAdmissionService(store);
-      const context = {
-        turnId: 'session-replay',
-        source: 'session-replay',
-      } as const;
-      const admitted = await admission.admitContents([imageContent()], context);
-      const admittedContent = admitted.find((_entry, index) => index === 0);
-      const block = admittedContent?.blocks.find(
-        (_entry, index) => index === 1,
-      );
-      if (block?.type !== 'media' || block.encoding !== 'reference') {
-        throw new Error('Expected admitted media reference');
-      }
-
-      const reservedBeforeRelease = await store.hasReservations(
-        block.contentId,
-      );
-      await admission.releaseContents(admitted, context);
-      const reservedAfterRelease = await store.hasReservations(block.contentId);
-
-      expect({ reservedBeforeRelease, reservedAfterRelease }).toStrictEqual({
-        reservedBeforeRelease: true,
-        reservedAfterRelease: false,
-      });
+    afterEach(async () => {
+      await rm(directory, { recursive: true, force: true });
     });
+    return () => directory;
+  }
 
-    it('admits supported image data URIs while preserving media semantics', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1024,
-      });
-      const admission = new MediaAdmissionService(store);
-      const sourcePath = join(tempDirectory(), 'private', 'pixel.png');
-      const media: InlineMediaBlock & { readonly sourcePath: string } = {
-        type: 'media',
-        mimeType: 'image/png',
-        encoding: 'base64',
-        data: `data:image/png;base64,${PNG_BASE64}`,
-        filename: 'provider-assets/pixel.png',
-        caption: 'one pixel',
-        dimensions: { width: 1, height: 1 },
-        semanticMetadata: {
-          detail: 'high',
-          options: { preserveTransparency: true },
-        },
-        providerFileIds: { provider: 'file-7' },
-        providerMetadata: { detail: 'high', vendorOption: 'exact' },
-        sourcePath,
-      };
-      const content: IContent = {
-        speaker: 'human',
-        blocks: [{ type: 'text', text: 'inspect this image' }, media],
-      };
-
-      const admitted = await admission.admitContent(content, {
-        turnId: 'turn-data-uri',
-        source: 'at-command',
-      });
-      const stored = admitted.blocks[1];
-      if (stored.type !== 'media' || stored.encoding !== 'reference') {
-        throw new Error('Expected media reference');
-      }
-
-      expect(stored).toMatchObject({
-        mimeType: 'image/png',
-        filename: 'provider-assets/pixel.png',
-        caption: 'one pixel',
-        dimensions: { width: 1, height: 1 },
-        semanticMetadata: {
-          detail: 'high',
-          options: { preserveTransparency: true },
-        },
-        providerFileIds: { provider: 'file-7' },
-        providerMetadata: { detail: 'high', vendorOption: 'exact' },
-      });
-      expect('sourcePath' in stored).toBe(false);
-      expect(JSON.stringify(stored)).not.toContain(tempDirectory());
-      expect(await store.readVerified(stored)).toStrictEqual(
-        new Uint8Array(Buffer.from(PNG_BASE64, 'base64')),
-      );
-    });
-
-    it('preserves model-visible metadata while excluding ingestion paths and raw media', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1024,
-      });
-      const admission = new MediaAdmissionService(store);
-      const sourcePath = join(tempDirectory(), 'private', 'diagram.png');
-      const caption =
-        'Architecture diagram from /Users/example/provider-captions/diagram.png';
-      const filename = 'provider-assets/diagrams/diagram.png?variant=exact';
-      const providerMetadata = {
-        detail: 'high',
-        vendorOptions: {
-          inputPath: '/Users/example/provider-options/diagram.json',
-          token: 'provider-semantic-token-3199',
-        },
-      };
-      const media: InlineMediaBlock & { readonly sourcePath: string } = {
-        type: 'media',
-        mimeType: 'image/png',
-        encoding: 'base64',
-        data: PNG_BASE64,
-        filename,
-        caption,
-        providerMetadata,
-        sourcePath,
-      };
-      const content: IContent = {
-        speaker: 'human',
-        blocks: [media],
-        metadata: { turnId: 'turn-private-metadata' },
-      };
-
-      const admitted = await admission.admitContent(content, {
-        turnId: 'turn-private-metadata',
-        source: 'at-command',
-      });
-      const block = admitted.blocks[0];
-      if (block.type !== 'media' || block.encoding !== 'reference') {
-        throw new Error('Expected admitted media reference');
-      }
-      const serialized = JSON.stringify(admitted);
-
-      expect({
-        caption: block.caption,
-        filename: block.filename,
-        providerMetadata: block.providerMetadata,
-      }).toStrictEqual({ caption, filename, providerMetadata });
-      expect('sourcePath' in block).toBe(false);
-      expect('data' in block).toBe(false);
-      expect(serialized).not.toContain(sourcePath);
-      expect(serialized).not.toContain(PNG_BASE64);
-    });
-
-    it('admits historically supported images whose dimensions are unknown', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 16,
-      });
-      const admission = new MediaAdmissionService(store);
-      const content: IContent = {
-        speaker: 'human',
-        blocks: [
-          {
-            type: 'media',
-            mimeType: 'image/tiff',
-            encoding: 'base64',
-            data: Buffer.from([1, 2, 3, 4]).toString('base64'),
-          },
-        ],
-      };
-
-      const admitted = await admission.admitContent(content, {
-        turnId: 'turn-unknown-dimensions',
-        source: 'tool-response',
-      });
-      const stored = admitted.blocks[0];
-
-      expect(stored).toMatchObject({
-        type: 'media',
-        encoding: 'reference',
-        mimeType: 'image/tiff',
-        byteLength: 4,
-      });
-      expect(
-        stored.type === 'media' && 'dimensions' in stored
-          ? stored.dimensions
-          : undefined,
-      ).toBeUndefined();
-    });
-    it('stores explicit original and selected variants without rerunning transformation policy', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 16,
-      });
-      const admission = new MediaAdmissionService(store);
-      const originalBytes = new Uint8Array([1, 2, 3, 4]);
-      const selectedBytes = new Uint8Array([9, 8, 7]);
-      const content: IContent = {
-        speaker: 'human',
-        blocks: [
-          {
-            type: 'media',
-            mimeType: 'image/webp',
-            encoding: 'base64',
-            data: Buffer.from(selectedBytes).toString('base64'),
-            originalData: Buffer.from(originalBytes).toString('base64'),
-            originalMimeType: 'image/png',
-            transformation: {
-              policyId: 'image-resize',
-              policyVersion: 1,
-              parameters: { maxLongEdge: 20 },
-            },
-          },
-        ],
-      };
-
-      const admitted = await admission.admitContent(content, {
-        turnId: 'turn-derived',
-        source: 'read-file',
-      });
-      const reference = admitted.blocks[0];
-      if (reference.type !== 'media' || reference.encoding !== 'reference') {
-        throw new Error('Expected media reference');
-      }
-
-      expect(reference.transformation).toStrictEqual({
-        policyId: 'image-resize',
-        policyVersion: 1,
-        parameters: { maxLongEdge: 20 },
-      });
-      expect(
-        await store.readObjectVerified(reference.originalObject),
-      ).toStrictEqual(originalBytes);
-      expect(await store.readVerified(reference)).toStrictEqual(selectedBytes);
-    });
-
-    it('preserves URL and legacy inline media without storing them', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 0,
-      });
-      const admission = new MediaAdmissionService(store);
-      const providerMetadata = {
-        inputPath: '/Users/example/provider-options/media.json',
-        token: 'provider-semantic-token-3199',
-      };
-      const content: IContent = {
-        speaker: 'human',
-        blocks: [
-          {
-            type: 'media',
-            mimeType: 'image/png',
-            encoding: 'url',
-            data: 'https://example.test/image.png',
-            caption: '/Users/example/provider-captions/url-image.png',
-            filename: 'provider-assets/url-image.png',
-            providerMetadata,
-          },
-          {
-            type: 'media',
-            mimeType: 'application/pdf',
-            encoding: 'base64',
-            data: 'AQID',
-            caption: '/Users/example/provider-captions/document.pdf',
-            filename: 'provider-assets/document.pdf',
-            providerMetadata,
-          },
-        ],
-      };
-
-      const admitted = await admission.admitContent(content, {
-        turnId: 'turn-url',
-        source: 'at-command',
-      });
-
-      expect(admitted).toBe(content);
-      expect(await store.getStoredByteLength()).toBe(0);
-    });
-
-    it('rejects quota failure with turn and media context before history mutation', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1,
-      });
-      const admission = new MediaAdmissionService(store);
-      const history = new HistoryService();
-
-      const work = admission.addToHistory(history, imageContent(), {
-        turnId: 'turn-quota',
-        source: 'tool-response',
-      });
-
-      await expect(work).rejects.toThrow(
-        /turn-quota.*tool-response.*media\[0\].*sha256:/,
-      );
-      expect(history.getAll()).toStrictEqual([]);
-    });
-
-    it('rejects malformed base64 before history mutation', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1024,
-      });
-      const admission = new MediaAdmissionService(store);
-      const history = new HistoryService();
-
-      const work = admission.addToHistory(
-        history,
-        imageContent('not base64!'),
+  function imageContent(data = PNG_BASE64): IContent {
+    return {
+      speaker: 'human',
+      blocks: [
+        { type: 'text', text: 'inspect this image' },
         {
-          turnId: 'turn-invalid',
-          source: 'generated-image',
+          type: 'media',
+          mimeType: 'image/png',
+          encoding: 'base64',
+          data,
+          caption: 'one pixel',
+          filename: 'pixel.png',
+          providerMetadata: { detail: 'high' },
         },
-      );
+      ],
+      metadata: { turnId: 'turn-7' },
+    };
+  }
 
-      await expect(work).rejects.toThrow(
-        /turn-invalid.*generated-image.*media\[0\]/,
-      );
-      expect(history.getAll()).toStrictEqual([]);
-    });
+  describe('media-admission-service', () => {
+    describe('MediaAdmissionService', () => {
+      const tempDirectory = useTempDirectory();
 
-    it('verifies existing references before provider or history use', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1024,
-      });
-      const admission = new MediaAdmissionService(store);
-      const admitted = await admission.admitContent(imageContent(), {
-        turnId: 'turn-original',
-        source: 'clipboard',
-      });
+      it('admits base64 image bytes before adding immutable references to history', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 1024,
+        });
+        const admission = new MediaAdmissionService(store);
+        const history = new HistoryService();
 
-      const verified = await admission.admitContent(admitted, {
-        turnId: 'turn-reused',
-        source: 'restored-history',
-      });
-
-      expect(verified).toBe(admitted);
-    });
-
-    it('rolls back every earlier reservation when a later media block fails', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1024,
-      });
-      const reference = await store.admit({
-        bytes: new Uint8Array([1, 2, 3]),
-        mimeType: 'image/png',
-        semanticMetadata: {},
-      });
-      const admission = new MediaAdmissionService(store);
-      const content: IContent = {
-        speaker: 'human',
-        metadata: { turnId: 'turn-partial-blocks' },
-        blocks: [
-          reference,
-          {
-            type: 'media',
-            mimeType: 'image/png',
-            encoding: 'base64',
-            data: 'not-base64',
-          },
-        ],
-      };
-
-      await expect(
-        admission.admitContent(content, {
-          turnId: 'turn-partial-blocks',
+        await admission.addToHistory(history, imageContent(), {
+          turnId: 'turn-7',
           source: 'clipboard',
-        }),
-      ).rejects.toThrow(/media admission failed/i);
+        });
 
-      expect(await store.hasReservations(reference.contentId)).toBe(false);
-    });
+        const stored = history.getAll()[0];
+        expect(stored.blocks[1]).toMatchObject({
+          type: 'media',
+          encoding: 'reference',
+          mimeType: 'image/png',
+          dimensions: { width: 1, height: 1 },
+          caption: 'one pixel',
+          filename: 'pixel.png',
+          providerMetadata: { detail: 'high' },
+        });
+        expect(JSON.stringify(stored)).not.toContain(PNG_BASE64);
+      });
 
-    it('rolls back reservations from earlier contents when a later content fails', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1024,
+      it('releases the exact reservations created for admitted contents', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 1024,
+        });
+        const admission = new MediaAdmissionService(store);
+        const context = {
+          turnId: 'session-replay',
+          source: 'session-replay',
+        } as const;
+        const admitted = await admission.admitContents(
+          [imageContent()],
+          context,
+        );
+        const admittedContent = admitted.find((_entry, index) => index === 0);
+        const block = admittedContent?.blocks.find(
+          (_entry, index) => index === 1,
+        );
+        if (block?.type !== 'media' || block.encoding !== 'reference') {
+          throw new Error('Expected admitted media reference');
+        }
+
+        const reservedBeforeRelease = await store.hasReservations(
+          block.contentId,
+        );
+        await admission.releaseContents(admitted, context);
+        const reservedAfterRelease = await store.hasReservations(
+          block.contentId,
+        );
+
+        expect({ reservedBeforeRelease, reservedAfterRelease }).toStrictEqual({
+          reservedBeforeRelease: true,
+          reservedAfterRelease: false,
+        });
       });
-      const reference = await store.admit({
-        bytes: new Uint8Array([4, 5, 6]),
-        mimeType: 'image/png',
-        semanticMetadata: {},
+
+      it('admits supported image data URIs while preserving media semantics', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 1024,
+        });
+        const admission = new MediaAdmissionService(store);
+        const sourcePath = join(tempDirectory(), 'private', 'pixel.png');
+        const media: InlineMediaBlock & { readonly sourcePath: string } = {
+          type: 'media',
+          mimeType: 'image/png',
+          encoding: 'base64',
+          data: `data:image/png;base64,${PNG_BASE64}`,
+          filename: 'provider-assets/pixel.png',
+          caption: 'one pixel',
+          dimensions: { width: 1, height: 1 },
+          semanticMetadata: {
+            detail: 'high',
+            options: { preserveTransparency: true },
+          },
+          providerFileIds: { provider: 'file-7' },
+          providerMetadata: { detail: 'high', vendorOption: 'exact' },
+          sourcePath,
+        };
+        const content: IContent = {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'inspect this image' }, media],
+        };
+
+        const admitted = await admission.admitContent(content, {
+          turnId: 'turn-data-uri',
+          source: 'at-command',
+        });
+        const stored = admitted.blocks[1];
+        if (stored.type !== 'media' || stored.encoding !== 'reference') {
+          throw new Error('Expected media reference');
+        }
+
+        expect(stored).toMatchObject({
+          mimeType: 'image/png',
+          filename: 'provider-assets/pixel.png',
+          caption: 'one pixel',
+          dimensions: { width: 1, height: 1 },
+          semanticMetadata: {
+            detail: 'high',
+            options: { preserveTransparency: true },
+          },
+          providerFileIds: { provider: 'file-7' },
+          providerMetadata: { detail: 'high', vendorOption: 'exact' },
+        });
+        expect('sourcePath' in stored).toBe(false);
+        expect(JSON.stringify(stored)).not.toContain(tempDirectory());
+        expect(await store.readVerified(stored)).toStrictEqual(
+          new Uint8Array(Buffer.from(PNG_BASE64, 'base64')),
+        );
       });
-      const admission = new MediaAdmissionService(store);
-      const contents: IContent[] = [
-        {
+
+      it('preserves model-visible metadata while excluding ingestion paths and raw media', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 1024,
+        });
+        const admission = new MediaAdmissionService(store);
+        const sourcePath = join(tempDirectory(), 'private', 'diagram.png');
+        const caption =
+          'Architecture diagram from /Users/example/provider-captions/diagram.png';
+        const filename = 'provider-assets/diagrams/diagram.png?variant=exact';
+        const providerMetadata = {
+          detail: 'high',
+          vendorOptions: {
+            inputPath: '/Users/example/provider-options/diagram.json',
+            token: 'provider-semantic-token-3199',
+          },
+        };
+        const media: InlineMediaBlock & { readonly sourcePath: string } = {
+          type: 'media',
+          mimeType: 'image/png',
+          encoding: 'base64',
+          data: PNG_BASE64,
+          filename,
+          caption,
+          providerMetadata,
+          sourcePath,
+        };
+        const content: IContent = {
           speaker: 'human',
-          metadata: { turnId: 'turn-first-content' },
-          blocks: [reference],
-        },
-        {
+          blocks: [media],
+          metadata: { turnId: 'turn-private-metadata' },
+        };
+
+        const admitted = await admission.admitContent(content, {
+          turnId: 'turn-private-metadata',
+          source: 'at-command',
+        });
+        const block = admitted.blocks[0];
+        if (block.type !== 'media' || block.encoding !== 'reference') {
+          throw new Error('Expected admitted media reference');
+        }
+        const serialized = JSON.stringify(admitted);
+
+        expect({
+          caption: block.caption,
+          filename: block.filename,
+          providerMetadata: block.providerMetadata,
+        }).toStrictEqual({ caption, filename, providerMetadata });
+        expect('sourcePath' in block).toBe(false);
+        expect('data' in block).toBe(false);
+        expect(serialized).not.toContain(sourcePath);
+        expect(serialized).not.toContain(PNG_BASE64);
+      });
+
+      it('admits historically supported images whose dimensions are unknown', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 16,
+        });
+        const admission = new MediaAdmissionService(store);
+        const content: IContent = {
           speaker: 'human',
-          metadata: { turnId: 'turn-second-content' },
           blocks: [
+            {
+              type: 'media',
+              mimeType: 'image/tiff',
+              encoding: 'base64',
+              data: Buffer.from([1, 2, 3, 4]).toString('base64'),
+            },
+          ],
+        };
+
+        const admitted = await admission.admitContent(content, {
+          turnId: 'turn-unknown-dimensions',
+          source: 'tool-response',
+        });
+        const stored = admitted.blocks[0];
+
+        expect(stored).toMatchObject({
+          type: 'media',
+          encoding: 'reference',
+          mimeType: 'image/tiff',
+          byteLength: 4,
+        });
+        expect(
+          stored.type === 'media' && 'dimensions' in stored
+            ? stored.dimensions
+            : undefined,
+        ).toBeUndefined();
+      });
+      it('stores explicit original and selected variants without rerunning transformation policy', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 16,
+        });
+        const admission = new MediaAdmissionService(store);
+        const originalBytes = new Uint8Array([1, 2, 3, 4]);
+        const selectedBytes = new Uint8Array([9, 8, 7]);
+        const content: IContent = {
+          speaker: 'human',
+          blocks: [
+            {
+              type: 'media',
+              mimeType: 'image/webp',
+              encoding: 'base64',
+              data: Buffer.from(selectedBytes).toString('base64'),
+              originalData: Buffer.from(originalBytes).toString('base64'),
+              originalMimeType: 'image/png',
+              transformation: {
+                policyId: 'image-resize',
+                policyVersion: 1,
+                parameters: { maxLongEdge: 20 },
+              },
+            },
+          ],
+        };
+
+        const admitted = await admission.admitContent(content, {
+          turnId: 'turn-derived',
+          source: 'read-file',
+        });
+        const reference = admitted.blocks[0];
+        if (reference.type !== 'media' || reference.encoding !== 'reference') {
+          throw new Error('Expected media reference');
+        }
+
+        expect(reference.transformation).toStrictEqual({
+          policyId: 'image-resize',
+          policyVersion: 1,
+          parameters: { maxLongEdge: 20 },
+        });
+        expect(
+          await store.readObjectVerified(reference.originalObject),
+        ).toStrictEqual(originalBytes);
+        expect(await store.readVerified(reference)).toStrictEqual(
+          selectedBytes,
+        );
+      });
+
+      it('preserves URL and legacy inline media without storing them', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 0,
+        });
+        const admission = new MediaAdmissionService(store);
+        const providerMetadata = {
+          inputPath: '/Users/example/provider-options/media.json',
+          token: 'provider-semantic-token-3199',
+        };
+        const content: IContent = {
+          speaker: 'human',
+          blocks: [
+            {
+              type: 'media',
+              mimeType: 'image/png',
+              encoding: 'url',
+              data: 'https://example.test/image.png',
+              caption: '/Users/example/provider-captions/url-image.png',
+              filename: 'provider-assets/url-image.png',
+              providerMetadata,
+            },
+            {
+              type: 'media',
+              mimeType: 'application/pdf',
+              encoding: 'base64',
+              data: 'AQID',
+              caption: '/Users/example/provider-captions/document.pdf',
+              filename: 'provider-assets/document.pdf',
+              providerMetadata,
+            },
+          ],
+        };
+
+        const admitted = await admission.admitContent(content, {
+          turnId: 'turn-url',
+          source: 'at-command',
+        });
+
+        expect(admitted).toBe(content);
+        expect(await store.getStoredByteLength()).toBe(0);
+      });
+
+      it('rejects quota failure with turn and media context before history mutation', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 1,
+        });
+        const admission = new MediaAdmissionService(store);
+        const history = new HistoryService();
+
+        const work = admission.addToHistory(history, imageContent(), {
+          turnId: 'turn-quota',
+          source: 'tool-response',
+        });
+
+        await expect(work).rejects.toThrow(
+          /turn-quota.*tool-response.*media\[0\].*sha256:/,
+        );
+        expect(history.getAll()).toStrictEqual([]);
+      });
+
+      it('rejects malformed base64 before history mutation', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 1024,
+        });
+        const admission = new MediaAdmissionService(store);
+        const history = new HistoryService();
+
+        const work = admission.addToHistory(
+          history,
+          imageContent('not base64!'),
+          {
+            turnId: 'turn-invalid',
+            source: 'generated-image',
+          },
+        );
+
+        await expect(work).rejects.toThrow(
+          /turn-invalid.*generated-image.*media\[0\]/,
+        );
+        expect(history.getAll()).toStrictEqual([]);
+      });
+
+      it('verifies existing references before provider or history use', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 1024,
+        });
+        const admission = new MediaAdmissionService(store);
+        const admitted = await admission.admitContent(imageContent(), {
+          turnId: 'turn-original',
+          source: 'clipboard',
+        });
+
+        const verified = await admission.admitContent(admitted, {
+          turnId: 'turn-reused',
+          source: 'restored-history',
+        });
+
+        expect(verified).toBe(admitted);
+      });
+
+      it('rolls back every earlier reservation when a later media block fails', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 1024,
+        });
+        const reference = await store.admit({
+          bytes: new Uint8Array([1, 2, 3]),
+          mimeType: 'image/png',
+          semanticMetadata: {},
+        });
+        const admission = new MediaAdmissionService(store);
+        const content: IContent = {
+          speaker: 'human',
+          metadata: { turnId: 'turn-partial-blocks' },
+          blocks: [
+            reference,
             {
               type: 'media',
               mimeType: 'image/png',
@@ -471,107 +439,148 @@ describe('media-admission-service', () => {
               data: 'not-base64',
             },
           ],
-        },
-      ];
+        };
 
-      await expect(
-        admission.admitContents(contents, {
-          turnId: 'turn-partial-contents',
+        await expect(
+          admission.admitContent(content, {
+            turnId: 'turn-partial-blocks',
+            source: 'clipboard',
+          }),
+        ).rejects.toThrow(/media admission failed/i);
+
+        expect(await store.hasReservations(reference.contentId)).toBe(false);
+      });
+
+      it('rolls back reservations from earlier contents when a later content fails', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 1024,
+        });
+        const reference = await store.admit({
+          bytes: new Uint8Array([4, 5, 6]),
+          mimeType: 'image/png',
+          semanticMetadata: {},
+        });
+        const admission = new MediaAdmissionService(store);
+        const contents: IContent[] = [
+          {
+            speaker: 'human',
+            metadata: { turnId: 'turn-first-content' },
+            blocks: [reference],
+          },
+          {
+            speaker: 'human',
+            metadata: { turnId: 'turn-second-content' },
+            blocks: [
+              {
+                type: 'media',
+                mimeType: 'image/png',
+                encoding: 'base64',
+                data: 'not-base64',
+              },
+            ],
+          },
+        ];
+
+        await expect(
+          admission.admitContents(contents, {
+            turnId: 'turn-partial-contents',
+            source: 'restored-history',
+          }),
+        ).rejects.toThrow(/turn-second-content/i);
+
+        expect(await store.hasReservations(reference.contentId)).toBe(false);
+      });
+
+      it('reports the admission failure and every rollback failure together', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 1024,
+        });
+        const reference = await store.admit({
+          bytes: new Uint8Array([7, 8, 9]),
+          mimeType: 'image/png',
+          semanticMetadata: {},
+        });
+        store.release = () => Promise.reject(new Error('rollback unavailable'));
+        const admission = new MediaAdmissionService(store);
+        const content: IContent = {
+          speaker: 'human',
+          metadata: { turnId: 'turn-rollback-failure' },
+          blocks: [
+            reference,
+            {
+              type: 'media',
+              mimeType: 'image/png',
+              encoding: 'base64',
+              data: 'not-base64',
+            },
+          ],
+        };
+
+        const error = await admission
+          .admitContent(content, {
+            turnId: 'turn-rollback-failure',
+            source: 'tool-response',
+          })
+          .catch((reason: unknown) => reason);
+
+        expect(error).toBeInstanceOf(AggregateError);
+        assertInstanceOf(
+          error,
+          AggregateError,
+          'Expected aggregate admission rollback error',
+        );
+        expect(error.errors).toHaveLength(2);
+        expect(String(error.errors[0])).toContain('turn-rollback-failure');
+        expect(String(error.errors[1])).toContain('rollback unavailable');
+      });
+
+      it('reports the physical media index when an earlier URL precedes a missing reference', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 1024,
+        });
+        const admission = new MediaAdmissionService(store);
+        const admitted = await admission.admitContent(imageContent(), {
+          turnId: 'turn-original',
+          source: 'clipboard',
+        });
+        const reference = admitted.blocks[1];
+        if (reference.type !== 'media' || reference.encoding !== 'reference') {
+          throw new Error('Expected admitted media reference');
+        }
+        await rm(
+          join(
+            store.rootDirectory,
+            'objects',
+            'sha256',
+            reference.contentId.slice('sha256:'.length),
+          ),
+        );
+        const content: IContent = {
+          speaker: 'human',
+          blocks: [
+            {
+              type: 'media',
+              mimeType: 'image/png',
+              encoding: 'url',
+              data: 'https://example.test/image.png',
+            },
+            reference,
+          ],
+          metadata: { id: 'content-42', turnId: 'turn-reused' },
+        };
+
+        const work = admission.admitContent(content, {
+          turnId: 'turn-reused',
           source: 'restored-history',
-        }),
-      ).rejects.toThrow(/turn-second-content/i);
+        });
 
-      expect(await store.hasReservations(reference.contentId)).toBe(false);
-    });
-
-    it('reports the admission failure and every rollback failure together', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1024,
+        await expect(work).rejects.toThrow(
+          /turn-reused.*restored-history.*media\[1\].*content-42.*sha256:/,
+        );
       });
-      const reference = await store.admit({
-        bytes: new Uint8Array([7, 8, 9]),
-        mimeType: 'image/png',
-        semanticMetadata: {},
-      });
-      store.release = () => Promise.reject(new Error('rollback unavailable'));
-      const admission = new MediaAdmissionService(store);
-      const content: IContent = {
-        speaker: 'human',
-        metadata: { turnId: 'turn-rollback-failure' },
-        blocks: [
-          reference,
-          {
-            type: 'media',
-            mimeType: 'image/png',
-            encoding: 'base64',
-            data: 'not-base64',
-          },
-        ],
-      };
-
-      const error = await admission
-        .admitContent(content, {
-          turnId: 'turn-rollback-failure',
-          source: 'tool-response',
-        })
-        .catch((reason: unknown) => reason);
-
-      expect(error).toBeInstanceOf(AggregateError);
-      assertInstanceOf(
-        error,
-        AggregateError,
-        'Expected aggregate admission rollback error',
-      );
-      expect(error.errors).toHaveLength(2);
-      expect(String(error.errors[0])).toContain('turn-rollback-failure');
-      expect(String(error.errors[1])).toContain('rollback unavailable');
-    });
-
-    it('reports the physical media index when an earlier URL precedes a missing reference', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1024,
-      });
-      const admission = new MediaAdmissionService(store);
-      const admitted = await admission.admitContent(imageContent(), {
-        turnId: 'turn-original',
-        source: 'clipboard',
-      });
-      const reference = admitted.blocks[1];
-      if (reference.type !== 'media' || reference.encoding !== 'reference') {
-        throw new Error('Expected admitted media reference');
-      }
-      await rm(
-        join(
-          store.rootDirectory,
-          'objects',
-          'sha256',
-          reference.contentId.slice('sha256:'.length),
-        ),
-      );
-      const content: IContent = {
-        speaker: 'human',
-        blocks: [
-          {
-            type: 'media',
-            mimeType: 'image/png',
-            encoding: 'url',
-            data: 'https://example.test/image.png',
-          },
-          reference,
-        ],
-        metadata: { id: 'content-42', turnId: 'turn-reused' },
-      };
-
-      const work = admission.admitContent(content, {
-        turnId: 'turn-reused',
-        source: 'restored-history',
-      });
-
-      await expect(work).rejects.toThrow(
-        /turn-reused.*restored-history.*media\[1\].*content-42.*sha256:/,
-      );
     });
   });
 });

--- a/packages/core/src/storage/media-session-lifecycle.test.ts
+++ b/packages/core/src/storage/media-session-lifecycle.test.ts
@@ -21,488 +21,495 @@ import { LocalMediaStore } from './local-media-store.js';
 import { MediaAdmissionService } from './media-admission-service.js';
 import { SessionPersistenceService } from './SessionPersistenceService.js';
 
-const PNG_BASE64 =
-  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Zl1sAAAAASUVORK5CYII=';
-
-function useTempDirectory(): () => string {
-  let directory = '';
-  beforeEach(async () => {
-    directory = await mkdtemp(join(tmpdir(), 'llxprt-media-session-'));
-  });
-  afterEach(async () => {
-    await rm(directory, { recursive: true, force: true });
-  });
-  return () => directory;
-}
-
-function inlineContent(): IContent {
-  return {
-    speaker: 'human',
-    blocks: [
-      {
-        type: 'media',
-        mimeType: 'image/png',
-        encoding: 'base64',
-        data: PNG_BASE64,
-      },
-    ],
-    metadata: { turnId: 'turn-media' },
-  };
-}
-
-function referenceFrom(content: IContent): MediaReferenceBlock {
-  const block = content.blocks[0];
-  if (block.type !== 'media' || block.encoding !== 'reference') {
-    throw new Error('Expected media reference');
-  }
-  return block;
-}
-
-class ReplayDiagnosticFailureStore extends LocalMediaStore {
-  override async readVerified(
-    _reference: MediaReferenceBlock,
-  ): Promise<Uint8Array> {
-    throw new Error('verification unavailable');
-  }
-
-  override async release(contentId: string, ownerId: string): Promise<void> {
-    let releaseFailure: unknown;
-    try {
-      await super.release(contentId, ownerId);
-    } catch (error) {
-      releaseFailure = error;
-    }
-    throw releaseFailure ?? new Error('release unavailable');
-  }
-}
-
-async function closeMediaStores(
-  stores: readonly LocalMediaStore[],
-): Promise<void> {
-  const failures: unknown[] = [];
-  for (const store of [...stores].reverse()) {
-    try {
-      await store.close();
-    } catch (error: unknown) {
-      failures.push(error);
-    }
-  }
-  if (failures.length === 1) throw failures[0];
-  if (failures.length > 1) {
-    throw new AggregateError(failures, 'Failed to close media stores');
-  }
-}
-
 describe('media-session-lifecycle', () => {
-  describe('media recording and persistence lifecycle', () => {
-    const tempDirectory = useTempDirectory();
+  const PNG_BASE64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Zl1sAAAAASUVORK5CYII=';
 
-    it('records references without raw bytes or absolute paths and replays verified media', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: join(tempDirectory(), 'media'),
-        quotaBytes: 1024,
-      });
-      const admitted = await new MediaAdmissionService(store).admitContent(
-        inlineContent(),
-        { turnId: 'turn-media', source: 'clipboard' },
-      );
-      const chatsDir = join(tempDirectory(), 'chats');
-      const recording = new SessionRecordingService({
-        sessionId: 'session-media',
-        projectHash: 'project-hash',
-        chatsDir,
-        workspaceDirs: [],
-        provider: 'test',
-        model: 'test',
-      });
+  function useTempDirectory(): () => string {
+    let directory = '';
+    beforeEach(async () => {
+      directory = await mkdtemp(join(tmpdir(), 'llxprt-media-session-'));
+    });
+    afterEach(async () => {
+      await rm(directory, { recursive: true, force: true });
+    });
+    return () => directory;
+  }
+
+  function inlineContent(): IContent {
+    return {
+      speaker: 'human',
+      blocks: [
+        {
+          type: 'media',
+          mimeType: 'image/png',
+          encoding: 'base64',
+          data: PNG_BASE64,
+        },
+      ],
+      metadata: { turnId: 'turn-media' },
+    };
+  }
+
+  function referenceFrom(content: IContent): MediaReferenceBlock {
+    const block = content.blocks[0];
+    if (block.type !== 'media' || block.encoding !== 'reference') {
+      throw new Error('Expected media reference');
+    }
+    return block;
+  }
+
+  class ReplayDiagnosticFailureStore extends LocalMediaStore {
+    override async readVerified(
+      _reference: MediaReferenceBlock,
+    ): Promise<Uint8Array> {
+      throw new Error('verification unavailable');
+    }
+
+    override async release(contentId: string, ownerId: string): Promise<void> {
+      let releaseFailure: unknown;
       try {
-        recording.recordContent(admitted);
-        await recording.flush();
-        const filePath = recording.getFilePath();
-        assertNotNull(filePath, 'Expected materialized recording');
-        const serialized = await readFile(filePath, 'utf8');
+        await super.release(contentId, ownerId);
+      } catch (error) {
+        releaseFailure = error;
+      }
+      throw releaseFailure ?? new Error('release unavailable');
+    }
+  }
+
+  async function closeMediaStores(
+    stores: readonly LocalMediaStore[],
+  ): Promise<void> {
+    const failures: unknown[] = [];
+    for (const store of [...stores].reverse()) {
+      try {
+        await store.close();
+      } catch (error: unknown) {
+        failures.push(error);
+      }
+    }
+    if (failures.length === 1) throw failures[0];
+    if (failures.length > 1) {
+      throw new AggregateError(failures, 'Failed to close media stores');
+    }
+  }
+
+  describe('media-session-lifecycle', () => {
+    describe('media recording and persistence lifecycle', () => {
+      const tempDirectory = useTempDirectory();
+
+      it('records references without raw bytes or absolute paths and replays verified media', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: join(tempDirectory(), 'media'),
+          quotaBytes: 1024,
+        });
+        const admitted = await new MediaAdmissionService(store).admitContent(
+          inlineContent(),
+          { turnId: 'turn-media', source: 'clipboard' },
+        );
+        const chatsDir = join(tempDirectory(), 'chats');
+        const recording = new SessionRecordingService({
+          sessionId: 'session-media',
+          projectHash: 'project-hash',
+          chatsDir,
+          workspaceDirs: [],
+          provider: 'test',
+          model: 'test',
+        });
+        try {
+          recording.recordContent(admitted);
+          await recording.flush();
+          const filePath = recording.getFilePath();
+          assertNotNull(filePath, 'Expected materialized recording');
+          const serialized = await readFile(filePath, 'utf8');
+          const replay = await replaySession(filePath, 'project-hash', {
+            mediaStore: store,
+          });
+          const versions = serialized
+            .trim()
+            .split('\n')
+            .map((line) => {
+              const parsed: unknown = JSON.parse(line);
+              if (
+                typeof parsed !== 'object' ||
+                parsed === null ||
+                !('v' in parsed)
+              ) {
+                throw new Error('Expected versioned recording line');
+              }
+              return parsed.v;
+            });
+          expect(versions).toStrictEqual([1, 2]);
+          expect(serialized).not.toContain(PNG_BASE64);
+          expect(serialized).not.toContain(tempDirectory());
+          expect(replay.ok).toBe(true);
+          if (!replay.ok) throw new Error(replay.error);
+          expect(referenceFrom(replay.history[0]).contentId).toBe(
+            referenceFrom(admitted).contentId,
+          );
+        } finally {
+          await recording.dispose();
+        }
+      });
+
+      it('persists exact media semantics without ingestion paths or raw media', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: join(tempDirectory(), 'media-private'),
+          quotaBytes: 1024,
+        });
+        const sourcePath = join(tempDirectory(), 'private', 'diagram.png');
+        const caption =
+          'Architecture diagram from /Users/example/provider-captions/diagram.png';
+        const filename = 'provider-assets/diagrams/diagram.png';
+        const providerMetadata = {
+          detail: 'high',
+          vendorOptions: {
+            inputPath: '/Users/example/provider-options/diagram.json',
+            token: 'provider-semantic-token-3199',
+          },
+        };
+        const media: InlineMediaBlock & { readonly sourcePath: string } = {
+          type: 'media',
+          mimeType: 'image/png',
+          encoding: 'base64',
+          data: PNG_BASE64,
+          filename,
+          caption,
+          providerMetadata,
+          sourcePath,
+        };
+        const admitted = await new MediaAdmissionService(store).admitContent(
+          {
+            speaker: 'human',
+            blocks: [media],
+            metadata: { turnId: 'turn-private-recording' },
+          },
+          { turnId: 'turn-private-recording', source: 'at-command' },
+        );
+        const recording = new SessionRecordingService({
+          sessionId: 'session-private-media',
+          projectHash: 'project-hash',
+          chatsDir: join(tempDirectory(), 'chats-private'),
+          workspaceDirs: [],
+          provider: 'test',
+          model: 'test',
+        });
+
+        try {
+          recording.recordContent(admitted);
+          await recording.flush();
+          const filePath = recording.getFilePath();
+          assertNotNull(filePath, 'Expected materialized recording');
+          const serialized = await readFile(filePath, 'utf8');
+
+          expect(serialized).toContain(JSON.stringify(caption));
+          expect(serialized).toContain(JSON.stringify(filename));
+          expect(serialized).toContain(JSON.stringify(providerMetadata));
+          expect(serialized).not.toContain(sourcePath);
+          expect(serialized).not.toContain(PNG_BASE64);
+        } finally {
+          await recording.dispose();
+        }
+      });
+
+      it('accepts legacy inline replay without a media store', async () => {
+        const filePath = join(tempDirectory(), 'legacy.jsonl');
+        const records = [
+          {
+            v: 1,
+            seq: 1,
+            ts: '2026-08-23T00:00:00.000Z',
+            type: 'session_start',
+            payload: {
+              sessionId: 'legacy',
+              projectHash: 'project-hash',
+              workspaceDirs: [],
+              provider: 'test',
+              model: 'test',
+              startTime: '2026-08-23T00:00:00.000Z',
+            },
+          },
+          {
+            v: 1,
+            seq: 2,
+            ts: '2026-08-23T00:00:01.000Z',
+            type: 'content',
+            payload: { content: inlineContent() },
+          },
+        ];
+        await writeFile(
+          filePath,
+          records.map((record) => JSON.stringify(record)).join('\n'),
+        );
+
+        const replay = await replaySession(filePath, 'project-hash');
+
+        expect(replay.ok).toBe(true);
+        if (!replay.ok) throw new Error(replay.error);
+        expect(replay.history[0]).toStrictEqual(inlineContent());
+      });
+
+      it('migrates legacy inline local media during replay while preserving URL media', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: join(tempDirectory(), 'replay-media'),
+          quotaBytes: 1024,
+        });
+        const filePath = join(tempDirectory(), 'legacy-with-store.jsonl');
+        const legacyContent: IContent = {
+          ...inlineContent(),
+          blocks: [
+            ...inlineContent().blocks,
+            {
+              type: 'media',
+              mimeType: 'image/png',
+              encoding: 'url',
+              data: 'https://example.test/image.png',
+            },
+          ],
+        };
+        const records = [
+          {
+            v: 1,
+            seq: 1,
+            ts: '2026-08-23T00:00:00.000Z',
+            type: 'session_start',
+            payload: {
+              sessionId: 'legacy-with-store',
+              projectHash: 'project-hash',
+              workspaceDirs: [],
+              provider: 'test',
+              model: 'test',
+              startTime: '2026-08-23T00:00:00.000Z',
+            },
+          },
+          {
+            v: 1,
+            seq: 2,
+            ts: '2026-08-23T00:00:01.000Z',
+            type: 'content',
+            payload: { content: legacyContent },
+          },
+        ];
+        await writeFile(
+          filePath,
+          records.map((record) => JSON.stringify(record)).join('\n'),
+        );
+
         const replay = await replaySession(filePath, 'project-hash', {
           mediaStore: store,
         });
-        const versions = serialized
-          .trim()
-          .split('\n')
-          .map((line) => {
-            const parsed: unknown = JSON.parse(line);
-            if (
-              typeof parsed !== 'object' ||
-              parsed === null ||
-              !('v' in parsed)
-            ) {
-              throw new Error('Expected versioned recording line');
-            }
-            return parsed.v;
-          });
-        expect(versions).toStrictEqual([1, 2]);
-        expect(serialized).not.toContain(PNG_BASE64);
-        expect(serialized).not.toContain(tempDirectory());
+
         expect(replay.ok).toBe(true);
         if (!replay.ok) throw new Error(replay.error);
-        expect(referenceFrom(replay.history[0]).contentId).toBe(
-          referenceFrom(admitted).contentId,
+        const localBlock = replay.history[0].blocks[0];
+        if (localBlock.type !== 'media')
+          throw new Error('Expected local media');
+        expect(localBlock.encoding).toBe('reference');
+        expect(replay.history[0].blocks[1]).toStrictEqual(
+          legacyContent.blocks[1],
         );
-      } finally {
-        await recording.dispose();
-      }
-    });
-
-    it('persists exact media semantics without ingestion paths or raw media', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: join(tempDirectory(), 'media-private'),
-        quotaBytes: 1024,
-      });
-      const sourcePath = join(tempDirectory(), 'private', 'diagram.png');
-      const caption =
-        'Architecture diagram from /Users/example/provider-captions/diagram.png';
-      const filename = 'provider-assets/diagrams/diagram.png';
-      const providerMetadata = {
-        detail: 'high',
-        vendorOptions: {
-          inputPath: '/Users/example/provider-options/diagram.json',
-          token: 'provider-semantic-token-3199',
-        },
-      };
-      const media: InlineMediaBlock & { readonly sourcePath: string } = {
-        type: 'media',
-        mimeType: 'image/png',
-        encoding: 'base64',
-        data: PNG_BASE64,
-        filename,
-        caption,
-        providerMetadata,
-        sourcePath,
-      };
-      const admitted = await new MediaAdmissionService(store).admitContent(
-        {
-          speaker: 'human',
-          blocks: [media],
-          metadata: { turnId: 'turn-private-recording' },
-        },
-        { turnId: 'turn-private-recording', source: 'at-command' },
-      );
-      const recording = new SessionRecordingService({
-        sessionId: 'session-private-media',
-        projectHash: 'project-hash',
-        chatsDir: join(tempDirectory(), 'chats-private'),
-        workspaceDirs: [],
-        provider: 'test',
-        model: 'test',
       });
 
-      try {
-        recording.recordContent(admitted);
-        await recording.flush();
-        const filePath = recording.getFilePath();
-        assertNotNull(filePath, 'Expected materialized recording');
-        const serialized = await readFile(filePath, 'utf8');
-
-        expect(serialized).toContain(JSON.stringify(caption));
-        expect(serialized).toContain(JSON.stringify(filename));
-        expect(serialized).toContain(JSON.stringify(providerMetadata));
-        expect(serialized).not.toContain(sourcePath);
-        expect(serialized).not.toContain(PNG_BASE64);
-      } finally {
-        await recording.dispose();
-      }
-    });
-
-    it('accepts legacy inline replay without a media store', async () => {
-      const filePath = join(tempDirectory(), 'legacy.jsonl');
-      const records = [
-        {
-          v: 1,
-          seq: 1,
-          ts: '2026-08-23T00:00:00.000Z',
-          type: 'session_start',
-          payload: {
-            sessionId: 'legacy',
-            projectHash: 'project-hash',
-            workspaceDirs: [],
-            provider: 'test',
-            model: 'test',
-            startTime: '2026-08-23T00:00:00.000Z',
-          },
-        },
-        {
-          v: 1,
-          seq: 2,
-          ts: '2026-08-23T00:00:01.000Z',
-          type: 'content',
-          payload: { content: inlineContent() },
-        },
-      ];
-      await writeFile(
-        filePath,
-        records.map((record) => JSON.stringify(record)).join('\n'),
-      );
-
-      const replay = await replaySession(filePath, 'project-hash');
-
-      expect(replay.ok).toBe(true);
-      if (!replay.ok) throw new Error(replay.error);
-      expect(replay.history[0]).toStrictEqual(inlineContent());
-    });
-
-    it('migrates legacy inline local media during replay while preserving URL media', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: join(tempDirectory(), 'replay-media'),
-        quotaBytes: 1024,
-      });
-      const filePath = join(tempDirectory(), 'legacy-with-store.jsonl');
-      const legacyContent: IContent = {
-        ...inlineContent(),
-        blocks: [
-          ...inlineContent().blocks,
-          {
-            type: 'media',
-            mimeType: 'image/png',
-            encoding: 'url',
-            data: 'https://example.test/image.png',
-          },
-        ],
-      };
-      const records = [
-        {
-          v: 1,
-          seq: 1,
-          ts: '2026-08-23T00:00:00.000Z',
-          type: 'session_start',
-          payload: {
-            sessionId: 'legacy-with-store',
-            projectHash: 'project-hash',
-            workspaceDirs: [],
-            provider: 'test',
-            model: 'test',
-            startTime: '2026-08-23T00:00:00.000Z',
-          },
-        },
-        {
-          v: 1,
-          seq: 2,
-          ts: '2026-08-23T00:00:01.000Z',
-          type: 'content',
-          payload: { content: legacyContent },
-        },
-      ];
-      await writeFile(
-        filePath,
-        records.map((record) => JSON.stringify(record)).join('\n'),
-      );
-
-      const replay = await replaySession(filePath, 'project-hash', {
-        mediaStore: store,
-      });
-
-      expect(replay.ok).toBe(true);
-      if (!replay.ok) throw new Error(replay.error);
-      const localBlock = replay.history[0].blocks[0];
-      if (localBlock.type !== 'media') throw new Error('Expected local media');
-      expect(localBlock.encoding).toBe('reference');
-      expect(replay.history[0].blocks[1]).toStrictEqual(
-        legacyContent.blocks[1],
-      );
-    });
-
-    it('rejects malformed, missing, and corrupt references after closing each store before external mutation', async () => {
-      const mediaRoot = join(tempDirectory(), 'media');
-      const sourceStore = new LocalMediaStore({
-        rootDirectory: mediaRoot,
-        quotaBytes: 1024,
-      });
-      const stores = [sourceStore];
-      try {
-        const admitted = await new MediaAdmissionService(
-          sourceStore,
-        ).admitContent(inlineContent(), {
-          turnId: 'turn-media',
-          source: 'generated-image',
-        });
-        const reference = referenceFrom(admitted);
-        const objectPath = join(
-          mediaRoot,
-          'objects',
-          'sha256',
-          reference.contentId.slice('sha256:'.length),
-        );
-        await sourceStore.close();
-
-        const verificationStore = new LocalMediaStore({
+      it('rejects malformed, missing, and corrupt references after closing each store before external mutation', async () => {
+        const mediaRoot = join(tempDirectory(), 'media');
+        const sourceStore = new LocalMediaStore({
           rootDirectory: mediaRoot,
           quotaBytes: 1024,
         });
-        stores.push(verificationStore);
-        const cases: readonly IContent[] = [
-          {
-            ...admitted,
-            blocks: [{ ...reference, contentId: 'invalid' }],
-          },
-          admitted,
-          admitted,
-        ];
-        const outcomes: Array<{
-          readonly ok: boolean;
-          readonly error: string | undefined;
-        }> = [];
-
-        for (const [index, content] of cases.entries()) {
-          const filePath = join(tempDirectory(), `case-${index}.jsonl`);
-          const records = [
-            {
-              v: 1,
-              seq: 1,
-              ts: '2026-08-23T00:00:00.000Z',
-              type: 'session_start',
-              payload: {
-                sessionId: `case-${index}`,
-                projectHash: 'project-hash',
-                workspaceDirs: [],
-                provider: 'test',
-                model: 'test',
-                startTime: '2026-08-23T00:00:00.000Z',
-              },
-            },
-            {
-              v: 1,
-              seq: 2,
-              ts: '2026-08-23T00:00:01.000Z',
-              type: 'content',
-              payload: { content },
-            },
-          ];
-          await writeFile(
-            filePath,
-            records.map((record) => JSON.stringify(record)).join('\n'),
+        const stores = [sourceStore];
+        try {
+          const admitted = await new MediaAdmissionService(
+            sourceStore,
+          ).admitContent(inlineContent(), {
+            turnId: 'turn-media',
+            source: 'generated-image',
+          });
+          const reference = referenceFrom(admitted);
+          const objectPath = join(
+            mediaRoot,
+            'objects',
+            'sha256',
+            reference.contentId.slice('sha256:'.length),
           );
-          if (index === 1) {
-            await rm(objectPath);
-          }
-          if (index === 2) {
-            await verificationStore.close();
-            await writeFile(objectPath, new Uint8Array(reference.byteLength));
-          }
-          const replayStore =
-            index === 2
-              ? new LocalMediaStore({
-                  rootDirectory: mediaRoot,
-                  quotaBytes: 1024,
-                })
-              : verificationStore;
-          if (index === 2) stores.push(replayStore);
-          const replay = await replaySession(filePath, 'project-hash', {
-            mediaStore: replayStore,
+          await sourceStore.close();
+
+          const verificationStore = new LocalMediaStore({
+            rootDirectory: mediaRoot,
+            quotaBytes: 1024,
           });
-          outcomes.push({
-            ok: replay.ok,
-            error: replay.ok ? undefined : replay.error,
-          });
-          if (index === 1) {
-            await verificationStore.admit({
-              bytes: Buffer.from(PNG_BASE64, 'base64'),
-              mimeType: 'image/png',
-              dimensions: { width: 1, height: 1 },
-              semanticMetadata: {},
+          stores.push(verificationStore);
+          const cases: readonly IContent[] = [
+            {
+              ...admitted,
+              blocks: [{ ...reference, contentId: 'invalid' }],
+            },
+            admitted,
+            admitted,
+          ];
+          const outcomes: Array<{
+            readonly ok: boolean;
+            readonly error: string | undefined;
+          }> = [];
+
+          for (const [index, content] of cases.entries()) {
+            const filePath = join(tempDirectory(), `case-${index}.jsonl`);
+            const records = [
+              {
+                v: 1,
+                seq: 1,
+                ts: '2026-08-23T00:00:00.000Z',
+                type: 'session_start',
+                payload: {
+                  sessionId: `case-${index}`,
+                  projectHash: 'project-hash',
+                  workspaceDirs: [],
+                  provider: 'test',
+                  model: 'test',
+                  startTime: '2026-08-23T00:00:00.000Z',
+                },
+              },
+              {
+                v: 1,
+                seq: 2,
+                ts: '2026-08-23T00:00:01.000Z',
+                type: 'content',
+                payload: { content },
+              },
+            ];
+            await writeFile(
+              filePath,
+              records.map((record) => JSON.stringify(record)).join('\n'),
+            );
+            if (index === 1) {
+              await rm(objectPath);
+            }
+            if (index === 2) {
+              await verificationStore.close();
+              await writeFile(objectPath, new Uint8Array(reference.byteLength));
+            }
+            const replayStore =
+              index === 2
+                ? new LocalMediaStore({
+                    rootDirectory: mediaRoot,
+                    quotaBytes: 1024,
+                  })
+                : verificationStore;
+            if (index === 2) stores.push(replayStore);
+            const replay = await replaySession(filePath, 'project-hash', {
+              mediaStore: replayStore,
             });
+            outcomes.push({
+              ok: replay.ok,
+              error: replay.ok ? undefined : replay.error,
+            });
+            if (index === 1) {
+              await verificationStore.admit({
+                bytes: Buffer.from(PNG_BASE64, 'base64'),
+                mimeType: 'image/png',
+                dimensions: { width: 1, height: 1 },
+                semanticMetadata: {},
+              });
+            }
           }
+
+          expect(outcomes.map((outcome) => outcome.ok)).toStrictEqual([
+            false,
+            false,
+            false,
+          ]);
+          expect(outcomes[0]?.error).toContain('contentId=invalid');
+          expect(outcomes[1]?.error).toContain(reference.contentId);
+          expect(outcomes[2]?.error).toContain(reference.contentId);
+          for (const outcome of outcomes) {
+            expect(outcome.error).toContain('turn=turn-media');
+          }
+        } finally {
+          await closeMediaStores(stores);
         }
-
-        expect(outcomes.map((outcome) => outcome.ok)).toStrictEqual([
-          false,
-          false,
-          false,
-        ]);
-        expect(outcomes[0]?.error).toContain('contentId=invalid');
-        expect(outcomes[1]?.error).toContain(reference.contentId);
-        expect(outcomes[2]?.error).toContain(reference.contentId);
-        for (const outcome of outcomes) {
-          expect(outcome.error).toContain('turn=turn-media');
-        }
-      } finally {
-        await closeMediaStores(stores);
-      }
-    });
-
-    it('preserves content and turn diagnostics when replay verification and release both fail', async () => {
-      const mediaRoot = join(tempDirectory(), 'aggregate-replay-media');
-      const sourceStore = new LocalMediaStore({
-        rootDirectory: mediaRoot,
-        quotaBytes: 1024,
-      });
-      const reference = await sourceStore.admit({
-        bytes: new Uint8Array([31, 32, 33]),
-        mimeType: 'application/octet-stream',
-        semanticMetadata: {},
-      });
-      const recording = new SessionRecordingService({
-        sessionId: 'aggregate-replay',
-        projectHash: 'project-hash',
-        chatsDir: join(tempDirectory(), 'aggregate-replay-chats'),
-        workspaceDirs: [],
-        provider: 'test',
-        model: 'test',
       });
 
-      try {
-        recording.recordContent({
-          speaker: 'human',
-          blocks: [reference],
-          metadata: { turnId: 'aggregate-replay-turn' },
-        });
-        await recording.flush();
-        const filePath = recording.getFilePath();
-        assertNotNull(filePath, 'Expected materialized recording');
-        const failingStore = new ReplayDiagnosticFailureStore({
+      it('preserves content and turn diagnostics when replay verification and release both fail', async () => {
+        const mediaRoot = join(tempDirectory(), 'aggregate-replay-media');
+        const sourceStore = new LocalMediaStore({
           rootDirectory: mediaRoot,
           quotaBytes: 1024,
         });
-
-        const replay = await replaySession(filePath, 'project-hash', {
-          mediaStore: failingStore,
+        const reference = await sourceStore.admit({
+          bytes: new Uint8Array([31, 32, 33]),
+          mimeType: 'application/octet-stream',
+          semanticMetadata: {},
+        });
+        const recording = new SessionRecordingService({
+          sessionId: 'aggregate-replay',
+          projectHash: 'project-hash',
+          chatsDir: join(tempDirectory(), 'aggregate-replay-chats'),
+          workspaceDirs: [],
+          provider: 'test',
+          model: 'test',
         });
 
-        expect(replay.ok).toBe(false);
-        if (replay.ok) throw new Error('Expected replay failure');
-        expect(replay.error).toContain(reference.contentId);
-        expect(replay.error).toContain('turn=aggregate-replay-turn');
-        expect(replay.error).toContain('verification unavailable');
-        expect(replay.error).toContain('release unavailable');
-      } finally {
-        await recording.dispose();
-      }
-    });
+        try {
+          recording.recordContent({
+            speaker: 'human',
+            blocks: [reference],
+            metadata: { turnId: 'aggregate-replay-turn' },
+          });
+          await recording.flush();
+          const filePath = recording.getFilePath();
+          assertNotNull(filePath, 'Expected materialized recording');
+          const failingStore = new ReplayDiagnosticFailureStore({
+            rootDirectory: mediaRoot,
+            quotaBytes: 1024,
+          });
 
-    it('persists reference sessions with bounded byte accounting and verifies on restore', async () => {
-      const projectRoot = join(tempDirectory(), 'project');
-      const storage = new Storage(projectRoot);
-      const store = new LocalMediaStore({
-        rootDirectory: join(storage.getProjectTempDir(), 'media'),
-        quotaBytes: 1024,
+          const replay = await replaySession(filePath, 'project-hash', {
+            mediaStore: failingStore,
+          });
+
+          expect(replay.ok).toBe(false);
+          if (replay.ok) throw new Error('Expected replay failure');
+          expect(replay.error).toContain(reference.contentId);
+          expect(replay.error).toContain('turn=aggregate-replay-turn');
+          expect(replay.error).toContain('verification unavailable');
+          expect(replay.error).toContain('release unavailable');
+        } finally {
+          await recording.dispose();
+        }
       });
-      const admitted = await new MediaAdmissionService(store).admitContent(
-        inlineContent(),
-        { turnId: 'turn-media', source: 'acp-image' },
-      );
-      const service = new SessionPersistenceService(storage, 'session-media', {
-        mediaStore: store,
-        maxQueueBytes: 1024 * 1024,
+
+      it('persists reference sessions with bounded byte accounting and verifies on restore', async () => {
+        const projectRoot = join(tempDirectory(), 'project');
+        const storage = new Storage(projectRoot);
+        const store = new LocalMediaStore({
+          rootDirectory: join(storage.getProjectTempDir(), 'media'),
+          quotaBytes: 1024,
+        });
+        const admitted = await new MediaAdmissionService(store).admitContent(
+          inlineContent(),
+          { turnId: 'turn-media', source: 'acp-image' },
+        );
+        const service = new SessionPersistenceService(
+          storage,
+          'session-media',
+          {
+            mediaStore: store,
+            maxQueueBytes: 1024 * 1024,
+          },
+        );
+
+        await service.save([admitted]);
+        await expect(
+          store.readVerified(referenceFrom(admitted)),
+        ).resolves.toBeInstanceOf(Uint8Array);
+        const restored = await service.loadMostRecent();
+
+        expect(service.getPendingByteCount()).toBe(0);
+        expect(restored?.history[0]).toStrictEqual(admitted);
+        const serialized = await readFile(service.getSessionFilePath(), 'utf8');
+        expect(serialized).not.toContain(PNG_BASE64);
+        expect(serialized).not.toContain(projectRoot);
+        await rm(storage.getProjectTempDir(), { recursive: true, force: true });
       });
-
-      await service.save([admitted]);
-      await expect(
-        store.readVerified(referenceFrom(admitted)),
-      ).resolves.toBeInstanceOf(Uint8Array);
-      const restored = await service.loadMostRecent();
-
-      expect(service.getPendingByteCount()).toBe(0);
-      expect(restored?.history[0]).toStrictEqual(admitted);
-      const serialized = await readFile(service.getSessionFilePath(), 'utf8');
-      expect(serialized).not.toContain(PNG_BASE64);
-      expect(serialized).not.toContain(projectRoot);
-      await rm(storage.getProjectTempDir(), { recursive: true, force: true });
     });
   });
 });

--- a/packages/core/src/storage/request-media-resolver.test.ts
+++ b/packages/core/src/storage/request-media-resolver.test.ts
@@ -25,228 +25,179 @@ import {
   RequestMediaResolver,
 } from './request-media-resolver.js';
 
-function useTempDirectory(): () => string {
-  let directory = '';
-  beforeEach(async () => {
-    directory = await mkdtemp(join(tmpdir(), 'llxprt-request-media-'));
-  });
-  afterEach(async () => {
-    if (directory !== '') {
-      await chmod(directory, 0o700).catch(() => undefined);
-      await rm(directory, { recursive: true, force: true });
-    }
-  });
-  return () => directory;
-}
-
-function content(
-  turnId: string,
-  blocks: IContent['blocks'],
-  speaker: IContent['speaker'] = 'human',
-): IContent {
-  return { speaker, blocks, metadata: { turnId } };
-}
-
-async function objectPath(
-  root: string,
-  reference: MediaReferenceBlock,
-): Promise<string> {
-  const digest = reference.contentId.slice('sha256:'.length);
-  const directory = join(root, 'objects', 'sha256');
-  const entries = await readdir(directory);
-  const match = entries.find((entry) => entry === digest);
-  if (match === undefined) {
-    throw new Error(`Object ${reference.contentId} was not stored`);
-  }
-  return join(directory, match);
-}
-
-async function admittedReference(
-  store: LocalMediaStore,
-  bytes: Uint8Array,
-): Promise<MediaReferenceBlock> {
-  return store.admit({
-    bytes,
-    mimeType: 'image/png',
-    dimensions: { width: 7, height: 5 },
-    semanticMetadata: { detail: 'high', source: 'tool' },
-    providerFileIds: { kimi: 'file_123' },
-  });
-}
-
-async function capturedError(work: Promise<unknown>): Promise<Error> {
-  try {
-    await work;
-  } catch (error) {
-    if (error instanceof Error) return error;
-    throw new Error('Expected an Error instance');
-  }
-  throw new Error('Expected operation to reject');
-}
-
-class FailOnceReleaseStore extends LocalMediaStore {
-  private releaseFailurePending = true;
-
-  override async release(contentId: string, ownerId: string): Promise<void> {
-    if (this.releaseFailurePending) {
-      this.releaseFailurePending = false;
-      throw new Error('induced release failure');
-    }
-    await super.release(contentId, ownerId);
-  }
-}
-
 describe('request-media-resolver', () => {
-  describe('RequestMediaResolver', () => {
-    const tempDirectory = useTempDirectory();
+  function useTempDirectory(): () => string {
+    let directory = '';
+    beforeEach(async () => {
+      directory = await mkdtemp(join(tmpdir(), 'llxprt-request-media-'));
+    });
+    afterEach(async () => {
+      if (directory !== '') {
+        await chmod(directory, 0o700).catch(() => undefined);
+        await rm(directory, { recursive: true, force: true });
+      }
+    });
+    return () => directory;
+  }
 
-    function store(quotaBytes = 1024): LocalMediaStore {
-      return new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes,
-      });
+  function content(
+    turnId: string,
+    blocks: IContent['blocks'],
+    speaker: IContent['speaker'] = 'human',
+  ): IContent {
+    return { speaker, blocks, metadata: { turnId } };
+  }
+
+  async function objectPath(
+    root: string,
+    reference: MediaReferenceBlock,
+  ): Promise<string> {
+    const digest = reference.contentId.slice('sha256:'.length);
+    const directory = join(root, 'objects', 'sha256');
+    const entries = await readdir(directory);
+    const match = entries.find((entry) => entry === digest);
+    if (match === undefined) {
+      throw new Error(`Object ${reference.contentId} was not stored`);
     }
+    return join(directory, match);
+  }
 
-    it('materializes selected references without changing block or message order', async () => {
-      const mediaStore = store();
-      const reference = await admittedReference(
-        mediaStore,
-        new Uint8Array([0, 1, 2, 253, 254, 255]),
-      );
-      const selected = [
-        content('turn-before', [{ type: 'text', text: 'before' }]),
-        content('turn-image', [
-          { type: 'text', text: 'caption prefix' },
-          {
-            ...reference,
-            caption: 'chart',
-            filename: 'chart.png',
-            providerMetadata: { detail: 'high' },
-          },
-          { type: 'text', text: 'caption suffix' },
-        ]),
-      ];
-      const resolver = new RequestMediaResolver(mediaStore);
-
-      const resolved = await resolver.resolve({
-        contents: selected,
-        requestId: 'request-1',
-        turnId: 'active-turn',
-        aggregateBudgetBytes: reference.normalizedBase64Length,
-      });
-
-      expect(resolved.withContents((contents) => contents)).toStrictEqual([
-        selected[0],
-        content('turn-image', [
-          { type: 'text', text: 'caption prefix' },
-          {
-            type: 'media',
-            encoding: 'base64',
-            data: 'AAEC/f7/',
-            mimeType: 'image/png',
-            caption: 'chart',
-            filename: 'chart.png',
-            providerMetadata: { detail: 'high' },
-            dimensions: { width: 7, height: 5 },
-            semanticMetadata: { detail: 'high', source: 'tool' },
-            providerFileIds: { kimi: 'file_123' },
-          },
-          { type: 'text', text: 'caption suffix' },
-        ]),
-      ]);
-      expect(resolved.accounting()).toStrictEqual({
-        selectedReferenceCount: 1,
-        uniqueContentCount: 1,
-        selectedNormalizedBytes: 8,
-        materializedNormalizedBytes: 8,
-        storeReadCount: 1,
-        reservedContentCount: 1,
-        released: false,
-      });
-      expect(await mediaStore.hasReservations(reference.contentId)).toBe(true);
-      const reachableContents = resolved.withContents((contents) => contents);
-      const providerEnvelope = resolved.withContents((contents) => ({
-        messages: [...contents],
-      }));
-      resolved.registerCleanup(() => {
-        providerEnvelope.messages.splice(0);
-      });
-
-      await resolved.release();
-      await resolved.release();
-
-      expect(await mediaStore.hasReservations(reference.contentId)).toBe(false);
-      expect(reachableContents).toStrictEqual([]);
-      expect(providerEnvelope.messages).toStrictEqual([]);
-      expect(() => resolved.withContents((contents) => contents)).toThrow(
-        /after release/i,
-      );
-      expect(resolved.accounting()).toStrictEqual({
-        selectedReferenceCount: 1,
-        uniqueContentCount: 1,
-        selectedNormalizedBytes: 8,
-        materializedNormalizedBytes: 0,
-        storeReadCount: 1,
-        reservedContentCount: 0,
-        released: true,
-      });
+  async function admittedReference(
+    store: LocalMediaStore,
+    bytes: Uint8Array,
+  ): Promise<MediaReferenceBlock> {
+    return store.admit({
+      bytes,
+      mimeType: 'image/png',
+      dimensions: { width: 7, height: 5 },
+      semanticMetadata: { detail: 'high', source: 'tool' },
+      providerFileIds: { kimi: 'file_123' },
     });
+  }
 
-    it('reads and materializes duplicate content once while preserving duplicate blocks', async () => {
-      const mediaStore = store();
-      const reference = await admittedReference(
-        mediaStore,
-        new Uint8Array([1, 2, 3]),
-      );
-      const resolver = new RequestMediaResolver(mediaStore);
+  async function capturedError(work: Promise<unknown>): Promise<Error> {
+    try {
+      await work;
+    } catch (error) {
+      if (error instanceof Error) return error;
+      throw new Error('Expected an Error instance');
+    }
+    throw new Error('Expected operation to reject');
+  }
 
-      const resolved = await resolver.resolve({
-        contents: [content('turn-duplicate', [reference, reference])],
-        requestId: 'request-duplicate',
-        turnId: 'active-turn',
-        aggregateBudgetBytes: 8,
+  class FailOnceReleaseStore extends LocalMediaStore {
+    private releaseFailurePending = true;
+
+    override async release(contentId: string, ownerId: string): Promise<void> {
+      if (this.releaseFailurePending) {
+        this.releaseFailurePending = false;
+        throw new Error('induced release failure');
+      }
+      await super.release(contentId, ownerId);
+    }
+  }
+
+  describe('request-media-resolver', () => {
+    describe('RequestMediaResolver', () => {
+      const tempDirectory = useTempDirectory();
+
+      function store(quotaBytes = 1024): LocalMediaStore {
+        return new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes,
+        });
+      }
+
+      it('materializes selected references without changing block or message order', async () => {
+        const mediaStore = store();
+        const reference = await admittedReference(
+          mediaStore,
+          new Uint8Array([0, 1, 2, 253, 254, 255]),
+        );
+        const selected = [
+          content('turn-before', [{ type: 'text', text: 'before' }]),
+          content('turn-image', [
+            { type: 'text', text: 'caption prefix' },
+            {
+              ...reference,
+              caption: 'chart',
+              filename: 'chart.png',
+              providerMetadata: { detail: 'high' },
+            },
+            { type: 'text', text: 'caption suffix' },
+          ]),
+        ];
+        const resolver = new RequestMediaResolver(mediaStore);
+
+        const resolved = await resolver.resolve({
+          contents: selected,
+          requestId: 'request-1',
+          turnId: 'active-turn',
+          aggregateBudgetBytes: reference.normalizedBase64Length,
+        });
+
+        expect(resolved.withContents((contents) => contents)).toStrictEqual([
+          selected[0],
+          content('turn-image', [
+            { type: 'text', text: 'caption prefix' },
+            {
+              type: 'media',
+              encoding: 'base64',
+              data: 'AAEC/f7/',
+              mimeType: 'image/png',
+              caption: 'chart',
+              filename: 'chart.png',
+              providerMetadata: { detail: 'high' },
+              dimensions: { width: 7, height: 5 },
+              semanticMetadata: { detail: 'high', source: 'tool' },
+              providerFileIds: { kimi: 'file_123' },
+            },
+            { type: 'text', text: 'caption suffix' },
+          ]),
+        ]);
+        expect(resolved.accounting()).toStrictEqual({
+          selectedReferenceCount: 1,
+          uniqueContentCount: 1,
+          selectedNormalizedBytes: 8,
+          materializedNormalizedBytes: 8,
+          storeReadCount: 1,
+          reservedContentCount: 1,
+          released: false,
+        });
+        expect(await mediaStore.hasReservations(reference.contentId)).toBe(
+          true,
+        );
+        const reachableContents = resolved.withContents((contents) => contents);
+        const providerEnvelope = resolved.withContents((contents) => ({
+          messages: [...contents],
+        }));
+        resolved.registerCleanup(() => {
+          providerEnvelope.messages.splice(0);
+        });
+
+        await resolved.release();
+        await resolved.release();
+
+        expect(await mediaStore.hasReservations(reference.contentId)).toBe(
+          false,
+        );
+        expect(reachableContents).toStrictEqual([]);
+        expect(providerEnvelope.messages).toStrictEqual([]);
+        expect(() => resolved.withContents((contents) => contents)).toThrow(
+          /after release/i,
+        );
+        expect(resolved.accounting()).toStrictEqual({
+          selectedReferenceCount: 1,
+          uniqueContentCount: 1,
+          selectedNormalizedBytes: 8,
+          materializedNormalizedBytes: 0,
+          storeReadCount: 1,
+          reservedContentCount: 0,
+          released: true,
+        });
       });
 
-      expect(
-        resolved.withContents((contents) => contents)[0]?.blocks,
-      ).toStrictEqual([
-        {
-          type: 'media',
-          encoding: 'base64',
-          data: 'AQID',
-          mimeType: 'image/png',
-          dimensions: { width: 7, height: 5 },
-          semanticMetadata: { detail: 'high', source: 'tool' },
-          providerFileIds: { kimi: 'file_123' },
-        },
-        {
-          type: 'media',
-          encoding: 'base64',
-          data: 'AQID',
-          mimeType: 'image/png',
-          dimensions: { width: 7, height: 5 },
-          semanticMetadata: { detail: 'high', source: 'tool' },
-          providerFileIds: { kimi: 'file_123' },
-        },
-      ]);
-      expect(resolved.accounting()).toStrictEqual({
-        selectedReferenceCount: 2,
-        uniqueContentCount: 1,
-        selectedNormalizedBytes: 8,
-        materializedNormalizedBytes: 4,
-        storeReadCount: 1,
-        reservedContentCount: 1,
-        released: false,
-      });
-      await resolved.release();
-    });
-
-    it.each([
-      ['zero', 0],
-      ['one byte under', 3],
-    ])(
-      'rejects a %s aggregate limit before reads or reservations',
-      async (_label, limit) => {
+      it('reads and materializes duplicate content once while preserving duplicate blocks', async () => {
         const mediaStore = store();
         const reference = await admittedReference(
           mediaStore,
@@ -254,280 +205,337 @@ describe('request-media-resolver', () => {
         );
         const resolver = new RequestMediaResolver(mediaStore);
 
-        const error = await capturedError(
-          resolver.resolve({
-            contents: [content('budget-turn', [reference])],
-            requestId: 'request-budget',
-            turnId: 'active-turn',
-            aggregateBudgetBytes: limit,
-          }),
-        );
-
-        expect(error).toBeInstanceOf(RequestMediaResolutionError);
-        expect(error.message).toContain(reference.contentId);
-        expect(error.message).toContain('budget-turn');
-        expect(resolver.accounting()).toStrictEqual({
-          activeRequestCount: 0,
-          reservedContentCount: 0,
-          materializedNormalizedBytes: 0,
-          storeReadCount: 0,
-        });
-        expect(await mediaStore.hasReservations(reference.contentId)).toBe(
-          false,
-        );
-      },
-    );
-
-    it('accepts an aggregate limit exactly equal to normalized selected bytes', async () => {
-      const mediaStore = store();
-      const reference = await admittedReference(
-        mediaStore,
-        new Uint8Array([1, 2, 3]),
-      );
-      const resolver = new RequestMediaResolver(mediaStore);
-
-      const resolved = await resolver.resolve({
-        contents: [content('exact-turn', [reference])],
-        requestId: 'request-exact',
-        turnId: 'active-turn',
-        aggregateBudgetBytes: 4,
-      });
-
-      expect(
-        resolved.withContents((contents) => contents)[0]?.blocks[0],
-      ).toMatchObject({
-        encoding: 'base64',
-        data: 'AQID',
-      });
-      await resolved.release();
-    });
-
-    it('validates every selected reference before reading any blob', async () => {
-      const mediaStore = store();
-      const first = await admittedReference(
-        mediaStore,
-        new Uint8Array([1, 2, 3]),
-      );
-      const malformed = {
-        ...first,
-        normalizedBase64Length: first.normalizedBase64Length + 1,
-      };
-      const resolver = new RequestMediaResolver(mediaStore);
-
-      const error = await capturedError(
-        resolver.resolve({
-          contents: [
-            content('valid-turn', [first]),
-            content('malformed-turn', [malformed]),
-          ],
-          requestId: 'request-malformed',
-          turnId: 'active-turn',
-          aggregateBudgetBytes: 100,
-        }),
-      );
-
-      expect(error.message).toContain(first.contentId);
-      expect(error.message).toContain('malformed-turn');
-      expect(resolver.accounting().storeReadCount).toBe(0);
-      expect(await mediaStore.hasReservations(first.contentId)).toBe(false);
-    });
-
-    it('identifies a missing content ID and turn and releases earlier reservations', async () => {
-      const mediaStore = store();
-      const first = await admittedReference(
-        mediaStore,
-        new Uint8Array([1, 2, 3]),
-      );
-      const missing = await admittedReference(
-        mediaStore,
-        new Uint8Array([4, 5, 6]),
-      );
-      await unlink(await objectPath(tempDirectory(), missing));
-      const resolver = new RequestMediaResolver(mediaStore);
-
-      const error = await capturedError(
-        resolver.resolve({
-          contents: [
-            content('first-turn', [first]),
-            content('missing-turn', [missing]),
-          ],
-          requestId: 'request-missing',
+        const resolved = await resolver.resolve({
+          contents: [content('turn-duplicate', [reference, reference])],
+          requestId: 'request-duplicate',
           turnId: 'active-turn',
           aggregateBudgetBytes: 8,
-        }),
-      );
+        });
 
-      expect(error.message).toContain(missing.contentId);
-      expect(error.message).toContain('missing-turn');
-      expect(resolver.accounting().storeReadCount).toBe(2);
-      expect(await mediaStore.hasReservations(first.contentId)).toBe(false);
-    });
-
-    it('includes legacy inline local media in the aggregate request budget', async () => {
-      const mediaStore = store();
-      const resolver = new RequestMediaResolver(mediaStore);
-      const inline = content('inline-budget-turn', [
-        {
-          type: 'media',
-          encoding: 'base64',
-          data: 'AQID',
-          mimeType: 'image/png',
-        },
-      ]);
-
-      const error = await capturedError(
-        resolver.resolve({
-          contents: [inline],
-          requestId: 'request-inline-budget',
-          turnId: 'active-turn',
-          aggregateBudgetBytes: 3,
-        }),
-      );
-
-      expect(error).toBeInstanceOf(RequestMediaResolutionError);
-      expect(error.message).toContain('inline-budget-turn');
-      expect(resolver.accounting().storeReadCount).toBe(0);
-    });
-
-    it('identifies hash-mismatched bytes and releases request accounting', async () => {
-      const mediaStore = store();
-      const reference = await admittedReference(
-        mediaStore,
-        new Uint8Array([1, 2, 3]),
-      );
-      await writeFile(
-        await objectPath(tempDirectory(), reference),
-        new Uint8Array([3, 2, 1]),
-      );
-      const resolver = new RequestMediaResolver(mediaStore);
-
-      const error = await capturedError(
-        resolver.resolve({
-          contents: [content('hash-turn', [reference])],
-          requestId: 'request-hash',
-          turnId: 'active-turn',
-          aggregateBudgetBytes: 4,
-        }),
-      );
-
-      expect(error.message).toContain(reference.contentId);
-      expect(error.message).toContain('hash-turn');
-      expect(resolver.accounting()).toStrictEqual({
-        activeRequestCount: 0,
-        reservedContentCount: 0,
-        materializedNormalizedBytes: 0,
-        storeReadCount: 1,
-      });
-    });
-
-    it('preserves URL and legacy inline media without a store read', async () => {
-      const mediaStore = store();
-      const selected = [
-        content('legacy-turn', [
+        expect(
+          resolved.withContents((contents) => contents)[0]?.blocks,
+        ).toStrictEqual([
           {
             type: 'media',
-            encoding: 'url',
-            data: 'https://example.test/image.png',
+            encoding: 'base64',
+            data: 'AQID',
             mimeType: 'image/png',
+            dimensions: { width: 7, height: 5 },
+            semanticMetadata: { detail: 'high', source: 'tool' },
+            providerFileIds: { kimi: 'file_123' },
           },
           {
             type: 'media',
             encoding: 'base64',
             data: 'AQID',
             mimeType: 'image/png',
+            dimensions: { width: 7, height: 5 },
+            semanticMetadata: { detail: 'high', source: 'tool' },
+            providerFileIds: { kimi: 'file_123' },
           },
-        ]),
-      ];
-      const resolver = new RequestMediaResolver(mediaStore);
-
-      const resolved = await resolver.resolve({
-        contents: selected,
-        requestId: 'request-legacy',
-        turnId: 'active-turn',
-        aggregateBudgetBytes: 4,
+        ]);
+        expect(resolved.accounting()).toStrictEqual({
+          selectedReferenceCount: 2,
+          uniqueContentCount: 1,
+          selectedNormalizedBytes: 8,
+          materializedNormalizedBytes: 4,
+          storeReadCount: 1,
+          reservedContentCount: 1,
+          released: false,
+        });
+        await resolved.release();
       });
 
-      expect(resolved.withContents((contents) => contents)).toStrictEqual(
-        selected,
+      it.each([
+        ['zero', 0],
+        ['one byte under', 3],
+      ])(
+        'rejects a %s aggregate limit before reads or reservations',
+        async (_label, limit) => {
+          const mediaStore = store();
+          const reference = await admittedReference(
+            mediaStore,
+            new Uint8Array([1, 2, 3]),
+          );
+          const resolver = new RequestMediaResolver(mediaStore);
+
+          const error = await capturedError(
+            resolver.resolve({
+              contents: [content('budget-turn', [reference])],
+              requestId: 'request-budget',
+              turnId: 'active-turn',
+              aggregateBudgetBytes: limit,
+            }),
+          );
+
+          expect(error).toBeInstanceOf(RequestMediaResolutionError);
+          expect(error.message).toContain(reference.contentId);
+          expect(error.message).toContain('budget-turn');
+          expect(resolver.accounting()).toStrictEqual({
+            activeRequestCount: 0,
+            reservedContentCount: 0,
+            materializedNormalizedBytes: 0,
+            storeReadCount: 0,
+          });
+          expect(await mediaStore.hasReservations(reference.contentId)).toBe(
+            false,
+          );
+        },
       );
-      expect(resolved.accounting().storeReadCount).toBe(0);
-      await resolved.release();
-    });
 
-    it('exposes bounded recovery after terminal cleanup fails and preserves both failures', async () => {
-      const mediaStore = new FailOnceReleaseStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 6,
-      });
-      const first = await admittedReference(
-        mediaStore,
-        new Uint8Array([1, 2, 3]),
-      );
-      const missing = await admittedReference(
-        mediaStore,
-        new Uint8Array([4, 5, 6]),
-      );
-      await unlink(await objectPath(tempDirectory(), missing));
-      const resolver = new RequestMediaResolver(mediaStore);
+      it('accepts an aggregate limit exactly equal to normalized selected bytes', async () => {
+        const mediaStore = store();
+        const reference = await admittedReference(
+          mediaStore,
+          new Uint8Array([1, 2, 3]),
+        );
+        const resolver = new RequestMediaResolver(mediaStore);
 
-      const error = await capturedError(
-        resolver.resolve({
-          contents: [
-            content('reserved-turn', [first]),
-            content('missing-turn', [missing]),
-          ],
-          requestId: 'request-cleanup-recovery',
-          turnId: 'active-turn',
-          aggregateBudgetBytes: 8,
-        }),
-      );
-
-      expect(error).toBeInstanceOf(AggregateError);
-      expect(error.message).toContain('resolution and cleanup failed');
-      expect(resolver.accounting()).toMatchObject({
-        activeRequestCount: 1,
-        reservedContentCount: 1,
-      });
-      expect(resolver.pendingReleaseCount()).toBe(1);
-
-      const recovery = await resolver.recoverPendingReleases();
-
-      expect(recovery).toStrictEqual({
-        attempted: 1,
-        recovered: 1,
-        remaining: 0,
-      });
-      expect(resolver.accounting()).toMatchObject({
-        activeRequestCount: 0,
-        reservedContentCount: 0,
-      });
-      expect(resolver.pendingReleaseCount()).toBe(0);
-      expect(await mediaStore.hasReservations(first.contentId)).toBe(false);
-    });
-
-    it('aborts before reading and leaves no request accounting', async () => {
-      const mediaStore = store();
-      const reference = await admittedReference(
-        mediaStore,
-        new Uint8Array([1, 2, 3]),
-      );
-      const controller = new AbortController();
-      controller.abort();
-      const resolver = new RequestMediaResolver(mediaStore);
-
-      const error = await capturedError(
-        resolver.resolve({
-          contents: [content('cancel-turn', [reference])],
-          requestId: 'request-cancel',
+        const resolved = await resolver.resolve({
+          contents: [content('exact-turn', [reference])],
+          requestId: 'request-exact',
           turnId: 'active-turn',
           aggregateBudgetBytes: 4,
-          signal: controller.signal,
-        }),
-      );
+        });
 
-      expect(error.name).toBe('AbortError');
-      expect(resolver.accounting().storeReadCount).toBe(0);
-      expect(await mediaStore.hasReservations(reference.contentId)).toBe(false);
+        expect(
+          resolved.withContents((contents) => contents)[0]?.blocks[0],
+        ).toMatchObject({
+          encoding: 'base64',
+          data: 'AQID',
+        });
+        await resolved.release();
+      });
+
+      it('validates every selected reference before reading any blob', async () => {
+        const mediaStore = store();
+        const first = await admittedReference(
+          mediaStore,
+          new Uint8Array([1, 2, 3]),
+        );
+        const malformed = {
+          ...first,
+          normalizedBase64Length: first.normalizedBase64Length + 1,
+        };
+        const resolver = new RequestMediaResolver(mediaStore);
+
+        const error = await capturedError(
+          resolver.resolve({
+            contents: [
+              content('valid-turn', [first]),
+              content('malformed-turn', [malformed]),
+            ],
+            requestId: 'request-malformed',
+            turnId: 'active-turn',
+            aggregateBudgetBytes: 100,
+          }),
+        );
+
+        expect(error.message).toContain(first.contentId);
+        expect(error.message).toContain('malformed-turn');
+        expect(resolver.accounting().storeReadCount).toBe(0);
+        expect(await mediaStore.hasReservations(first.contentId)).toBe(false);
+      });
+
+      it('identifies a missing content ID and turn and releases earlier reservations', async () => {
+        const mediaStore = store();
+        const first = await admittedReference(
+          mediaStore,
+          new Uint8Array([1, 2, 3]),
+        );
+        const missing = await admittedReference(
+          mediaStore,
+          new Uint8Array([4, 5, 6]),
+        );
+        await unlink(await objectPath(tempDirectory(), missing));
+        const resolver = new RequestMediaResolver(mediaStore);
+
+        const error = await capturedError(
+          resolver.resolve({
+            contents: [
+              content('first-turn', [first]),
+              content('missing-turn', [missing]),
+            ],
+            requestId: 'request-missing',
+            turnId: 'active-turn',
+            aggregateBudgetBytes: 8,
+          }),
+        );
+
+        expect(error.message).toContain(missing.contentId);
+        expect(error.message).toContain('missing-turn');
+        expect(resolver.accounting().storeReadCount).toBe(2);
+        expect(await mediaStore.hasReservations(first.contentId)).toBe(false);
+      });
+
+      it('includes legacy inline local media in the aggregate request budget', async () => {
+        const mediaStore = store();
+        const resolver = new RequestMediaResolver(mediaStore);
+        const inline = content('inline-budget-turn', [
+          {
+            type: 'media',
+            encoding: 'base64',
+            data: 'AQID',
+            mimeType: 'image/png',
+          },
+        ]);
+
+        const error = await capturedError(
+          resolver.resolve({
+            contents: [inline],
+            requestId: 'request-inline-budget',
+            turnId: 'active-turn',
+            aggregateBudgetBytes: 3,
+          }),
+        );
+
+        expect(error).toBeInstanceOf(RequestMediaResolutionError);
+        expect(error.message).toContain('inline-budget-turn');
+        expect(resolver.accounting().storeReadCount).toBe(0);
+      });
+
+      it('identifies hash-mismatched bytes and releases request accounting', async () => {
+        const mediaStore = store();
+        const reference = await admittedReference(
+          mediaStore,
+          new Uint8Array([1, 2, 3]),
+        );
+        await writeFile(
+          await objectPath(tempDirectory(), reference),
+          new Uint8Array([3, 2, 1]),
+        );
+        const resolver = new RequestMediaResolver(mediaStore);
+
+        const error = await capturedError(
+          resolver.resolve({
+            contents: [content('hash-turn', [reference])],
+            requestId: 'request-hash',
+            turnId: 'active-turn',
+            aggregateBudgetBytes: 4,
+          }),
+        );
+
+        expect(error.message).toContain(reference.contentId);
+        expect(error.message).toContain('hash-turn');
+        expect(resolver.accounting()).toStrictEqual({
+          activeRequestCount: 0,
+          reservedContentCount: 0,
+          materializedNormalizedBytes: 0,
+          storeReadCount: 1,
+        });
+      });
+
+      it('preserves URL and legacy inline media without a store read', async () => {
+        const mediaStore = store();
+        const selected = [
+          content('legacy-turn', [
+            {
+              type: 'media',
+              encoding: 'url',
+              data: 'https://example.test/image.png',
+              mimeType: 'image/png',
+            },
+            {
+              type: 'media',
+              encoding: 'base64',
+              data: 'AQID',
+              mimeType: 'image/png',
+            },
+          ]),
+        ];
+        const resolver = new RequestMediaResolver(mediaStore);
+
+        const resolved = await resolver.resolve({
+          contents: selected,
+          requestId: 'request-legacy',
+          turnId: 'active-turn',
+          aggregateBudgetBytes: 4,
+        });
+
+        expect(resolved.withContents((contents) => contents)).toStrictEqual(
+          selected,
+        );
+        expect(resolved.accounting().storeReadCount).toBe(0);
+        await resolved.release();
+      });
+
+      it('exposes bounded recovery after terminal cleanup fails and preserves both failures', async () => {
+        const mediaStore = new FailOnceReleaseStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 6,
+        });
+        const first = await admittedReference(
+          mediaStore,
+          new Uint8Array([1, 2, 3]),
+        );
+        const missing = await admittedReference(
+          mediaStore,
+          new Uint8Array([4, 5, 6]),
+        );
+        await unlink(await objectPath(tempDirectory(), missing));
+        const resolver = new RequestMediaResolver(mediaStore);
+
+        const error = await capturedError(
+          resolver.resolve({
+            contents: [
+              content('reserved-turn', [first]),
+              content('missing-turn', [missing]),
+            ],
+            requestId: 'request-cleanup-recovery',
+            turnId: 'active-turn',
+            aggregateBudgetBytes: 8,
+          }),
+        );
+
+        expect(error).toBeInstanceOf(AggregateError);
+        expect(error.message).toContain('resolution and cleanup failed');
+        expect(resolver.accounting()).toMatchObject({
+          activeRequestCount: 1,
+          reservedContentCount: 1,
+        });
+        expect(resolver.pendingReleaseCount()).toBe(1);
+
+        const recovery = await resolver.recoverPendingReleases();
+
+        expect(recovery).toStrictEqual({
+          attempted: 1,
+          recovered: 1,
+          remaining: 0,
+        });
+        expect(resolver.accounting()).toMatchObject({
+          activeRequestCount: 0,
+          reservedContentCount: 0,
+        });
+        expect(resolver.pendingReleaseCount()).toBe(0);
+        expect(await mediaStore.hasReservations(first.contentId)).toBe(false);
+      });
+
+      it('aborts before reading and leaves no request accounting', async () => {
+        const mediaStore = store();
+        const reference = await admittedReference(
+          mediaStore,
+          new Uint8Array([1, 2, 3]),
+        );
+        const controller = new AbortController();
+        controller.abort();
+        const resolver = new RequestMediaResolver(mediaStore);
+
+        const error = await capturedError(
+          resolver.resolve({
+            contents: [content('cancel-turn', [reference])],
+            requestId: 'request-cancel',
+            turnId: 'active-turn',
+            aggregateBudgetBytes: 4,
+            signal: controller.signal,
+          }),
+        );
+
+        expect(error.name).toBe('AbortError');
+        expect(resolver.accounting().storeReadCount).toBe(0);
+        expect(await mediaStore.hasReservations(reference.contentId)).toBe(
+          false,
+        );
+      });
     });
   });
 });

--- a/packages/providers/src/__tests__/provider-media-recovery.entry.test.ts
+++ b/packages/providers/src/__tests__/provider-media-recovery.entry.test.ts
@@ -24,339 +24,343 @@ import type { IProvider } from '../IProvider.js';
 import { AnthropicProvider } from '../anthropic/AnthropicProvider.js';
 import { OpenAIProvider } from '../openai/OpenAIProvider.js';
 
-const originalFetch = globalThis.fetch;
+describe('provider-media-recovery', () => {
+  const originalFetch = globalThis.fetch;
 
-type ProviderKind = 'anthropic' | 'chat';
-type FailureKind = 'missing' | 'corrupt' | 'hash-mismatch' | 'over-budget';
+  type ProviderKind = 'anthropic' | 'chat';
+  type FailureKind = 'missing' | 'corrupt' | 'hash-mismatch' | 'over-budget';
 
-interface ProviderCase {
-  readonly kind: ProviderKind;
-  readonly model: string;
-  readonly baseURL: string;
-}
+  interface ProviderCase {
+    readonly kind: ProviderKind;
+    readonly model: string;
+    readonly baseURL: string;
+  }
 
-const PROVIDERS: readonly ProviderCase[] = [
-  {
-    kind: 'anthropic',
-    model: 'claude-sonnet-4-20250514',
-    baseURL: 'https://api.anthropic.com',
-  },
-  {
-    kind: 'chat',
-    model: 'gpt-4.1',
-    baseURL: 'https://api.openai.com/v1',
-  },
-];
-const FAILURES: readonly FailureKind[] = [
-  'missing',
-  'corrupt',
-  'hash-mismatch',
-  'over-budget',
-];
-
-function useTempDirectory(): () => string {
-  let directory = '';
-  beforeEach(async () => {
-    directory = await mkdtemp(join(tmpdir(), 'llxprt-provider-media-entry-'));
-  });
-  afterEach(async () => {
-    globalThis.fetch = originalFetch;
-    if (directory !== '') {
-      await chmod(directory, 0o700).catch(() => undefined);
-      await rm(directory, { recursive: true, force: true });
-    }
-  });
-  return () => directory;
-}
-
-function providerFor(providerCase: ProviderCase): IProvider {
-  return providerCase.kind === 'anthropic'
-    ? new AnthropicProvider('test-key', providerCase.baseURL)
-    : new OpenAIProvider('test-key', providerCase.baseURL);
-}
-
-function successfulResponse(kind: ProviderKind): Response {
-  if (kind === 'anthropic') {
-    return Response.json({
-      id: 'msg_media',
-      type: 'message',
-      role: 'assistant',
+  const PROVIDERS: readonly ProviderCase[] = [
+    {
+      kind: 'anthropic',
       model: 'claude-sonnet-4-20250514',
-      content: [{ type: 'text', text: 'ok' }],
-      stop_reason: 'end_turn',
-      stop_sequence: null,
-      usage: { input_tokens: 1, output_tokens: 1 },
+      baseURL: 'https://api.anthropic.com',
+    },
+    {
+      kind: 'chat',
+      model: 'gpt-4.1',
+      baseURL: 'https://api.openai.com/v1',
+    },
+  ];
+  const FAILURES: readonly FailureKind[] = [
+    'missing',
+    'corrupt',
+    'hash-mismatch',
+    'over-budget',
+  ];
+
+  function useTempDirectory(): () => string {
+    let directory = '';
+    beforeEach(async () => {
+      directory = await mkdtemp(join(tmpdir(), 'llxprt-provider-media-entry-'));
+    });
+    afterEach(async () => {
+      globalThis.fetch = originalFetch;
+      if (directory !== '') {
+        await chmod(directory, 0o700).catch(() => undefined);
+        await rm(directory, { recursive: true, force: true });
+      }
+    });
+    return () => directory;
+  }
+
+  function providerFor(providerCase: ProviderCase): IProvider {
+    return providerCase.kind === 'anthropic'
+      ? new AnthropicProvider('test-key', providerCase.baseURL)
+      : new OpenAIProvider('test-key', providerCase.baseURL);
+  }
+
+  function successfulResponse(kind: ProviderKind): Response {
+    if (kind === 'anthropic') {
+      return Response.json({
+        id: 'msg_media',
+        type: 'message',
+        role: 'assistant',
+        model: 'claude-sonnet-4-20250514',
+        content: [{ type: 'text', text: 'ok' }],
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      });
+    }
+    return Response.json({
+      id: 'chatcmpl-media',
+      object: 'chat.completion',
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: 'ok' },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
     });
   }
-  return Response.json({
-    id: 'chatcmpl-media',
-    object: 'chat.completion',
-    choices: [
-      {
-        index: 0,
-        message: { role: 'assistant', content: 'ok' },
-        finish_reason: 'stop',
+
+  async function requestBodyText(
+    body: BodyInit | null | undefined,
+  ): Promise<string> {
+    return body === null || body === undefined ? '' : new Response(body).text();
+  }
+
+  async function admitted(
+    store: LocalMediaStore,
+    bytes: Uint8Array,
+    policyVersion: number,
+  ): Promise<MediaReferenceBlock> {
+    return store.admit({
+      bytes,
+      mimeType: 'image/png',
+      semanticMetadata: { selectedBy: 'recorded-policy' },
+      transformation: {
+        policyId: 'image-selection',
+        policyVersion,
+        parameters: { maxLongEdge: 1024 },
       },
-    ],
-    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
-  });
-}
-
-async function requestBodyText(
-  body: BodyInit | null | undefined,
-): Promise<string> {
-  return body === null || body === undefined ? '' : new Response(body).text();
-}
-
-async function admitted(
-  store: LocalMediaStore,
-  bytes: Uint8Array,
-  policyVersion: number,
-): Promise<MediaReferenceBlock> {
-  return store.admit({
-    bytes,
-    mimeType: 'image/png',
-    semanticMetadata: { selectedBy: 'recorded-policy' },
-    transformation: {
-      policyId: 'image-selection',
-      policyVersion,
-      parameters: { maxLongEdge: 1024 },
-    },
-  });
-}
-
-function history(references: readonly MediaReferenceBlock[]): IContent[] {
-  return references.map((reference, index) => ({
-    speaker: 'human',
-    metadata: { turnId: `turn-media-${index}` },
-    blocks: [{ type: 'text', text: `image ${index}` }, reference],
-  }));
-}
-
-function objectPath(
-  store: LocalMediaStore,
-  reference: MediaReferenceBlock,
-): string {
-  return join(
-    store.rootDirectory,
-    'objects',
-    'sha256',
-    reference.contentId.slice('sha256:'.length),
-  );
-}
-
-async function damageReference(
-  kind: FailureKind,
-  store: LocalMediaStore,
-  reference: MediaReferenceBlock,
-): Promise<void> {
-  if (kind === 'missing') {
-    await unlink(objectPath(store, reference));
-    return;
+    });
   }
-  if (kind === 'corrupt') {
-    await writeFile(objectPath(store, reference), new Uint8Array([1]));
-    return;
+
+  function history(references: readonly MediaReferenceBlock[]): IContent[] {
+    return references.map((reference, index) => ({
+      speaker: 'human',
+      metadata: { turnId: `turn-media-${index}` },
+      blocks: [{ type: 'text', text: `image ${index}` }, reference],
+    }));
   }
-  if (kind === 'hash-mismatch') {
-    await writeFile(
-      objectPath(store, reference),
-      new Uint8Array(reference.byteLength).fill(255),
+
+  function objectPath(
+    store: LocalMediaStore,
+    reference: MediaReferenceBlock,
+  ): string {
+    return join(
+      store.rootDirectory,
+      'objects',
+      'sha256',
+      reference.contentId.slice('sha256:'.length),
     );
   }
-}
 
-function callOptions(
-  providerCase: ProviderCase,
-  provider: IProvider,
-  contents: IContent[],
-  resolver: RequestMediaResolver,
-  budget: number,
-  signal?: AbortSignal,
-): ReturnType<typeof createProviderCallOptions> {
-  const settings = new SettingsService();
-  settings.setProviderSetting(provider.name, 'model', providerCase.model);
-  settings.setProviderSetting(provider.name, 'streaming', 'disabled');
-  settings.setProviderSetting(provider.name, 'prompt-caching', 'off');
-  const config = createRuntimeConfigStub(settings);
-  const runtime = createProviderRuntimeContext({
-    settingsService: settings,
-    config,
-    runtimeId: `${providerCase.kind}-media-entry`,
-    mediaResolver: resolver,
-    requestMediaBudgetBytes: budget,
-  });
-  const invocation = createRuntimeInvocationContext({
-    runtime,
-    settings,
-    providerName: provider.name,
-    ephemeralsSnapshot: {
-      streaming: 'disabled',
-      'prompt-caching': 'off',
-      retries: 1,
-      retrywait: 1,
-    },
-    ...(signal === undefined ? {} : { signal }),
-  });
-  return createProviderCallOptions({
-    providerName: provider.name,
-    contents,
-    settings,
-    config,
-    runtime,
-    invocation,
-    resolved: {
-      model: providerCase.model,
-      baseURL: providerCase.baseURL,
-      authToken: 'test-key',
-    },
-  });
-}
-
-async function drain(
-  provider: IProvider,
-  options: ReturnType<typeof callOptions>,
-): Promise<void> {
-  for await (const _content of provider.generateChatCompletion(options)) {
-    // Drain the real provider parser.
+  async function damageReference(
+    kind: FailureKind,
+    store: LocalMediaStore,
+    reference: MediaReferenceBlock,
+  ): Promise<void> {
+    if (kind === 'missing') {
+      await unlink(objectPath(store, reference));
+      return;
+    }
+    if (kind === 'corrupt') {
+      await writeFile(objectPath(store, reference), new Uint8Array([1]));
+      return;
+    }
+    if (kind === 'hash-mismatch') {
+      await writeFile(
+        objectPath(store, reference),
+        new Uint8Array(reference.byteLength).fill(255),
+      );
+    }
   }
-}
 
-describe('provider-media-recovery', () => {
-  describe('stateless provider media recovery entry points', () => {
-    const tempDirectory = useTempDirectory();
+  function callOptions(
+    providerCase: ProviderCase,
+    provider: IProvider,
+    contents: IContent[],
+    resolver: RequestMediaResolver,
+    budget: number,
+    signal?: AbortSignal,
+  ): ReturnType<typeof createProviderCallOptions> {
+    const settings = new SettingsService();
+    settings.setProviderSetting(provider.name, 'model', providerCase.model);
+    settings.setProviderSetting(provider.name, 'streaming', 'disabled');
+    settings.setProviderSetting(provider.name, 'prompt-caching', 'off');
+    const config = createRuntimeConfigStub(settings);
+    const runtime = createProviderRuntimeContext({
+      settingsService: settings,
+      config,
+      runtimeId: `${providerCase.kind}-media-entry`,
+      mediaResolver: resolver,
+      requestMediaBudgetBytes: budget,
+    });
+    const invocation = createRuntimeInvocationContext({
+      runtime,
+      settings,
+      providerName: provider.name,
+      ephemeralsSnapshot: {
+        streaming: 'disabled',
+        'prompt-caching': 'off',
+        retries: 1,
+        retrywait: 1,
+      },
+      ...(signal === undefined ? {} : { signal }),
+    });
+    return createProviderCallOptions({
+      providerName: provider.name,
+      contents,
+      settings,
+      config,
+      runtime,
+      invocation,
+      resolved: {
+        model: providerCase.model,
+        baseURL: providerCase.baseURL,
+        authToken: 'test-key',
+      },
+    });
+  }
 
-    for (const providerCase of PROVIDERS) {
-      it(`${providerCase.kind} sends full logical history with the exact recorded selected variants after provider or policy changes`, async () => {
-        const store = new LocalMediaStore({
-          rootDirectory: tempDirectory(),
-          quotaBytes: 1024,
-        });
-        const first = await admitted(store, new Uint8Array([1, 2, 3]), 1);
-        const second = await admitted(store, new Uint8Array([9, 8, 7, 6]), 2);
-        const resolver = new RequestMediaResolver(store);
-        let body = '';
-        globalThis.fetch = async (_input, init): Promise<Response> => {
-          body = await requestBodyText(init?.body);
-          return successfulResponse(providerCase.kind);
-        };
-        const provider = providerFor(providerCase);
+  async function drain(
+    provider: IProvider,
+    options: ReturnType<typeof callOptions>,
+  ): Promise<void> {
+    for await (const _content of provider.generateChatCompletion(options)) {
+      // Drain the real provider parser.
+    }
+  }
 
-        await drain(
-          provider,
-          callOptions(
-            providerCase,
-            provider,
-            history([first, second]),
-            resolver,
-            first.normalizedBase64Length + second.normalizedBase64Length,
-          ),
-        );
+  describe('provider-media-recovery', () => {
+    describe('stateless provider media recovery entry points', () => {
+      const tempDirectory = useTempDirectory();
 
-        expect(body).toContain(Buffer.from([1, 2, 3]).toString('base64'));
-        expect(body).toContain(Buffer.from([9, 8, 7, 6]).toString('base64'));
-        expect(resolver.accounting()).toStrictEqual({
-          activeRequestCount: 0,
-          reservedContentCount: 0,
-          materializedNormalizedBytes: 0,
-          storeReadCount: 2,
-        });
-      });
-
-      for (const failure of FAILURES) {
-        it(`${providerCase.kind} fails ${failure} referenced media before network submission`, async () => {
+      for (const providerCase of PROVIDERS) {
+        it(`${providerCase.kind} sends full logical history with the exact recorded selected variants after provider or policy changes`, async () => {
           const store = new LocalMediaStore({
             rootDirectory: tempDirectory(),
             quotaBytes: 1024,
           });
-          const reference = await admitted(
-            store,
-            new Uint8Array([1, 2, 3, 4]),
-            1,
-          );
-          if (failure !== 'over-budget') {
-            await damageReference(failure, store, reference);
-          }
+          const first = await admitted(store, new Uint8Array([1, 2, 3]), 1);
+          const second = await admitted(store, new Uint8Array([9, 8, 7, 6]), 2);
           const resolver = new RequestMediaResolver(store);
-          let networkSubmissionCount = 0;
-          globalThis.fetch = async (): Promise<Response> => {
-            networkSubmissionCount += 1;
+          let body = '';
+          globalThis.fetch = async (_input, init): Promise<Response> => {
+            body = await requestBodyText(init?.body);
             return successfulResponse(providerCase.kind);
           };
           const provider = providerFor(providerCase);
-          const budget =
-            failure === 'over-budget'
-              ? reference.normalizedBase64Length - 1
-              : reference.normalizedBase64Length;
 
-          const error = await drain(
+          await drain(
             provider,
             callOptions(
               providerCase,
               provider,
-              history([reference]),
+              history([first, second]),
               resolver,
-              budget,
+              first.normalizedBase64Length + second.normalizedBase64Length,
             ),
-          ).catch((reason: unknown) => reason);
+          );
 
-          expect(error).toBeInstanceOf(Error);
-          expect(String(error)).toContain('turn-media-0');
-          expect(networkSubmissionCount).toBe(0);
-          expect(resolver.accounting().activeRequestCount).toBe(0);
-          expect(await store.hasReservations(reference.contentId)).toBe(false);
+          expect(body).toContain(Buffer.from([1, 2, 3]).toString('base64'));
+          expect(body).toContain(Buffer.from([9, 8, 7, 6]).toString('base64'));
+          expect(resolver.accounting()).toStrictEqual({
+            activeRequestCount: 0,
+            reservedContentCount: 0,
+            materializedNormalizedBytes: 0,
+            storeReadCount: 2,
+          });
         });
+
+        for (const failure of FAILURES) {
+          it(`${providerCase.kind} fails ${failure} referenced media before network submission`, async () => {
+            const store = new LocalMediaStore({
+              rootDirectory: tempDirectory(),
+              quotaBytes: 1024,
+            });
+            const reference = await admitted(
+              store,
+              new Uint8Array([1, 2, 3, 4]),
+              1,
+            );
+            if (failure !== 'over-budget') {
+              await damageReference(failure, store, reference);
+            }
+            const resolver = new RequestMediaResolver(store);
+            let networkSubmissionCount = 0;
+            globalThis.fetch = async (): Promise<Response> => {
+              networkSubmissionCount += 1;
+              return successfulResponse(providerCase.kind);
+            };
+            const provider = providerFor(providerCase);
+            const budget =
+              failure === 'over-budget'
+                ? reference.normalizedBase64Length - 1
+                : reference.normalizedBase64Length;
+
+            const error = await drain(
+              provider,
+              callOptions(
+                providerCase,
+                provider,
+                history([reference]),
+                resolver,
+                budget,
+              ),
+            ).catch((reason: unknown) => reason);
+
+            expect(error).toBeInstanceOf(Error);
+            expect(String(error)).toContain('turn-media-0');
+            expect(networkSubmissionCount).toBe(0);
+            expect(resolver.accounting().activeRequestCount).toBe(0);
+            expect(await store.hasReservations(reference.contentId)).toBe(
+              false,
+            );
+          });
+        }
       }
-    }
 
-    it('releases Chat media reservations when an in-flight request is cancelled', async () => {
-      const providerCase = PROVIDERS.find((entry) => entry.kind === 'chat');
-      assertDefined(providerCase, 'Chat provider case is missing');
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1024,
-      });
-      const reference = await admitted(store, new Uint8Array([5, 6, 7]), 1);
-      const resolver = new RequestMediaResolver(store);
-      const controller = new AbortController();
-      let announceStarted = (): void => {
-        throw new Error('Request start was not wired');
-      };
-      const started = new Promise<void>((resolve) => {
-        announceStarted = resolve;
-      });
-      let rejectRequest = (_error: Error): void => {
-        throw new Error('Request rejection was not wired');
-      };
-      globalThis.fetch = async (): Promise<Response> => {
-        announceStarted();
-        return new Promise<Response>((_resolve, reject) => {
-          rejectRequest = reject;
+      it('releases Chat media reservations when an in-flight request is cancelled', async () => {
+        const providerCase = PROVIDERS.find((entry) => entry.kind === 'chat');
+        assertDefined(providerCase, 'Chat provider case is missing');
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 1024,
         });
-      };
-      const provider = providerFor(providerCase);
-      const work = drain(
-        provider,
-        callOptions(
-          providerCase,
+        const reference = await admitted(store, new Uint8Array([5, 6, 7]), 1);
+        const resolver = new RequestMediaResolver(store);
+        const controller = new AbortController();
+        let announceStarted = (): void => {
+          throw new Error('Request start was not wired');
+        };
+        const started = new Promise<void>((resolve) => {
+          announceStarted = resolve;
+        });
+        let rejectRequest = (_error: Error): void => {
+          throw new Error('Request rejection was not wired');
+        };
+        globalThis.fetch = async (): Promise<Response> => {
+          announceStarted();
+          return new Promise<Response>((_resolve, reject) => {
+            rejectRequest = reject;
+          });
+        };
+        const provider = providerFor(providerCase);
+        const work = drain(
           provider,
-          history([reference]),
-          resolver,
-          reference.normalizedBase64Length,
-          controller.signal,
-        ),
-      );
+          callOptions(
+            providerCase,
+            provider,
+            history([reference]),
+            resolver,
+            reference.normalizedBase64Length,
+            controller.signal,
+          ),
+        );
 
-      await started;
-      expect(await store.hasReservations(reference.contentId)).toBe(true);
-      const cancellation = new Error('cancelled by test');
-      controller.abort(cancellation);
-      rejectRequest(cancellation);
-      const error = await work.catch((reason: unknown) => reason);
+        await started;
+        expect(await store.hasReservations(reference.contentId)).toBe(true);
+        const cancellation = new Error('cancelled by test');
+        controller.abort(cancellation);
+        rejectRequest(cancellation);
+        const error = await work.catch((reason: unknown) => reason);
 
-      expect(error).toBeInstanceOf(Error);
-      expect(await store.hasReservations(reference.contentId)).toBe(false);
-      expect(resolver.accounting().activeRequestCount).toBe(0);
+        expect(error).toBeInstanceOf(Error);
+        expect(await store.hasReservations(reference.contentId)).toBe(false);
+        expect(resolver.accounting().activeRequestCount).toBe(0);
+      });
     });
   });
 });

--- a/packages/providers/src/kimi/kimiFileUpload.test.ts
+++ b/packages/providers/src/kimi/kimiFileUpload.test.ts
@@ -13,7 +13,10 @@
  * See the License for the specific language.
  */
 
-import { assertInstanceOf, errorMessage } from '@vybestack/llxprt-code-test-utils';
+import {
+  assertInstanceOf,
+  errorMessage,
+} from '@vybestack/llxprt-code-test-utils';
 import { describe, it, expect, beforeEach, vi } from 'bun:test';
 import {
   uploadKimiFiles,

--- a/packages/providers/src/openai-responses/OpenAIResponsesProvider.websocketFallback.test.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesProvider.websocketFallback.test.ts
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { assertDefined, blockTextOrEmpty } from '@vybestack/llxprt-code-test-utils';
+import {
+  assertDefined,
+  blockTextOrEmpty,
+} from '@vybestack/llxprt-code-test-utils';
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { SettingsService } from '@vybestack/llxprt-code-settings';
 import { OpenAIResponsesProvider } from './OpenAIResponsesProvider.js';
@@ -141,7 +144,7 @@ async function runRequest(
   }
   const text = chunks
     .flatMap((c) => c.blocks)
-    .map((b) => (blockTextOrEmpty(b)))
+    .map((b) => blockTextOrEmpty(b))
     .join('');
   void fetchCalls;
   return text;

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.codex.resumedChain.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.codex.resumedChain.test.ts
@@ -287,7 +287,7 @@ describe('OpenAIResponsesProvider Codex resumed chain @issue:3160', () => {
 
       const resumedAnswer = resumedMessages
         .flatMap((message) => message.blocks)
-        .map((block) => (blockTextOrEmpty(block)))
+        .map((block) => blockTextOrEmpty(block))
         .join('');
       const turn2Contents: IContent[] = [
         ...resumedContents,

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.codex.stateful.recovery.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.codex.stateful.recovery.test.ts
@@ -23,7 +23,10 @@
  * turn-2 history is fed verbatim from turn-1's ACTUAL yielded IContents.
  */
 
-import { assertDefined, blockTextOrEmpty } from '@vybestack/llxprt-code-test-utils';
+import {
+  assertDefined,
+  blockTextOrEmpty,
+} from '@vybestack/llxprt-code-test-utils';
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import {
   clearActiveProviderRuntimeContext,
@@ -130,7 +133,7 @@ describe('OpenAIResponsesProvider Codex stateful — parent rejection recovery a
 
         const text = messages
           .flatMap((m) => m.blocks)
-          .map((b) => (blockTextOrEmpty(b)))
+          .map((b) => blockTextOrEmpty(b))
           .join('');
         expect(text).toContain('recovered text');
       } finally {

--- a/packages/providers/src/openai-responses/__tests__/openai-responses-media-resolution.stateful.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/openai-responses-media-resolution.stateful.test.ts
@@ -30,478 +30,497 @@ import {
 } from '../openAIResponsesWebSocketTransport.test-helpers.js';
 import { buildCodexOAuthManager } from '../codexStateful.test-helpers.js';
 
-const OPENAI_BASE_URL = 'https://api.openai.com/v1';
-const CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex';
-const originalFetch = global.fetch;
-
-class SocketCodexProvider extends OpenAIResponsesProvider {
-  constructor(private readonly harness: SocketHarness) {
-    super('codex-api-key', CODEX_BASE_URL, undefined, buildCodexOAuthManager());
-  }
-
-  protected override createWebSocketTransport(): WebSocketTransport {
-    return createCodexResponsesWebSocketTransport({
-      openSocket: this.harness.openSocket,
-    });
-  }
-}
-
-function useTempDirectory(): () => string {
-  let directory = '';
-  beforeEach(async () => {
-    directory = await mkdtemp(join(tmpdir(), 'llxprt-responses-media-'));
-  });
-  afterEach(async () => {
-    global.fetch = originalFetch;
-    if (directory !== '') {
-      await chmod(directory, 0o700).catch(() => undefined);
-      await rm(directory, { recursive: true, force: true });
-    }
-  });
-  return () => directory;
-}
-
-function completedResponse(id: string): Response {
-  const encoder = new TextEncoder();
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(
-        encoder.encode(
-          `data: {"type":"response.output_text.delta","delta":"ok"}\n\n`,
-        ),
-      );
-      controller.enqueue(
-        encoder.encode(
-          `data: {"type":"response.completed","response":{"id":"${id}","status":"completed"}}\n\n`,
-        ),
-      );
-      controller.enqueue(encoder.encode('data: [DONE]\n\n'));
-      controller.close();
-    },
-  });
-  return new Response(stream, {
-    status: 200,
-    headers: { 'content-type': 'text/event-stream' },
-  });
-}
-
-function parentRejectedResponse(): Response {
-  return new Response(
-    JSON.stringify({
-      error: {
-        message: "Previous response with id 'resp_parent' not found",
-        type: 'invalid_request_error',
-      },
-    }),
-    { status: 400, headers: { 'content-type': 'application/json' } },
-  );
-}
-
-function history(
-  beforeParent: MediaReferenceBlock,
-  afterParent: MediaReferenceBlock,
-  parentBaseURL = OPENAI_BASE_URL,
-): IContent[] {
-  return [
-    {
-      speaker: 'human',
-      metadata: { turnId: 'turn-before-parent' },
-      blocks: [beforeParent],
-    },
-    {
-      speaker: 'ai',
-      metadata: {
-        id: 'resp_parent',
-        responsesStored: true,
-        providerBaseURL: parentBaseURL,
-        turnId: 'turn-parent',
-      },
-      blocks: [{ type: 'text', text: 'stored response' }],
-    },
-    {
-      speaker: 'human',
-      metadata: { turnId: 'turn-after-parent' },
-      blocks: [afterParent],
-    },
-  ];
-}
-
-function objectPath(
-  store: LocalMediaStore,
-  reference: MediaReferenceBlock,
-): string {
-  return join(
-    store.rootDirectory,
-    'objects',
-    'sha256',
-    reference.contentId.slice('sha256:'.length),
-  );
-}
-
-async function runRequest(
-  provider: OpenAIResponsesProvider,
-  contents: IContent[],
-  resolver: RequestMediaResolver,
-  budget: number,
-  stateful = true,
-): Promise<void> {
-  const settings = new SettingsService();
-  settings.setProviderSetting(provider.name, 'model', 'gpt-5.6');
-  const config = createRuntimeConfigStub(settings);
-  const runtime = createProviderRuntimeContext({
-    settingsService: settings,
-    config,
-    runtimeId: 'responses-media-stateful',
-    mediaResolver: resolver,
-    requestMediaBudgetBytes: budget,
-  });
-  const invocation = createRuntimeInvocationContext({
-    runtime,
-    settings,
-    providerName: provider.name,
-    ephemeralsSnapshot: { 'responses-stateful': stateful },
-  });
-  const options = createProviderCallOptions({
-    providerName: provider.name,
-    contents,
-    settings,
-    config,
-    runtime,
-    invocation,
-    ephemerals: { 'responses-stateful': stateful },
-  });
-
-  for await (const _content of provider.generateChatCompletion(options)) {
-    // Drain the real transport parser.
-  }
-}
-
-async function admitted(
-  store: LocalMediaStore,
-  bytes: Uint8Array,
-): Promise<MediaReferenceBlock> {
-  return store.admit({
-    bytes,
-    mimeType: 'image/png',
-    semanticMetadata: { variantPolicy: 'admitted-v1' },
-  });
-}
-
 describe('openai-responses-media-resolution', () => {
-  describe('OpenAI Responses stateful media resolution', () => {
-    const tempDirectory = useTempDirectory();
+  const OPENAI_BASE_URL = 'https://api.openai.com/v1';
+  const CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex';
+  const originalFetch = global.fetch;
 
-    it('reads only post-parent media when the stateful parent is usable', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1024,
-      });
-      const beforeParent = await admitted(store, new Uint8Array([1, 2, 3]));
-      const afterParent = await admitted(store, new Uint8Array([4, 5, 6]));
-      await unlink(objectPath(store, beforeParent));
-      const resolver = new RequestMediaResolver(store);
-      const requestBodies: string[] = [];
-      global.fetch = async (_input, init): Promise<Response> => {
-        requestBodies.push(await new Response(init?.body).text());
-        return completedResponse('resp_next');
-      };
-      const provider = new OpenAIResponsesProvider('test-key', OPENAI_BASE_URL);
-
-      await runRequest(
-        provider,
-        history(beforeParent, afterParent),
-        resolver,
-        beforeParent.normalizedBase64Length +
-          afterParent.normalizedBase64Length,
+  class SocketCodexProvider extends OpenAIResponsesProvider {
+    constructor(private readonly harness: SocketHarness) {
+      super(
+        'codex-api-key',
+        CODEX_BASE_URL,
+        undefined,
+        buildCodexOAuthManager(),
       );
+    }
 
-      expect(requestBodies).toHaveLength(1);
-      expect(requestBodies[0]).not.toContain('AQID');
-      expect(requestBodies[0]).toContain('BAUG');
-      expect(requestBodies[0]).toContain(
-        '"previous_response_id":"resp_parent"',
-      );
-      expect(resolver.accounting()).toStrictEqual({
-        activeRequestCount: 0,
-        reservedContentCount: 0,
-        materializedNormalizedBytes: 0,
-        storeReadCount: 1,
+    protected override createWebSocketTransport(): WebSocketTransport {
+      return createCodexResponsesWebSocketTransport({
+        openSocket: this.harness.openSocket,
       });
+    }
+  }
+
+  function useTempDirectory(): () => string {
+    let directory = '';
+    beforeEach(async () => {
+      directory = await mkdtemp(join(tmpdir(), 'llxprt-responses-media-'));
+    });
+    afterEach(async () => {
+      global.fetch = originalFetch;
+      if (directory !== '') {
+        await chmod(directory, 0o700).catch(() => undefined);
+        await rm(directory, { recursive: true, force: true });
+      }
+    });
+    return () => directory;
+  }
+
+  function completedResponse(id: string): Response {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            `data: {"type":"response.output_text.delta","delta":"ok"}\n\n`,
+          ),
+        );
+        controller.enqueue(
+          encoder.encode(
+            `data: {"type":"response.completed","response":{"id":"${id}","status":"completed"}}\n\n`,
+          ),
+        );
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+        controller.close();
+      },
+    });
+    return new Response(stream, {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    });
+  }
+
+  function parentRejectedResponse(): Response {
+    return new Response(
+      JSON.stringify({
+        error: {
+          message: "Previous response with id 'resp_parent' not found",
+          type: 'invalid_request_error',
+        },
+      }),
+      { status: 400, headers: { 'content-type': 'application/json' } },
+    );
+  }
+
+  function history(
+    beforeParent: MediaReferenceBlock,
+    afterParent: MediaReferenceBlock,
+    parentBaseURL = OPENAI_BASE_URL,
+  ): IContent[] {
+    return [
+      {
+        speaker: 'human',
+        metadata: { turnId: 'turn-before-parent' },
+        blocks: [beforeParent],
+      },
+      {
+        speaker: 'ai',
+        metadata: {
+          id: 'resp_parent',
+          responsesStored: true,
+          providerBaseURL: parentBaseURL,
+          turnId: 'turn-parent',
+        },
+        blocks: [{ type: 'text', text: 'stored response' }],
+      },
+      {
+        speaker: 'human',
+        metadata: { turnId: 'turn-after-parent' },
+        blocks: [afterParent],
+      },
+    ];
+  }
+
+  function objectPath(
+    store: LocalMediaStore,
+    reference: MediaReferenceBlock,
+  ): string {
+    return join(
+      store.rootDirectory,
+      'objects',
+      'sha256',
+      reference.contentId.slice('sha256:'.length),
+    );
+  }
+
+  async function runRequest(
+    provider: OpenAIResponsesProvider,
+    contents: IContent[],
+    resolver: RequestMediaResolver,
+    budget: number,
+    stateful = true,
+  ): Promise<void> {
+    const settings = new SettingsService();
+    settings.setProviderSetting(provider.name, 'model', 'gpt-5.6');
+    const config = createRuntimeConfigStub(settings);
+    const runtime = createProviderRuntimeContext({
+      settingsService: settings,
+      config,
+      runtimeId: 'responses-media-stateful',
+      mediaResolver: resolver,
+      requestMediaBudgetBytes: budget,
+    });
+    const invocation = createRuntimeInvocationContext({
+      runtime,
+      settings,
+      providerName: provider.name,
+      ephemeralsSnapshot: { 'responses-stateful': stateful },
+    });
+    const options = createProviderCallOptions({
+      providerName: provider.name,
+      contents,
+      settings,
+      config,
+      runtime,
+      invocation,
+      ephemerals: { 'responses-stateful': stateful },
     });
 
-    it('releases the suffix and resolves exact full history after parent rejection', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1024,
-      });
-      const beforeParent = await admitted(store, new Uint8Array([1, 2, 3]));
-      const afterParent = await admitted(store, new Uint8Array([4, 5, 6]));
-      const resolver = new RequestMediaResolver(store);
-      const requestBodies: string[] = [];
-      global.fetch = async (_input, init): Promise<Response> => {
-        requestBodies.push(await new Response(init?.body).text());
-        return requestBodies.length === 1
-          ? parentRejectedResponse()
-          : completedResponse('resp_recovered');
-      };
-      const provider = new OpenAIResponsesProvider('test-key', OPENAI_BASE_URL);
+    for await (const _content of provider.generateChatCompletion(options)) {
+      // Drain the real transport parser.
+    }
+  }
 
-      await runRequest(
-        provider,
-        history(beforeParent, afterParent),
-        resolver,
-        beforeParent.normalizedBase64Length +
-          afterParent.normalizedBase64Length,
-      );
-
-      expect(requestBodies).toHaveLength(2);
-      expect(requestBodies[1]).toContain('AQID');
-      expect(requestBodies[1]).toContain('BAUG');
-      expect(requestBodies[1]).not.toContain('previous_response_id');
-      expect(resolver.accounting()).toStrictEqual({
-        activeRequestCount: 0,
-        reservedContentCount: 0,
-        materializedNormalizedBytes: 0,
-        storeReadCount: 3,
-      });
+  async function admitted(
+    store: LocalMediaStore,
+    bytes: Uint8Array,
+  ): Promise<MediaReferenceBlock> {
+    return store.admit({
+      bytes,
+      mimeType: 'image/png',
+      semanticMetadata: { variantPolicy: 'admitted-v1' },
     });
+  }
 
-    it('resolves full history when the stored parent belongs to another endpoint', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1024,
-      });
-      const beforeParent = await admitted(store, new Uint8Array([1, 2, 3]));
-      const afterParent = await admitted(store, new Uint8Array([4, 5, 6]));
-      const resolver = new RequestMediaResolver(store);
-      const requestBodies: string[] = [];
-      global.fetch = async (_input, init): Promise<Response> => {
-        requestBodies.push(await new Response(init?.body).text());
-        return completedResponse('resp_endpoint');
-      };
-      const provider = new OpenAIResponsesProvider('test-key', OPENAI_BASE_URL);
+  describe('openai-responses-media-resolution', () => {
+    describe('OpenAI Responses stateful media resolution', () => {
+      const tempDirectory = useTempDirectory();
 
-      await runRequest(
-        provider,
-        history(beforeParent, afterParent, 'https://other.example/v1'),
-        resolver,
-        beforeParent.normalizedBase64Length +
-          afterParent.normalizedBase64Length,
-      );
-
-      expect(requestBodies[0]).toContain('AQID');
-      expect(requestBodies[0]).toContain('BAUG');
-      expect(requestBodies[0]).not.toContain('previous_response_id');
-      expect(resolver.accounting().storeReadCount).toBe(2);
-    });
-
-    it('resolves exact full history when stateful policy invalidates the chain', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1024,
-      });
-      const beforeParent = await admitted(store, new Uint8Array([1, 2, 3]));
-      const afterParent = await admitted(store, new Uint8Array([4, 5, 6]));
-      const resolver = new RequestMediaResolver(store);
-      const requestBodies: string[] = [];
-      global.fetch = async (_input, init): Promise<Response> => {
-        requestBodies.push(await new Response(init?.body).text());
-        return completedResponse('resp_stateless');
-      };
-      const provider = new OpenAIResponsesProvider('test-key', OPENAI_BASE_URL);
-
-      await runRequest(
-        provider,
-        history(beforeParent, afterParent),
-        resolver,
-        beforeParent.normalizedBase64Length +
-          afterParent.normalizedBase64Length,
-        false,
-      );
-
-      expect(requestBodies).toHaveLength(1);
-      expect(requestBodies[0]).toContain('AQID');
-      expect(requestBodies[0]).toContain('BAUG');
-      expect(requestBodies[0]).not.toContain('previous_response_id');
-      expect(resolver.accounting().storeReadCount).toBe(2);
-    });
-
-    it('sends only the exact post-parent media bytes over the Codex WebSocket', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1024,
-      });
-      const beforeParent = await admitted(store, new Uint8Array([1, 2, 3]));
-      const afterParent = await admitted(store, new Uint8Array([4, 5, 6]));
-      await unlink(objectPath(store, beforeParent));
-      const resolver = new RequestMediaResolver(store);
-      const harness = new SocketHarness([completingScript('ok')]);
-      const provider = new SocketCodexProvider(harness);
-
-      await runRequest(
-        provider,
-        history(beforeParent, afterParent, CODEX_BASE_URL),
-        resolver,
-        afterParent.normalizedBase64Length,
-      );
-
-      expect(harness.sockets).toHaveLength(1);
-      const wireBody = harness.sockets[0]?.sent[0];
-      expect(wireBody).toBeDefined();
-      expect(wireBody).toContain('BAUG');
-      expect(wireBody).not.toContain('AQID');
-      expect(wireBody).toContain('previous_response_id');
-      expect(resolver.accounting()).toStrictEqual({
-        activeRequestCount: 0,
-        reservedContentCount: 0,
-        materializedNormalizedBytes: 0,
-        storeReadCount: 1,
-      });
-    });
-    it.each(['missing', 'corrupt', 'hash-mismatch', 'over-budget'])(
-      'fails %s post-parent media before Codex socket or HTTP submission',
-      async (failure) => {
+      it('reads only post-parent media when the stateful parent is usable', async () => {
         const store = new LocalMediaStore({
           rootDirectory: tempDirectory(),
           quotaBytes: 1024,
         });
         const beforeParent = await admitted(store, new Uint8Array([1, 2, 3]));
-        const invalid = await admitted(store, new Uint8Array([4, 5, 6]));
-        if (failure === 'missing') {
-          await unlink(objectPath(store, invalid));
-        } else if (failure === 'corrupt') {
-          await writeFile(objectPath(store, invalid), new Uint8Array([4]));
-        } else if (failure === 'hash-mismatch') {
-          await writeFile(
-            objectPath(store, invalid),
-            new Uint8Array([7, 8, 9]),
-          );
-        }
-        const resolver = new RequestMediaResolver(store);
-        const harness = new SocketHarness([completingScript('unreachable')]);
-        let httpSubmissions = 0;
-        global.fetch = async (): Promise<Response> => {
-          httpSubmissions += 1;
-          return completedResponse('unreachable');
-        };
-        const provider = new SocketCodexProvider(harness);
-        const budget =
-          failure === 'over-budget'
-            ? invalid.normalizedBase64Length - 1
-            : invalid.normalizedBase64Length;
-
-        const error = await runRequest(
-          provider,
-          history(beforeParent, invalid, CODEX_BASE_URL),
-          resolver,
-          budget,
-        ).catch((reason: unknown) => reason);
-
-        expect(error).toBeInstanceOf(Error);
-        expect(String(error)).toContain('turn-after-parent');
-        expect(harness.sockets).toHaveLength(0);
-        expect(httpSubmissions).toBe(0);
-        expect(resolver.accounting().activeRequestCount).toBe(0);
-        expect(await store.hasReservations(invalid.contentId)).toBe(false);
-      },
-    );
-
-    it('rebuilds exact full media history for Codex HTTP fallback after transport loss', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1024,
-      });
-      const beforeParent = await admitted(store, new Uint8Array([1, 2, 3]));
-      const afterParent = await admitted(store, new Uint8Array([4, 5, 6]));
-      const resolver = new RequestMediaResolver(store);
-      const harness = new SocketHarness([
-        (socket) => {
-          socket.open();
-          socket.onSend = () =>
-            socket.serverClose({
-              code: 1006,
-              reason: 'transport lost',
-              wasClean: false,
-            });
-        },
-      ]);
-      const requestBodies: string[] = [];
-      global.fetch = async (_input, init): Promise<Response> => {
-        requestBodies.push(await new Response(init?.body).text());
-        return completedResponse('resp_http_fallback');
-      };
-      const provider = new SocketCodexProvider(harness);
-
-      await runRequest(
-        provider,
-        history(beforeParent, afterParent, CODEX_BASE_URL),
-        resolver,
-        beforeParent.normalizedBase64Length +
-          afterParent.normalizedBase64Length,
-      );
-
-      expect(harness.sockets).toHaveLength(1);
-      expect(requestBodies).toHaveLength(1);
-      expect(requestBodies[0]).toContain('AQID');
-      expect(requestBodies[0]).toContain('BAUG');
-      expect(requestBodies[0]).not.toContain('previous_response_id');
-      expect(resolver.accounting()).toStrictEqual({
-        activeRequestCount: 0,
-        reservedContentCount: 0,
-        materializedNormalizedBytes: 0,
-        storeReadCount: 3,
-      });
-    });
-
-    it.each(['missing', 'corrupt', 'hash-mismatch', 'over-budget'])(
-      'fails %s full-history media before network submission',
-      async (failure) => {
-        const store = new LocalMediaStore({
-          rootDirectory: tempDirectory(),
-          quotaBytes: 1024,
-        });
-        const invalid = await admitted(store, new Uint8Array([1, 2, 3]));
         const afterParent = await admitted(store, new Uint8Array([4, 5, 6]));
-        if (failure === 'missing') {
-          await unlink(objectPath(store, invalid));
-        } else if (failure === 'corrupt') {
-          await writeFile(objectPath(store, invalid), new Uint8Array([9]));
-        } else if (failure === 'hash-mismatch') {
-          await writeFile(
-            objectPath(store, invalid),
-            new Uint8Array([9, 9, 9]),
-          );
-        }
+        await unlink(objectPath(store, beforeParent));
         const resolver = new RequestMediaResolver(store);
-        let networkSubmissionCount = 0;
-        global.fetch = async (): Promise<Response> => {
-          networkSubmissionCount += 1;
-          return completedResponse('unexpected');
+        const requestBodies: string[] = [];
+        global.fetch = async (_input, init): Promise<Response> => {
+          requestBodies.push(await new Response(init?.body).text());
+          return completedResponse('resp_next');
         };
         const provider = new OpenAIResponsesProvider(
           'test-key',
           OPENAI_BASE_URL,
         );
-        const fullBudget =
-          invalid.normalizedBase64Length + afterParent.normalizedBase64Length;
-        const budget =
-          failure === 'over-budget'
-            ? invalid.normalizedBase64Length - 1
-            : fullBudget;
 
-        const error = await runRequest(
+        await runRequest(
           provider,
-          history(invalid, afterParent, 'https://other.example/v1'),
+          history(beforeParent, afterParent),
           resolver,
-          budget,
-        ).catch((reason: unknown) => reason);
+          beforeParent.normalizedBase64Length +
+            afterParent.normalizedBase64Length,
+        );
 
-        expect(error).toBeInstanceOf(Error);
-        expect(String(error)).toContain('turn-before-parent');
-        expect(networkSubmissionCount).toBe(0);
-        expect(resolver.accounting().activeRequestCount).toBe(0);
-        expect(await store.hasReservations(invalid.contentId)).toBe(false);
-      },
-    );
+        expect(requestBodies).toHaveLength(1);
+        expect(requestBodies[0]).not.toContain('AQID');
+        expect(requestBodies[0]).toContain('BAUG');
+        expect(requestBodies[0]).toContain(
+          '"previous_response_id":"resp_parent"',
+        );
+        expect(resolver.accounting()).toStrictEqual({
+          activeRequestCount: 0,
+          reservedContentCount: 0,
+          materializedNormalizedBytes: 0,
+          storeReadCount: 1,
+        });
+      });
+
+      it('releases the suffix and resolves exact full history after parent rejection', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 1024,
+        });
+        const beforeParent = await admitted(store, new Uint8Array([1, 2, 3]));
+        const afterParent = await admitted(store, new Uint8Array([4, 5, 6]));
+        const resolver = new RequestMediaResolver(store);
+        const requestBodies: string[] = [];
+        global.fetch = async (_input, init): Promise<Response> => {
+          requestBodies.push(await new Response(init?.body).text());
+          return requestBodies.length === 1
+            ? parentRejectedResponse()
+            : completedResponse('resp_recovered');
+        };
+        const provider = new OpenAIResponsesProvider(
+          'test-key',
+          OPENAI_BASE_URL,
+        );
+
+        await runRequest(
+          provider,
+          history(beforeParent, afterParent),
+          resolver,
+          beforeParent.normalizedBase64Length +
+            afterParent.normalizedBase64Length,
+        );
+
+        expect(requestBodies).toHaveLength(2);
+        expect(requestBodies[1]).toContain('AQID');
+        expect(requestBodies[1]).toContain('BAUG');
+        expect(requestBodies[1]).not.toContain('previous_response_id');
+        expect(resolver.accounting()).toStrictEqual({
+          activeRequestCount: 0,
+          reservedContentCount: 0,
+          materializedNormalizedBytes: 0,
+          storeReadCount: 3,
+        });
+      });
+
+      it('resolves full history when the stored parent belongs to another endpoint', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 1024,
+        });
+        const beforeParent = await admitted(store, new Uint8Array([1, 2, 3]));
+        const afterParent = await admitted(store, new Uint8Array([4, 5, 6]));
+        const resolver = new RequestMediaResolver(store);
+        const requestBodies: string[] = [];
+        global.fetch = async (_input, init): Promise<Response> => {
+          requestBodies.push(await new Response(init?.body).text());
+          return completedResponse('resp_endpoint');
+        };
+        const provider = new OpenAIResponsesProvider(
+          'test-key',
+          OPENAI_BASE_URL,
+        );
+
+        await runRequest(
+          provider,
+          history(beforeParent, afterParent, 'https://other.example/v1'),
+          resolver,
+          beforeParent.normalizedBase64Length +
+            afterParent.normalizedBase64Length,
+        );
+
+        expect(requestBodies[0]).toContain('AQID');
+        expect(requestBodies[0]).toContain('BAUG');
+        expect(requestBodies[0]).not.toContain('previous_response_id');
+        expect(resolver.accounting().storeReadCount).toBe(2);
+      });
+
+      it('resolves exact full history when stateful policy invalidates the chain', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 1024,
+        });
+        const beforeParent = await admitted(store, new Uint8Array([1, 2, 3]));
+        const afterParent = await admitted(store, new Uint8Array([4, 5, 6]));
+        const resolver = new RequestMediaResolver(store);
+        const requestBodies: string[] = [];
+        global.fetch = async (_input, init): Promise<Response> => {
+          requestBodies.push(await new Response(init?.body).text());
+          return completedResponse('resp_stateless');
+        };
+        const provider = new OpenAIResponsesProvider(
+          'test-key',
+          OPENAI_BASE_URL,
+        );
+
+        await runRequest(
+          provider,
+          history(beforeParent, afterParent),
+          resolver,
+          beforeParent.normalizedBase64Length +
+            afterParent.normalizedBase64Length,
+          false,
+        );
+
+        expect(requestBodies).toHaveLength(1);
+        expect(requestBodies[0]).toContain('AQID');
+        expect(requestBodies[0]).toContain('BAUG');
+        expect(requestBodies[0]).not.toContain('previous_response_id');
+        expect(resolver.accounting().storeReadCount).toBe(2);
+      });
+
+      it('sends only the exact post-parent media bytes over the Codex WebSocket', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 1024,
+        });
+        const beforeParent = await admitted(store, new Uint8Array([1, 2, 3]));
+        const afterParent = await admitted(store, new Uint8Array([4, 5, 6]));
+        await unlink(objectPath(store, beforeParent));
+        const resolver = new RequestMediaResolver(store);
+        const harness = new SocketHarness([completingScript('ok')]);
+        const provider = new SocketCodexProvider(harness);
+
+        await runRequest(
+          provider,
+          history(beforeParent, afterParent, CODEX_BASE_URL),
+          resolver,
+          afterParent.normalizedBase64Length,
+        );
+
+        expect(harness.sockets).toHaveLength(1);
+        const wireBody = harness.sockets[0]?.sent[0];
+        expect(wireBody).toBeDefined();
+        expect(wireBody).toContain('BAUG');
+        expect(wireBody).not.toContain('AQID');
+        expect(wireBody).toContain('previous_response_id');
+        expect(resolver.accounting()).toStrictEqual({
+          activeRequestCount: 0,
+          reservedContentCount: 0,
+          materializedNormalizedBytes: 0,
+          storeReadCount: 1,
+        });
+      });
+      it.each(['missing', 'corrupt', 'hash-mismatch', 'over-budget'])(
+        'fails %s post-parent media before Codex socket or HTTP submission',
+        async (failure) => {
+          const store = new LocalMediaStore({
+            rootDirectory: tempDirectory(),
+            quotaBytes: 1024,
+          });
+          const beforeParent = await admitted(store, new Uint8Array([1, 2, 3]));
+          const invalid = await admitted(store, new Uint8Array([4, 5, 6]));
+          if (failure === 'missing') {
+            await unlink(objectPath(store, invalid));
+          } else if (failure === 'corrupt') {
+            await writeFile(objectPath(store, invalid), new Uint8Array([4]));
+          } else if (failure === 'hash-mismatch') {
+            await writeFile(
+              objectPath(store, invalid),
+              new Uint8Array([7, 8, 9]),
+            );
+          }
+          const resolver = new RequestMediaResolver(store);
+          const harness = new SocketHarness([completingScript('unreachable')]);
+          let httpSubmissions = 0;
+          global.fetch = async (): Promise<Response> => {
+            httpSubmissions += 1;
+            return completedResponse('unreachable');
+          };
+          const provider = new SocketCodexProvider(harness);
+          const budget =
+            failure === 'over-budget'
+              ? invalid.normalizedBase64Length - 1
+              : invalid.normalizedBase64Length;
+
+          const error = await runRequest(
+            provider,
+            history(beforeParent, invalid, CODEX_BASE_URL),
+            resolver,
+            budget,
+          ).catch((reason: unknown) => reason);
+
+          expect(error).toBeInstanceOf(Error);
+          expect(String(error)).toContain('turn-after-parent');
+          expect(harness.sockets).toHaveLength(0);
+          expect(httpSubmissions).toBe(0);
+          expect(resolver.accounting().activeRequestCount).toBe(0);
+          expect(await store.hasReservations(invalid.contentId)).toBe(false);
+        },
+      );
+
+      it('rebuilds exact full media history for Codex HTTP fallback after transport loss', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 1024,
+        });
+        const beforeParent = await admitted(store, new Uint8Array([1, 2, 3]));
+        const afterParent = await admitted(store, new Uint8Array([4, 5, 6]));
+        const resolver = new RequestMediaResolver(store);
+        const harness = new SocketHarness([
+          (socket) => {
+            socket.open();
+            socket.onSend = () =>
+              socket.serverClose({
+                code: 1006,
+                reason: 'transport lost',
+                wasClean: false,
+              });
+          },
+        ]);
+        const requestBodies: string[] = [];
+        global.fetch = async (_input, init): Promise<Response> => {
+          requestBodies.push(await new Response(init?.body).text());
+          return completedResponse('resp_http_fallback');
+        };
+        const provider = new SocketCodexProvider(harness);
+
+        await runRequest(
+          provider,
+          history(beforeParent, afterParent, CODEX_BASE_URL),
+          resolver,
+          beforeParent.normalizedBase64Length +
+            afterParent.normalizedBase64Length,
+        );
+
+        expect(harness.sockets).toHaveLength(1);
+        expect(requestBodies).toHaveLength(1);
+        expect(requestBodies[0]).toContain('AQID');
+        expect(requestBodies[0]).toContain('BAUG');
+        expect(requestBodies[0]).not.toContain('previous_response_id');
+        expect(resolver.accounting()).toStrictEqual({
+          activeRequestCount: 0,
+          reservedContentCount: 0,
+          materializedNormalizedBytes: 0,
+          storeReadCount: 3,
+        });
+      });
+
+      it.each(['missing', 'corrupt', 'hash-mismatch', 'over-budget'])(
+        'fails %s full-history media before network submission',
+        async (failure) => {
+          const store = new LocalMediaStore({
+            rootDirectory: tempDirectory(),
+            quotaBytes: 1024,
+          });
+          const invalid = await admitted(store, new Uint8Array([1, 2, 3]));
+          const afterParent = await admitted(store, new Uint8Array([4, 5, 6]));
+          if (failure === 'missing') {
+            await unlink(objectPath(store, invalid));
+          } else if (failure === 'corrupt') {
+            await writeFile(objectPath(store, invalid), new Uint8Array([9]));
+          } else if (failure === 'hash-mismatch') {
+            await writeFile(
+              objectPath(store, invalid),
+              new Uint8Array([9, 9, 9]),
+            );
+          }
+          const resolver = new RequestMediaResolver(store);
+          let networkSubmissionCount = 0;
+          global.fetch = async (): Promise<Response> => {
+            networkSubmissionCount += 1;
+            return completedResponse('unexpected');
+          };
+          const provider = new OpenAIResponsesProvider(
+            'test-key',
+            OPENAI_BASE_URL,
+          );
+          const fullBudget =
+            invalid.normalizedBase64Length + afterParent.normalizedBase64Length;
+          const budget =
+            failure === 'over-budget'
+              ? invalid.normalizedBase64Length - 1
+              : fullBudget;
+
+          const error = await runRequest(
+            provider,
+            history(invalid, afterParent, 'https://other.example/v1'),
+            resolver,
+            budget,
+          ).catch((reason: unknown) => reason);
+
+          expect(error).toBeInstanceOf(Error);
+          expect(String(error)).toContain('turn-before-parent');
+          expect(networkSubmissionCount).toBe(0);
+          expect(resolver.accounting().activeRequestCount).toBe(0);
+          expect(await store.hasReservations(invalid.contentId)).toBe(false);
+        },
+      );
+    });
   });
 });

--- a/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.idleTimeout.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesWebSocketTransport.idleTimeout.test.ts
@@ -100,7 +100,7 @@ describe('Codex Responses WebSocket stream idle timeout', () => {
     );
     const text = messages
       .flatMap((message) => message.blocks)
-      .map((block) => (blockTextOrEmpty(block)))
+      .map((block) => blockTextOrEmpty(block))
       .join('');
 
     expect(text).toBe('tickticktick');

--- a/packages/providers/src/utils/request-media-resolution.test.ts
+++ b/packages/providers/src/utils/request-media-resolution.test.ts
@@ -31,486 +31,500 @@ import { convertToVercelMessages } from '../openai-vercel/messageConversion.js';
 import { getContentPreview } from './contentPreview.js';
 import { resolveRequestMedia } from './request-media-resolution.js';
 
-function useTempDirectory(): () => string {
-  let directory = '';
-  beforeEach(async () => {
-    directory = await mkdtemp(join(tmpdir(), 'llxprt-provider-media-'));
-  });
-  afterEach(async () => {
-    if (directory !== '') {
-      await chmod(directory, 0o700).catch(() => undefined);
-      await rm(directory, { recursive: true, force: true });
-    }
-  });
-  return () => directory;
-}
-
-interface MediaPresentation {
-  readonly mimeType: string;
-  readonly caption: string;
-  readonly filename: string;
-  readonly width: number;
-  readonly height: number;
-  readonly detail: 'auto' | 'high' | 'low';
-  readonly providerFileId: string;
-}
-
-const DEFAULT_PRESENTATION: MediaPresentation = {
-  mimeType: 'image/png',
-  caption: 'terminal screenshot',
-  filename: 'screen.png',
-  width: 3,
-  height: 2,
-  detail: 'high',
-  providerFileId: 'file_stable',
-};
-
-function inlineMedia(
-  data: string,
-  presentation = DEFAULT_PRESENTATION,
-): InlineMediaBlock {
-  return {
-    type: 'media',
-    encoding: 'base64',
-    data,
-    mimeType: presentation.mimeType,
-    caption: presentation.caption,
-    filename: presentation.filename,
-    providerMetadata: { detail: presentation.detail },
-    dimensions: {
-      width: presentation.width,
-      height: presentation.height,
-    },
-    semanticMetadata: { source: 'tool', detail: presentation.detail },
-    providerFileIds: { kimi: presentation.providerFileId },
-  };
-}
-
-function history(
-  media: InlineMediaBlock | MediaReferenceBlock,
-  mediaFirst = false,
-): IContent[] {
-  const textBlock = { type: 'text' as const, text: 'capture the terminal' };
-  const toolResponseBlock = {
-    type: 'tool_response' as const,
-    callId: 'call_media',
-    toolName: 'screenshot',
-    result: 'captured',
-  };
-  return [
-    {
-      speaker: 'human',
-      metadata: { turnId: 'turn-user' },
-      blocks: mediaFirst ? [media, textBlock] : [textBlock, media],
-    },
-    {
-      speaker: 'ai',
-      metadata: { turnId: 'turn-tool-call' },
-      blocks: [
-        {
-          type: 'tool_call',
-          id: 'call_media',
-          name: 'screenshot',
-          parameters: { region: 'terminal' },
-        },
-      ],
-    },
-    {
-      speaker: 'tool',
-      metadata: { turnId: 'turn-tool-response' },
-      blocks: mediaFirst
-        ? [media, toolResponseBlock]
-        : [toolResponseBlock, media],
-    },
-  ];
-}
-
-function serializedProviderStructures(
-  contents: IContent[],
-): Record<string, string> {
-  const settings = { get: (_key: string): unknown => undefined };
-  const anthropicOptions = {
-    isOAuth: false,
-    reasoningEnabled: false,
-    config: undefined,
-    unprefixToolName: (name: string): string => name,
-    logger: { debug: (_message: () => string): void => undefined },
-  };
-  return {
-    responses: JSON.stringify(buildResponsesInputFromContent(contents)),
-    chat: JSON.stringify(
-      buildMessagesWithReasoning(contents, { settings }, 'openai', undefined),
-    ),
-    anthropic: JSON.stringify(
-      convertToAnthropicMessages(contents, anthropicOptions),
-    ),
-    multimodal: JSON.stringify(
-      mediaFormatConverter.convertHistoryToGeminiFormat(contents),
-    ),
-    vercel: JSON.stringify(convertToVercelMessages(contents)),
-  };
-}
-
 describe('request-media-resolution', () => {
-  describe('provider request media resolution', () => {
-    const tempDirectory = useTempDirectory();
-
-    it('produces byte-equivalent provider structures for inline and referenced media', async () => {
-      const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2]);
-      const data = Buffer.from(bytes).toString('base64');
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1024,
-      });
-      const reference = await store.admit({
-        bytes,
-        mimeType: 'image/png',
-        dimensions: { width: 3, height: 2 },
-        semanticMetadata: { source: 'tool', detail: 'high' },
-        providerFileIds: { kimi: 'file_stable' },
-      });
-      const decoratedReference: MediaReferenceBlock = {
-        ...reference,
-        caption: 'terminal screenshot',
-        filename: 'screen.png',
-        providerMetadata: { detail: 'high' },
-      };
-      const resolver = new RequestMediaResolver(store);
-      const runtime = {
-        settingsService: new SettingsService(),
-        runtimeId: 'provider-parity',
-        mediaResolver: resolver,
-        requestMediaBudgetBytes: reference.normalizedBase64Length * 2,
-      };
-
-      const resolved = await resolveRequestMedia(
-        runtime,
-        history(decoratedReference),
-        undefined,
-      );
-
-      expect(
-        serializedProviderStructures(
-          resolved.withContents((contents) => contents),
-        ),
-      ).toStrictEqual(serializedProviderStructures(history(inlineMedia(data))));
-      expect(resolved.accounting().storeReadCount).toBe(1);
-      expect(await store.hasReservations(reference.contentId)).toBe(true);
-      await resolved.release();
-      expect(await store.hasReservations(reference.contentId)).toBe(false);
+  function useTempDirectory(): () => string {
+    let directory = '';
+    beforeEach(async () => {
+      directory = await mkdtemp(join(tmpdir(), 'llxprt-provider-media-'));
     });
+    afterEach(async () => {
+      if (directory !== '') {
+        await chmod(directory, 0o700).catch(() => undefined);
+        await rm(directory, { recursive: true, force: true });
+      }
+    });
+    return () => directory;
+  }
 
-    it('preserves model media semantics through admission while diagnostics redact them', async () => {
-      const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 5, 6, 7, 8]);
-      const data = Buffer.from(bytes).toString('base64');
-      const caption =
-        'Use the label from /Users/example/provider-captions/hero.png verbatim';
-      const filename = 'provider-assets/hero image.png';
-      const providerMetadata = {
-        detail: 'high',
-        vendor: {
-          inputPath: '/Users/example/provider-options/image.json',
-          token: 'provider-semantic-token-3199',
-          sequence: ['first', 'second'],
-        },
-      };
-      const modelVisibleMedia: InlineMediaBlock = {
-        type: 'media',
-        encoding: 'base64',
-        data,
-        mimeType: 'image/png',
-        caption,
-        filename,
-        providerMetadata,
-        dimensions: { width: 3, height: 2 },
-        semanticMetadata: { source: 'tool', detail: 'high' },
-        providerFileIds: { kimi: 'file_semantic' },
-        providerFiles: [
+  interface MediaPresentation {
+    readonly mimeType: string;
+    readonly caption: string;
+    readonly filename: string;
+    readonly width: number;
+    readonly height: number;
+    readonly detail: 'auto' | 'high' | 'low';
+    readonly providerFileId: string;
+  }
+
+  const DEFAULT_PRESENTATION: MediaPresentation = {
+    mimeType: 'image/png',
+    caption: 'terminal screenshot',
+    filename: 'screen.png',
+    width: 3,
+    height: 2,
+    detail: 'high',
+    providerFileId: 'file_stable',
+  };
+
+  function inlineMedia(
+    data: string,
+    presentation = DEFAULT_PRESENTATION,
+  ): InlineMediaBlock {
+    return {
+      type: 'media',
+      encoding: 'base64',
+      data,
+      mimeType: presentation.mimeType,
+      caption: presentation.caption,
+      filename: presentation.filename,
+      providerMetadata: { detail: presentation.detail },
+      dimensions: {
+        width: presentation.width,
+        height: presentation.height,
+      },
+      semanticMetadata: { source: 'tool', detail: presentation.detail },
+      providerFileIds: { kimi: presentation.providerFileId },
+    };
+  }
+
+  function history(
+    media: InlineMediaBlock | MediaReferenceBlock,
+    mediaFirst = false,
+  ): IContent[] {
+    const textBlock = { type: 'text' as const, text: 'capture the terminal' };
+    const toolResponseBlock = {
+      type: 'tool_response' as const,
+      callId: 'call_media',
+      toolName: 'screenshot',
+      result: 'captured',
+    };
+    return [
+      {
+        speaker: 'human',
+        metadata: { turnId: 'turn-user' },
+        blocks: mediaFirst ? [media, textBlock] : [textBlock, media],
+      },
+      {
+        speaker: 'ai',
+        metadata: { turnId: 'turn-tool-call' },
+        blocks: [
           {
-            provider: 'kimi',
-            baseURL: 'https://api.example.test',
-            credentialHash: 'credential-hash-semantic',
-            fileId: 'file_semantic',
-            byteLength: bytes.byteLength,
-            scope: 'session',
-            scopeId: 'session-semantic',
-            createdAt: 1_788_000_000_000,
-            expiresAt: 1_788_003_600_000,
-            deletion: 'retain',
-            zeroDataRetention: 'not-applicable',
-            deletionState: 'active',
+            type: 'tool_call',
+            id: 'call_media',
+            name: 'screenshot',
+            parameters: { region: 'terminal' },
           },
         ],
-      };
-      const localSourcePath = join(tempDirectory(), 'private', 'hero.png');
-      const sourceMedia: InlineMediaBlock & { readonly sourcePath: string } = {
-        ...modelVisibleMedia,
-        sourcePath: localSourcePath,
-      };
-      const sourceContent: IContent = {
-        speaker: 'human',
-        metadata: { turnId: 'turn-semantic-media' },
-        blocks: [sourceMedia],
-      };
-      const expectedContent: IContent = {
-        ...sourceContent,
-        blocks: [modelVisibleMedia],
-      };
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1024,
-      });
-      const admitted = await new MediaAdmissionService(store).admitContent(
-        sourceContent,
-        { turnId: 'turn-semantic-media', source: 'tool-response' },
-      );
-      const reference = admitted.blocks[0];
-      if (reference.type !== 'media' || reference.encoding !== 'reference') {
-        throw new Error('Expected admitted media reference');
-      }
+      },
+      {
+        speaker: 'tool',
+        metadata: { turnId: 'turn-tool-response' },
+        blocks: mediaFirst
+          ? [media, toolResponseBlock]
+          : [toolResponseBlock, media],
+      },
+    ];
+  }
 
-      expect({
-        caption: reference.caption,
-        filename: reference.filename,
-        providerMetadata: reference.providerMetadata,
-      }).toStrictEqual({ caption, filename, providerMetadata });
-      expect(reference).not.toHaveProperty('sourcePath');
-      expect(reference).not.toHaveProperty('data');
-
-      const diagnostic = getContentPreview([reference], 10_000);
-      expect(diagnostic).not.toContain(caption);
-      expect(diagnostic).not.toContain(localSourcePath);
-      expect(diagnostic).not.toContain('provider-semantic-token-3199');
-      expect(diagnostic).not.toContain(data);
-
-      const resolver = new RequestMediaResolver(store);
-      const resolved = await resolver.resolve({
-        contents: [admitted],
-        requestId: 'request-semantic-media',
-        turnId: 'turn-semantic-media',
-        aggregateBudgetBytes: reference.normalizedBase64Length,
-      });
-
-      try {
-        const materialized = resolved.withContents((contents) => contents);
-        expect(materialized[0]?.blocks[0]).toStrictEqual(modelVisibleMedia);
-        expect(serializedProviderStructures(materialized)).toStrictEqual(
-          serializedProviderStructures([expectedContent]),
-        );
-      } finally {
-        await resolved.release();
-      }
-    });
-
-    it('preserves provider request identity across media bytes and presentation metadata', async () => {
-      const safeToken = fc
-        .array(fc.constantFrom('a', 'b', 'c', 'x', 'y', 'z', '0', '1'), {
-          minLength: 1,
-          maxLength: 12,
-        })
-        .map((characters) => characters.join(''));
-      const mediaCase = fc.record({
-        bytes: fc.uint8Array({ minLength: 1, maxLength: 64 }),
-        mimeType: fc.constantFrom(
-          'image/png',
-          'image/jpeg',
-          'image/webp',
-          'image/gif',
-        ),
-        caption: safeToken,
-        filename: safeToken.map((name) => `${name}.img`),
-        width: fc.integer({ min: 1, max: 4096 }),
-        height: fc.integer({ min: 1, max: 4096 }),
-        detail: fc.constantFrom('auto', 'high', 'low'),
-        providerFileId: safeToken.map((id) => `file_${id}`),
-        mediaFirst: fc.boolean(),
-      });
-
-      await fc.assert(
-        fc.asyncProperty(mediaCase, async (sample) => {
-          const presentation: MediaPresentation = {
-            mimeType: sample.mimeType,
-            caption: sample.caption,
-            filename: sample.filename,
-            width: sample.width,
-            height: sample.height,
-            detail: sample.detail,
-            providerFileId: sample.providerFileId,
-          };
-          const store = new LocalMediaStore({
-            rootDirectory: tempDirectory(),
-            quotaBytes: 1024 * 1024,
-          });
-          const reference = await store.admit({
-            bytes: sample.bytes,
-            mimeType: presentation.mimeType,
-            dimensions: {
-              width: presentation.width,
-              height: presentation.height,
-            },
-            semanticMetadata: {
-              source: 'tool',
-              detail: presentation.detail,
-            },
-            providerFileIds: { kimi: presentation.providerFileId },
-          });
-          const decoratedReference: MediaReferenceBlock = {
-            ...reference,
-            caption: presentation.caption,
-            filename: presentation.filename,
-            providerMetadata: { detail: presentation.detail },
-          };
-          const resolver = new RequestMediaResolver(store);
-          const resolved = await resolveRequestMedia(
-            {
-              settingsService: new SettingsService(),
-              runtimeId: 'provider-property-parity',
-              mediaResolver: resolver,
-              requestMediaBudgetBytes: reference.normalizedBase64Length * 2,
-            },
-            history(decoratedReference, sample.mediaFirst),
-            undefined,
-          );
-
-          try {
-            const inline = inlineMedia(
-              Buffer.from(sample.bytes).toString('base64'),
-              presentation,
-            );
-            expect(
-              serializedProviderStructures(
-                resolved.withContents((contents) => contents),
-              ),
-            ).toStrictEqual(
-              serializedProviderStructures(history(inline, sample.mediaFirst)),
-            );
-          } finally {
-            await resolved.release();
-          }
-        }),
-        { numRuns: 25 },
-      );
-    });
-
-    it('rejects reference metadata over budget before a provider converter runs', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1024,
-      });
-      const reference = await store.admit({
-        bytes: new Uint8Array([1, 2, 3]),
-        mimeType: 'image/png',
-        semanticMetadata: {},
-      });
-      const resolver = new RequestMediaResolver(store);
-      const runtime = {
-        settingsService: new SettingsService(),
-        runtimeId: 'provider-budget',
-        mediaResolver: resolver,
-        requestMediaBudgetBytes: reference.normalizedBase64Length - 1,
-      };
-
-      const error = await resolveRequestMedia(
-        runtime,
-        history(reference),
-        undefined,
-      ).catch((reason: unknown) => reason);
-
-      expect(error).toBeInstanceOf(RequestMediaResolutionError);
-      expect(String(error)).toContain(reference.contentId);
-      expect(String(error)).toContain('turn-user');
-      expect(resolver.accounting().storeReadCount).toBe(0);
-      expect(await store.hasReservations(reference.contentId)).toBe(false);
-    });
-
-    it('preserves the reason from an already-aborted inline-only request', async () => {
-      const controller = new AbortController();
-      const abortReason = new DOMException(
-        'cancelled media request',
-        'AbortError',
-      );
-      controller.abort(abortReason);
-      const contents: IContent[] = [
-        {
-          speaker: 'human',
-          metadata: { turnId: 'turn-aborted-inline' },
-          blocks: [inlineMedia('aW1hZ2U=')],
-        },
-      ];
-
-      const error = await resolveRequestMedia(
-        undefined,
-        contents,
-        controller.signal,
-      ).catch((reason: unknown) => reason);
-
-      expect(error).toBe(abortReason);
-    });
-
-    it('keeps every provider converter fail-fast for unresolved references', async () => {
-      const store = new LocalMediaStore({
-        rootDirectory: tempDirectory(),
-        quotaBytes: 1024,
-      });
-      const reference = await store.admit({
-        bytes: new Uint8Array([7, 8, 9]),
-        mimeType: 'image/png',
-        semanticMetadata: {},
-      });
-      const contents = history(reference);
-      const settings = { get: (_key: string): unknown => undefined };
-      const anthropicOptions = {
-        isOAuth: false,
-        reasoningEnabled: false,
-        config: undefined,
-        unprefixToolName: (name: string): string => name,
-        logger: { debug: (_message: () => string): void => undefined },
-      };
-
-      expect(() => buildResponsesInputFromContent(contents)).toThrow(
-        reference.contentId,
-      );
-      expect(() =>
+  function serializedProviderStructures(
+    contents: IContent[],
+  ): Record<string, string> {
+    const settings = { get: (_key: string): unknown => undefined };
+    const anthropicOptions = {
+      isOAuth: false,
+      reasoningEnabled: false,
+      config: undefined,
+      unprefixToolName: (name: string): string => name,
+      logger: { debug: (_message: () => string): void => undefined },
+    };
+    return {
+      responses: JSON.stringify(buildResponsesInputFromContent(contents)),
+      chat: JSON.stringify(
         buildMessagesWithReasoning(contents, { settings }, 'openai', undefined),
-      ).toThrow(reference.contentId);
-      expect(() =>
+      ),
+      anthropic: JSON.stringify(
         convertToAnthropicMessages(contents, anthropicOptions),
-      ).toThrow(reference.contentId);
-      expect(() =>
+      ),
+      multimodal: JSON.stringify(
         mediaFormatConverter.convertHistoryToGeminiFormat(contents),
-      ).toThrow(reference.contentId);
-      expect(() => convertToVercelMessages(contents)).toThrow(
-        reference.contentId,
-      );
-    });
+      ),
+      vercel: JSON.stringify(convertToVercelMessages(contents)),
+    };
+  }
 
-    it('runs every unchanged-request cleanup once in LIFO order after a failure', async () => {
-      const resolved = await resolveRequestMedia(
-        undefined,
-        [{ speaker: 'human', blocks: [{ type: 'text', text: 'hello' }] }],
-        undefined,
-      );
-      const order: string[] = [];
-      resolved.registerCleanup(() => {
-        order.push('first');
-      });
-      resolved.registerCleanup(() => {
-        order.push('failing');
-        throw new Error('cleanup failed');
-      });
-      resolved.registerCleanup(() => {
-        order.push('last');
+  describe('request-media-resolution', () => {
+    describe('provider request media resolution', () => {
+      const tempDirectory = useTempDirectory();
+
+      it('produces byte-equivalent provider structures for inline and referenced media', async () => {
+        const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2]);
+        const data = Buffer.from(bytes).toString('base64');
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 1024,
+        });
+        const reference = await store.admit({
+          bytes,
+          mimeType: 'image/png',
+          dimensions: { width: 3, height: 2 },
+          semanticMetadata: { source: 'tool', detail: 'high' },
+          providerFileIds: { kimi: 'file_stable' },
+        });
+        const decoratedReference: MediaReferenceBlock = {
+          ...reference,
+          caption: 'terminal screenshot',
+          filename: 'screen.png',
+          providerMetadata: { detail: 'high' },
+        };
+        const resolver = new RequestMediaResolver(store);
+        const runtime = {
+          settingsService: new SettingsService(),
+          runtimeId: 'provider-parity',
+          mediaResolver: resolver,
+          requestMediaBudgetBytes: reference.normalizedBase64Length * 2,
+        };
+
+        const resolved = await resolveRequestMedia(
+          runtime,
+          history(decoratedReference),
+          undefined,
+        );
+
+        expect(
+          serializedProviderStructures(
+            resolved.withContents((contents) => contents),
+          ),
+        ).toStrictEqual(
+          serializedProviderStructures(history(inlineMedia(data))),
+        );
+        expect(resolved.accounting().storeReadCount).toBe(1);
+        expect(await store.hasReservations(reference.contentId)).toBe(true);
+        await resolved.release();
+        expect(await store.hasReservations(reference.contentId)).toBe(false);
       });
 
-      const error = await resolved.release().catch((reason: unknown) => reason);
-      await resolved.release();
+      it('preserves model media semantics through admission while diagnostics redact them', async () => {
+        const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 5, 6, 7, 8]);
+        const data = Buffer.from(bytes).toString('base64');
+        const caption =
+          'Use the label from /Users/example/provider-captions/hero.png verbatim';
+        const filename = 'provider-assets/hero image.png';
+        const providerMetadata = {
+          detail: 'high',
+          vendor: {
+            inputPath: '/Users/example/provider-options/image.json',
+            token: 'provider-semantic-token-3199',
+            sequence: ['first', 'second'],
+          },
+        };
+        const modelVisibleMedia: InlineMediaBlock = {
+          type: 'media',
+          encoding: 'base64',
+          data,
+          mimeType: 'image/png',
+          caption,
+          filename,
+          providerMetadata,
+          dimensions: { width: 3, height: 2 },
+          semanticMetadata: { source: 'tool', detail: 'high' },
+          providerFileIds: { kimi: 'file_semantic' },
+          providerFiles: [
+            {
+              provider: 'kimi',
+              baseURL: 'https://api.example.test',
+              credentialHash: 'credential-hash-semantic',
+              fileId: 'file_semantic',
+              byteLength: bytes.byteLength,
+              scope: 'session',
+              scopeId: 'session-semantic',
+              createdAt: 1_788_000_000_000,
+              expiresAt: 1_788_003_600_000,
+              deletion: 'retain',
+              zeroDataRetention: 'not-applicable',
+              deletionState: 'active',
+            },
+          ],
+        };
+        const localSourcePath = join(tempDirectory(), 'private', 'hero.png');
+        const sourceMedia: InlineMediaBlock & { readonly sourcePath: string } =
+          {
+            ...modelVisibleMedia,
+            sourcePath: localSourcePath,
+          };
+        const sourceContent: IContent = {
+          speaker: 'human',
+          metadata: { turnId: 'turn-semantic-media' },
+          blocks: [sourceMedia],
+        };
+        const expectedContent: IContent = {
+          ...sourceContent,
+          blocks: [modelVisibleMedia],
+        };
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 1024,
+        });
+        const admitted = await new MediaAdmissionService(store).admitContent(
+          sourceContent,
+          { turnId: 'turn-semantic-media', source: 'tool-response' },
+        );
+        const reference = admitted.blocks[0];
+        if (reference.type !== 'media' || reference.encoding !== 'reference') {
+          throw new Error('Expected admitted media reference');
+        }
 
-      expect(error).toBeInstanceOf(AggregateError);
-      expect(order).toStrictEqual(['last', 'failing', 'first']);
-      expect(resolved.accounting().released).toBe(true);
-      expect(() => resolved.withContents((contents) => contents)).toThrow(
-        /after release/i,
-      );
+        expect({
+          caption: reference.caption,
+          filename: reference.filename,
+          providerMetadata: reference.providerMetadata,
+        }).toStrictEqual({ caption, filename, providerMetadata });
+        expect(reference).not.toHaveProperty('sourcePath');
+        expect(reference).not.toHaveProperty('data');
+
+        const diagnostic = getContentPreview([reference], 10_000);
+        expect(diagnostic).not.toContain(caption);
+        expect(diagnostic).not.toContain(localSourcePath);
+        expect(diagnostic).not.toContain('provider-semantic-token-3199');
+        expect(diagnostic).not.toContain(data);
+
+        const resolver = new RequestMediaResolver(store);
+        const resolved = await resolver.resolve({
+          contents: [admitted],
+          requestId: 'request-semantic-media',
+          turnId: 'turn-semantic-media',
+          aggregateBudgetBytes: reference.normalizedBase64Length,
+        });
+
+        try {
+          const materialized = resolved.withContents((contents) => contents);
+          expect(materialized[0]?.blocks[0]).toStrictEqual(modelVisibleMedia);
+          expect(serializedProviderStructures(materialized)).toStrictEqual(
+            serializedProviderStructures([expectedContent]),
+          );
+        } finally {
+          await resolved.release();
+        }
+      });
+
+      it('preserves provider request identity across media bytes and presentation metadata', async () => {
+        const safeToken = fc
+          .array(fc.constantFrom('a', 'b', 'c', 'x', 'y', 'z', '0', '1'), {
+            minLength: 1,
+            maxLength: 12,
+          })
+          .map((characters) => characters.join(''));
+        const mediaCase = fc.record({
+          bytes: fc.uint8Array({ minLength: 1, maxLength: 64 }),
+          mimeType: fc.constantFrom(
+            'image/png',
+            'image/jpeg',
+            'image/webp',
+            'image/gif',
+          ),
+          caption: safeToken,
+          filename: safeToken.map((name) => `${name}.img`),
+          width: fc.integer({ min: 1, max: 4096 }),
+          height: fc.integer({ min: 1, max: 4096 }),
+          detail: fc.constantFrom('auto', 'high', 'low'),
+          providerFileId: safeToken.map((id) => `file_${id}`),
+          mediaFirst: fc.boolean(),
+        });
+
+        await fc.assert(
+          fc.asyncProperty(mediaCase, async (sample) => {
+            const presentation: MediaPresentation = {
+              mimeType: sample.mimeType,
+              caption: sample.caption,
+              filename: sample.filename,
+              width: sample.width,
+              height: sample.height,
+              detail: sample.detail,
+              providerFileId: sample.providerFileId,
+            };
+            const store = new LocalMediaStore({
+              rootDirectory: tempDirectory(),
+              quotaBytes: 1024 * 1024,
+            });
+            const reference = await store.admit({
+              bytes: sample.bytes,
+              mimeType: presentation.mimeType,
+              dimensions: {
+                width: presentation.width,
+                height: presentation.height,
+              },
+              semanticMetadata: {
+                source: 'tool',
+                detail: presentation.detail,
+              },
+              providerFileIds: { kimi: presentation.providerFileId },
+            });
+            const decoratedReference: MediaReferenceBlock = {
+              ...reference,
+              caption: presentation.caption,
+              filename: presentation.filename,
+              providerMetadata: { detail: presentation.detail },
+            };
+            const resolver = new RequestMediaResolver(store);
+            const resolved = await resolveRequestMedia(
+              {
+                settingsService: new SettingsService(),
+                runtimeId: 'provider-property-parity',
+                mediaResolver: resolver,
+                requestMediaBudgetBytes: reference.normalizedBase64Length * 2,
+              },
+              history(decoratedReference, sample.mediaFirst),
+              undefined,
+            );
+
+            try {
+              const inline = inlineMedia(
+                Buffer.from(sample.bytes).toString('base64'),
+                presentation,
+              );
+              expect(
+                serializedProviderStructures(
+                  resolved.withContents((contents) => contents),
+                ),
+              ).toStrictEqual(
+                serializedProviderStructures(
+                  history(inline, sample.mediaFirst),
+                ),
+              );
+            } finally {
+              await resolved.release();
+            }
+          }),
+          { numRuns: 25 },
+        );
+      });
+
+      it('rejects reference metadata over budget before a provider converter runs', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 1024,
+        });
+        const reference = await store.admit({
+          bytes: new Uint8Array([1, 2, 3]),
+          mimeType: 'image/png',
+          semanticMetadata: {},
+        });
+        const resolver = new RequestMediaResolver(store);
+        const runtime = {
+          settingsService: new SettingsService(),
+          runtimeId: 'provider-budget',
+          mediaResolver: resolver,
+          requestMediaBudgetBytes: reference.normalizedBase64Length - 1,
+        };
+
+        const error = await resolveRequestMedia(
+          runtime,
+          history(reference),
+          undefined,
+        ).catch((reason: unknown) => reason);
+
+        expect(error).toBeInstanceOf(RequestMediaResolutionError);
+        expect(String(error)).toContain(reference.contentId);
+        expect(String(error)).toContain('turn-user');
+        expect(resolver.accounting().storeReadCount).toBe(0);
+        expect(await store.hasReservations(reference.contentId)).toBe(false);
+      });
+
+      it('preserves the reason from an already-aborted inline-only request', async () => {
+        const controller = new AbortController();
+        const abortReason = new DOMException(
+          'cancelled media request',
+          'AbortError',
+        );
+        controller.abort(abortReason);
+        const contents: IContent[] = [
+          {
+            speaker: 'human',
+            metadata: { turnId: 'turn-aborted-inline' },
+            blocks: [inlineMedia('aW1hZ2U=')],
+          },
+        ];
+
+        const error = await resolveRequestMedia(
+          undefined,
+          contents,
+          controller.signal,
+        ).catch((reason: unknown) => reason);
+
+        expect(error).toBe(abortReason);
+      });
+
+      it('keeps every provider converter fail-fast for unresolved references', async () => {
+        const store = new LocalMediaStore({
+          rootDirectory: tempDirectory(),
+          quotaBytes: 1024,
+        });
+        const reference = await store.admit({
+          bytes: new Uint8Array([7, 8, 9]),
+          mimeType: 'image/png',
+          semanticMetadata: {},
+        });
+        const contents = history(reference);
+        const settings = { get: (_key: string): unknown => undefined };
+        const anthropicOptions = {
+          isOAuth: false,
+          reasoningEnabled: false,
+          config: undefined,
+          unprefixToolName: (name: string): string => name,
+          logger: { debug: (_message: () => string): void => undefined },
+        };
+
+        expect(() => buildResponsesInputFromContent(contents)).toThrow(
+          reference.contentId,
+        );
+        expect(() =>
+          buildMessagesWithReasoning(
+            contents,
+            { settings },
+            'openai',
+            undefined,
+          ),
+        ).toThrow(reference.contentId);
+        expect(() =>
+          convertToAnthropicMessages(contents, anthropicOptions),
+        ).toThrow(reference.contentId);
+        expect(() =>
+          mediaFormatConverter.convertHistoryToGeminiFormat(contents),
+        ).toThrow(reference.contentId);
+        expect(() => convertToVercelMessages(contents)).toThrow(
+          reference.contentId,
+        );
+      });
+
+      it('runs every unchanged-request cleanup once in LIFO order after a failure', async () => {
+        const resolved = await resolveRequestMedia(
+          undefined,
+          [{ speaker: 'human', blocks: [{ type: 'text', text: 'hello' }] }],
+          undefined,
+        );
+        const order: string[] = [];
+        resolved.registerCleanup(() => {
+          order.push('first');
+        });
+        resolved.registerCleanup(() => {
+          order.push('failing');
+          throw new Error('cleanup failed');
+        });
+        resolved.registerCleanup(() => {
+          order.push('last');
+        });
+
+        const error = await resolved
+          .release()
+          .catch((reason: unknown) => reason);
+        await resolved.release();
+
+        expect(error).toBeInstanceOf(AggregateError);
+        expect(order).toStrictEqual(['last', 'failing', 'first']);
+        expect(resolved.accounting().released).toBe(true);
+        expect(() => resolved.withContents((contents) => contents)).toThrow(
+          /after release/i,
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
## What

Three stacked failures were hiding inside the `Lint (Javascript)` job on `dev/0.12.0`, each masking the next; this PR peels all three so the job, and the board, go green.

**Layer 1 (#3484)**: the branch's committed `package-lock.json` carried 15 `"peer": true` entries that `check:lockfile` rejects. They are exactly what npm 11.6.2 writes before `scripts/postinstall.cjs` strips them (a step that never ran when the file was committed under bun). Fix: apply the stripper's own transform; 300 bytes removed, nothing else changed, `bun.lock` untouched. CI log now prints `Lockfile check passed.`

**Layer 2 (#3487)**: 10 test files were committed with prettier drift. Fixed with the repo's own formatter (+33/−21, exactly those 10 files, 122 targeted tests pass). The CI format step now passes.

**Layer 3 (#3489, option 4)**: eslint exited 1 with 0 errors and 807 warnings (781 `jest/no-conditional-in-test`, 26 `jest/require-top-level-describe`) against `lint:ci --max-warnings 0`. Fixed by treating the two rules differently:
- `jest/no-conditional-in-test` → `'off'` with the repo's `eslint-policy-allow-off` marker (matching `main`'s format, cleanup tracked in #3129). The harm it targets, a skippable assertion, stays enforced at error by `jest/no-conditional-expect`, which reports zero violations.
- `jest/require-top-level-describe` stays `'warn'` and all 26 reports are fixed by wrapping each affected file in a root `describe`: the shared lifecycle helpers (`useTempDirectory()`/`useTempDir()`) stay defined exactly once, but inside the wrapper. Zero duplication, zero disables; 12 files got an additive wrapper, and `ProfileCreateWizard/validation.test.ts` (already 3 describes deep, at the `jest/max-nested-describe` cap) got an outermost-replacement instead. The rule remains live for every file including new ones.

## Verification

- eslint on all 13 wrapped files: 0 errors, 0 warnings
- All 13 files' targeted tests: 209 pass / 0 fail / 0 skip, identical counts to the pre-change baseline
- Wrap diffs are pure code motion: `git diff -w` shows only the wrapper plus prettier printWidth reflows; no assertions or logic changed
- Scratch-verified per file before committing (13/13 → zero `require-top-level-describe` reports), evidence on #3489

## Alternatives considered

Rejected alternatives and the full decision record (warning-budget ratchet modeled on `gate:agents-neutral`, plain demotion of both rules, full 807-warning burn-down) are documented on #3489.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

macOS: targeted eslint/prettier/bun test on every touched file; CI runs the full suite on Linux.

## Linked issues / bugs

Fixes #3484
Fixes #3487
Fixes #3489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for media resolution, provider recovery, storage locking, session lifecycle, and request cancellation scenarios.
  * Reorganized test suites for clearer grouping and improved lifecycle handling.
* **Style**
  * Standardized test formatting, imports, and expression readability.
* **Chores**
  * Updated linting rules to better support conditional test setup while retaining enforcement for conditional assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->