### PR TITLE
fix(providers): degrade instead of throwing for unrecognized claimed model identities (Fixes #3485)

### DIFF
--- a/packages/providers/src/runtime/providerManagerRuntimeFactories.test.ts
+++ b/packages/providers/src/runtime/providerManagerRuntimeFactories.test.ts
@@ -10,10 +10,15 @@ import type {
   RuntimeContentGeneratorFactory,
   RuntimeTokenizerFactory,
 } from '@vybestack/llxprt-code-core';
+import type { RuntimePromptEstimateRequest } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeTokenizerFactory.js';
 import { ProviderContentGenerator } from '@vybestack/llxprt-code-providers';
 import { configureProviderRuntimeFactories } from '../composition/index.js';
 import { createRuntimeTokenizerFactory } from '../composition/runtimeTokenizerFactory.js';
 import { ModelPromptEstimatorError } from '../tokenizers/ModelPromptEstimatorError.js';
+import {
+  CLAUDE_FABLE_5_CALIBRATION,
+  CLAUDE_FABLE_5_ESTIMATOR_FAMILY,
+} from '../tokenizers/claude/claudeCalibrationAssets.js';
 import type { TiktokenModuleLoader } from '../tokenizers/o200kBaseCounter.js';
 import {
   activateIsolatedRuntimeContext,
@@ -72,6 +77,28 @@ describe('configureProviderRuntimeFactories', () => {
     ).toBeDefined();
   });
 
+  function buildClaudeEstimateRequest(
+    canonicalModel: string,
+    activeProvider = 'claudecode',
+  ): RuntimePromptEstimateRequest {
+    return {
+      activeProvider,
+      canonicalModel,
+      protocol: 'anthropic-messages',
+      wireMethod: 'messages/v1',
+      finalizedProjection: {
+        kind: 'llxprt-provider-prompt-v3',
+        protocol: 'anthropic-messages',
+        promptText: JSON.stringify({
+          system: 'You are helpful.',
+          messages: [{ role: 'user', content: 'Explain tokenization.' }],
+        }),
+      },
+      projectionRevision: 3,
+      legacyEstimate: () => Promise.resolve(1234),
+    };
+  }
+
   /**
    * The Claude 5 registrations are only useful if the composition root
    * actually installs them, so this asserts through the composed factory
@@ -103,44 +130,44 @@ describe('configureProviderRuntimeFactories', () => {
       'anthropic-claude-fable-5',
     );
 
-    const estimateRequest = (
-      canonicalModel: string,
-      activeProvider: string,
-    ) => ({
-      activeProvider,
-      canonicalModel,
-      protocol: 'anthropic-messages' as const,
-      wireMethod: 'messages/v1' as const,
-      finalizedProjection: {
-        kind: 'llxprt-provider-prompt-v3' as const,
-        protocol: 'anthropic-messages' as const,
-        promptText: JSON.stringify({
-          system: 'You are helpful.',
-          messages: [{ role: 'user', content: 'Explain tokenization.' }],
-        }),
-      },
-      projectionRevision: 3,
-      legacyEstimate: () => Promise.resolve(1234),
-    });
-
     const opus = await tokenizerFactory!.estimatePrompt(
-      estimateRequest('claude-opus-5', 'anthropic'),
+      buildClaudeEstimateRequest('claude-opus-5', 'anthropic'),
     );
     expect(opus.family).toBe('anthropic-claude-opus-5');
     expect(opus.method).toBe('calibrated');
     expect(opus.count).toBeGreaterThan(0);
 
     const fable = await tokenizerFactory!.estimatePrompt(
-      estimateRequest('claude-fable-5', 'anthropic'),
+      buildClaudeEstimateRequest('claude-fable-5', 'anthropic'),
     );
     expect(fable.family).toBe('anthropic-claude-fable-5');
     expect(fable.method).toBe('calibrated');
     expect(fable.estimatorVersion).not.toBe(opus.estimatorVersion);
 
     const proxied = await tokenizerFactory!.estimatePrompt(
-      estimateRequest('claude-opus-5', 'zai'),
+      buildClaudeEstimateRequest('claude-opus-5', 'zai'),
     );
     expect(proxied.family).toBe('legacy-unregistered');
+  });
+
+  /**
+   * Issue #3485: a point release such as claude-fable-5-1 must inherit its
+   * family calibration instead of throwing an unresolved-identity error on
+   * the request path. This exercises the runtime tokenizer factory directly.
+   */
+  it('estimates a Claude 5 point release with the family calibration', async () => {
+    const factory = createRuntimeTokenizerFactory();
+    const result = await factory.estimatePrompt(
+      buildClaudeEstimateRequest('claude-fable-5-1'),
+    );
+
+    expect(result.family).toBe(CLAUDE_FABLE_5_ESTIMATOR_FAMILY);
+    expect(result.family).not.toBe('legacy-unresolved-identity');
+    expect(result.method).toBe('calibrated');
+    expect(result.estimatorVersion).toBe(
+      CLAUDE_FABLE_5_CALIBRATION.estimatorVersion,
+    );
+    expect(result.count).toBeGreaterThan(0);
   });
 
   it('preserves an explicitly injected tokenizer factory as the authoritative runtime factory', async () => {

--- a/packages/providers/src/tokenizers/Gpt56O200kPromptEstimator.test.ts
+++ b/packages/providers/src/tokenizers/Gpt56O200kPromptEstimator.test.ts
@@ -216,7 +216,7 @@ describe('ModelPromptEstimatorRegistry', () => {
       method: 'calibrated',
       family: 'legacy-unregistered',
     });
-    expect(input.legacyEstimate).toHaveBeenCalledOnce();
+    expect(input.legacyEstimate).toHaveBeenCalledTimes(1);
   });
 
   it.each([
@@ -226,15 +226,19 @@ describe('ModelPromptEstimatorRegistry', () => {
     'gpt-05.06',
     'gpt-5.06',
   ])(
-    'rejects claimed malformed identity %s without legacy fallback',
+    'falls back to the legacy estimate for claimed malformed identity %s',
     async (model) => {
       const input = request(model);
-      expect(
-        await captureRejection(registry.estimatePrompt(input)),
-      ).toMatchObject({
-        code: 'unresolved-model-identity',
+      const result = await registry.estimatePrompt(input);
+      expect(result).toMatchObject({
+        count: 999,
+        method: 'calibrated',
+        family: 'legacy-unresolved-identity',
+        estimatorVersion: 'core-estimate-tokens-v1',
+        assetRevision: 'none',
+        projectionRevision: 3,
       });
-      expect(input.legacyEstimate).not.toHaveBeenCalled();
+      expect(input.legacyEstimate).toHaveBeenCalledTimes(1);
     },
   );
 
@@ -291,7 +295,6 @@ describe('createDefaultEstimatorRegistrations', () => {
       claim: /^test-extra-default/,
       matches: (model: string) => model.startsWith('test-extra-default'),
       protocols: new Set<PromptEnvelopeProtocol>(['openai-responses']),
-      identityErrorHint: 'use a test-extra-default model',
       estimate: async (estimateRequest) => ({
         count: await estimateRequest.legacyEstimate(),
         method: 'calibrated',

--- a/packages/providers/src/tokenizers/ModelPromptEstimatorError.ts
+++ b/packages/providers/src/tokenizers/ModelPromptEstimatorError.ts
@@ -7,7 +7,6 @@
 import type { PromptEnvelopeProtocol } from '@vybestack/llxprt-code-core/runtime/contracts/PromptEstimation.js';
 
 export type ModelPromptEstimatorErrorCode =
-  | 'unresolved-model-identity'
   | 'unsupported-protocol'
   | 'asset-unavailable'
   | 'projection-unavailable'

--- a/packages/providers/src/tokenizers/ModelPromptEstimatorRegistry.ts
+++ b/packages/providers/src/tokenizers/ModelPromptEstimatorRegistry.ts
@@ -9,6 +9,7 @@ import type {
   RuntimePromptEstimateResult,
 } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeTokenizerFactory.js';
 import type { PromptEnvelopeProtocol } from '@vybestack/llxprt-code-core/runtime/contracts/PromptEstimation.js';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import { isSanctionedGpt56Model } from '../openai/openaiModelPolicy.js';
 import {
   createGpt56PromptEstimator,
@@ -22,8 +23,14 @@ export interface ModelPromptEstimatorRegistration {
   readonly family: string;
   readonly claim: RegExp;
   readonly matches: (model: string) => boolean;
+  /**
+   * Optional rule recognizing a *point release* of the family: a claimed
+   * model that is not a sanctioned identity but is close enough to inherit
+   * the family's estimate (with an explicit warning) instead of falling back
+   * to the legacy heuristic.
+   */
+  readonly matchesPointRelease?: (model: string) => boolean;
   readonly protocols: ReadonlySet<PromptEnvelopeProtocol>;
-  readonly identityErrorHint: string;
   /**
    * Optional active-provider restriction.
    *
@@ -49,8 +56,6 @@ export const GPT_56_PROMPT_ESTIMATOR_REGISTRATION: ModelPromptEstimatorRegistrat
       'openai-chat',
       'openai-responses',
     ]),
-    identityErrorHint:
-      'use a sanctioned GPT-5.6 base, sol, terra, or luna alias with latest or a valid date snapshot',
     estimate: estimateGpt56Prompt,
   });
 
@@ -118,20 +123,59 @@ function appliesToRequest(
   return registration.appliesToProvider?.(request.activeProvider) ?? true;
 }
 
-function createIdentityError(
+const degradationLogger = new DebugLogger('llxprt:model-prompt-estimator');
+
+/**
+ * Degradation warnings fire once per provider+model per process: the first
+ * estimate for a pair tells the user their token counts may be off, and
+ * repeating that on every request would only bury it in noise.
+ */
+const warnedDegradations = new Set<string>();
+
+function warnDegradationOnce(
+  request: RuntimePromptEstimateRequest,
+  detail: string,
+): void {
+  const key = `${request.activeProvider}:${request.canonicalModel}`;
+  if (warnedDegradations.has(key)) return;
+  warnedDegradations.add(key);
+  degradationLogger.warn(
+    `model ${request.canonicalModel} on provider ${request.activeProvider} ${detail}`,
+  );
+}
+
+function warnPointReleaseOnce(
   request: RuntimePromptEstimateRequest,
   registration: ModelPromptEstimatorRegistration,
-): ModelPromptEstimatorError {
-  return new ModelPromptEstimatorError(
-    'unresolved-model-identity',
-    {
-      activeProvider: request.activeProvider,
-      canonicalModel: request.canonicalModel,
-      protocol: request.protocol,
-      family: registration.family,
-    },
-    registration.identityErrorHint,
+): void {
+  warnDegradationOnce(
+    request,
+    `is not directly calibrated; applying ${registration.family} calibration until a dedicated calibration exists; estimates may be less accurate`,
   );
+}
+
+function warnLegacyFallbackOnce(
+  request: RuntimePromptEstimateRequest,
+  registration: ModelPromptEstimatorRegistration,
+): void {
+  warnDegradationOnce(
+    request,
+    `is not a sanctioned identity of ${registration.family}; falling back to the legacy estimate; token estimates may be inaccurate`,
+  );
+}
+
+async function legacyEstimate(
+  request: RuntimePromptEstimateRequest,
+  family: string,
+): Promise<RuntimePromptEstimateResult> {
+  return {
+    count: await request.legacyEstimate(),
+    method: 'calibrated',
+    family,
+    estimatorVersion: 'core-estimate-tokens-v1',
+    assetRevision: 'none',
+    projectionRevision: request.projectionRevision,
+  };
 }
 
 function createProtocolError(
@@ -179,17 +223,17 @@ export class ModelPromptEstimatorRegistry {
         ? claimed
         : undefined;
     if (registration === undefined) {
-      return {
-        count: await request.legacyEstimate(),
-        method: 'calibrated',
-        family: 'legacy-unregistered',
-        estimatorVersion: 'core-estimate-tokens-v1',
-        assetRevision: 'none',
-        projectionRevision: request.projectionRevision,
-      };
+      return legacyEstimate(request, 'legacy-unregistered');
     }
     if (!registration.matches(request.canonicalModel)) {
-      throw createIdentityError(request, registration);
+      // The registry sits on the request path, so an unresolved identity must
+      // degrade, never throw: a point release inherits the family estimate,
+      // anything else falls back to the legacy heuristic. Both warn once.
+      if (registration.matchesPointRelease?.(request.canonicalModel) !== true) {
+        warnLegacyFallbackOnce(request, registration);
+        return legacyEstimate(request, 'legacy-unresolved-identity');
+      }
+      warnPointReleaseOnce(request, registration);
     }
     if (!registration.protocols.has(request.protocol)) {
       throw createProtocolError(request, registration);

--- a/packages/providers/src/tokenizers/claude/claudeCalibrationAssets.ts
+++ b/packages/providers/src/tokenizers/claude/claudeCalibrationAssets.ts
@@ -14,6 +14,8 @@ import {
 import {
   CLAUDE_FABLE_5_CLAIM,
   CLAUDE_OPUS_5_CLAIM,
+  isClaudeFable5PointReleaseModel,
+  isClaudeOpus5PointReleaseModel,
   isSanctionedClaudeFable5Model,
   isSanctionedClaudeOpus5Model,
 } from './claudeModelIdentity.js';
@@ -140,9 +142,14 @@ export interface Claude5FamilySpec {
   readonly canonicalModelFamily: string;
   readonly claim: RegExp;
   readonly matches: (model: string) => boolean;
+  /**
+   * Point releases of the family line (e.g. `claude-fable-5-1`) inherit the
+   * family calibration with an explicit warning until a dedicated
+   * calibration exists.
+   */
+  readonly matchesPointRelease?: (model: string) => boolean;
   readonly protocols: ReadonlySet<PromptEnvelopeProtocol>;
   readonly appliesToProvider: (activeProvider: string) => boolean;
-  readonly identityErrorHint: string;
   /** Absent when the model has no activatable calibration. */
   readonly calibration: ClaudeCalibration | undefined;
   /** Present exactly when `calibration` is absent. */
@@ -156,10 +163,9 @@ export const CLAUDE_5_FAMILY_SPECS: readonly Claude5FamilySpec[] =
       canonicalModelFamily: 'claude-opus-5',
       claim: CLAUDE_OPUS_5_CLAIM,
       matches: isSanctionedClaudeOpus5Model,
+      matchesPointRelease: isClaudeOpus5PointReleaseModel,
       protocols: CLAUDE_5_ANTHROPIC_PROTOCOLS,
       appliesToProvider: isClaude5CalibratedProvider,
-      identityErrorHint:
-        'use claude-opus-5, claude-opus-5-latest, or a claude-opus-5-YYYYMMDD snapshot with a real calendar date',
       calibration: CLAUDE_OPUS_5_CALIBRATION,
       withheldReason: undefined,
     }),
@@ -168,10 +174,9 @@ export const CLAUDE_5_FAMILY_SPECS: readonly Claude5FamilySpec[] =
       canonicalModelFamily: 'claude-fable-5',
       claim: CLAUDE_FABLE_5_CLAIM,
       matches: isSanctionedClaudeFable5Model,
+      matchesPointRelease: isClaudeFable5PointReleaseModel,
       protocols: CLAUDE_5_ANTHROPIC_PROTOCOLS,
       appliesToProvider: isClaude5CalibratedProvider,
-      identityErrorHint:
-        'use claude-fable-5, claude-fable-5-latest, or a claude-fable-5-YYYYMMDD snapshot with a real calendar date',
       calibration: CLAUDE_FABLE_5_CALIBRATION,
       withheldReason: undefined,
     }),

--- a/packages/providers/src/tokenizers/claude/claudeModelIdentity.test.ts
+++ b/packages/providers/src/tokenizers/claude/claudeModelIdentity.test.ts
@@ -8,6 +8,8 @@ import { describe, expect, it } from 'bun:test';
 import {
   CLAUDE_FABLE_5_CLAIM,
   CLAUDE_OPUS_5_CLAIM,
+  isClaudeFable5PointReleaseModel,
+  isClaudeOpus5PointReleaseModel,
   isSanctionedClaudeFable5Model,
   isSanctionedClaudeOpus5Model,
 } from './claudeModelIdentity.js';
@@ -80,7 +82,7 @@ describe('Claude 5 anchored model identity', () => {
     expect(isSanctionedClaudeOpus5Model('claude-opus-5-20000229')).toBe(true);
   });
 
-  it('claims lookalike suffixes so they fail loudly instead of silently', () => {
+  it('claims lookalike suffixes so they take an explicit warned legacy fallback', () => {
     expect(CLAUDE_OPUS_5_CLAIM.test('claude-opus-5-mini')).toBe(true);
     expect(isSanctionedClaudeOpus5Model('claude-opus-5-mini')).toBe(false);
     expect(CLAUDE_FABLE_5_CLAIM.test('claude-fable-5-mini')).toBe(true);
@@ -101,5 +103,78 @@ describe('Claude 5 anchored model identity', () => {
   it('claims each family without claiming the other', () => {
     expect(CLAUDE_OPUS_5_CLAIM.test('claude-fable-5')).toBe(false);
     expect(CLAUDE_FABLE_5_CLAIM.test('claude-opus-5')).toBe(false);
+  });
+});
+
+describe('Claude 5 point-release model identity', () => {
+  const OPUS_5_POINT_RELEASES = [
+    'claude-opus-5-1',
+    'claude-opus-5-2',
+    'claude-opus-5-1-latest',
+    'claude-opus-5-1-20260829',
+    'claude-opus-5-12345678-latest',
+    'claude-opus-5-12345678-20260829',
+    'CLAUDE-OPUS-5-1',
+    'Claude-Opus-5-1-Latest',
+  ];
+
+  const FABLE_5_POINT_RELEASES = [
+    'claude-fable-5-1',
+    'claude-fable-5-2',
+    'claude-fable-5-1-latest',
+    'claude-fable-5-1-20260829',
+    'claude-fable-5-12345678-latest',
+    'CLAUDE-FABLE-5-1-20260829',
+  ];
+
+  const POINT_RELEASE_NEAR_MISSES = [
+    'claude-opus-5-1-20261345',
+    'claude-opus-5-1-2',
+    'claude-opus-5-mini',
+    'claude-opus-5-thinking',
+    'claude-opus-5-1-',
+    'claude-opus-5-latest',
+    'claude-opus-5-20260829',
+    'claude-opus-5-20261345',
+    'claude-opus-5-12345678',
+    'claude-fable-5-12345678',
+    'claude-opus-50',
+    'claude-opus-4-8',
+    'claude-fable-5',
+    '',
+  ];
+
+  it.each(OPUS_5_POINT_RELEASES)(
+    'accepts %s as an Opus 5 point release',
+    (model) => {
+      expect(isClaudeOpus5PointReleaseModel(model)).toBe(true);
+    },
+  );
+
+  it.each(FABLE_5_POINT_RELEASES)(
+    'accepts %s as a Fable 5 point release',
+    (model) => {
+      expect(isClaudeFable5PointReleaseModel(model)).toBe(true);
+    },
+  );
+
+  it.each(POINT_RELEASE_NEAR_MISSES)(
+    'rejects the near miss %s as a point release',
+    (model) => {
+      expect(isClaudeOpus5PointReleaseModel(model)).toBe(false);
+      expect(isClaudeFable5PointReleaseModel(model)).toBe(false);
+    },
+  );
+
+  it('does not let either family claim the other point releases', () => {
+    expect(isClaudeFable5PointReleaseModel('claude-opus-5-1')).toBe(false);
+    expect(isClaudeOpus5PointReleaseModel('claude-fable-5-1')).toBe(false);
+  });
+
+  it('keeps point releases outside the sanctioned identity', () => {
+    expect(isClaudeOpus5PointReleaseModel('claude-opus-5-1')).toBe(true);
+    expect(isSanctionedClaudeOpus5Model('claude-opus-5-1')).toBe(false);
+    expect(isClaudeFable5PointReleaseModel('claude-fable-5-1')).toBe(true);
+    expect(isSanctionedClaudeFable5Model('claude-fable-5-1')).toBe(false);
   });
 });

--- a/packages/providers/src/tokenizers/claude/claudeModelIdentity.ts
+++ b/packages/providers/src/tokenizers/claude/claudeModelIdentity.ts
@@ -21,9 +21,9 @@ const FABLE_5_PREFIX = 'claude-fable-5';
 
 /**
  * Claim patterns are deliberately broader than identity: a lookalike such as
- * `claude-opus-5-mini` is claimed by the family so it fails with an actionable
- * identity error instead of silently falling through to a generic character
- * heuristic.
+ * `claude-opus-5-mini` is claimed by the family so it takes an explicit,
+ * warned legacy fallback instead of silently falling through to a generic
+ * character heuristic.
  */
 export const CLAUDE_OPUS_5_CLAIM = /^claude-opus-5(?:$|-)/i;
 export const CLAUDE_FABLE_5_CLAIM = /^claude-fable-5(?:$|-)/i;
@@ -46,4 +46,41 @@ export function isSanctionedClaudeOpus5Model(model: string): boolean {
 
 export function isSanctionedClaudeFable5Model(model: string): boolean {
   return matchesAnchoredIdentity(FABLE_5_PREFIX, model);
+}
+
+/**
+ * A point release is the family prefix plus one additional numeric version
+ * segment, optionally followed by `-latest` or a real compact `-YYYYMMDD`
+ * date: `claude-fable-5-1`, `claude-fable-5-1-latest`,
+ * `claude-fable-5-1-20260829`.
+ *
+ * A bare 8-digit run directly after the prefix is the date-snapshot shape
+ * rather than a version segment, so a bare `-20260829` (or an impossible date
+ * like `-20261345`) is never a point release; with a `-latest` or real date
+ * suffix the digits are a version segment again
+ * (`claude-fable-5-12345678-latest`). Point releases are not sanctioned
+ * identities; they inherit the family calibration with an explicit warning
+ * until a dedicated calibration exists.
+ */
+const POINT_RELEASE_QUALIFIER = /^-(\d+)(?:-latest)?$/;
+const POINT_RELEASE_DATE_QUALIFIER = /^-\d+-[0-9]{8}$/;
+
+function matchesAnchoredPointRelease(prefix: string, model: string): boolean {
+  const normalized = model.toLowerCase();
+  if (!normalized.startsWith(prefix)) return false;
+  const qualifier = normalized.slice(prefix.length);
+  if (POINT_RELEASE_DATE_QUALIFIER.test(qualifier)) {
+    return isCompactDateSnapshot(qualifier.slice(-8));
+  }
+  const match = POINT_RELEASE_QUALIFIER.exec(qualifier);
+  if (match === null) return false;
+  return qualifier.endsWith('-latest') || match[1].length !== 8;
+}
+
+export function isClaudeOpus5PointReleaseModel(model: string): boolean {
+  return matchesAnchoredPointRelease(OPUS_5_PREFIX, model);
+}
+
+export function isClaudeFable5PointReleaseModel(model: string): boolean {
+  return matchesAnchoredPointRelease(FABLE_5_PREFIX, model);
 }

--- a/packages/providers/src/tokenizers/claude/claudePromptEstimator.test.ts
+++ b/packages/providers/src/tokenizers/claude/claudePromptEstimator.test.ts
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
 import * as tiktoken from '@dqbd/tiktoken';
 import type {
   RuntimePromptEstimateRequest,
   RuntimePromptEstimateResult,
 } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeTokenizerFactory.js';
 import type { PromptEnvelopeProtocol } from '@vybestack/llxprt-code-core/runtime/contracts/PromptEstimation.js';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import { PROJECTION_REVISION } from '../../runtime/promptEnvelopeProjections.js';
 import { ModelPromptEstimatorError } from '../ModelPromptEstimatorError.js';
 import { ModelPromptEstimatorRegistry } from '../ModelPromptEstimatorRegistry.js';
@@ -400,6 +401,23 @@ describe('Claude 5 incremental history counter', () => {
     );
   });
 
+  it('counts a point-release history entry with the family marginal calibration', async () => {
+    const tokenizer = createClaudeRuntimeTokenizer(
+      'claudecode',
+      'claude-fable-5-1',
+    );
+    expect(tokenizer).toBeDefined();
+    const encoder = tiktoken.get_encoding('o200k_base');
+    const baseTokens = encoder.encode(HISTORY_TEXT, [], []).length;
+    expect(await tokenizer!.countTokens(HISTORY_TEXT)).toBe(
+      applyClaudeMarginalCalibration(
+        baseTokens,
+        extractClaudeContentFeatures(HISTORY_TEXT),
+        CLAUDE_FABLE_5_CALIBRATION,
+      ),
+    );
+  });
+
   /**
    * The intercept is per-request framing carried by the synchronized baseline.
    * Charging it to every history entry would inflate the running total by
@@ -545,38 +563,142 @@ describe('Claude 5 registry composition', () => {
     expect(fable.estimatorVersion).toContain('claude-fable-5');
   });
 
-  it('rejects a Fable 5 lookalike with an actionable identity error', async () => {
-    const error = await captureRejection(
-      registry.estimatePrompt(
-        request(
-          { promptText: CONTENT_SHAPES.prose },
-          {
-            canonicalModel: 'claude-fable-5-mini',
-          },
-        ),
+  it('estimates a Fable 5 point release with its family calibration instead of the legacy estimate', async () => {
+    const legacyEstimate = vi.fn(() => Promise.resolve(4242));
+    const result = await registry.estimatePrompt(
+      request(
+        { promptText: CONTENT_SHAPES.prose },
+        {
+          activeProvider: 'claudecode',
+          canonicalModel: 'claude-fable-5-1',
+          legacyEstimate,
+        },
       ),
     );
-    expect(error).toBeInstanceOf(ModelPromptEstimatorError);
-    expect((error as ModelPromptEstimatorError).code).toBe(
-      'unresolved-model-identity',
+    expect(result.family).toBe(CLAUDE_FABLE_5_ESTIMATOR_FAMILY);
+    expect(result.method).toBe('calibrated');
+    expect(result.estimatorVersion).toBe(
+      CLAUDE_FABLE_5_CALIBRATION.estimatorVersion,
+    );
+    expect(result.count).toBeGreaterThan(0);
+    expect(legacyEstimate).not.toHaveBeenCalled();
+  });
+
+  it('estimates an Opus 5 point release with the opus calibration', async () => {
+    const legacyEstimate = vi.fn(() => Promise.resolve(4242));
+    const result = await registry.estimatePrompt(
+      request(
+        { promptText: CONTENT_SHAPES.prose },
+        {
+          activeProvider: 'claudecode',
+          canonicalModel: 'claude-opus-5-1',
+          legacyEstimate,
+        },
+      ),
+    );
+    expect(result.family).toBe(CLAUDE_OPUS_5_ESTIMATOR_FAMILY);
+    expect(result.method).toBe('calibrated');
+    expect(result.estimatorVersion).toBe(
+      CLAUDE_OPUS_5_CALIBRATION.estimatorVersion,
+    );
+    expect(legacyEstimate).not.toHaveBeenCalled();
+  });
+
+  it('estimates a dated point release with the family calibration', async () => {
+    const result = await registry.estimatePrompt(
+      request(
+        { promptText: CONTENT_SHAPES.prose },
+        {
+          activeProvider: 'claudecode',
+          canonicalModel: 'claude-fable-5-1-20260829',
+        },
+      ),
+    );
+    expect(result.family).toBe(CLAUDE_FABLE_5_ESTIMATOR_FAMILY);
+    expect(result.estimatorVersion).toBe(
+      CLAUDE_FABLE_5_CALIBRATION.estimatorVersion,
     );
   });
 
-  it('rejects an Opus 5 lookalike with an actionable identity error', async () => {
-    const error = await captureRejection(
-      registry.estimatePrompt(
-        request(
-          { promptText: CONTENT_SHAPES.prose },
-          {
-            canonicalModel: 'claude-opus-5-mini',
-          },
-        ),
+  it('estimates an eight-digit point release with -latest using the family calibration', async () => {
+    const legacyEstimate = vi.fn(() => Promise.resolve(4242));
+    const result = await registry.estimatePrompt(
+      request(
+        { promptText: CONTENT_SHAPES.prose },
+        {
+          activeProvider: 'claudecode',
+          canonicalModel: 'claude-fable-5-12345678-latest',
+          legacyEstimate,
+        },
       ),
     );
-    expect(error).toBeInstanceOf(ModelPromptEstimatorError);
-    expect((error as ModelPromptEstimatorError).code).toBe(
-      'unresolved-model-identity',
+    expect(result.family).toBe(CLAUDE_FABLE_5_ESTIMATOR_FAMILY);
+    expect(result.method).toBe('calibrated');
+    expect(result.estimatorVersion).toBe(
+      CLAUDE_FABLE_5_CALIBRATION.estimatorVersion,
     );
+    expect(legacyEstimate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the legacy estimate for a point release with an impossible date', async () => {
+    const legacyEstimate = vi.fn(() => Promise.resolve(4242));
+    const result = await registry.estimatePrompt(
+      request(
+        { promptText: CONTENT_SHAPES.prose },
+        {
+          activeProvider: 'claudecode',
+          canonicalModel: 'claude-fable-5-1-20261345',
+          legacyEstimate,
+        },
+      ),
+    );
+    expect(result).toMatchObject({
+      count: 4242,
+      method: 'calibrated',
+      family: 'legacy-unresolved-identity',
+      estimatorVersion: 'core-estimate-tokens-v1',
+      assetRevision: 'none',
+      projectionRevision: PROJECTION_REVISION,
+    });
+    expect(legacyEstimate).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the legacy estimate for a Fable 5 lookalike', async () => {
+    const legacyEstimate = vi.fn(() => Promise.resolve(4242));
+    const result = await registry.estimatePrompt(
+      request(
+        { promptText: CONTENT_SHAPES.prose },
+        { canonicalModel: 'claude-fable-5-mini', legacyEstimate },
+      ),
+    );
+    expect(result).toMatchObject({
+      count: 4242,
+      method: 'calibrated',
+      family: 'legacy-unresolved-identity',
+      estimatorVersion: 'core-estimate-tokens-v1',
+      assetRevision: 'none',
+      projectionRevision: PROJECTION_REVISION,
+    });
+    expect(legacyEstimate).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the legacy estimate for an Opus 5 lookalike', async () => {
+    const legacyEstimate = vi.fn(() => Promise.resolve(4242));
+    const result = await registry.estimatePrompt(
+      request(
+        { promptText: CONTENT_SHAPES.prose },
+        { canonicalModel: 'claude-opus-5-mini', legacyEstimate },
+      ),
+    );
+    expect(result).toMatchObject({
+      count: 4242,
+      method: 'calibrated',
+      family: 'legacy-unresolved-identity',
+      estimatorVersion: 'core-estimate-tokens-v1',
+      assetRevision: 'none',
+      projectionRevision: PROJECTION_REVISION,
+    });
+    expect(legacyEstimate).toHaveBeenCalledTimes(1);
   });
 
   it.each(['openai-chat', 'openai-responses'] as const)(
@@ -616,21 +738,43 @@ describe('Claude 5 registry composition', () => {
     },
   );
 
-  it('still rejects an unsanctioned model id on a calibrated provider', async () => {
+  it('still throws unsupported-protocol for a point release over the wrong protocol', async () => {
     const error = await captureRejection(
       registry.estimatePrompt(
         request(
-          { promptText: CONTENT_SHAPES.prose },
+          { promptText: CONTENT_SHAPES.prose, protocol: 'openai-chat' },
           {
             activeProvider: 'claudecode',
-            canonicalModel: 'claude-opus-5-mini',
+            canonicalModel: 'claude-fable-5-1',
+            protocol: 'openai-chat',
           },
         ),
       ),
     );
+    expect(error).toBeInstanceOf(ModelPromptEstimatorError);
     expect((error as ModelPromptEstimatorError).code).toBe(
-      'unresolved-model-identity',
+      'unsupported-protocol',
     );
+  });
+
+  it('falls back to the legacy estimate for an unsanctioned model id on a calibrated provider', async () => {
+    const legacyEstimate = vi.fn(() => Promise.resolve(4242));
+    const result = await registry.estimatePrompt(
+      request(
+        { promptText: CONTENT_SHAPES.prose },
+        {
+          activeProvider: 'claudecode',
+          canonicalModel: 'claude-opus-5-thinking',
+          legacyEstimate,
+        },
+      ),
+    );
+    expect(result).toMatchObject({
+      count: 4242,
+      method: 'calibrated',
+      family: 'legacy-unresolved-identity',
+    });
+    expect(legacyEstimate).toHaveBeenCalledTimes(1);
   });
 
   it('does not claim other Claude models', () => {
@@ -642,5 +786,73 @@ describe('Claude 5 registry composition', () => {
     ]) {
       expect(registry.claimsModel(model)).toBe(false);
     }
+  });
+
+  describe('degradation warnings', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = vi
+        .spyOn(DebugLogger.prototype, 'warn')
+        .mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('warns once per process that a point release inherits the family calibration', async () => {
+      const estimate = () =>
+        registry.estimatePrompt(
+          request(
+            { promptText: CONTENT_SHAPES.prose },
+            {
+              activeProvider: 'claudecode',
+              canonicalModel: 'claude-fable-5-3',
+            },
+          ),
+        );
+      const first = await estimate();
+      expect(first.family).toBe(CLAUDE_FABLE_5_ESTIMATOR_FAMILY);
+      await estimate();
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = String(warnSpy.mock.calls[0]?.[0] ?? '');
+      expect(message).toContain('claude-fable-5-3');
+      expect(message).toContain(CLAUDE_FABLE_5_ESTIMATOR_FAMILY);
+      expect(message).toContain('claudecode');
+      expect(message).toContain('not directly calibrated');
+    });
+
+    it('warns once per process that an unsanctioned lookalike falls back to the legacy estimate', async () => {
+      const estimate = () =>
+        registry.estimatePrompt(
+          request(
+            { promptText: CONTENT_SHAPES.prose },
+            {
+              activeProvider: 'claudecode',
+              canonicalModel: 'claude-fable-5-thinking',
+            },
+          ),
+        );
+      const first = await estimate();
+      expect(first.family).toBe('legacy-unresolved-identity');
+      await estimate();
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = String(warnSpy.mock.calls[0]?.[0] ?? '');
+      expect(message).toContain('claude-fable-5-thinking');
+      expect(message).toContain(CLAUDE_FABLE_5_ESTIMATOR_FAMILY);
+      expect(message).toContain('claudecode');
+      expect(message).toContain('legacy');
+    });
+
+    it('does not warn for a sanctioned model on a calibrated provider', async () => {
+      const result = await registry.estimatePrompt(
+        request({ promptText: CONTENT_SHAPES.prose }),
+      );
+      expect(result.family).toBe(CLAUDE_OPUS_5_ESTIMATOR_FAMILY);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/providers/src/tokenizers/claude/claudePromptEstimator.ts
+++ b/packages/providers/src/tokenizers/claude/claudePromptEstimator.ts
@@ -161,14 +161,25 @@ export async function estimateClaude5Prompt(
   }
 }
 
+function acceptsModelIdentity(
+  spec: Claude5FamilySpec,
+  canonicalModel: string,
+): boolean {
+  return (
+    spec.matches(canonicalModel) ||
+    (spec.matchesPointRelease?.(canonicalModel) ?? false)
+  );
+}
+
 /**
  * Per-entry token counter for incremental history accounting.
  *
  * Uses the same calibration as the pre-send estimate but in its marginal form,
  * because a history entry carries content, not the per-request framing the
- * intercept models. Returns undefined for anything this family has not
- * measured, so unclaimed models keep their existing counter rather than
- * receiving coefficients fitted elsewhere.
+ * intercept models. Point releases are counted with their family's marginal
+ * calibration, matching how their envelope is estimated. Returns undefined
+ * for anything this family has not measured, so unclaimed models keep their
+ * existing counter rather than receiving coefficients fitted elsewhere.
  */
 export function createClaudeRuntimeTokenizer(
   activeProvider: string,
@@ -177,7 +188,7 @@ export function createClaudeRuntimeTokenizer(
   const spec = CLAUDE_5_FAMILY_SPECS.find(
     (candidate) =>
       candidate.claim.test(canonicalModel) &&
-      candidate.matches(canonicalModel) &&
+      acceptsModelIdentity(candidate, canonicalModel) &&
       candidate.appliesToProvider(activeProvider),
   );
   const calibration = spec?.calibration;
@@ -216,9 +227,9 @@ function toRegistration(
     family: spec.family,
     claim: spec.claim,
     matches: spec.matches,
+    matchesPointRelease: spec.matchesPointRelease,
     protocols: spec.protocols,
     appliesToProvider: spec.appliesToProvider,
-    identityErrorHint: spec.identityErrorHint,
     estimate: (request: RuntimePromptEstimateRequest) =>
       estimateClaude5Prompt(request, spec),
   });

--- a/packages/providers/src/tokenizers/official/officialPromptEstimators.ts
+++ b/packages/providers/src/tokenizers/official/officialPromptEstimators.ts
@@ -39,7 +39,6 @@ interface OfficialFamilySpec {
   readonly claim: RegExp;
   readonly identity: RegExp;
   readonly protocols: ReadonlySet<PromptEnvelopeProtocol>;
-  readonly identityErrorHint: string;
   readonly create: () => OfficialSegmentCounter;
 }
 
@@ -73,8 +72,6 @@ const OFFICIAL_FAMILY_SPECS: readonly OfficialFamilySpec[] = Object.freeze([
     claim: /^(?:[a-z0-9_.-]+\/)?kimi-k3(?:$|-)/i,
     identity: /^(?:[a-z0-9_.-]+\/)?kimi-k3(?:-[a-z0-9.-]+)?$/i,
     protocols: OPENAI_CHAT_ONLY,
-    identityErrorHint:
-      'use a canonical kimi-k3 model id, optionally with a vendor prefix or dated snapshot suffix',
     create: () => new KimiK3Tokenizer(),
   },
   {
@@ -84,8 +81,6 @@ const OFFICIAL_FAMILY_SPECS: readonly OfficialFamilySpec[] = Object.freeze([
     claim: /^(?:[a-z0-9_.-]+\/)?glm-5\.2(?:$|-)/i,
     identity: /^(?:[a-z0-9_.-]+\/)?glm-5\.2(?:-[a-z0-9.-]+)?$/i,
     protocols: OPENAI_CHAT_AND_ANTHROPIC,
-    identityErrorHint:
-      'use a canonical glm-5.2 model id, optionally with a vendor prefix or dated snapshot suffix',
     create: () => new GlmTokenizer(),
   },
   {
@@ -95,8 +90,6 @@ const OFFICIAL_FAMILY_SPECS: readonly OfficialFamilySpec[] = Object.freeze([
     claim: /^(?:[a-z0-9_.-]+\/)?minimax-m3(?:$|-)/i,
     identity: /^(?:[a-z0-9_.-]+\/)?minimax-m3(?:-[a-z0-9.-]+)?$/i,
     protocols: OPENAI_CHAT_ONLY,
-    identityErrorHint:
-      'use a canonical minimax-m3 model id, optionally with a vendor prefix or dated snapshot suffix',
     create: () => new MinimaxTokenizer(),
   },
 ]);
@@ -232,7 +225,6 @@ function toRegistration(
     claim: spec.claim,
     matches: (model: string) => spec.identity.test(model),
     protocols: spec.protocols,
-    identityErrorHint: spec.identityErrorHint,
     estimate: (request: RuntimePromptEstimateRequest) =>
       estimateOfficialPrompt(request, spec),
   });

--- a/project-plans/estimator-identity-fallback-3485/PLAN.md
+++ b/project-plans/estimator-identity-fallback-3485/PLAN.md
@@ -1,0 +1,242 @@
+# Plan: Prompt estimator must not block unrecognized model identities (Issue #3485)
+
+Plan ID: PLAN-20260901-ISSUE3485
+Generated: 2026-09-01 (amended same day after owner direction)
+Total Phases: 1
+Requirements: REQ-3485-1 (no-throw), REQ-3485-2 (point releases inherit family calibration), REQ-3485-3 (warn on every degradation), REQ-3485-4 (no other behavior change), REQ-3485-5 (dead code removal)
+
+## Problem
+
+`ModelPromptEstimatorRegistry.estimatePrompt`
+(`packages/providers/src/tokenizers/ModelPromptEstimatorRegistry.ts`) throws
+`ModelPromptEstimatorError('unresolved-model-identity')` when a model ID is
+*claimed* by a registration's claim regex (e.g. `/^claude-fable-5(?:$|-)/i`)
+but fails that family's sanctioned-identity check (bare alias, `-latest`, or a
+real `-YYYYMMDD` snapshot). A newly released model such as
+`claude-fable-5-1` is claimed-but-unsanctioned, so every send throws, the error
+propagates through `providerContentEnforcement.estimateProviderProjection`
+("Token projection failed at initial stage during provider-content hard-limit
+enforcement: ..."), and the request aborts. Users cannot use new model releases
+in claimed families at all (issue #3485).
+
+Owner direction (2026-09-01): point releases of a known line (e.g.
+`claude-fable-5-1`) must NOT fall back to the legacy estimator — they must use
+the family's calibration (fable-5 for fable-5-1) until a dedicated calibration
+exists, with a warning. Legacy fallback is only for non-versioned lookalikes.
+
+## Accepted behavior
+
+### REQ-3485-1: No-throw for claimed-but-unsanctioned identities
+
+**Full text**: For a model claimed by a registration whose `matches` check
+fails, `estimatePrompt` MUST NOT throw. It MUST either inherit the family
+estimate (REQ-3485-2, point releases) or return the legacy-path result
+(REQ-3485-3 path): `count` from `request.legacyEstimate()`, `method:
+'calibrated'`, `estimatorVersion: 'core-estimate-tokens-v1'`, `assetRevision:
+'none'`, `projectionRevision` echoed, family `'legacy-unresolved-identity'`.
+
+**Behavior**:
+- GIVEN: provider `claudecode`, model `claude-opus-5-mini`, protocol
+  `anthropic-messages`
+- WHEN: the runtime estimates the finalized prompt envelope
+- THEN: estimation resolves with the legacy count and the request proceeds
+
+**Why**: The registry sits on the request path; any throw blocks usage of the
+model entirely.
+
+### REQ-3485-2: Point releases inherit the family calibration
+
+**Full text**: When a claimed-but-unsanctioned model is a *point release* of
+the family — the qualifier after the family prefix is one additional numeric
+version segment, optionally followed by `-latest` or a real compact
+`-YYYYMMDD` date — the registration's estimate MUST be used (the family's
+calibration, e.g. fable-5's for `claude-fable-5-1`), after the same
+protocol check sanctioned models pass. Only the Claude 5 families declare this
+rule (GPT-5.6 and official families keep `matchesPointRelease` unset).
+
+**Behavior**:
+- GIVEN: provider `claudecode`, model `claude-fable-5-1`, protocol
+  `anthropic-messages` (the issue's exact case)
+- WHEN: the runtime estimates the finalized prompt envelope
+- THEN: the result comes from the fable-5 calibration — `family
+  'anthropic-claude-fable-5'`, `method 'calibrated'`, the real fable-5
+  `estimatorVersion`/`assetRevision` — and `legacyEstimate` is NOT called
+
+**Why**: A point release of the same model line keeps the line's tokenizer
+characteristics; the calibrated family estimate is far closer than the ~34%
+MAPE character heuristic. The owner explicitly directed this over legacy.
+
+### REQ-3485-3: Warn on every degradation
+
+**Full text**: Both degradations (point-release inheritance and
+legacy-unregistered fallback) MUST emit one warning per `provider:model` pair
+per process through a module-level `DebugLogger`
+('llxprt:model-prompt-estimator'). The point-release warning states the model
+is not directly calibrated and the family calibration is applied until a
+dedicated one exists, so estimates may be less accurate. The legacy warning
+states the identity is not sanctioned and the generic estimate may be
+inaccurate.
+
+**Behavior**:
+- GIVEN: `claude-fable-5-1` estimated twice in one process
+- WHEN: each estimate runs
+- THEN: the warning fires exactly once; the second estimate is warning-free
+
+**Why**: The issue asks to be warned that estimates could be off; the debug
+channel is the providers package's established warning mechanism.
+
+### REQ-3485-4: No other behavior change
+
+**Full text**: Sanctioned identities keep their calibrated estimation
+unchanged; sanctioned models (and point releases) on unsupported protocols
+still throw `unsupported-protocol`; unclaimed models keep the silent
+legacy-unregistered path (no warning); claims on providers the family does not
+apply to (e.g. `claude-fable-5-1` via `zai`) keep the silent legacy path;
+`claimsModel`/`getEstimatorFamily` stay claim-based; sanctioned-identity rules
+in `claudeModelIdentity.ts` (`isSanctionedClaude*`) and `openaiModelPolicy.ts`
+are NOT widened; calibration assets, `providerContentEnforcement`,
+`promptEnvelopeSendSeam`, and the load-balancer `projection-unavailable` guard
+are untouched. The Claude runtime tokenizer
+(`createClaudeRuntimeTokenizer`) MUST also accept point releases so per-entry
+history accounting uses the same marginal calibration as envelope estimation.
+
+### REQ-3485-5: Dead code removal
+
+**Full text**: Remove the now-unreachable `'unresolved-model-identity'` from
+`ModelPromptEstimatorErrorCode`, delete `createIdentityError` in the registry,
+and remove the `identityErrorHint` field from
+`ModelPromptEstimatorRegistration`, `Claude5FamilySpec`, the Claude specs, the
+GPT-5.6 registration, and the official family specs (it existed only to build
+the removed error).
+
+## Point-release identity rule (Claude 5)
+
+New helpers in `claudeModelIdentity.ts`, e.g.
+`isClaudeOpus5PointReleaseModel` / `isClaudeFable5PointReleaseModel` sharing
+one predicate over `(prefix, model)`:
+
+- qualifier after the family prefix (case-insensitive) MUST match
+  `-\d+` (one numeric version segment), optionally followed by exactly
+  `-latest` or `-\d{8}` where the 8 digits are a real calendar date (reuse
+  `isCompactDateSnapshot`)
+- anything else (`-mini`, `-thinking`, `-1-20261345` invalid date, `-1-2`
+  nested segments, trailing `-`, `-latest` without a numeric segment) is NOT a
+  point release → legacy fallback path
+
+Sanctioned identity lists (bare, `-latest`, real `-YYYYMMDD`) are unchanged;
+point releases are a separate, explicitly warned category.
+
+## Registration interface change
+
+`ModelPromptEstimatorRegistration` gains an optional
+`matchesPointRelease?: (model: string) => boolean`. The registry's
+claimed-but-unsanctioned branch becomes:
+
+1. `matchesPointRelease?.(model) === true` → warn-once → protocol check →
+   `registration.estimate(request)`
+2. otherwise → warn-once → legacy result with family
+   `'legacy-unresolved-identity'`
+
+`Claude5FamilySpec` gains the same optional field, wired through
+`toRegistration`; `createClaudeRuntimeTokenizer` matches
+`matches(m) || matchesPointRelease?.(m)`.
+
+## Boundary cases
+
+- `claude-fable-5-1` — the issue's case; fable-5 calibration, warns once.
+- `claude-fable-5-1-latest`, `claude-fable-5-1-20260829` (real date) —
+  point releases; same.
+- `claude-opus-5-1` — point release of the opus family; opus-5 calibration.
+- `CLAUDE-FABLE-5-1` — case-insensitive claim; point release (warning uses the
+  reported model string).
+- Lookalikes: `claude-opus-5-mini`, `claude-fable-5-mini`, `gpt-5.6-mini`,
+  `gpt-5.6-solar`, `gpt-5.6-2026-02-30`, `claude-opus-5-20261345`,
+  `claude-fable-5-1-20261345` — legacy fallback, warn once.
+- Point release on non-calibrated provider (`claude-fable-5-1` via `zai`):
+  registration does not apply — silent legacy path, no warning (unchanged).
+- Point release/sanctioned + wrong protocol (`claude-fable-5-1` over
+  `openai-chat`): still throws `unsupported-protocol`.
+- Unclaimed (`gpt-4.1`, `claude-opus-4-8`): silent legacy path, no warning.
+
+## Test plan (behavioral, TS/Bun)
+
+1. `packages/providers/src/tokenizers/claude/claudeModelIdentity.test.ts`
+   - ADD point-release predicate tests: accepts `-1`, `-2`, `-1-latest`,
+     `-1-20260829`; rejects `-1-20261345`, `-1-2`, `-mini`, `-1-`, `-latest`,
+     `-20260829` (no numeric segment); per-family separation
+     (`claude-opus-5-1` is not a fable point release).
+   - Existing sanctioned/near-miss lists unchanged.
+2. `packages/providers/src/tokenizers/claude/claudePromptEstimator.test.ts`
+   - ADD: `claude-fable-5-1` via claudecode resolves with fable-5 family,
+     method 'calibrated', real fable-5 estimatorVersion, `legacyEstimate` not
+     called; `claude-opus-5-1` → opus family; date-suffixed
+     `claude-fable-5-1-20260829` → point release;
+     `claude-fable-5-1-20261345` → legacy fallback.
+   - REWRITE the three rejection tests ('rejects a Fable 5 lookalike...',
+     'rejects an Opus 5 lookalike...', 'still rejects an unsanctioned model
+     id on a calibrated provider') to assert legacy fallback: resolves,
+     `count` equals the legacy estimate, family
+     `'legacy-unresolved-identity'`, `legacyEstimate` called.
+   - ADD warning assertions (DebugLogger spy pattern consistent with existing
+     prototype spies in the package): point-release warning fires once and not
+     on the second estimate; legacy warning fires once.
+   - `createClaudeRuntimeTokenizer` block: ADD
+     `createClaudeRuntimeTokenizer('claudecode', 'claude-fable-5-1')` defined
+     and counting with the fable marginal calibration; keep the
+     `claude-opus-5-mini` undefined case.
+3. `packages/providers/src/tokenizers/Gpt56O200kPromptEstimator.test.ts`
+   - REPLACE 'rejects claimed malformed identity %s without legacy fallback'
+     with legacy-fallback assertions for the same model list (family
+     `'legacy-unresolved-identity'`, count 999, legacyEstimate called).
+   - GPT-5.6 declares no point-release rule, so all lookalikes take the
+     legacy path.
+4. `packages/providers/src/runtime/providerManagerRuntimeFactories.test.ts`
+   - ADD: full `createRuntimeTokenizerFactory().estimatePrompt` with
+     `claude-fable-5-1` (anthropic-messages projection, claudecode provider)
+     resolves with the fable-5 family — proves the composition wiring lets the
+     issue's request through with family calibration (follow the existing
+     loader-injection pattern if needed for the encoder).
+5. Existing tests that must stay green unchanged: unsupported-protocol
+   rejections (Claude + GPT-5.6 + official framing separation), unclaimed
+   legacy fallback, sanctioned identity routing, calibration gating,
+   runtime-tokenizer provider restriction.
+
+## Files
+
+- Modify: `packages/providers/src/tokenizers/ModelPromptEstimatorRegistry.ts`
+  (claimed-but-unsanctioned: point-release inheritance or legacy fallback;
+  warn-once via new DebugLogger; delete `createIdentityError`; drop
+  `identityErrorHint`; add optional `matchesPointRelease`)
+- Modify: `packages/providers/src/tokenizers/ModelPromptEstimatorError.ts`
+  (remove the error code)
+- Modify: `packages/providers/src/tokenizers/claude/claudeModelIdentity.ts`
+  (point-release predicate helpers)
+- Modify:
+  `packages/providers/src/tokenizers/claude/claudeCalibrationAssets.ts`
+  (`Claude5FamilySpec.matchesPointRelease` + both specs)
+- Modify: `packages/providers/src/tokenizers/claude/claudePromptEstimator.ts`
+  (forward `matchesPointRelease` in `toRegistration`; runtime tokenizer
+  accepts point releases)
+- Modify: `packages/providers/src/tokenizers/Gpt56O200kPromptEstimator.ts`
+  (drop `identityErrorHint` from the registration constant)
+- Modify: `packages/providers/src/tokenizers/official/officialPromptEstimators.ts`
+  (drop `identityErrorHint` from `OfficialFamilySpec` and registrations)
+- Modify tests listed above.
+
+## Out of scope (explicitly)
+
+- Widening sanctioned identity (`isSanctionedClaude*`) or the GPT/official
+  identity rules; point releases are a separate warned category, not
+  "sanctioned".
+- Point-release rules for GPT-5.6 or official families (their versioning is
+  different; raise separately if a real release needs it).
+- UI-visible notice beyond the debug-channel warning (would need a new
+  cross-package event surface; raise separately if wanted).
+- Changes to calibration assets, enforcement, send seam, or the load-balancer
+  `projection-unavailable` guard.
+
+## Verification
+
+Full cycle per the issue workflow (`npm run test`, `lint`, `typecheck`,
+`format`, `build`, bun smoke with profile stepfun-37), plus targeted:
+`bun test packages/providers/src/tokenizers/ packages/providers/src/runtime/providerManagerRuntimeFactories.test.ts`


### PR DESCRIPTION
## TLDR

The prompt estimator registry threw `unresolved-model-identity` for any model claimed by a family registration but absent from that family's sanctioned identity list, so a newly released model like `claude-fable-5-1` could not be used at all: the throw sits on the request path and every send aborted with "Token projection failed at initial stage during provider-content hard-limit enforcement". The registry now degrades instead of throwing. Point releases of a Claude 5 line inherit the family calibration (fable-5's coefficients for `claude-fable-5-1`), and every other claimed-but-unsanctioned lookalike falls back to the legacy estimate. Both paths warn once per `provider:model` pair through the `llxprt:model-prompt-estimator` debug channel so the user knows the estimate may be off.

Fixes #3485.

## Dive Deeper

**Behavior matrix (all covered by tests):**

| Input | Before | After |
| --- | --- | --- |
| `claude-fable-5-1` (issue's case) | threw, request aborted | fable-5 calibration, warn once |
| `claude-fable-5-1-latest`, `claude-fable-5-1-20260829` | threw | fable-5 calibration, warn once |
| `claude-opus-5-1` (any point release of the line) | threw | opus-5 calibration, warn once |
| `claude-opus-5-mini`, `claude-fable-5-thinking`, `gpt-5.6-solar`, `gpt-5.6-2026-02-30` | threw | legacy estimate, family `legacy-unresolved-identity`, warn once |
| sanctioned ids (`claude-fable-5`, `-latest`, real date snapshots) | calibrated | calibrated (unchanged) |
| point release on wrong protocol (`openai-chat`) | `unsupported-protocol` throw | `unsupported-protocol` throw (unchanged) |
| point release on non-calibrated provider (`zai`) | silent legacy path | silent legacy path (unchanged) |
| unclaimed models (`gpt-4.1`, `claude-opus-4-8`) | silent legacy path | silent legacy path (unchanged) |

**Point-release identity rule** (`claudeModelIdentity.ts`): the qualifier after the family prefix must be one numeric version segment, optionally followed by exactly `-latest` or a real `-YYYYMMDD` compact date (validated as a calendar date). A bare 8-digit run directly after the prefix is the date-snapshot shape, not a version segment, so bare `-20260829` and impossible dates like `-20261345` are never point releases; suffixed forms like `-12345678-latest` are. Nested segments (`-1-2`), trailing dashes, `-mini`-style lookalikes, and wrong-family prefixes are rejected. Matching is case-insensitive and per-family (opus point releases do not match the fable predicate).

**Mechanics:** `ModelPromptEstimatorRegistration` gains optional `matchesPointRelease`; the claimed-but-unsanctioned branch warns once, then either runs the family estimate after the usual protocol check or returns the legacy result (`method: 'calibrated'`, `estimatorVersion: 'core-estimate-tokens-v1'`, `assetRevision: 'none'`, family `legacy-unresolved-identity`). Only the two Claude 5 family specs declare the rule; GPT-5.6 and the official families keep it unset. `createClaudeRuntimeTokenizer` accepts point releases the same way so per-entry history accounting uses the family's marginal calibration. The now-unreachable `unresolved-model-identity` error code, `createIdentityError`, and every `identityErrorHint` field are removed. Sanctioned identity rules, calibration coefficients, `providerContentEnforcement`, the send seam, and the load-balancer `projection-unavailable` guard are untouched.

**Review notes:** deepthinker compliance review passed all five plan requirements with zero findings on the final tree. An open-code-review finding claimed no test asserts the degradation warning; that is incorrect, `claudePromptEstimator.test.ts` spies `DebugLogger.prototype.warn` and asserts warn-once for both degradation paths, and the same finding's unbounded-set concern covers only distinct degraded `provider:model` pairs, so no reset/LRU API was added (fail fast over defensive machinery).

Plan: `project-plans/estimator-identity-fallback-3485/PLAN.md`.

## Reviewer Test Plan

- `bun test packages/providers/src/tokenizers/ packages/providers/src/runtime/providerManagerRuntimeFactories.test.ts` (305 tests, ~6s) covers the matrix above end to end, including the composed runtime factory resolving `claude-fable-5-1` with family `anthropic-claude-fable-5` and the real fable-5 `estimatorVersion`.
- Manual reproduction of the issue: run the CLI with `claudecode:claude-fable-5-1` (previously every send failed with the token-projection error); it now proceeds, and the first estimate logs the point-release warning through debug channel `llxprt:model-prompt-estimator`.
- Negative check: a malformed variant like `claude-fable-5-1-20261345` still sends (legacy estimate) with the legacy-fallback warning; `claude-fable-5-1` over `openai-chat` still throws `unsupported-protocol`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Full verification cycle on macOS (darwin/arm64): test 9297/9298 pass, lint, typecheck, format, build, and the stepfun-37 bun smoke all exit 0. The single test failure was `packages/cli/src/utils/sandbox-entrypoint.test.ts` snapshotting the real user config dir while concurrent sibling sessions were writing to it; it passes in isolation and is tracked in #3480, unrelated to this change.

## Linked issues / bugs

Fixes #3485
Related to #3480 (pre-existing local flake observed during verification, not touched by this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude 5 point-release models are now recognized and use their family’s calibrated prompt estimates.
  * Supported dated and “latest” model variants receive accurate token estimates.

* **Bug Fixes**
  * Unrecognized model identities now fall back gracefully to legacy estimation instead of failing.
  * Degradation warnings are shown only once per provider and model.
  * Invalid or lookalike model names continue using safe legacy estimates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->