### PR TITLE
fix(compression): escalate LB guard callback to full reduction ladder (Fixes #3499)

### DIFF
--- a/packages/agents/src/compression/CompressionHandler.ts
+++ b/packages/agents/src/compression/CompressionHandler.ts
@@ -55,7 +55,10 @@ import {
   estimatePendingTokens,
   getCompletionBudget,
 } from './compressionBudgeting.js';
-import { ProviderContentEnforcer } from './providerContentEnforcement.js';
+import {
+  ProviderContentEnforcer,
+  type CompressionGuardInfo,
+} from './providerContentEnforcement.js';
 import {
   TOKEN_SAFETY_MARGIN,
   CONTEXT_LIMIT_FUDGE_FACTOR,
@@ -375,7 +378,10 @@ export class CompressionHandler {
       return;
     }
 
-    const callback = async (_contents: IContent[]): Promise<IContent[]> => {
+    const callback = async (
+      _contents: IContent[],
+      guard?: CompressionGuardInfo,
+    ): Promise<IContent[]> => {
       if (pendingContents === undefined) {
         throw new Error(
           'Compression callback invoked but the pending-content boundary is ' +
@@ -386,7 +392,12 @@ export class CompressionHandler {
         );
       }
       try {
-        return await enforcer.compressAndRecompose(pendingContents, promptId);
+        return await enforcer.compressAndRecompose(
+          pendingContents,
+          promptId,
+          guard,
+          provider,
+        );
       } catch (error) {
         this.logger.warn(
           () => '[CompressionHandler] Compression callback failed',

--- a/packages/agents/src/compression/__tests__/compression-retry-provider-hardlimit.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-retry-provider-hardlimit.test.ts
@@ -743,19 +743,20 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
   });
 
   // -----------------------------------------------------------------------
-  // Test H: compressAndRecompose callback contract (issue #2588 regression).
+  // Test H: compressAndRecompose callback contract (issue #2588 regression,
+  // updated for issue #3499).
   //
   // compressAndRecompose is invoked from the provider compression callback
-  // (CompressionHandler.attachCompressionCallback). That callback's try/catch
-  // expects failure to THROW so the provider can reject the request.
-  // runCompressionAndRecompose catches errors/non-COMPRESSED results and
-  // returns them as structured compressionFailure — compressAndRecompose must
-  // rethrow that failure so the callback contract is honored, while the
-  // enforcement orchestration (enforce) continues to consume structured
+  // (CompressionHandler.attachCompressionCallback). It now runs the full
+  // escalation ladder: a plain compression failure or non-COMPRESSED result
+  // no longer aborts the callback — truncation rescues the request — but the
+  // compression failure still surfaces in the structured overflow error when
+  // even truncation cannot fit, preserving the provider rejection contract.
+  // The enforcement orchestration (enforce) continues to consume structured
   // failures for its own retry/truncation/overflow diagnostics.
   // -----------------------------------------------------------------------
-  describe('compressAndRecompose callback contract (rethrow compressionFailure)', () => {
-    it('throws when performCompression throws during callback compression', async () => {
+  describe('compressAndRecompose callback contract (overflow surfaces compressionFailure)', () => {
+    it('reports the compression failure through the structured overflow error when performCompression throws and truncation cannot fit', async () => {
       runtimeContext = buildRuntimeContext(historyService, {
         contextLimit: STANDARD_CONTEXT_LIMIT,
         compressionThreshold: COMPRESSION_THRESHOLD,
@@ -766,7 +767,7 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
 
       const harness = buildEnforcerHarness(historyService, runtimeContext);
       vi.spyOn(historyService, 'estimateTokensForContents').mockResolvedValue(
-        10_000,
+        150_000,
       );
 
       harness.deps.performCompression.mockRejectedValue(
@@ -778,7 +779,7 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
       ).rejects.toThrow('callback compression network failure');
     });
 
-    it('throws when performCompression returns a non-COMPRESSED result during callback compression', async () => {
+    it('reports a non-COMPRESSED result through the structured overflow error when truncation cannot fit', async () => {
       runtimeContext = buildRuntimeContext(historyService, {
         contextLimit: STANDARD_CONTEXT_LIMIT,
         compressionThreshold: COMPRESSION_THRESHOLD,
@@ -789,15 +790,16 @@ describe('ProviderContentEnforcer hard-limit retry policy (Issue #2588)', () => 
 
       const harness = buildEnforcerHarness(historyService, runtimeContext);
       vi.spyOn(historyService, 'estimateTokensForContents').mockResolvedValue(
-        10_000,
+        150_000,
       );
 
       harness.deps.performCompression.mockResolvedValue(
         PerformCompressionResult.FAILED,
       );
 
-      // A non-COMPRESSED result is a failure in the callback context; it must
-      // throw (not silently return unprojected contents).
+      // A non-COMPRESSED result no longer throws directly; the ladder first
+      // attempts truncation, and the failure surfaces via the structured
+      // overflow error only when nothing fits.
       await expect(
         harness.enforcer.compressAndRecompose([pending], 'test-prompt'),
       ).rejects.toThrow(/Auto compression did not complete/);

--- a/packages/agents/src/compression/__tests__/compression-unsafe-extraction.test.ts
+++ b/packages/agents/src/compression/__tests__/compression-unsafe-extraction.test.ts
@@ -203,13 +203,16 @@ describe('ProviderContentEnforcer envelope-based enforcement (issue #2304)', () 
     const pending = makeUserMessage('new pending request');
 
     const harness = buildEnforcerHarness(historyService, runtimeContext);
-    vi.spyOn(historyService, 'estimateTokensForContents').mockResolvedValue(
-      10_000,
-    );
+    const estimateSpy = vi
+      .spyOn(historyService, 'estimateTokensForContents')
+      .mockResolvedValue(135_000);
 
     harness.deps.performCompression.mockImplementation(async () => {
       historyService.clear();
       historyService.add(makeUserMessage('compressed summary'));
+      // Post-compression estimate fits the margin-adjusted limit, so the
+      // callback ladder returns after the compression round.
+      estimateSpy.mockResolvedValue(100_000);
       return PerformCompressionResult.COMPRESSED;
     });
 

--- a/packages/agents/src/compression/__tests__/providerContentEnforcement.callbackEscalation.test.ts
+++ b/packages/agents/src/compression/__tests__/providerContentEnforcement.callbackEscalation.test.ts
@@ -1,0 +1,414 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral tests for issue #3499: when the load-balancer context guard
+ * invokes the provider compression callback, the enforcer must run the full
+ * reduction ladder (density optimization, compression, ineffective retry,
+ * deficit-exact history truncation, unified tool-response truncation) and,
+ * when the guard supplies its estimate and limit, target
+ * `guard.contextLimit - overhead` instead of its own budget-derived ceiling.
+ *
+ * The tests use the REAL ProviderContentEnforcer over a REAL HistoryService
+ * with real token estimation, driving the REAL TopDownTruncationStrategy
+ * through the real compression-context builder — the same wiring
+ * CompressionHandler uses. Assertions are on returned contents and token
+ * projections, never on mock interactions.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'bun:test';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
+import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
+import { PerformCompressionResult } from '@vybestack/llxprt-code-core/core/turn.js';
+import {
+  ProviderContentEnforcer,
+  type ProviderContentEnforcementDeps,
+} from '../providerContentEnforcement.js';
+import { TopDownTruncationStrategy } from '../TopDownTruncationStrategy.js';
+import { buildCompressionContext } from '../compressionContextBuilder.js';
+import { computeMarginAdjustedLimit } from '../contextLimitPolicy.js';
+import {
+  buildRuntimeContext,
+  buildMockContentGenerator,
+} from '../../core/__tests__/chatSession-density-helpers.js';
+import { ChatSession } from '../../core/chatSession.js';
+import type { CompressionCallback } from '@vybestack/llxprt-code-providers';
+import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
+
+const MODEL = 'test-model';
+const HISTORY_MESSAGES = 14;
+const MESSAGE_WORDS = 280;
+// Simulated tool-schema/prompt overhead the contents-only estimator cannot
+// see — the reason the guard's estimate exceeds the enforcer's own estimate.
+const GUARD_OVERHEAD = 350;
+const SESSION_CONTEXT_LIMIT = 200_000;
+
+interface GuardInfo {
+  estimatedTokens: number;
+  contextLimit: number;
+}
+
+type GuardAwareCallback = (
+  contents: IContent[],
+  guard?: GuardInfo,
+) => Promise<IContent[]>;
+
+function makeLogger(): DebugLogger {
+  return {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  } as unknown as DebugLogger;
+}
+
+function textContent(speaker: IContent['speaker'], text: string): IContent {
+  return { speaker, blocks: [{ type: 'text', text }] };
+}
+
+function resultText(contents: IContent[]): string {
+  return contents
+    .flatMap((content) => content.blocks)
+    .filter((block) => block.type === 'text')
+    .map((block) => block.text)
+    .join('\n');
+}
+
+function seedHistory(historyService: HistoryService): void {
+  for (let i = 0; i < HISTORY_MESSAGES; i++) {
+    // Zero-padded markers keep substring assertions unambiguous.
+    historyService.add(
+      textContent(
+        i % 2 === 0 ? 'human' : 'ai',
+        `entry ${String(i).padStart(2, '0')} ${'word '.repeat(MESSAGE_WORDS)}`,
+      ),
+    );
+  }
+}
+
+function makePending(): IContent {
+  return textContent(
+    'human',
+    `pending-marker ${'word '.repeat(MESSAGE_WORDS)}`,
+  );
+}
+
+/** Build guard facts whose estimate exceeds its limit by `excess` tokens. */
+function guardOverBy(initialEstimate: number, excess: number): GuardInfo {
+  return {
+    estimatedTokens: initialEstimate + GUARD_OVERHEAD,
+    contextLimit: initialEstimate + GUARD_OVERHEAD - excess,
+  };
+}
+
+/** effectiveLimit the enforcer must satisfy: guard.contextLimit - overhead. */
+function effectiveLimitFor(guard: GuardInfo): number {
+  return guard.contextLimit - GUARD_OVERHEAD;
+}
+
+function expectCapturedCallback(
+  callback: GuardAwareCallback | null,
+): GuardAwareCallback {
+  expect(callback).not.toBeNull();
+  if (callback === null) {
+    throw new Error('Expected compression callback to be captured');
+  }
+  return callback;
+}
+
+/**
+ * Wire performFallbackCompression exactly as CompressionHandler does: build a
+ * real compression context carrying the caller-supplied target, run the real
+ * TopDownTruncationStrategy, and commit its candidate history.
+ */
+function buildFallbackCompression(
+  historyService: HistoryService,
+  runtimeContext: AgentRuntimeContext,
+  logger: DebugLogger,
+): ProviderContentEnforcementDeps['performFallbackCompression'] {
+  return async (promptId, applyResult, targetTokenCount) => {
+    const context = await buildCompressionContext(
+      promptId,
+      runtimeContext,
+      historyService,
+      () =>
+        Promise.resolve({
+          provider: {} as never,
+          runtime: {} as never,
+        }),
+      undefined,
+      logger,
+      { targetTokenCount },
+    );
+    const result = await new TopDownTruncationStrategy().compress(context);
+    if (result.kind === 'noop') {
+      return false;
+    }
+    await applyResult(result.newHistory);
+    return true;
+  };
+}
+
+/**
+ * Replace history with itself minus its oldest entry — a compression round
+ * that under-delivers relative to a multi-message deficit.
+ */
+async function shedOldestMessage(
+  historyService: HistoryService,
+): Promise<void> {
+  const original = [...historyService.getCurated()];
+  historyService.clear();
+  for (const entry of original.slice(1)) {
+    historyService.add(entry);
+  }
+  await historyService.waitForTokenUpdates();
+}
+
+interface DirectHarness {
+  enforcer: ProviderContentEnforcer;
+  historyService: HistoryService;
+  pending: IContent;
+  contents: IContent[];
+  initialEstimate: number;
+}
+
+async function buildDirectHarness(options: {
+  contextLimit: number;
+  compression?: 'noop' | 'underdeliver';
+}): Promise<DirectHarness> {
+  const historyService = new HistoryService();
+  const runtimeContext = buildRuntimeContext(historyService, {
+    contextLimit: options.contextLimit,
+    compressionThreshold: 0.8,
+  });
+  const logger = makeLogger();
+  seedHistory(historyService);
+  await historyService.waitForTokenUpdates();
+  const pending = makePending();
+  const contents = historyService.getCuratedForProvider([pending]);
+  const initialEstimate = await historyService.estimateTokensForContents(
+    contents,
+    MODEL,
+  );
+
+  let compressionCalls = 0;
+  const deps: ProviderContentEnforcementDeps = {
+    historyService,
+    runtimeContext,
+    generationConfig: {},
+    providerRuntimeNullable: undefined,
+    logger,
+    ensureDensityOptimized: vi.fn().mockResolvedValue(undefined),
+    performCompression: vi.fn(async () => {
+      compressionCalls++;
+      if (options.compression === 'underdeliver' && compressionCalls === 1) {
+        await shedOldestMessage(historyService);
+        return PerformCompressionResult.COMPRESSED;
+      }
+      return PerformCompressionResult.NOOP;
+    }),
+    performFallbackCompression: buildFallbackCompression(
+      historyService,
+      runtimeContext,
+      logger,
+    ),
+    getPromptTokenBaseline: () => null,
+    resetPromptTokenBaseline: () => {},
+    restorePromptTokenBaseline: () => {},
+  };
+
+  return {
+    enforcer: new ProviderContentEnforcer(deps),
+    historyService,
+    pending,
+    contents,
+    initialEstimate,
+  };
+}
+
+describe('ProviderContentEnforcer compression-callback escalation (issue #3499)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('T2: escalates past an under-delivering compression round and truncates history to the guard target', async () => {
+    const historyService = new HistoryService();
+    const runtimeContext = buildRuntimeContext(historyService, {
+      contextLimit: SESSION_CONTEXT_LIMIT,
+      compressionThreshold: 0.8,
+    });
+    seedHistory(historyService);
+    const pending = makePending();
+    const chat = new ChatSession(
+      runtimeContext,
+      buildMockContentGenerator(),
+      {},
+      [],
+    );
+    const handler = chat['compressionHandler'];
+
+    let compressionCalls = 0;
+    vi.spyOn(handler, 'performCompression').mockImplementation(async () => {
+      compressionCalls++;
+      if (compressionCalls === 1) {
+        await shedOldestMessage(historyService);
+        return PerformCompressionResult.COMPRESSED;
+      }
+      return PerformCompressionResult.NOOP;
+    });
+
+    let capturedCallback: GuardAwareCallback | null = null;
+    const providerWithCallback = {
+      name: 'load-balancer',
+      generateChatCompletion: vi.fn(),
+      setCompressionCallback: vi.fn((cb: CompressionCallback | null) => {
+        if (cb !== null) {
+          capturedCallback = cb;
+        }
+      }),
+    };
+
+    const contents = historyService.getCuratedForProvider([pending]);
+    const initialEstimate = await historyService.estimateTokensForContents(
+      contents,
+      MODEL,
+    );
+    await handler.enforceProviderContents(
+      { contents, pendingContents: [pending] },
+      'prompt-3499',
+      providerWithCallback as unknown as IProvider,
+    );
+
+    const callback = expectCapturedCallback(capturedCallback);
+    const guard = guardOverBy(initialEstimate, 900);
+    const result = await callback(contents, guard);
+
+    const finalEstimate = await historyService.estimateTokensForContents(
+      result,
+      MODEL,
+    );
+    expect(finalEstimate).toBeLessThanOrEqual(effectiveLimitFor(guard));
+    // Compression shed only entry 00; truncation had to remove more than
+    // that for the payload to fit the guard target, while entry 03 onward
+    // survives and the pending request is preserved.
+    expect(resultText(result)).not.toContain('entry 00');
+    expect(resultText(result)).not.toContain('entry 01');
+    expect(resultText(result)).toContain('entry 03');
+    expect(resultText(result)).toContain('pending-marker');
+  });
+
+  it('T3: returns fitting contents instead of throwing when compression is a structural no-op', async () => {
+    const harness = await buildDirectHarness({
+      contextLimit: SESSION_CONTEXT_LIMIT,
+      compression: 'noop',
+    });
+    const guard = guardOverBy(harness.initialEstimate, 900);
+    const historyTokensBefore = harness.historyService.getTotalTokens();
+
+    const result = await harness.enforcer.compressAndRecompose(
+      [harness.pending],
+      'prompt-3499',
+      guard,
+    );
+
+    const finalEstimate =
+      await harness.historyService.estimateTokensForContents(result, MODEL);
+    expect(finalEstimate).toBeLessThanOrEqual(effectiveLimitFor(guard));
+    expect(harness.historyService.getTotalTokens()).toBeLessThan(
+      historyTokensBefore,
+    );
+  });
+
+  it('T3: throws the structured overflow error when even truncation cannot fit the guard limit', async () => {
+    const harness = await buildDirectHarness({
+      contextLimit: SESSION_CONTEXT_LIMIT,
+      compression: 'noop',
+    });
+    const guard: GuardInfo = {
+      estimatedTokens: harness.initialEstimate + GUARD_OVERHEAD,
+      contextLimit: 40,
+    };
+
+    await expect(
+      harness.enforcer.compressAndRecompose(
+        [harness.pending],
+        'prompt-3499',
+        guard,
+      ),
+    ).rejects.toThrow(
+      /Request still exceeds the safety-adjusted context limit/,
+    );
+  });
+
+  it('T4: targets contextLimit minus overhead for a small deficit instead of over-cutting', async () => {
+    const harness = await buildDirectHarness({
+      contextLimit: SESSION_CONTEXT_LIMIT,
+      compression: 'noop',
+    });
+    const guard = guardOverBy(harness.initialEstimate, 800);
+    const historyTokensBefore = harness.historyService.getTotalTokens();
+
+    const result = await harness.enforcer.compressAndRecompose(
+      [harness.pending],
+      'prompt-3499',
+      guard,
+    );
+
+    const finalEstimate =
+      await harness.historyService.estimateTokensForContents(result, MODEL);
+    expect(finalEstimate).toBeLessThanOrEqual(effectiveLimitFor(guard));
+    // A deficit-exact target removes roughly the deficit; a default
+    // completion-budget ceiling (~limit/2) would land far below this floor.
+    expect(finalEstimate).toBeGreaterThan(effectiveLimitFor(guard) - 800);
+    expect(finalEstimate).toBeGreaterThan(guard.contextLimit / 2);
+    expect(harness.historyService.getTotalTokens()).toBeLessThan(
+      historyTokensBefore,
+    );
+  });
+
+  it('T4: converges against the enforcer own limits when no guard info is supplied', async () => {
+    const contextLimit = 6_000;
+    const harness = await buildDirectHarness({
+      contextLimit,
+      compression: 'noop',
+    });
+    const historyTokensBefore = harness.historyService.getTotalTokens();
+    const completionBudget = Math.min(65_536, Math.floor(contextLimit * 0.5));
+    const marginAdjustedLimit = computeMarginAdjustedLimit(contextLimit);
+
+    const result = await harness.enforcer.compressAndRecompose(
+      [harness.pending],
+      'prompt-3499',
+    );
+
+    const finalEstimate =
+      await harness.historyService.estimateTokensForContents(result, MODEL);
+    expect(finalEstimate + completionBudget).toBeLessThanOrEqual(
+      marginAdjustedLimit,
+    );
+    expect(harness.historyService.getTotalTokens()).toBeLessThan(
+      historyTokensBefore,
+    );
+    expect(resultText(result)).toContain('pending-marker');
+  });
+
+  it('T4: keeps an empty pending boundary a no-op regardless of guard facts', async () => {
+    const harness = await buildDirectHarness({
+      contextLimit: SESSION_CONTEXT_LIMIT,
+      compression: 'noop',
+    });
+    const guard = guardOverBy(harness.initialEstimate, 900);
+
+    const result = await harness.enforcer.compressAndRecompose(
+      [],
+      'prompt-3499',
+      guard,
+    );
+
+    expect(result).toStrictEqual([]);
+  });
+});

--- a/packages/agents/src/compression/providerContentEnforcement.ts
+++ b/packages/agents/src/compression/providerContentEnforcement.ts
@@ -12,7 +12,10 @@ import {
   type IContent,
 } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { AgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
-import type { RuntimeProvider as IProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
+import type {
+  RuntimeProvider as IProvider,
+  RuntimeCompressionGuardInfo,
+} from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
 import type { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
 import { PerformCompressionResult } from '@vybestack/llxprt-code-core/core/turn.js';
 import { getCompletionBudget } from './compressionBudgeting.js';
@@ -62,6 +65,13 @@ interface ContextLimits {
   marginAdjustedLimit: number;
   compressionThreshold: number;
 }
+
+/**
+ * Guard facts supplied by the load-balancer context guard when it invokes the
+ * compression callback: its own finalized-envelope estimate and the configured
+ * per-sub-profile context limit (issue #3499).
+ */
+export type CompressionGuardInfo = RuntimeCompressionGuardInfo;
 
 interface ProjectionResult {
   contents: IContent[];
@@ -125,37 +135,13 @@ export class ProviderContentEnforcer {
       return postOpt.contents;
     }
 
-    const firstResult = await this.runCompressionAndRecompose(
-      promptId,
-      envelope.pendingContents,
-      limits.completionBudget,
-      model,
-    );
-    if (firstResult.projected <= limits.marginAdjustedLimit) {
-      return firstResult.contents;
-    }
-
-    const retryResult = await this.retryCompressionIfIneffective(
-      promptId,
-      envelope.pendingContents,
-      limits.completionBudget,
-      model,
-      limits.marginAdjustedLimit,
-      postOpt.projected,
-      firstResult,
-    );
-    if (retryResult.projected <= limits.marginAdjustedLimit) {
-      return retryResult.contents;
-    }
-
-    return this.enforceTruncation(
+    return this.enforceWithEscalation(
       promptId,
       envelope.pendingContents,
       limits,
       model,
       initialProjected,
-      retryResult.compressionFailure,
-      retryResult.projected,
+      postOpt.projected,
     );
   }
 
@@ -293,33 +279,143 @@ export class ProviderContentEnforcer {
   }
 
   /**
-   * Compresses history and recomposes it with pending content.
+   * Compresses history and recomposes it with pending content, escalating
+   * through the same reduction ladder as enforce() (density optimization,
+   * compression, ineffective-compression retry, deficit-exact history
+   * truncation, unified tool-response truncation) so a structurally
+   * ineffective compression round no longer dead-ends the callback.
    *
-   * @throws When compression throws or returns a non-COMPRESSED result.
+   * When guard facts are supplied, the ladder targets the guard's limit minus
+   * the per-request overhead the contents-only estimator cannot see, with no
+   * completion budget of its own — the guard defines the contract being
+   * satisfied (issue #3499). Without guard facts it converges against the
+   * enforcer's own computed limits.
+   *
+   * @throws When even unified tool-response truncation cannot fit the target
+   * (structured context-overflow error).
    */
   async compressAndRecompose(
     pendingContents: IContent[],
     promptId: string,
+    guard?: CompressionGuardInfo,
+    provider?: IProvider,
   ): Promise<IContent[]> {
     if (pendingContents.length === 0) {
       return [];
     }
-    const result = await this.runCompressionAndRecompose(
+    const model = this.resolveModel(provider);
+    const { limits, initialProjected } = await this.computeCallbackLimits(
+      pendingContents,
+      guard,
+      provider,
+      model,
+    );
+    const postOpt = await this.optimizeAndProject(
+      pendingContents,
+      limits.completionBudget,
+      model,
+    );
+    if (postOpt.projected <= limits.marginAdjustedLimit) {
+      return postOpt.contents;
+    }
+    return this.enforceWithEscalation(
       promptId,
       pendingContents,
-      0,
-      this.deps.runtimeContext.state.model,
+      limits,
+      model,
+      initialProjected,
+      postOpt.projected,
     );
-    // runCompressionAndRecompose catches errors/non-COMPRESSED results and
-    // returns them as a structured compressionFailure. The provider compression
-    // callback contract (attachCompressionCallback) expects failure to throw
-    // so the provider can reject the request. Rethrow here honors that contract;
-    // the enforcement orchestration (enforce) consumes the structured failure
-    // directly via runCompressionAndRecompose and is unaffected.
-    if (result.compressionFailure !== undefined) {
-      throw result.compressionFailure;
+  }
+
+  /**
+   * Compression → ineffective-compression retry → truncation escalation
+   * shared by the pre-send enforce() path and the provider compression
+   * callback. Projections and limits must follow one budget convention per
+   * call, supplied via `limits`.
+   */
+  private async enforceWithEscalation(
+    promptId: string,
+    pendingContents: IContent[],
+    limits: ContextLimits,
+    model: string,
+    initialProjected: number,
+    preCompressionProjected: number,
+  ): Promise<IContent[]> {
+    const firstResult = await this.runCompressionAndRecompose(
+      promptId,
+      pendingContents,
+      limits.completionBudget,
+      model,
+    );
+    if (firstResult.projected <= limits.marginAdjustedLimit) {
+      return firstResult.contents;
     }
-    return result.contents;
+
+    const retryResult = await this.retryCompressionIfIneffective(
+      promptId,
+      pendingContents,
+      limits.completionBudget,
+      model,
+      limits.marginAdjustedLimit,
+      preCompressionProjected,
+      firstResult,
+    );
+    if (retryResult.projected <= limits.marginAdjustedLimit) {
+      return retryResult.contents;
+    }
+
+    return this.enforceTruncation(
+      promptId,
+      pendingContents,
+      limits,
+      model,
+      initialProjected,
+      retryResult.compressionFailure,
+      retryResult.projected,
+    );
+  }
+
+  /**
+   * Limits for the compression-callback entry point. Guard facts override the
+   * enforcer's own budget-derived limits: the guard's estimate covers the full
+   * finalized envelope (tool schemas, system prompt) the contents-only
+   * estimator cannot see, so that difference is treated as fixed overhead and
+   * the fit predicate mirrors the guard's own check,
+   * ownEstimate(contents') + overhead <= guard.contextLimit, with no
+   * completion budget re-reserved (issue #3499).
+   */
+  private async computeCallbackLimits(
+    pendingContents: IContent[],
+    guard: CompressionGuardInfo | undefined,
+    provider: IProvider | undefined,
+    model: string,
+  ): Promise<{ limits: ContextLimits; initialProjected: number }> {
+    if (guard === undefined) {
+      const limits = this.computeContextLimits(provider, model);
+      const initialProjected = await this.estimateProviderProjection(
+        this.recomposeProviderContents(pendingContents),
+        limits.completionBudget,
+        model,
+        'initial',
+      );
+      return { limits, initialProjected };
+    }
+    const initialProjected = await this.estimateProviderProjection(
+      this.recomposeProviderContents(pendingContents),
+      0,
+      model,
+      'initial',
+    );
+    const overhead = Math.max(0, guard.estimatedTokens - initialProjected);
+    const effectiveLimit = Math.max(1, guard.contextLimit - overhead);
+    const limits: ContextLimits = {
+      completionBudget: 0,
+      limit: guard.contextLimit,
+      marginAdjustedLimit: effectiveLimit,
+      compressionThreshold: effectiveLimit,
+    };
+    return { limits, initialProjected };
   }
 
   private async truncateToolResponsesUnified(

--- a/packages/core/src/runtime/contracts/RuntimeProvider.ts
+++ b/packages/core/src/runtime/contracts/RuntimeProvider.ts
@@ -37,6 +37,12 @@ export interface RuntimeToolset {
   functionDeclarations: RuntimeToolDeclaration[];
 }
 
+/** Guard facts a provider supplies when its context guard invokes the compression callback (issue #3499). */
+export interface RuntimeCompressionGuardInfo {
+  readonly estimatedTokens: number;
+  readonly contextLimit: number;
+}
+
 /**
  * Core-owned structural provider contract.
  *
@@ -64,7 +70,12 @@ export interface RuntimeProvider {
   clearAuth?(): void;
 
   setCompressionCallback?(
-    callback: ((contents: IContent[]) => Promise<IContent[]>) | null,
+    callback:
+      | ((
+          contents: IContent[],
+          guard?: RuntimeCompressionGuardInfo,
+        ) => Promise<IContent[]>)
+      | null,
   ): void;
 
   getServerTools(): string[];

--- a/packages/core/src/runtime/contracts/index.ts
+++ b/packages/core/src/runtime/contracts/index.ts
@@ -16,6 +16,7 @@
  */
 
 export type {
+  RuntimeCompressionGuardInfo,
   RuntimeProvider,
   RuntimeToolDeclaration,
   RuntimeToolset,

--- a/packages/providers/src/LoadBalancingProvider.ts
+++ b/packages/providers/src/LoadBalancingProvider.ts
@@ -248,7 +248,10 @@ export class LoadBalancingProvider implements IProvider {
     );
     let compressed: IContent[];
     try {
-      compressed = await this.compressionCallback(clonedContents);
+      compressed = await this.compressionCallback(clonedContents, {
+        estimatedTokens: result.tokens,
+        contextLimit,
+      });
     } catch (error) {
       throw new LoadBalancerCompressionCallbackError({
         profileName: this.config.profileName,

--- a/packages/providers/src/__tests__/LoadBalancingProvider.compressionGuard.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.compressionGuard.test.ts
@@ -1,0 +1,231 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral tests for the load-balancer context guard passing its token
+ * facts to the compression callback (issue #3499).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'bun:test';
+import { ProviderManager } from '../ProviderManager.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import {
+  LoadBalancingProvider,
+  type ResolvedSubProfile,
+} from '../LoadBalancingProvider.js';
+import type { GenerateChatOptions, IProvider } from '../IProvider.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { RuntimeTokenizerFactory } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeTokenizerFactory.js';
+import type { RuntimeTokenizer } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeTokenizer.js';
+
+interface GuardInfo {
+  estimatedTokens: number;
+  contextLimit: number;
+}
+
+function createTextContent(text: string): IContent {
+  return { speaker: 'human', blocks: [{ type: 'text', text }] };
+}
+
+function createResolvedSubProfile(
+  overrides: Partial<ResolvedSubProfile>,
+): ResolvedSubProfile {
+  return {
+    name: overrides.name ?? 'sub',
+    providerName: overrides.providerName ?? 'openai',
+    model: overrides.model ?? 'gpt-4.1',
+    baseURL: overrides.baseURL,
+    authToken: overrides.authToken ?? 'test-token',
+    authKeyfile: overrides.authKeyfile,
+    contextWindow: overrides.contextWindow,
+    ephemeralSettings: overrides.ephemeralSettings ?? {},
+    modelParams: overrides.modelParams ?? {},
+  };
+}
+
+function createMockProvider(overrides: Partial<IProvider> = {}): IProvider {
+  return {
+    name: overrides.name ?? 'mock-provider',
+    generateChatCompletion:
+      overrides.generateChatCompletion ??
+      async function* (): AsyncGenerator<IContent> {
+        yield { speaker: 'ai', blocks: [{ type: 'text', text: 'ok' }] };
+      },
+    getModels: overrides.getModels ?? (async () => []),
+    getDefaultModel: overrides.getDefaultModel ?? (() => 'mock-model'),
+    getServerTools: overrides.getServerTools ?? (() => []),
+    invokeServerTool: overrides.invokeServerTool ?? (async () => ({})),
+  };
+}
+
+function createCountingTokenizer(
+  spy: (text: string) => void,
+): RuntimeTokenizer {
+  return {
+    countTokens: (content: unknown) => {
+      if (typeof content !== 'string') {
+        return Promise.reject(
+          new Error(`countTokens received non-string input: ${typeof content}`),
+        );
+      }
+      spy(content);
+      return Promise.resolve(Math.ceil(content.length / 4));
+    },
+  };
+}
+
+function createTokenizerFactory(
+  tokenizerMap: Record<string, RuntimeTokenizer>,
+): RuntimeTokenizerFactory {
+  return {
+    getTokenizer: (
+      providerName: string,
+      model?: string,
+    ): RuntimeTokenizer | undefined => tokenizerMap[model ?? providerName],
+    estimatePrompt: (request) =>
+      request.legacyEstimate().then((count) => ({
+        count,
+        method: 'exact',
+        family: 'test',
+        estimatorVersion: 'test',
+        assetRevision: 'test',
+        projectionRevision: request.projectionRevision,
+      })),
+  };
+}
+
+async function consumeIterator(
+  provider: LoadBalancingProvider,
+  contents: IContent[],
+): Promise<IContent[]> {
+  const results: IContent[] = [];
+  for await (const chunk of provider.generateChatCompletion({
+    contents,
+  } as GenerateChatOptions)) {
+    results.push(chunk);
+  }
+  return results;
+}
+
+describe('LoadBalancingProvider - compression guard facts (issue #3499)', () => {
+  let settingsService: SettingsService;
+  let config: Config;
+  let providerManager: ProviderManager;
+
+  beforeEach(() => {
+    settingsService = new SettingsService();
+    config = createRuntimeConfigStub(settingsService);
+    providerManager = new ProviderManager({ settingsService, config });
+  });
+
+  it('passes the guard estimate and context limit to the compression callback', async () => {
+    const factory = createTokenizerFactory({
+      'gpt-4.1': createCountingTokenizer(() => {}),
+    });
+    providerManager.setTokenizerFactory(factory);
+    const sentToOpenAi: IContent[][] = [];
+    providerManager.registerProvider(
+      createMockProvider({
+        name: 'openai',
+        async *generateChatCompletion(
+          optionsOrContent: GenerateChatOptions | IContent[],
+        ): AsyncGenerator<IContent> {
+          const contents = Array.isArray(optionsOrContent)
+            ? optionsOrContent
+            : optionsOrContent.contents;
+          sentToOpenAi.push(structuredClone(contents));
+          yield { speaker: 'ai', blocks: [{ type: 'text', text: 'ok' }] };
+        },
+      }),
+    );
+
+    const contextLimit = 10;
+    const provider = new LoadBalancingProvider(
+      {
+        profileName: 'guard-facts-test',
+        strategy: 'round-robin',
+        contextLimit,
+        subProfiles: [
+          createResolvedSubProfile({
+            name: 'gpt',
+            providerName: 'openai',
+            model: 'gpt-4.1',
+          }),
+        ],
+      },
+      providerManager,
+    );
+
+    const requestText = 'this is a very long message that exceeds the limit';
+    let capturedGuard: GuardInfo | undefined;
+    const compressionCallback = vi.fn(
+      async (_contents: IContent[], guard?: GuardInfo): Promise<IContent[]> => {
+        capturedGuard = guard;
+        return [createTextContent('ok')];
+      },
+    );
+    provider.setCompressionCallback(compressionCallback);
+
+    const result = await consumeIterator(provider, [
+      createTextContent(requestText),
+    ]);
+
+    // The counting tokenizer is the estimator under test; the guard must
+    // report exactly the number it computed for the over-limit request.
+    const expectedEstimate = Math.ceil(requestText.length / 4);
+    expect(expectedEstimate).toBeGreaterThan(contextLimit);
+    expect(compressionCallback).toHaveBeenCalledTimes(1);
+    expect(capturedGuard).toStrictEqual({
+      estimatedTokens: expectedEstimate,
+      contextLimit,
+    });
+    // The compressed payload re-estimates under the limit, so the request
+    // proceeds (existing guard behavior).
+    expect(sentToOpenAi).toStrictEqual([[createTextContent('ok')]]);
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('still invokes single-argument callbacks when the estimate exceeds the limit', async () => {
+    const factory = createTokenizerFactory({
+      'gpt-4.1': createCountingTokenizer(() => {}),
+    });
+    providerManager.setTokenizerFactory(factory);
+    providerManager.registerProvider(
+      createMockProvider({
+        name: 'openai',
+        getDefaultModel: () => 'gpt-4.1',
+      }),
+    );
+
+    const provider = new LoadBalancingProvider(
+      {
+        profileName: 'legacy-callback-test',
+        strategy: 'round-robin',
+        contextLimit: 10,
+        subProfiles: [
+          createResolvedSubProfile({
+            name: 'gpt',
+            providerName: 'openai',
+            model: 'gpt-4.1',
+          }),
+        ],
+      },
+      providerManager,
+    );
+
+    const compressionCallback = vi.fn(async (_contents: IContent[]) => [
+      createTextContent('ok'),
+    ]);
+    provider.setCompressionCallback(compressionCallback);
+
+    const result = await consumeIterator(provider, [
+      createTextContent('this is a very long message that exceeds the limit'),
+    ]);
+
+    expect(compressionCallback).toHaveBeenCalledTimes(1);
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/providers/src/loadBalancing/loadBalancerTypes.ts
+++ b/packages/providers/src/loadBalancing/loadBalancerTypes.ts
@@ -4,9 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { RuntimeCompressionGuardInfo } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 
-export type CompressionCallback = (contents: IContent[]) => Promise<IContent[]>;
+export type CompressionCallback = (
+  contents: IContent[],
+  guard?: RuntimeCompressionGuardInfo,
+) => Promise<IContent[]>;
 
 export interface LoadBalancerSubProfile {
   name: string;

--- a/project-plans/issue3499/plan.md
+++ b/project-plans/issue3499/plan.md
@@ -1,0 +1,229 @@
+# Issue #3499 — Load-balancer context guard must compress or otherwise handle overflow instead of dead-ending
+
+## Problem restated from evidence
+
+A session on a `load-balancer` profile ("glm", sub-profiles zai / ollamaglm51 /
+chutesglm52, all with a 200000-token limit) failed the turn with:
+
+```
+API Error: Load balancer "glm" context limit exceeded for all eligible backends:
+zai: ... estimated 200266 tokens exceeds configured limit 200000;
+ollamaglm51: ... estimated 203333 ...; chutesglm52: ... estimated 204973 ...
+```
+
+The session was marginally over the limit (zai by 266 tokens). The user expects
+the system to "compress or otherwise handle it" — the same way direct-provider
+traffic is handled — rather than kill the turn with an API error.
+
+## Root-cause analysis
+
+Two code paths meet at this failure, and each has a gap.
+
+### Gap 1 — the guard's only remediation is one compression round
+
+`LoadBalancingProvider.enforceTokenLimitForTarget`
+(`packages/providers/src/LoadBalancingProvider.ts`) estimates the finalized
+prompt per sub-profile and, when the estimate exceeds the target limit, calls
+`compressForContextLimit`, which:
+
+1. invokes `this.compressionCallback(clonedContents)` exactly once, then
+2. re-estimates, and if still over the limit returns `undefined`, and then
+3. throws `LoadBalancerContextLimitError` → failover walks every backend →
+   `LoadBalancerAllContextLimitsExceededError` → the turn dies.
+
+The callback maps to
+`ProviderContentEnforcer.compressAndRecompose`
+(`packages/agents/src/compression/providerContentEnforcement.ts`), which runs
+ONE `performCompression` with `completionBudget = 0` and no fit check. It has
+none of the escalation the pre-send `enforce()` ladder has: no
+ineffective-compression retry, no fallback history truncation, no unified
+tool-response truncation. So when compression is structurally ineffective for
+the deficit (recent-turn and memory exclusions leave little compressible mass;
+the session is only a few hundred tokens over), the guard dead-ends even though
+the machinery to shed those tokens exists and is used for direct providers.
+This matches the evidence: the per-backend messages are plain
+`LoadBalancerContextLimitError`s, i.e. the callback returned contents (did not
+throw) and the re-estimate still exceeded the limit.
+
+### Gap 2 — the callback cannot target the guard's limit
+
+The guard's estimate is the sub-profile's full finalized envelope: the delegate
+provider's `projectPromptEnvelope` projection, which includes tool-schema
+rendering (that is why the three backends report 200266 / 203333 / 204973 for
+the same conversation). The enforcer's own estimate is contents-only (the
+load-balancer implements no `projectPromptEnvelope`, so the app-side finalized
+estimate is null and enforcement falls back to a contents-only estimate). The
+callback receives only `contents` — it does not know the guard's estimate or
+limit — so even with the full ladder it can only converge by luck of its
+completion-budget margin covering the tool-schema overhead it cannot see.
+
+## Accepted behavior
+
+### AB1 — the compression callback escalates to the full reduction ladder
+
+When the load-balancer guard invokes the compression callback,
+`ProviderContentEnforcer.compressAndRecompose` must run the same escalation as
+`enforce()`:
+
+1. density optimization + recomposition,
+2. compression (`performCompression`, cooldown bypassed),
+3. ineffective-compression retry (< 5% reduction),
+4. fallback history truncation to a deficit-exact target
+   (`computeHistoryTruncationTarget` semantics),
+5. unified tool-response truncation as the last resort,
+
+and return contents that fit the target limit. A plain compression failure or
+structural no-op no longer aborts the callback; truncation rescues the request.
+Only when even tool-response truncation cannot fit does the callback throw
+(preserving the provider callback failure contract:
+`LoadBalancerCompressionCallbackError` → failover → aggregate error).
+
+### AB2 — the callback targets the guard's actual limit
+
+The `CompressionCallback` protocol gains an optional second argument the
+load-balancer populates from its guard state:
+
+```ts
+type CompressionCallback = (
+  contents: IContent[],
+  guard?: { estimatedTokens: number; contextLimit: number },
+) => Promise<IContent[]>;
+```
+
+`LoadBalancingProvider.compressForContextLimit` passes
+`{ estimatedTokens: result.tokens, contextLimit }`. When the guard info is
+present, the enforcer derives the per-request overhead it cannot see
+(`overhead = guard.estimatedTokens - ownEstimate(originalContents)`, clamped at
+0) and enforces `ownEstimate(contents') <= guard.contextLimit - overhead`
+without adding its own completion budget (the guard defines the contract being
+satisfied; re-reserving a 65536-token default budget would discard tens of
+thousands of tokens of live context unnecessarily). Truncation targets that
+deficit exactly, so the request converges onto the guard instead of over-cutting
+or under-cutting. When the guard info is absent (any other caller), the ladder
+runs against the enforcer's own computed limits (still strictly better than
+today's single compression round).
+
+Backward compatibility: existing callbacks that take only `contents` remain
+assignable (fewer-parameters functions are assignable to the widened type); the
+providers-package tests with `(contents) => ...` fakes keep passing unchanged.
+
+### AB3 — behavior of the guard itself is otherwise unchanged
+
+- Estimation, `getTargetContextLimit` (min of shared and member limits),
+  failover walking, aggregate error text, metrics/circuit-breaker accounting,
+  and transport are untouched.
+- Round-robin and failover strategies both benefit through the shared
+  `enforceTokenLimitForTarget` → `compressForContextLimit` path.
+- When no callback is attached (embedders that never call
+  `setCompressionCallback`) the guard still throws as today.
+
+### AB4 — the overflow error stays honest
+
+If reduction is genuinely impossible (limit smaller than the un-truncatable
+payload), the callback throws the structured overflow error
+(`buildContextOverflowError`) and the load balancer surfaces it through the
+existing failover aggregate — a clear "cannot fit" message, not a silent
+oversize send.
+
+## Explicitly out of scope
+
+- Prompt-envelope estimation parity for load-balancer profiles (making the
+  app-side pre-send estimate tool-schema aware, e.g. a load-balancer
+  `projectPromptEnvelope`). That is the Gap 2 root cause and deserves its own
+  design (backend selection happens at send time, so projection parity has
+  ambiguity to resolve). Filed as a follow-up issue; this PR links it.
+- Changing LB guard semantics (limits, budget reservation inside the guard,
+  bypassing the guard, "proceed anyway" modes).
+- Compression strategy changes, new strategies, cooldown policy changes.
+- UI/UX changes for the error text beyond what falls out of AB1/AB2.
+- Any provider-estimator rework beyond passing the two guard numbers through.
+
+## Test plan (written first, behavioral, `bun:test`)
+
+Follows the existing patterns in
+`packages/agents/src/compression/__tests__/compressionCallback.test.ts` and
+`providerContentEnforcement.historyTruncationTarget.test.ts` (real
+HistoryService + real ChatSession compression handler; duck-typed provider
+carrying `setCompressionCallback`; assertions on recomposed contents and token
+projections, not mock interactions).
+
+### T1 — providers: guard passes token facts to the callback
+
+In `packages/providers/src/__tests__/LoadBalancingProvider.compressionAccounting.test.ts`
+(or a sibling file matching its fixtures): over-limit request, callback captures
+its second argument → `{ estimatedTokens, contextLimit }` equal the guard's
+estimate and limit; the compressed result is accepted when the re-estimate fits
+(existing behavior, still green).
+
+### T2 — agents: callback escalates when compression is insufficient
+
+Real history sized so the guard target is missed by a small deficit after
+`performCompression` (compression configured to be structurally ineffective or
+to under-deliver — e.g. `top-down-truncation` with an exclusion-heavy layout).
+Invoke the captured callback with guard info. Assert: returned contents'
+projection (own estimator + overhead model) is at or under
+`contextLimit - overhead`, and history actually shrank (truncation applied).
+Under the current code this test fails (callback returns still-over contents or
+throws the noop error).
+
+### T3 — agents: compression no-op / failure no longer dead-ends
+
+Callback path where `performCompression` reports noop/failure but history has
+truncatable mass → callback returns fitting contents (does not throw).
+Where truncation cannot fit (absurdly small limit) → callback throws the
+structured overflow error (contract preserved).
+
+### T4 — agents: exact targeting (no over-cut)
+
+History where the deficit is a few hundred tokens: with guard info, the ladder
+must NOT shrink contents to the default-budget ceiling (~limit/2); it targets
+`contextLimit - overhead`. Without guard info, ladder still converges against
+own limits (AB2 fallback branch).
+
+### T5 — regression
+
+Full `npm run test`; the existing LB compression/failover suites and
+`compressionCallback.test.ts` stay green (callback-attachment, cleanup-on-error,
+pending-content preservation, `compression-provider-fallback-propagation`).
+
+## Verification
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+`npm run build`, then
+`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.
+
+## Review rounds
+
+At most two deepthinker review rounds and two OCR rounds (initial + one
+remediation). Findings triaged Blocker-Fix / In-scope-Fix / Reject / Defer;
+remaining MEDIUM/LOW after round two are documented here as known follow-ups.
+
+### Outcome
+
+- deepthinker round 1: AB1/AB3/AB4 pass. Two findings:
+  - MEDIUM (In-scope-Fix, fixed): the guard shape was duplicated across
+    packages and missing from core's `RuntimeProvider.setCompressionCallback`
+    contract. Remediated: `RuntimeCompressionGuardInfo` defined once in core
+    (`packages/core/src/runtime/contracts/RuntimeProvider.ts`), re-exported
+    from the contracts index, referenced by providers' `CompressionCallback`
+    and agents' `CompressionGuardInfo` alias. Type-only change.
+  - LOW (Defer): the overhead model (`guard.estimatedTokens - own estimate`)
+    is an approximation; if the estimator gap grows after reduction the
+    callback can satisfy its internal predicate yet fail the LB's independent
+    re-check. Verified fail-safe: the LB re-estimates before any backend send
+    and a failed re-check degrades to today's context-limit/failover outcome;
+    no oversize request can be sent. The estimator-gap seam is the subject of
+    the follow-up estimation-parity issue.
+- deepthinker round 2: PASS (finding 1 resolved, finding 2 deferral sound, no
+  regressions; 415 targeted tests green).
+- OCR (zai-anthropic profile): 1 round, 10 files, 0 findings.
+
+### Known follow-ups (deferred)
+
+1. LB prompt-envelope estimation parity: load-balancer profiles implement no
+   `projectPromptEnvelope`, so app-side pre-send estimates are tool-schema
+   blind for LB traffic and the guard sees a larger number than pre-send
+   enforcement. Filed as a separate issue (linked from the PR).
+2. Integration test wiring the real callback through a delegate projection
+   whose estimate changes after escalation (covers the deferred approximation
+   seam above once parity lands).


### PR DESCRIPTION
## TLDR

A load-balancer session marginally over the context limit (266 tokens over in the reporting case) dead-ended the whole turn with `LoadBalancerAllContextLimitsExceededError` after every backend rejected it. The guard's only remediation was one compression callback round with no fit check and no truncation fallbacks, and the callback had no visibility into the guard's estimate or limit. This PR escalates the callback to the full reduction ladder used by pre-send enforcement, targeted at the guard's actual limit, so marginal over-limit sessions get compressed or truncated instead of dying. Fixes #3499.

## Dive Deeper

**Root cause (two gaps meeting):**

1. `LoadBalancingProvider.enforceTokenLimitForTarget` estimates the finalized prompt per sub-profile (including tool schemas via the delegate's envelope projection). On over-limit it calls `compressForContextLimit`, which invoked `compressionCallback` exactly once and re-estimated; if still over, it threw `LoadBalancerContextLimitError` → failover walked every backend → aggregate error → turn dead. The callback mapped to `ProviderContentEnforcer.compressAndRecompose`, which ran one `performCompression` with `completionBudget=0`, no fit check, no ineffective-retry, no truncation — none of the escalation the pre-send `enforce()` ladder has. For a session only a few hundred tokens over with little compressible mass, compression is structurally ineffective and the guard dead-ended.
2. The callback received only `contents` — it could not target the guard's limit because the guard's estimate covers the full envelope (tool schemas, rendered prompt) while the enforcer's own estimate is contents-only.

**The fix:**

- **Providers** (`loadBalancerTypes.ts`, `LoadBalancingProvider.ts`): `CompressionCallback` gains an optional second argument `guard?: { estimatedTokens, contextLimit }`; the LB passes its guard facts when invoking the callback. Single-argument callbacks remain assignable (backward compatible; covered by test).
- **Agents** (`CompressionHandler.ts`, `providerContentEnforcement.ts`): `compressAndRecompose` now runs the same escalation ladder as `enforce()` — density optimization → compression → ineffective-compression retry → deficit-exact history truncation → unified tool-response truncation — via a shared `enforceWithEscalation` extraction so both paths stay identical (`enforce()` behavior unchanged; the extraction is argument-preserving). With guard facts it derives `overhead = max(0, guard.estimatedTokens - ownEstimate(budget 0))` and enforces `ownEstimate(contents') <= guard.contextLimit - overhead` with no completion budget of its own (the guard defines the contract; re-reserving a 65536-token default budget would discard tens of thousands of tokens of live context). Without guard facts it converges against its own computed limits — still strictly better than the old single round.
- **Core** (`RuntimeProvider.ts`, contracts index): the guard shape is defined once as `RuntimeCompressionGuardInfo` and the `setCompressionCallback` contract is widened to match; providers and agents reference the core type so the seam cannot drift between packages. Type-only change.
- **Failure contract preserved:** when even tool-response truncation cannot fit, the callback throws the structured overflow error → `LoadBalancerCompressionCallbackError` → failover → aggregate error. A clear "cannot fit", never a silent oversize send.

**Deferred (filed as #3507):** LB prompt-envelope estimation parity — the app-side pre-send estimate is tool-schema blind for LB traffic, which is why the session passed pre-send enforcement and tripped the guard. The overhead model here is an approximation; it is fail-safe (the LB independently re-estimates before any backend send, and a failed re-check degrades to today's failover outcome).

Plan: `project-plans/issue3499/plan.md`.

## Reviewer Test Plan

- `cd packages/agents && bun test src/compression/__tests__/providerContentEnforcement.callbackEscalation.test.ts` — the issue's exact scenario: compression under-delivers on a marginal deficit, the ladder truncates to the guard target and returns fitting contents; the overflow throw only when truncation cannot fit; deficit-exact targeting (no over-cut to the ~limit/2 default budget); the no-guard fallback branch; empty-pending no-op.
- `cd packages/providers && bun test src/__tests__/LoadBalancingProvider.compressionGuard.test.ts` — the guard passes exactly `{estimatedTokens, contextLimit}` to the callback (asserted against the counting tokenizer's actual output), and legacy single-argument callbacks still work.
- `cd packages/providers && bun test src/__tests__/LoadBalancingProvider.compressionAccounting.test.ts src/__tests__/LoadBalancingProvider.tokenAccounting.test.ts` — existing guard/failover contracts unchanged.
- Full cycle run locally: `npm run test` (719 files, 0 fail), `lint`, `typecheck`, `format`, `build`, and the `stepfun-37` smoke profile.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3499
Related to #3507 (deferred estimation-parity follow-up)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of oversized requests by escalating through compression and truncation steps when an initial compression attempt is insufficient.
  * Requests now better respect the provider’s context limit, including required overhead.
  * Structured overflow errors are reported only when available reduction steps cannot make the request fit.
  * Existing compression callbacks without guard details remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->