### PR TITLE
fix(providers): route credential proxy audit records off the TUI terminal (Fixes #3490)

### DIFF
--- a/packages/cli/src/cliSandbox.test.ts
+++ b/packages/cli/src/cliSandbox.test.ts
@@ -31,7 +31,7 @@ import {
 import { start_sandbox } from './utils/sandbox.js';
 import {
   auditLog,
-  setTuiOwnsTerminal,
+  resetAuditLogStateForTesting,
 } from '@vybestack/llxprt-code-providers/auth.js';
 import { coreEvents, CoreEvent } from '@vybestack/llxprt-code-core';
 import { initializeOutputListenersAndFlush } from './session/outputListeners.js';
@@ -270,6 +270,45 @@ function useUnsetSandboxEnv(): void {
 }
 
 /**
+ * Resets audit-log routing state — terminal ownership, the deferred buffer
+ * and its overflow counter — before AND after every test. An afterEach-only
+ * reset cannot clear records buffered while ownership is already released,
+ * and cannot protect a block that enters dirty; the beforeEach half closes
+ * both gaps.
+ */
+function useAuditLogStateReset(): void {
+  beforeEach(() => {
+    resetAuditLogStateForTesting();
+  });
+  afterEach(() => {
+    resetAuditLogStateForTesting();
+  });
+}
+
+/** Type guard for a valid Node buffer encoding name. */
+function isBufferEncoding(value: unknown): value is BufferEncoding {
+  return typeof value === 'string' && Buffer.isEncoding(value);
+}
+
+/**
+ * Decodes one stderr write chunk into text. Byte chunks must be decoded,
+ * not stringified: String(Uint8Array) yields "[object Uint8Array]", which
+ * would let a broken implementation pass assertions like
+ * expect(stderr).toBe('').
+ */
+function decodeStderrChunk(
+  chunk: string | Uint8Array,
+  encoding: unknown,
+): string {
+  if (typeof chunk === 'string') {
+    return chunk;
+  }
+  return Buffer.from(chunk).toString(
+    isBufferEncoding(encoding) ? encoding : 'utf8',
+  );
+}
+
+/**
  * Installs a stderr collector that records every byte written while it is
  * active, keeping the bytes off the runner's own output. The stream is an
  * external sink being observed, not the unit under test.
@@ -278,8 +317,8 @@ function collectStderr(): { captured: () => string; restore: () => void } {
   const chunks: string[] = [];
   const writeSpy = vi
     .spyOn(process.stderr, 'write')
-    .mockImplementation((chunk: string | Uint8Array) => {
-      chunks.push(typeof chunk === 'string' ? chunk : String(chunk));
+    .mockImplementation((chunk: string | Uint8Array, ...rest: unknown[]) => {
+      chunks.push(decodeStderrChunk(chunk, rest[0]));
       return true;
     });
   return {
@@ -372,6 +411,7 @@ describe('maybeHopIntoSandbox hop-exit stdio flush (#3408)', () => {
 describe('maybeHopIntoSandbox TUI terminal ownership (#3490)', () => {
   const startSandboxMock = start_sandbox as Mock<typeof start_sandbox>;
   useUnsetSandboxEnv();
+  useAuditLogStateReset();
 
   /**
    * Stubs start_sandbox to drive a real INFO audit record mid-hop and
@@ -393,7 +433,6 @@ describe('maybeHopIntoSandbox TUI terminal ownership (#3490)', () => {
     // The file-level factory default; other describes in this file depend
     // on exit code 7.
     startSandboxMock.mockImplementation(async () => 7);
-    setTuiOwnsTerminal(false);
     __resetCleanupStateForTesting();
   });
 

--- a/packages/cli/src/cliSandbox.test.ts
+++ b/packages/cli/src/cliSandbox.test.ts
@@ -11,7 +11,15 @@
  * the full sandbox hop.
  */
 
-import { describe, expect, it, afterEach, vi } from 'bun:test';
+import {
+  describe,
+  expect,
+  it,
+  beforeEach,
+  afterEach,
+  vi,
+  type Mock,
+} from 'bun:test';
 import * as coreModule from '@vybestack/llxprt-code-core';
 import {
   resolveContainerMemoryMB,
@@ -20,6 +28,11 @@ import {
   maybeHopIntoSandbox,
   type SandboxHopOptions,
 } from './cliSandbox.js';
+import { start_sandbox } from './utils/sandbox.js';
+import {
+  auditLog,
+  setTuiOwnsTerminal,
+} from '@vybestack/llxprt-code-providers/auth.js';
 import { coreEvents, CoreEvent } from '@vybestack/llxprt-code-core';
 import { initializeOutputListenersAndFlush } from './session/outputListeners.js';
 import {
@@ -205,7 +218,100 @@ describe('injectStdinIntoArgs', () => {
   });
 });
 
+function buildHopOptions(
+  interactive = false,
+  argv: SandboxHopOptions['argv'] = {} as SandboxHopOptions['argv'],
+): SandboxHopOptions {
+  return {
+    config: {
+      getSandbox: () => ({ command: 'docker', image: 'test-image' }),
+      getDebugMode: () => false,
+      isInteractive: () => interactive,
+    } as SandboxHopOptions['config'],
+    settings: {
+      merged: { ui: { autoConfigureMaxOldSpaceSize: false } },
+    } as SandboxHopOptions['settings'],
+    argv,
+    workspaceRoot: '/tmp/ws',
+    runtimeSettingsService: {} as SandboxHopOptions['runtimeSettingsService'],
+    initialAuthFailed: false,
+    readStdin: async () => '',
+    hasPipedInput: false,
+    bootstrapSelection: null,
+  };
+}
+
+/** A minimal direct-image invocation on a TTY: image flags, no prompt. */
+function imageModeArgv(): SandboxHopOptions['argv'] {
+  return {
+    imagePrompt: 'a watercolor capybara',
+    imageOutput: 'capybara.png',
+  } as SandboxHopOptions['argv'];
+}
+
+/**
+ * Ensures the SANDBOX env var is absent for each test in the describe and
+ * restores the saved value afterwards, so hop tests exercise the hop path
+ * regardless of the environment the runner provides. One registered
+ * lifecycle instead of a save/delete/restore block inside every test.
+ */
+function useUnsetSandboxEnv(): void {
+  const previous = process.env.SANDBOX;
+  beforeEach(() => {
+    delete process.env.SANDBOX;
+  });
+  afterEach(() => {
+    if (previous === undefined) {
+      delete process.env.SANDBOX;
+    } else {
+      process.env.SANDBOX = previous;
+    }
+  });
+}
+
+/**
+ * Installs a stderr collector that records every byte written while it is
+ * active, keeping the bytes off the runner's own output. The stream is an
+ * external sink being observed, not the unit under test.
+ */
+function collectStderr(): { captured: () => string; restore: () => void } {
+  const chunks: string[] = [];
+  const writeSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: string | Uint8Array) => {
+      chunks.push(typeof chunk === 'string' ? chunk : String(chunk));
+      return true;
+    });
+  return {
+    captured: () => chunks.join(''),
+    restore: () => writeSpy.mockRestore(),
+  };
+}
+
+/**
+ * Drives a real INFO audit record and returns the stderr bytes it produced:
+ * empty while a TUI owns the terminal, the JSON line otherwise. INFO is the
+ * probe severity because it is never buffered, so the observed bytes are
+ * exactly the bytes the routing decision produced at that moment.
+ */
+function auditInfoStderr(op: string): string {
+  const collector = collectStderr();
+  try {
+    auditLog('INFO', 99, op);
+  } finally {
+    collector.restore();
+  }
+  return collector.captured();
+}
+
+/** Number of times needle appears in haystack, without regex escaping. */
+function occurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
 describe('maybeHopIntoSandbox hop-exit stdio flush (#3408)', () => {
+  useUnsetSandboxEnv();
+
   afterEach(() => {
     vi.restoreAllMocks();
     coreEvents.removeAllListeners(CoreEvent.Output);
@@ -213,29 +319,7 @@ describe('maybeHopIntoSandbox hop-exit stdio flush (#3408)', () => {
     __resetCleanupStateForTesting();
   });
 
-  function buildHopOptions(): SandboxHopOptions {
-    return {
-      config: {
-        getSandbox: () => ({ command: 'docker', image: 'test-image' }),
-        getDebugMode: () => false,
-      } as SandboxHopOptions['config'],
-      settings: {
-        merged: { ui: { autoConfigureMaxOldSpaceSize: false } },
-      } as SandboxHopOptions['settings'],
-      argv: {} as SandboxHopOptions['argv'],
-      workspaceRoot: '/tmp/ws',
-      runtimeSettingsService: {} as SandboxHopOptions['runtimeSettingsService'],
-      initialAuthFailed: false,
-      readStdin: async () => '',
-      hasPipedInput: false,
-      bootstrapSelection: null,
-    };
-  }
-
   it('flushes the patched-stdio backlog to the fd-direct writer before the hop exit sentinel fires', async () => {
-    const originalSandbox = process.env.SANDBOX;
-    delete process.env.SANDBOX;
-
     // Mirror cli.tsx setupProcessLifecycle: patch stdio and register the
     // sync-cleanup flush that runExitCleanup drains on the hop exit path.
     const cleanupStdio = coreModule.patchStdio();
@@ -280,12 +364,144 @@ describe('maybeHopIntoSandbox hop-exit stdio flush (#3408)', () => {
     } finally {
       // Restores the spies (including process.exit) before anything else.
       vi.restoreAllMocks();
-      if (originalSandbox === undefined) {
-        delete process.env.SANDBOX;
-      } else {
-        process.env.SANDBOX = originalSandbox;
-      }
       cleanupStdio();
     }
+  });
+});
+
+describe('maybeHopIntoSandbox TUI terminal ownership (#3490)', () => {
+  const startSandboxMock = start_sandbox as Mock<typeof start_sandbox>;
+  useUnsetSandboxEnv();
+
+  /**
+   * Stubs start_sandbox to drive a real INFO audit record mid-hop and
+   * capture the stderr bytes it produced. Where those bytes went is the
+   * observable routing the ownership flag exists for: empty while a TUI
+   * owns the terminal, the JSON record otherwise.
+   */
+  function stubSandboxWithAuditProbe(): { stderrDuringHop: string } {
+    const probe = { stderrDuringHop: '' };
+    startSandboxMock.mockImplementation(async () => {
+      probe.stderrDuringHop = auditInfoStderr('hop_probe');
+      return 7;
+    });
+    return probe;
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // The file-level factory default; other describes in this file depend
+    // on exit code 7.
+    startSandboxMock.mockImplementation(async () => 7);
+    setTuiOwnsTerminal(false);
+    __resetCleanupStateForTesting();
+  });
+
+  it('routes audit bytes away from stderr for an interactive hop and restores default routing afterwards', async () => {
+    const probe = stubSandboxWithAuditProbe();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('exit sentinel');
+    }) as typeof process.exit);
+
+    await expect(maybeHopIntoSandbox(buildHopOptions(true))).rejects.toThrow(
+      'exit sentinel',
+    );
+
+    expect(exitSpy.mock.calls[0]?.[0]).toBe(7);
+    // The sandbox TUI owned the terminal for the whole hop, so the live
+    // proxy's INFO record produced zero stderr bytes...
+    expect(probe.stderrDuringHop).toBe('');
+    // ...and once the hop settled, default stderr routing was back.
+    expect(auditInfoStderr('post_hop_probe')).toContain(
+      '"op":"post_hop_probe"',
+    );
+  });
+
+  it('keeps audit records on stderr for a non-interactive hop', async () => {
+    const probe = stubSandboxWithAuditProbe();
+    vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('exit sentinel');
+    }) as typeof process.exit);
+
+    await expect(maybeHopIntoSandbox(buildHopOptions(false))).rejects.toThrow(
+      'exit sentinel',
+    );
+
+    // Default mode: the audit record still reaches stderr byte for byte,
+    // during the hop and after it.
+    expect(probe.stderrDuringHop).toContain('"op":"hop_probe"');
+    expect(auditInfoStderr('post_hop_probe')).toContain(
+      '"op":"post_hop_probe"',
+    );
+  });
+
+  it('does not claim the terminal for an interactive direct-image invocation that never mounts Ink', async () => {
+    const probe = stubSandboxWithAuditProbe();
+    vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('exit sentinel');
+    }) as typeof process.exit);
+
+    await expect(
+      maybeHopIntoSandbox(buildHopOptions(true, imageModeArgv())),
+    ).rejects.toThrow('exit sentinel');
+
+    // Direct image mode dispatches after the hop without mounting a TUI, so
+    // the audit record keeps its default stderr routing throughout.
+    expect(probe.stderrDuringHop).toContain('"op":"hop_probe"');
+  });
+
+  it('restores default audit routing when start_sandbox rejects', async () => {
+    const stderrInsideRejectedHop = { value: '' };
+    startSandboxMock.mockImplementation(async () => {
+      stderrInsideRejectedHop.value = auditInfoStderr('rejection_probe');
+      throw new Error('sandbox boom');
+    });
+
+    await expect(maybeHopIntoSandbox(buildHopOptions(true))).rejects.toThrow(
+      'sandbox boom',
+    );
+
+    // The claim was live right up to the failure (the INFO record produced
+    // zero stderr bytes)...
+    expect(stderrInsideRejectedHop.value).toBe('');
+    // ...and the rejection path released it (default stderr routing back).
+    expect(auditInfoStderr('post_rejection_probe')).toContain(
+      '"op":"post_rejection_probe"',
+    );
+  });
+
+  it('flushes WARN and ERROR records deferred during an interactive hop to stderr exactly once', async () => {
+    startSandboxMock.mockImplementation(async () => {
+      auditLog('WARN', 98, 'hop_warn');
+      auditLog('ERROR', 98, 'hop_error');
+      return 7;
+    });
+    vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('exit sentinel');
+    }) as typeof process.exit);
+
+    // The collector spans the whole hop: ownership defers both records, and
+    // the release in the hop's finally is the only thing that may write.
+    const collector = collectStderr();
+    let stderrAfterHop = '';
+    try {
+      await expect(maybeHopIntoSandbox(buildHopOptions(true))).rejects.toThrow(
+        'exit sentinel',
+      );
+    } finally {
+      stderrAfterHop = collector.captured();
+      collector.restore();
+    }
+
+    // The host has no feedback subscriber during the hop, so the operator's
+    // copy is exactly the two deferred records, in order, once each.
+    expect(occurrences(stderrAfterHop, '"component":"credential-proxy"')).toBe(
+      2,
+    );
+    expect(occurrences(stderrAfterHop, '"op":"hop_warn"')).toBe(1);
+    expect(occurrences(stderrAfterHop, '"op":"hop_error"')).toBe(1);
+    expect(stderrAfterHop.indexOf('"op":"hop_warn"')).toBeLessThan(
+      stderrAfterHop.indexOf('"op":"hop_error"'),
+    );
   });
 });

--- a/packages/cli/src/cliSandbox.ts
+++ b/packages/cli/src/cliSandbox.ts
@@ -6,7 +6,10 @@
 
 import { type Config, ExitCodes } from '@vybestack/llxprt-code-core';
 import type { SettingsService } from '@vybestack/llxprt-code-settings';
+import { setTuiOwnsTerminal } from '@vybestack/llxprt-code-providers/auth.js';
 import { loadCliConfig } from './config/config.js';
+import { isImageModeActive } from './config/imageMode.js';
+import { buildImageModeFlags } from './config/imageModeDispatch.js';
 import { start_sandbox } from './utils/sandbox.js';
 import {
   computeSandboxMemoryArgs,
@@ -199,12 +202,27 @@ export async function maybeHopIntoSandbox(
       : undefined;
   const finalSandboxArgs = augmentArgvWithInternalEnvPath(sandboxArgs, envPath);
 
-  const exitCode = await start_sandbox(
-    sandboxConfig,
-    sandboxMemoryArgs,
-    partialConfig,
-    finalSandboxArgs,
+  // From here until start_sandbox settles, the sandbox Ink TUI owns this
+  // terminal, so credential-proxy audit records must route to their file
+  // sink / the feedback surface instead of stderr (#3490). Direct image
+  // mode dispatches after the hop without ever mounting Ink, so an
+  // interactive-looking TTY must not claim ownership for it; the image-flag
+  // pair is the same one the post-hop dispatch uses, so the two can never
+  // disagree.
+  setTuiOwnsTerminal(
+    config.isInteractive() && !isImageModeActive(buildImageModeFlags(argv)),
   );
+  let exitCode: number;
+  try {
+    exitCode = await start_sandbox(
+      sandboxConfig,
+      sandboxMemoryArgs,
+      partialConfig,
+      finalSandboxArgs,
+    );
+  } finally {
+    setTuiOwnsTerminal(false);
+  }
   // Drains the patched-stdio backlog (registered flush) before the bare exit
   // that terminates this process, mirroring the initialAuthFailed branch.
   await runExitCleanup();

--- a/packages/providers/src/auth/index.ts
+++ b/packages/providers/src/auth/index.ts
@@ -101,7 +101,13 @@ export {
 // Production needs only the ownership setter; `auditLog` stays public so
 // CLI-package hop tests can drive a real audit record through the real
 // routing (this subpath is the package's only auth entry point).
-export { auditLog, setTuiOwnsTerminal } from './proxy/audit-log.js';
+// `resetAuditLogStateForTesting` is test-only (ownership flag, deferred
+// buffer and overflow counter) and must not be used by production code.
+export {
+  auditLog,
+  resetAuditLogStateForTesting,
+  setTuiOwnsTerminal,
+} from './proxy/audit-log.js';
 
 // ─── File-backed OAuth Settings Provider ─────────────────────────────────────
 // Isolated-runtime OAuth enablement surface: reads the user-scope global

--- a/packages/providers/src/auth/index.ts
+++ b/packages/providers/src/auth/index.ts
@@ -94,6 +94,15 @@ export {
   executeGitHubOp,
 } from './proxy/github-broker.js';
 
+// ─── Proxy Audit Log ─────────────────────────────────────────────────────────
+// Durable audit sink plus explicit TUI-terminal ownership for the credential
+// proxy (#3490): when the sandbox hop hands the terminal to the Ink TUI,
+// audit records must route to the file sink / feedback surface, not stderr.
+// Production needs only the ownership setter; `auditLog` stays public so
+// CLI-package hop tests can drive a real audit record through the real
+// routing (this subpath is the package's only auth entry point).
+export { auditLog, setTuiOwnsTerminal } from './proxy/audit-log.js';
+
 // ─── File-backed OAuth Settings Provider ─────────────────────────────────────
 // Isolated-runtime OAuth enablement surface: reads the user-scope global
 // settings file so provider instances built outside the CLI (subagents /

--- a/packages/providers/src/auth/proxy/__tests__/audit-log-sink.test.ts
+++ b/packages/providers/src/auth/proxy/__tests__/audit-log-sink.test.ts
@@ -1,0 +1,305 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the credential-proxy audit sink and TUI terminal
+ * ownership (#3490).
+ *
+ * The proxy runs in the host process that then hands its terminal to the
+ * sandbox Ink TUI, so stderr bytes at that point corrupt the interface. These
+ * tests pin where each record lands in both modes: the durable sink file is
+ * always written, stderr receives bytes only when no TUI owns the terminal,
+ * and WARN/ERROR reach the user through the feedback event surface instead.
+ *
+ * The log dir is redirected through LLXPRT_LOG_HOME to a real temp dir (no fs
+ * mocking); Storage.getGlobalLogDir() reads the env at call time, which is
+ * what makes the override a seam.
+ *
+ * @plan PLAN-20260901-PROXYAUDIT
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  coreEvents,
+  CoreEvent,
+  type UserFeedbackPayload,
+} from '@vybestack/llxprt-code-core';
+import { auditLog, setTuiOwnsTerminal, tuiOwnsTerminal } from '../audit-log.js';
+
+const SINK_FILE_NAME = 'credential-proxy-audit.log';
+/** A realistically shaped GitHub token; must never survive into any sink. */
+const SECRET = 'ghp_BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+
+/**
+ * Points LLXPRT_LOG_HOME at a fresh temp dir for each test and restores plus
+ * removes it afterwards, so every auditLog call resolves a real sink dir and
+ * no test reads another test's file. One shared lifecycle helper instead of
+ * per-describe boilerplate.
+ */
+function useIsolatedLogHome(): () => string {
+  let logHome = '';
+  const previous = process.env.LLXPRT_LOG_HOME;
+  beforeEach(() => {
+    logHome = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-sink-'));
+    process.env.LLXPRT_LOG_HOME = logHome;
+  });
+  afterEach(() => {
+    if (previous === undefined) {
+      delete process.env.LLXPRT_LOG_HOME;
+    } else {
+      process.env.LLXPRT_LOG_HOME = previous;
+    }
+    fs.rmSync(logHome, { recursive: true, force: true });
+  });
+  return () => logHome;
+}
+
+/**
+ * Subscribes to the user-feedback surface for each test and returns a lazy
+ * accessor for what it saw. A real listener is used rather than a spy
+ * because emitFeedback buffers while nobody listens; the subscription is
+ * what turns the publish into observable behavior.
+ */
+function captureUserFeedback(): () => UserFeedbackPayload[] {
+  const payloads: UserFeedbackPayload[] = [];
+  const listener = (payload: UserFeedbackPayload): void => {
+    payloads.push(payload);
+  };
+  beforeEach(() => {
+    coreEvents.on(CoreEvent.UserFeedback, listener);
+  });
+  afterEach(() => {
+    coreEvents.removeListener(CoreEvent.UserFeedback, listener);
+    payloads.length = 0;
+  });
+  return () => payloads;
+}
+
+/**
+ * Captures everything written to process.stderr while `emit` runs. The
+ * stream is an external sink being observed, not the unit under test; the
+ * spy also keeps the bytes off the runner's own output.
+ */
+function captureStderrDuring(emit: () => void): string {
+  const chunks: string[] = [];
+  const writeSpy = vi
+    .spyOn(process.stderr, 'write')
+    .mockImplementation((chunk: string | Uint8Array) => {
+      chunks.push(typeof chunk === 'string' ? chunk : String(chunk));
+      return true;
+    });
+  try {
+    emit();
+  } finally {
+    writeSpy.mockRestore();
+  }
+  return chunks.join('');
+}
+
+/** Reads the sink file back and returns its individual JSON lines. */
+function readSinkLines(logHome: string): string[] {
+  return fs
+    .readFileSync(path.join(logHome, SINK_FILE_NAME), 'utf8')
+    .trimEnd()
+    .split('\n');
+}
+
+/**
+ * The host topology these tests pin: the credential proxy runs in the host
+ * process, whose coreEvents singleton has NO UserFeedback subscriber — the
+ * Ink UI that subscribes lives in the spawned sandbox child, and per-process
+ * events cannot cross that boundary. No feedback listener is installed here,
+ * so operator visibility must come from the deferred stderr flush alone.
+ */
+describe('deferred stderr flush on ownership release, no feedback subscriber (#3490)', () => {
+  const logHome = useIsolatedLogHome();
+
+  // No test may leak ownership into another suite: the flag is process state.
+  afterEach(() => {
+    setTuiOwnsTerminal(false);
+  });
+
+  it('holds WARN and ERROR stderr bytes while owned, then flushes exactly those lines in order on release', () => {
+    setTuiOwnsTerminal(true);
+    const duringOwnership = captureStderrDuring(() => {
+      auditLog('WARN', 10, 'deferred_warn');
+      auditLog('ERROR', 10, 'deferred_error');
+    });
+    const onRelease = captureStderrDuring(() => {
+      setTuiOwnsTerminal(false);
+    });
+
+    const lines = readSinkLines(logHome());
+    expect(duringOwnership).toBe('');
+    expect(lines.length).toBe(2);
+    expect(lines[0]).toContain('"op":"deferred_warn"');
+    expect(lines[1]).toContain('"op":"deferred_error"');
+    // Byte for byte the same lines the sink holds, in order, exactly once.
+    expect(onRelease).toBe(`${lines.join('\n')}\n`);
+  });
+
+  it('keeps an INFO recorded under ownership off stderr before and after release', () => {
+    const stderr = captureStderrDuring(() => {
+      setTuiOwnsTerminal(true);
+      auditLog('INFO', 11, 'sink_only_info');
+      setTuiOwnsTerminal(false);
+    });
+
+    const lines = readSinkLines(logHome());
+    expect(lines.length).toBe(1);
+    expect(lines[0]).toContain('"op":"sink_only_info"');
+    expect(stderr).toBe('');
+  });
+
+  it('writes nothing on release when no records were buffered', () => {
+    const stderr = captureStderrDuring(() => {
+      setTuiOwnsTerminal(true);
+      setTuiOwnsTerminal(false);
+    });
+
+    expect(stderr).toBe('');
+  });
+
+  it('does not reprint buffered lines on a second release', () => {
+    setTuiOwnsTerminal(true);
+    const firstRelease = captureStderrDuring(() => {
+      auditLog('WARN', 13, 'printed_once');
+      setTuiOwnsTerminal(false);
+    });
+    const secondRelease = captureStderrDuring(() => {
+      setTuiOwnsTerminal(false);
+    });
+
+    expect(firstRelease).toContain('"op":"printed_once"');
+    expect(secondRelease).toBe('');
+  });
+});
+
+describe('auditLog sink and TUI terminal ownership (#3490)', () => {
+  const logHome = useIsolatedLogHome();
+  const feedback = captureUserFeedback();
+
+  // No test may leak ownership into another suite: the flag is process state.
+  afterEach(() => {
+    setTuiOwnsTerminal(false);
+  });
+
+  it('does not own the terminal by default', () => {
+    expect(tuiOwnsTerminal()).toBe(false);
+  });
+
+  /**
+   * AB1 + AB3: the sink is unconditional, and under TUI ownership INFO goes
+   * nowhere else.
+   */
+  it('routes INFO to the sink only while a TUI owns the terminal', () => {
+    setTuiOwnsTerminal(true);
+    const stderr = captureStderrDuring(() => {
+      auditLog('INFO', 1, 'handshake_ok', { status: 'ok' });
+    });
+
+    const lines = readSinkLines(logHome());
+    expect(lines.length).toBe(1);
+    expect(lines[0]).toContain('"op":"handshake_ok"');
+    expect(lines[0]).toContain('"level":"INFO"');
+    expect(stderr).toBe('');
+    expect(feedback()).toEqual([]);
+  });
+
+  /** AB4: WARN reaches the user through the feedback surface, not stderr. */
+  it('publishes WARN as feedback instead of stderr while a TUI owns the terminal', () => {
+    setTuiOwnsTerminal(true);
+    const stderr = captureStderrDuring(() => {
+      auditLog('WARN', 2, 'frame_decode_error', { reason: 'truncated' });
+    });
+
+    const lines = readSinkLines(logHome());
+    expect(lines.length).toBe(1);
+    expect(stderr).toBe('');
+    expect(feedback().length).toBe(1);
+    expect(feedback()[0].severity).toBe('warning');
+    expect(feedback()[0].message).toBe(lines[0]);
+  });
+
+  /** AB4: ERROR maps to the error severity on the same surface. */
+  it('publishes ERROR as feedback instead of stderr while a TUI owns the terminal', () => {
+    setTuiOwnsTerminal(true);
+    const stderr = captureStderrDuring(() => {
+      auditLog('ERROR', 3, 'process_frames_error');
+    });
+
+    const lines = readSinkLines(logHome());
+    expect(lines.length).toBe(1);
+    expect(stderr).toBe('');
+    expect(feedback().length).toBe(1);
+    expect(feedback()[0].severity).toBe('error');
+    expect(feedback()[0].message).toBe(lines[0]);
+  });
+
+  /**
+   * AB2: without TUI ownership the stderr path is unchanged — the same
+   * lines the sink holds, one JSON record per line, byte for byte.
+   */
+  it('writes INFO, WARN and ERROR to both stderr and the sink when no TUI owns the terminal', () => {
+    const stderr = captureStderrDuring(() => {
+      auditLog('INFO', 4, 'connect');
+      auditLog('WARN', 4, 'frame_flood');
+      auditLog('ERROR', 4, 'unhandled_dispatch');
+    });
+
+    const lines = readSinkLines(logHome());
+    expect(lines.length).toBe(3);
+    expect(lines[0]).toContain('"op":"connect"');
+    expect(lines[1]).toContain('"op":"frame_flood"');
+    expect(lines[2]).toContain('"op":"unhandled_dispatch"');
+    expect(stderr).toBe(`${lines.join('\n')}\n`);
+    expect(feedback()).toEqual([]);
+  });
+
+  /** AB1: the no-secrets property holds in the durable file, not just stderr. */
+  it('redacts token-shaped detail values in the sink file', () => {
+    captureStderrDuring(() => {
+      auditLog('INFO', 5, 'get_api_key', { name: 'github-pat', key: SECRET });
+    });
+
+    const sink = fs.readFileSync(path.join(logHome(), SINK_FILE_NAME), 'utf8');
+    expect(sink).not.toContain(SECRET);
+    expect(sink).toContain('"op":"get_api_key"');
+  });
+
+  /** AB1: a missing audit record is itself a security signal. */
+  it('still writes a sink record when details cannot be serialised', () => {
+    captureStderrDuring(() => {
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+      auditLog('WARN', 6, 'circular_op', circular);
+    });
+
+    const lines = readSinkLines(logHome());
+    expect(lines.length).toBe(1);
+    expect(lines[0]).toContain('"op":"circular_op"');
+    expect(lines[0]).toContain('unserialisable');
+  });
+
+  /**
+   * AB1: a sink that cannot be written must neither crash auditLog nor
+   * suppress the default-mode stderr record.
+   */
+  it('keeps the stderr record and does not throw when the sink location is unwritable', () => {
+    const blocker = path.join(logHome(), 'blocker');
+    fs.writeFileSync(blocker, 'occupies the path the sink dir would need');
+    process.env.LLXPRT_LOG_HOME = path.join(blocker, 'log');
+
+    const stderr = captureStderrDuring(() => {
+      auditLog('ERROR', 7, 'sink_unwritable_probe');
+    });
+
+    expect(stderr).toContain('"op":"sink_unwritable_probe"');
+  });
+});

--- a/packages/providers/src/auth/proxy/__tests__/audit-log-sink.test.ts
+++ b/packages/providers/src/auth/proxy/__tests__/audit-log-sink.test.ts
@@ -30,7 +30,12 @@ import {
   CoreEvent,
   type UserFeedbackPayload,
 } from '@vybestack/llxprt-code-core';
-import { auditLog, setTuiOwnsTerminal, tuiOwnsTerminal } from '../audit-log.js';
+import {
+  auditLog,
+  resetAuditLogStateForTesting,
+  setTuiOwnsTerminal,
+  tuiOwnsTerminal,
+} from '../audit-log.js';
 
 const SINK_FILE_NAME = 'credential-proxy-audit.log';
 /** A realistically shaped GitHub token; must never survive into any sink. */
@@ -82,6 +87,45 @@ function captureUserFeedback(): () => UserFeedbackPayload[] {
 }
 
 /**
+ * Resets audit-log routing state — terminal ownership, the deferred buffer
+ * and its overflow counter — before AND after every test. An afterEach-only
+ * reset cannot clear records buffered while ownership is already released,
+ * and cannot protect a block that enters dirty; the beforeEach half closes
+ * both gaps. One registered lifecycle instead of per-describe boilerplate.
+ */
+function useAuditLogStateReset(): void {
+  beforeEach(() => {
+    resetAuditLogStateForTesting();
+  });
+  afterEach(() => {
+    resetAuditLogStateForTesting();
+  });
+}
+
+/** Type guard for a valid Node buffer encoding name. */
+function isBufferEncoding(value: unknown): value is BufferEncoding {
+  return typeof value === 'string' && Buffer.isEncoding(value);
+}
+
+/**
+ * Decodes one stderr write chunk into text. Byte chunks must be decoded,
+ * not stringified: String(Uint8Array) yields "[object Uint8Array]", which
+ * would let a broken implementation pass assertions like
+ * expect(stderr).toBe('').
+ */
+function decodeStderrChunk(
+  chunk: string | Uint8Array,
+  encoding: unknown,
+): string {
+  if (typeof chunk === 'string') {
+    return chunk;
+  }
+  return Buffer.from(chunk).toString(
+    isBufferEncoding(encoding) ? encoding : 'utf8',
+  );
+}
+
+/**
  * Captures everything written to process.stderr while `emit` runs. The
  * stream is an external sink being observed, not the unit under test; the
  * spy also keeps the bytes off the runner's own output.
@@ -90,8 +134,8 @@ function captureStderrDuring(emit: () => void): string {
   const chunks: string[] = [];
   const writeSpy = vi
     .spyOn(process.stderr, 'write')
-    .mockImplementation((chunk: string | Uint8Array) => {
-      chunks.push(typeof chunk === 'string' ? chunk : String(chunk));
+    .mockImplementation((chunk: string | Uint8Array, ...rest: unknown[]) => {
+      chunks.push(decodeStderrChunk(chunk, rest[0]));
       return true;
     });
   try {
@@ -100,6 +144,25 @@ function captureStderrDuring(emit: () => void): string {
     writeSpy.mockRestore();
   }
   return chunks.join('');
+}
+
+/** Type guard narrowing a parsed JSON line to an object for field access. */
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Parses one audit line as a JSON object. A line that fails to parse or is
+ * not an object corrupts the one-JSON-object-per-line contract, so it fails
+ * the test right here rather than via substring lookups that would pass on
+ * malformed records.
+ */
+function parseAuditRecord(line: string): Record<string, unknown> {
+  const parsed: unknown = JSON.parse(line);
+  if (!isJsonObject(parsed)) {
+    throw new Error(`audit line is not a JSON object: ${line}`);
+  }
+  return parsed;
 }
 
 /** Reads the sink file back and returns its individual JSON lines. */
@@ -119,11 +182,7 @@ function readSinkLines(logHome: string): string[] {
  */
 describe('deferred stderr flush on ownership release, no feedback subscriber (#3490)', () => {
   const logHome = useIsolatedLogHome();
-
-  // No test may leak ownership into another suite: the flag is process state.
-  afterEach(() => {
-    setTuiOwnsTerminal(false);
-  });
+  useAuditLogStateReset();
 
   it('holds WARN and ERROR stderr bytes while owned, then flushes exactly those lines in order on release', () => {
     setTuiOwnsTerminal(true);
@@ -179,16 +238,108 @@ describe('deferred stderr flush on ownership release, no feedback subscriber (#3
     expect(firstRelease).toContain('"op":"printed_once"');
     expect(secondRelease).toBe('');
   });
+
+  it('delivers every record of an acquire-release-re-acquire cycle to stderr exactly once, in order', () => {
+    setTuiOwnsTerminal(true);
+    auditLog('WARN', 14, 'cycle_first_warn');
+    const firstFlush = captureStderrDuring(() => {
+      setTuiOwnsTerminal(false);
+    });
+
+    setTuiOwnsTerminal(true);
+    auditLog('ERROR', 14, 'cycle_second_error');
+    const secondFlush = captureStderrDuring(() => {
+      setTuiOwnsTerminal(false);
+    });
+
+    // Each flush carries its own cycle's record exactly once...
+    expect(firstFlush).toContain('"op":"cycle_first_warn"');
+    expect(firstFlush).not.toContain('"op":"cycle_second_error"');
+    expect(secondFlush).toContain('"op":"cycle_second_error"');
+    // ...and the second flush does not reprint the first cycle's record.
+    expect(secondFlush).not.toContain('"op":"cycle_first_warn"');
+    const combined = firstFlush + secondFlush;
+    expect(combined.split('"op":"cycle_first_warn"').length - 1).toBe(1);
+    expect(combined.split('"op":"cycle_second_error"').length - 1).toBe(1);
+    expect(combined.indexOf('"op":"cycle_first_warn"')).toBeLessThan(
+      combined.indexOf('"op":"cycle_second_error"'),
+    );
+  });
+
+  /**
+   * The deferred buffer is bounded (module constant MAX_DEFERRED_LINES =
+   * 256) because frame_decode_error / process_frames_error fire per
+   * incoming proxy-socket chunk: a hostile client can otherwise buffer one
+   * record per chunk for a whole session. 260 records = 4 dropped + 256
+   * retained; the arithmetic below pins that exact split.
+   */
+  it('keeps only the most recent deferred lines and announces the truncation before them on flush', () => {
+    setTuiOwnsTerminal(true);
+    const duringOwnership = captureStderrDuring(() => {
+      for (let i = 0; i < 260; i++) {
+        auditLog('WARN', 15, `overflow_${String(i).padStart(3, '0')}`);
+      }
+    });
+    const flush = captureStderrDuring(() => {
+      setTuiOwnsTerminal(false);
+    });
+
+    // Durability is unaffected by the bound: every record, dropped or
+    // retained, reached the sink.
+    const sinkLines = readSinkLines(logHome());
+    expect(sinkLines.length).toBe(260);
+    expect(sinkLines[0]).toContain('"op":"overflow_000"');
+    expect(sinkLines[259]).toContain('"op":"overflow_259"');
+    expect(duringOwnership).toBe('');
+
+    // One summary line first, then the 256 newest records in order.
+    const flushedLines = flush.trimEnd().split(String.fromCharCode(10));
+    expect(flushedLines.length).toBe(257);
+    const summary = parseAuditRecord(flushedLines[0]);
+    expect(summary.level).toBe('WARN');
+    expect(summary.component).toBe('credential-proxy');
+    expect(summary.op).toBe('audit_deferred_overflow');
+    expect(summary.details).toEqual({ dropped: 4 });
+    expect(flushedLines[1]).toContain('"op":"overflow_004"');
+    expect(flushedLines[256]).toContain('"op":"overflow_259"');
+    // The oldest records are gone from the flush, the retained ones appear
+    // exactly once.
+    expect(flush).not.toContain('"op":"overflow_003"');
+    expect(flush.split('"op":"overflow_004"').length - 1).toBe(1);
+    expect(flush.split('"op":"overflow_259"').length - 1).toBe(1);
+  });
+
+  it('does not repeat the truncation summary on a later flush after an overflow was flushed', () => {
+    setTuiOwnsTerminal(true);
+    captureStderrDuring(() => {
+      for (let i = 0; i < 257; i++) {
+        auditLog('ERROR', 16, `post_overflow_${i}`);
+      }
+    });
+    const overflowFlush = captureStderrDuring(() => {
+      setTuiOwnsTerminal(false);
+    });
+
+    setTuiOwnsTerminal(true);
+    auditLog('WARN', 16, 'after_overflow_warn');
+    const nextFlush = captureStderrDuring(() => {
+      setTuiOwnsTerminal(false);
+    });
+
+    expect(overflowFlush).toContain('"op":"audit_deferred_overflow"');
+    // The dropped counter resets with the buffer: a later flush without a
+    // new overflow carries only its own record.
+    expect(nextFlush.trimEnd().split(String.fromCharCode(10)).length).toBe(1);
+    expect(nextFlush).toContain('"op":"after_overflow_warn"');
+    expect(nextFlush).not.toContain('"op":"audit_deferred_overflow"');
+    expect(nextFlush).not.toContain('"op":"post_overflow_0"');
+  });
 });
 
 describe('auditLog sink and TUI terminal ownership (#3490)', () => {
   const logHome = useIsolatedLogHome();
   const feedback = captureUserFeedback();
-
-  // No test may leak ownership into another suite: the flag is process state.
-  afterEach(() => {
-    setTuiOwnsTerminal(false);
-  });
+  useAuditLogStateReset();
 
   it('does not own the terminal by default', () => {
     expect(tuiOwnsTerminal()).toBe(false);
@@ -263,18 +414,22 @@ describe('auditLog sink and TUI terminal ownership (#3490)', () => {
   });
 
   /** AB1: the no-secrets property holds in the durable file, not just stderr. */
-  it('redacts token-shaped detail values in the sink file', () => {
-    captureStderrDuring(() => {
+  it('redacts token-shaped detail values in the sink file and on stderr', () => {
+    const stderr = captureStderrDuring(() => {
       auditLog('INFO', 5, 'get_api_key', { name: 'github-pat', key: SECRET });
     });
 
     const sink = fs.readFileSync(path.join(logHome(), SINK_FILE_NAME), 'utf8');
     expect(sink).not.toContain(SECRET);
     expect(sink).toContain('"op":"get_api_key"');
+    // Default mode copies the same redacted line to stderr; the secret must
+    // not survive on that surface either.
+    expect(stderr).not.toContain(SECRET);
+    expect(stderr).toContain('"op":"get_api_key"');
   });
 
   /** AB1: a missing audit record is itself a security signal. */
-  it('still writes a sink record when details cannot be serialised', () => {
+  it('still writes a valid JSON sink record when details cannot be serialised', () => {
     captureStderrDuring(() => {
       const circular: Record<string, unknown> = {};
       circular.self = circular;
@@ -283,8 +438,13 @@ describe('auditLog sink and TUI terminal ownership (#3490)', () => {
 
     const lines = readSinkLines(logHome());
     expect(lines.length).toBe(1);
-    expect(lines[0]).toContain('"op":"circular_op"');
-    expect(lines[0]).toContain('unserialisable');
+    // The fallback record must remain a parseable JSONL object with the
+    // fields a consumer relies on; substring matches alone would pass on a
+    // malformed line that corrupts the sink.
+    const record = parseAuditRecord(lines[0]);
+    expect(record.op).toBe('circular_op');
+    expect(record.level).toBe('WARN');
+    expect(record.details).toBe('unserialisable');
   });
 
   /**

--- a/packages/providers/src/auth/proxy/audit-log.ts
+++ b/packages/providers/src/auth/proxy/audit-log.ts
@@ -24,6 +24,18 @@ export type AuditLevel = 'INFO' | 'WARN' | 'ERROR';
 const SINK_FILE_NAME = 'credential-proxy-audit.log';
 
 /**
+ * Upper bound on records held per TUI-ownership span (#3490). frame_decode_error
+ * (WARN) and process_frames_error (ERROR) fire per incoming proxy-socket chunk,
+ * so a broken or hostile client can otherwise buffer one record per chunk for a
+ * whole sandbox session — an unbounded-memory path that would also dump an
+ * enormous block to stderr at release. 256 keeps the flush readable while
+ * bounding the worst case. When full, the OLDEST records are dropped in favor
+ * of the newest, and a summary line reports the drop on flush. Durability is
+ * unaffected: every dropped record is already in the file sink.
+ */
+const MAX_DEFERRED_LINES = 256;
+
+/**
  * Whether an Ink TUI owns this process's terminal (#3490). Set by the CLI
  * around the sandbox hop, when the host hands its terminal to the sandbox
  * TUI and stderr bytes would corrupt the interface.
@@ -36,8 +48,16 @@ let tuiOwned = false;
  * coreEvents feedback — the Ink UI subscribing to it lives in the child,
  * and per-process events cannot cross that boundary — so without this
  * buffer the host's warnings and errors would never reach the operator.
+ * Bounded to MAX_DEFERRED_LINES, keeping the most recent lines.
  */
 const deferredDuringOwnership: string[] = [];
+
+/**
+ * Count of records evicted from {@link deferredDuringOwnership} because the
+ * buffer was full. Reported once as the first line of the flush, then reset
+ * alongside the buffer.
+ */
+let droppedFromDeferred = 0;
 
 /**
  * Marks terminal ownership for the audit log. The only production caller is
@@ -62,6 +82,18 @@ export function tuiOwnsTerminal(): boolean {
 }
 
 /**
+ * Resets the audit-log routing state: terminal ownership, the deferred
+ * buffer and the overflow counter. Test-only — deterministic per-test state
+ * for suites that drive ownership; production resets ownership through
+ * {@link setTuiOwnsTerminal} alone.
+ */
+export function resetAuditLogStateForTesting(): void {
+  tuiOwned = false;
+  deferredDuringOwnership.length = 0;
+  droppedFromDeferred = 0;
+}
+
+/**
  * Writes one formatted record line to stderr through the guarded path shared
  * by the default write and the deferred flush. A closed or full stream must
  * never crash the proxy.
@@ -78,13 +110,29 @@ function writeRecordToStderr(line: string): void {
 
 /**
  * Emits the WARN/ERROR lines deferred while a TUI owned the terminal, then
- * clears the buffer so a later release cannot reprint them.
+ * clears the buffer so a later release cannot reprint them. When records
+ * were dropped to keep the buffer at MAX_DEFERRED_LINES, a summary line
+ * goes out FIRST so the operator knows the block is truncated; it is a JSON
+ * object of the same shape as the records so the stream stays
+ * one-JSON-object-per-line.
  */
 function flushDeferredLines(): void {
+  if (droppedFromDeferred > 0) {
+    writeRecordToStderr(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        level: 'WARN' satisfies AuditLevel,
+        component: 'credential-proxy',
+        op: 'audit_deferred_overflow',
+        details: { dropped: droppedFromDeferred },
+      }),
+    );
+  }
   for (const line of deferredDuringOwnership) {
     writeRecordToStderr(line);
   }
   deferredDuringOwnership.length = 0;
+  droppedFromDeferred = 0;
 }
 
 /**
@@ -168,6 +216,12 @@ export function auditLog(
     // (for any process that has a subscriber) and are deferred to stderr so
     // the hop host — which has none — can flush them once the child exits.
     if (level !== 'INFO') {
+      if (deferredDuringOwnership.length >= MAX_DEFERRED_LINES) {
+        // Keep the most recent records; the evicted ones are already in the
+        // durable sink, so this trades stderr flush volume, not durability.
+        deferredDuringOwnership.shift();
+        droppedFromDeferred++;
+      }
       deferredDuringOwnership.push(line);
       coreEvents.emitFeedback(level === 'WARN' ? 'warning' : 'error', line);
     }

--- a/packages/providers/src/auth/proxy/audit-log.ts
+++ b/packages/providers/src/auth/proxy/audit-log.ts
@@ -8,15 +8,100 @@
  * Standalone audit-log function extracted from CredentialProxyServer to
  * keep the server file under the ESLint max-lines threshold.
  *
- * @plan PLAN-20260731-GHBROKER.P05
+ * @plan PLAN-20260731-GHBROKER.P05, PLAN-20260901-PROXYAUDIT
  * @requirement REQ-006, REQ-007
- * @pseudocode 002-frame-and-cancel.md (structural extraction only)
  */
 
-/** Log severity level. */
+import { appendFileSync, mkdirSync } from 'node:fs';
+import * as path from 'node:path';
+import { Storage } from '@vybestack/llxprt-code-storage';
+import { coreEvents } from '@vybestack/llxprt-code-core/utils/events.js';
 import { redactTokenShaped } from './github-broker-errors.js';
 
+/** Log severity level. */
 export type AuditLevel = 'INFO' | 'WARN' | 'ERROR';
+
+const SINK_FILE_NAME = 'credential-proxy-audit.log';
+
+/**
+ * Whether an Ink TUI owns this process's terminal (#3490). Set by the CLI
+ * around the sandbox hop, when the host hands its terminal to the sandbox
+ * TUI and stderr bytes would corrupt the interface.
+ */
+let tuiOwned = false;
+
+/**
+ * WARN/ERROR lines recorded while a TUI owned the terminal (#3490). The
+ * host process that spawns the sandbox child has no UI subscriber for
+ * coreEvents feedback — the Ink UI subscribing to it lives in the child,
+ * and per-process events cannot cross that boundary — so without this
+ * buffer the host's warnings and errors would never reach the operator.
+ */
+const deferredDuringOwnership: string[] = [];
+
+/**
+ * Marks terminal ownership for the audit log. The only production caller is
+ * maybeHopIntoSandbox(); every other entry point keeps the default (false)
+ * stderr behavior. Releasing ownership (owned -> not-owned, once the sandbox
+ * child has exited and the terminal is free) flushes the WARN/ERROR lines
+ * deferred while it was held; re-asserting the current value does nothing.
+ */
+export function setTuiOwnsTerminal(owned: boolean): void {
+  if (tuiOwned === owned) {
+    return;
+  }
+  tuiOwned = owned;
+  if (!owned) {
+    flushDeferredLines();
+  }
+}
+
+/** Read accessor mirroring {@link setTuiOwnsTerminal}. */
+export function tuiOwnsTerminal(): boolean {
+  return tuiOwned;
+}
+
+/**
+ * Writes one formatted record line to stderr through the guarded path shared
+ * by the default write and the deferred flush. A closed or full stream must
+ * never crash the proxy.
+ */
+function writeRecordToStderr(line: string): void {
+  try {
+    if (!process.stderr.destroyed) {
+      process.stderr.write(line + '\n');
+    }
+  } catch {
+    // stderr may be closed or full — audit logging must never crash the proxy
+  }
+}
+
+/**
+ * Emits the WARN/ERROR lines deferred while a TUI owned the terminal, then
+ * clears the buffer so a later release cannot reprint them.
+ */
+function flushDeferredLines(): void {
+  for (const line of deferredDuringOwnership) {
+    writeRecordToStderr(line);
+  }
+  deferredDuringOwnership.length = 0;
+}
+
+/**
+ * Appends one JSON line to the durable sink under the global log dir. The
+ * dir is resolved per write so LLXPRT_LOG_HOME / LLXPRT_CONFIG_HOME
+ * overrides are honored. A sink that cannot be written must never take the
+ * proxy down or suppress the other record surfaces.
+ */
+function appendToSink(line: string): void {
+  try {
+    const logDir = Storage.getGlobalLogDir();
+    mkdirSync(logDir, { recursive: true });
+    appendFileSync(path.join(logDir, SINK_FILE_NAME), line + '\n');
+  } catch {
+    // An unwritable sink degrades durability, not availability.
+  }
+}
 
 /**
  * Audit-log callback signature. Matches the CredentialProxyServer.auditLog
@@ -30,7 +115,8 @@ export type AuditLogFn = (
 ) => void;
 
 /**
- * Emits a structured JSON log line to stderr for security audit purposes.
+ * Emits a structured, redacted JSON audit line to the durable sink and, per
+ * terminal ownership, to stderr and/or the user-feedback surface (#3490).
  *
  * `details` is caller-supplied, so the no-secrets property is enforced here
  * rather than asserted in prose: every emitted string is run through the
@@ -75,11 +161,17 @@ export function auditLog(
       details: 'unserialisable',
     });
   }
-  try {
-    if (!process.stderr.destroyed) {
-      process.stderr.write(line + '\n');
+  appendToSink(line);
+  if (tuiOwned) {
+    // The sandbox TUI is drawing on this process's terminal; zero bytes may
+    // reach stderr. WARN/ERROR still surface through the UI feedback path
+    // (for any process that has a subscriber) and are deferred to stderr so
+    // the hop host — which has none — can flush them once the child exits.
+    if (level !== 'INFO') {
+      deferredDuringOwnership.push(line);
+      coreEvents.emitFeedback(level === 'WARN' ? 'warning' : 'error', line);
     }
-  } catch {
-    // stderr may be closed or full — audit logging must never crash the proxy
+    return;
   }
+  writeRecordToStderr(line);
 }

--- a/project-plans/issue3490-proxy-audit-sink.md
+++ b/project-plans/issue3490-proxy-audit-sink.md
@@ -1,0 +1,131 @@
+# Issue #3490 — Credential proxy audit log must not write to a TUI-owned terminal
+
+Plan id: `PLAN-20260901-PROXYAUDIT`
+
+## Problem
+
+`auditLog()` in `packages/providers/src/auth/proxy/audit-log.ts` writes a JSON
+line to `process.stderr` for every credential-proxy event, at every severity,
+unconditionally. The credential proxy runs in the host process that then hands
+the terminal to an Ink TUI (the sandbox child), so proxy bookkeeping lands on
+the same file descriptor the interface is drawing on.
+
+## Where the proxy actually runs (verified)
+
+- `createAndStartProxy()` (`sandbox-proxy-lifecycle.ts`) is constructed only
+  from `packages/cli/src/utils/sandbox-containers.ts:637`, reached via
+  `setupCredentialProxy()` from `sandbox-containers.ts` and
+  `sandbox-exec.ts:480` (`startCredentialProxyGuarded`). Both run inside
+  `start_sandbox()`.
+- `start_sandbox()` is called from exactly one place:
+  `maybeHopIntoSandbox()` in `packages/cli/src/cliSandbox.ts:202`.
+- The host process keeps `patchStdio()` active for the whole hop, so raw
+  `process.stderr.write` from the proxy is routed to `coreEvents` `Output` and
+  buffered (no listener is registered on the host hop path) until
+  `runExitCleanup()` drains it after the child exits. That drain is the
+  "block dump at teardown" in the issue; the live overwrite is the same bytes
+  reaching the shared terminal.
+- The proxy server is therefore never live in a process rendering its own Ink
+  UI. The terminal handoff at `start_sandbox()` is the single seam where a TUI
+  takes ownership.
+
+## Accepted behavior
+
+Scope is `auditLog()` plus the one call site that marks terminal handoff.
+
+### AB1 — durable sink, always
+
+Every audit record, at every level, in every mode, is appended as one JSON line
+to a file sink at `<Storage.getGlobalLogDir()>/credential-proxy-audit.log`.
+`Storage.getGlobalLogDir()` is honored per write, so `LLXPRT_LOG_HOME` (and the
+`LLXPRT_CONFIG_HOME` fallback) redirect the sink. The directory is created if
+absent. Sink failures never throw out of `auditLog()`.
+
+### AB2 — default (no TUI owns the terminal): unchanged stderr behavior
+
+When no TUI owns the terminal, `auditLog()` writes the same JSON line to
+`process.stderr` it writes today, for INFO, WARN and ERROR alike, still guarded
+by `process.stderr.destroyed` and still swallowing write failures. This is the
+non-interactive and non-TUI path required by acceptance criterion 4.
+
+### AB3 — TUI owns the terminal: zero stderr bytes
+
+When a TUI owns the terminal, `auditLog()` writes no bytes to `process.stderr`
+at any level. INFO records go to the sink only.
+
+### AB4 — WARN/ERROR stay visible via the UI error surface, plus a deferred stderr flush on release
+
+When a TUI owns the terminal, WARN and ERROR records are additionally published
+through `coreEvents.emitFeedback()` (severity `warning` / `error`) — the
+existing user-feedback surface — carrying the same redacted line content. They
+are not written to `process.stderr` while ownership is held.
+
+`coreEvents` is a per-process in-memory singleton: the credential proxy runs
+in the HOST process while the Ink UI subscribing to `CoreEvent.UserFeedback`
+runs in the separately spawned sandbox child, so the host's publish cannot
+reach that UI during the hop (and the teardown drain installs listeners only
+for `Output`/`ConsoleLog`, so the feedback backlog is dropped). Transporting
+notifications over host-to-sandbox IPC was considered and rejected as a new
+subsystem, out of scope for this issue.
+
+The operator-visible fallback is a deferred flush: while ownership is held,
+WARN/ERROR lines are buffered in module state. When `setTuiOwnsTerminal(false)`
+transitions from owned to not-owned — the sandbox child has exited and the
+terminal is free, so the write cannot corrupt anything — the buffered lines
+are written to `process.stderr` through the same guarded path as the normal
+stderr record (`process.stderr.destroyed` check, same catch), and the buffer
+is cleared. Releasing ownership with an empty buffer writes nothing;
+re-asserting the current ownership value is a no-op, so nothing is duplicated
+or reprinted. INFO is never buffered and never reaches stderr under TUI
+ownership (sink only).
+
+### AB5 — ownership is explicit and scoped to the handoff
+
+`audit-log.ts` exports `setTuiOwnsTerminal(owned: boolean): void`. The CLI sets
+it to `true` immediately before `start_sandbox()` in `maybeHopIntoSandbox()`
+when the session is interactive (`config.isInteractive()`), and restores it to
+`false` in a `finally` once `start_sandbox()` returns or throws. Nothing else
+sets it. Default is `false`, so every other entry point (unit tests, scripts,
+non-interactive runs, library consumers) keeps AB2 behavior.
+
+Redaction and the unserialisable-details fallback are unchanged and apply to
+the sink line, the stderr line and the feedback message identically.
+
+## Boundary cases the tests must pin
+
+1. INFO under TUI ownership: sink line present, zero stderr bytes, no feedback.
+2. WARN and ERROR under TUI ownership: sink line present, zero stderr bytes,
+   feedback emitted with matching severity.
+3. INFO/WARN/ERROR without TUI ownership: stderr line present (today's bytes)
+   AND sink line present.
+4. Token-shaped values in `details` are redacted in the sink file, not just on
+   stderr.
+5. Unserialisable `details` still produce a record in the sink.
+6. Ownership is restored to `false` after the handoff, including when
+   `start_sandbox()` throws.
+7. A sink that cannot be written (unwritable log dir) does not throw out of
+   `auditLog()` and does not suppress the stderr path in default mode.
+
+## Test plan
+
+Real filesystem, no fs mocking: point `LLXPRT_LOG_HOME` at a per-test temp dir
+and read the file back. `process.stderr.write` is captured the way the existing
+suite already does it (`github-broker-security.test.ts`), which is capture of an
+external sink, not a mock of the unit under test.
+
+- New file `packages/providers/src/auth/proxy/__tests__/audit-log-sink.test.ts`
+  (bun:test) covering boundary cases 1-5 and 7. Shared temp-dir lifecycle helper
+  registered once, per the test-writing rules; ownership flag reset in
+  `afterEach`.
+- Existing `github-broker-security.test.ts` redaction/unserialisable cases stay
+  green unchanged (they exercise the default no-TUI path).
+- CLI-side behavioral test for boundary case 6 next to the existing
+  `cliSandbox` tests: the flag is set for the duration of the interactive hop,
+  is not set for a non-interactive hop, and is restored when `start_sandbox()`
+  rejects.
+
+## Out of scope
+
+Log rotation/retention for the new sink, changing any audit call site's level,
+routing other components' stderr writes, and the `sandbox-proxy-lifecycle.ts`
+`stop()` warning write.


### PR DESCRIPTION
## TLDR

`auditLog()` in the credential proxy wrote a JSON line to `process.stderr` for every event, at every severity, unconditionally. The proxy runs in the **host** CLI process, which then hands its terminal to an Ink TUI running in the spawned **sandbox child**, so routine `connect` / `handshake_ok` / `get_api_key` / `disconnect` records were drawn on top of the interface and accumulated into a block dump at teardown that read like a crash report.

This separates the two things that were conflated: the durability requirement (an audit record must not vanish) and the destination (stderr, shared with the UI). Records now always go to a durable file sink; stderr is used only when no TUI owns the terminal.

Reviewers should look hardest at two things: the **deferred WARN/ERROR flush** in `audit-log.ts` (why it exists is a process-boundary problem, explained below), and the **ownership predicate** in `cliSandbox.ts`.

## Dive Deeper

### Where the corruption actually comes from

`createAndStartProxy()` is constructed only from `sandbox-containers.ts`, reached via `setupCredentialProxy()` from both `sandbox-containers.ts` and `sandbox-exec.ts`. Both run inside `start_sandbox()`, which is called from exactly one place: `maybeHopIntoSandbox()` in `cliSandbox.ts`. The host keeps `patchStdio()` active across the whole hop, so proxy stderr bytes are buffered on `coreEvents` and drained by `runExitCleanup()` after the child exits. The terminal handoff at `start_sandbox()` is the single seam where a TUI takes ownership.

### What changed

**Durable sink, always.** Every record, at every level, in every mode, is appended as one JSON line to `<Storage.getGlobalLogDir()>/credential-proxy-audit.log`. The log dir is resolved per write, so `LLXPRT_LOG_HOME` and the `LLXPRT_CONFIG_HOME` fallback still redirect it. The directory is created if absent. A sink that cannot be written degrades durability, not availability.

**Explicit terminal ownership.** `setTuiOwnsTerminal()` is exported from `audit-log.ts` and called from exactly one production site: `maybeHopIntoSandbox()`, immediately before `start_sandbox()`, released in a `finally`. Default is `false`, so every other entry point — non-interactive runs, scripts, library consumers, tests — keeps today's behavior.

**Zero stderr bytes under ownership.** While a TUI owns the terminal, INFO goes to the sink only. Nothing reaches `process.stderr` at any level.

**WARN/ERROR remain visible.** They are published to the `coreEvents` user-feedback surface, which is the right surface for any process that has a subscriber. But `coreEvents` is a per-process in-memory singleton and the subscribing Ink UI lives in the *child*; the host has no `UserFeedback` listener, and `initializeOutputListenersAndFlush()` drains the feedback backlog to nobody at teardown. Publishing alone would therefore have made proxy warnings and errors invisible — a regression. So WARN/ERROR are also held and flushed to stderr on the ownership release transition. By then the child has exited and the terminal is free, so the write cannot corrupt anything. Re-asserting the current ownership value is a no-op, an empty buffer writes nothing, and the buffer is cleared after flushing so a second release cannot reprint.

Transporting these notifications to the child over IPC was considered and rejected: it is a new subsystem, well beyond the scope of this fix.

**The ownership predicate is not just `isInteractive()`.** `resolveInteractiveMode()` consults only `promptWords` / `prompt` / `promptInteractive` / `experimentalAcp` and `process.stdin.isTTY` — never the image flags. Direct image mode is dispatched *after* the hop and never mounts Ink, so `llxprt --image-prompt X --image-output out.png` on a TTY reports `isInteractive() === true` while no TUI ever appears. The predicate is therefore `config.isInteractive() && !isImageModeActive(buildImageModeFlags(argv))`, using the same pair `detectImageModeFromArgv()` uses in `cli.tsx` so the hop and the dispatch cannot disagree.

**Unchanged.** The default path writes the same bytes to stderr it always did, at all three levels, still guarded by `process.stderr.destroyed` and still swallowing write failures. Redaction (`redactTokenShaped`) and the unserialisable-details fallback apply identically to the sink line, the stderr line and the feedback message.

### Deliberate non-changes

Log rotation for the new sink, severity changes at any call site, and other components' stderr writes are all out of scope. Two `try`/`catch` swallow points exist by design under the repo's fail-fast rule — the sink write and the stderr write. No third was added; `emitFeedback()` is deliberately left unwrapped.

### Review findings triaged

**Pre-PR review** raised five items, all addressed: the host/child feedback gap (fixed by the deferred flush), the `isInteractive()` predicate (fixed), tests that modelled a subscriber production does not have (four new no-subscriber tests added), duplicated `SANDBOX` env lifecycle in the CLI tests (extracted to a registered helper), and an over-wide public barrel (`tuiOwnsTerminal`, `AuditLevel`, `AuditLogFn` removed from `auth/index.ts`).

**PR review** raised eight; six are fixed in the second commit and two declined. Fixed: the deferred buffer is now bounded (see below); the stderr capture helpers decoded byte chunks with `String(chunk)`, which would have let the central `expect(stderr).toBe('')` assertion pass even if the implementation wrote Buffers; per-test audit state is reset in `beforeEach` as well as `afterEach`; and coverage was added for re-acquiring ownership after a flush, for redaction on stderr rather than only in the sink, and for the unserialisable fallback being parseable JSON.

The buffer bound deserves a note, because an earlier pass declined it. The argument that changed it: `frame_decode_error` (WARN) and `process_frames_error` (ERROR) fire **per incoming socket chunk**, not per connection, so a broken or hostile client can buffer one record per chunk for a whole sandbox session. That is a real unbounded-memory path, and it would also produce exactly the giant stderr block this issue set out to remove. The buffer now caps at 256, keeps the newest records, and reports evictions once as an `audit_deferred_overflow` record emitted ahead of the retained lines. Durability is untouched — evicted records are already in the file sink.

Declined, both under the fail-fast rule: awaiting a microtask before restoring the stderr spy (guards a hypothetical future async write path; `auditLog` is synchronous by construction), and wrapping `coreEvents.emitFeedback()` in try/catch (a throwing listener is an upstream bug that must surface; the two swallow points here are deliberately enumerated). A performance suggestion to cache the resolved log dir and batch appends asynchronously was also declined: `auditLog` is a cold path (19 INFO, 7 WARN, 4 ERROR call sites, a handful of records per session), the synchronous append is what makes the record durable without a flush lifecycle, and per-write resolution is the deliberate env test seam.

## Reviewer Test Plan

**The behavior, without a sandbox.** The routing is exercised directly by `packages/providers/src/auth/proxy/__tests__/audit-log-sink.test.ts`, which uses a real temp dir via `LLXPRT_LOG_HOME` and the real `process.stderr` — no fs mocking:

```bash
bun test packages/providers/src/auth/proxy/__tests__/audit-log-sink.test.ts
cd packages/cli && bun test src/cliSandbox.test.ts
```

**The original repro.** Start a sandboxed session and let it run past the first credential fetch and at least one 300 s idle reconnect:

```bash
llxprt --sandbox --sandbox-engine podman
```

Expect: no proxy JSON over the interface during the session, and no block of INFO records at teardown. Then confirm the records were kept, not dropped:

```bash
# macOS; Linux: ~/.local/state/llxprt-code/
tail -f ~/Library/Logs/llxprt-code/credential-proxy-audit.log
```

Every `connect`, `handshake_ok`, `get_api_key` and `disconnect` should be there, one JSON object per line.

**The non-TUI path is unchanged.** A non-interactive sandboxed run should still print audit records to stderr exactly as before:

```bash
llxprt --sandbox -p "say hi" 2>&1 | grep credential-proxy
```

**WARN/ERROR visibility.** Hardest to stage naturally; the four no-subscriber tests in the provider suite pin it. If you want to see it live, a proxy handshake failure during an interactive sandbox session should print nothing during the session and surface the WARN/ERROR lines once the sandbox exits.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS at both commits: `npm run format`, `npm run typecheck`, `npm run lint`, `npm run build` all clean, and the full `npm run test` suite green (9303 passed; one unrelated failure on the second run was a concurrent-session race in `sandbox-entrypoint.test.ts`, which snapshots the real config dir and passes 18/18 in isolation). The `stepfun-37` startup smoke test passes. `bun scripts/test-audit/scan.ts` reports no `MOCK_MIRROR`, `ALWAYS_TRUE`, `SELF_CONFIRMING` or `NO_ASSERT` findings on any touched file. Windows, Linux and the live container/seatbelt sandbox paths are not exercised locally; the sandbox-facing logic is covered by the CLI hop tests.

## Linked issues / bugs

Fixes #3490

Related to #3451, where this same output made the credential proxy look implicated when the routine disconnects were the ordinary 300 s idle timeout.
