### PR TITLE
fix(telemetry): time agents-layer turns from raw token deltas (Fixes #3493)

### DIFF
--- a/packages/agents/src/core/StreamProcessor.ts
+++ b/packages/agents/src/core/StreamProcessor.ts
@@ -53,9 +53,13 @@ import { filterHookRestrictedBlocks } from './hookToolRestrictions.js';
 import {
   attachStreamTiming,
   logStreamTelemetry,
+  RawTokenDeltaBridge,
   StreamTimingTracker,
 } from './streamTelemetryLogger.js';
-import { LOGICAL_REQUEST_ID_KEY } from '@vybestack/llxprt-code-providers';
+import {
+  LOGICAL_REQUEST_ID_KEY,
+  RAW_TOKEN_DELTA_SINK_KEY,
+} from '@vybestack/llxprt-code-providers';
 import { canonicalizeToolName } from './toolGovernance.js';
 import {
   buildRequestContentsResult,
@@ -121,6 +125,16 @@ export class StreamProcessor {
   private currentTurnPromptId: string | null = null;
   private currentAttemptIndex = 0;
 
+  /**
+   * Raw token-delta bridge for the attempt in flight (#3493). Null when no
+   * attempt is in flight; minted fresh per attempt in
+   * makeApiCallAndProcessStream so an abandoned attempt's stream cannot feed
+   * the next attempt's tracker. The sink rides request metadata, which the
+   * providers layer treats as optional — an absent sink simply means "no raw
+   * signal" and visible-chunk timing applies.
+   */
+  private currentRawTokenDeltaBridge: RawTokenDeltaBridge | null = null;
+
   getPromptEnvelopeEstimate(): PromptEnvelopeEstimate | null {
     return this.currentPromptEnvelopeEstimate;
   }
@@ -157,6 +171,7 @@ export class StreamProcessor {
   ): Promise<AsyncGenerator<ModelStreamChunk>> {
     this.currentPromptEnvelopeEstimate = null;
     this.currentAttemptIndex = attemptIndex ?? 0;
+    this.currentRawTokenDeltaBridge = new RawTokenDeltaBridge();
     const provider = this.providerResolver('stream');
 
     const providerBaseUrl = this.runtimeContext.state.baseUrl;
@@ -429,6 +444,9 @@ export class StreamProcessor {
         // join caller-side registries (#3257); internal plumbing, never sent
         // on the wire.
         [LOGICAL_REQUEST_ID_KEY]: promptId,
+        // Raw token-delta timing sink for agents-layer per-attempt timing
+        // (#3493); internal plumbing, never sent on the wire.
+        [RAW_TOKEN_DELTA_SINK_KEY]: this.currentRawTokenDeltaBridge?.notify,
       },
       userMemory,
       systemInstruction: extractSystemInstructionText(
@@ -474,6 +492,10 @@ export class StreamProcessor {
       });
 
       const streamResponse = provider.generateChatCompletion(prepared.options);
+      // Captured explicitly (not read inside the generator below): a later
+      // attempt replaces the instance field, and the explicit parameter is
+      // what keeps this attempt's stream wired to this attempt's tracker.
+      const rawTokenDeltaBridge = this.currentRawTokenDeltaBridge;
 
       return await this._consumeFirstChunkAndReturn(
         streamResponse,
@@ -481,6 +503,7 @@ export class StreamProcessor {
         promptId,
         startTime,
         hookRestrictedAllowedTools,
+        rawTokenDeltaBridge,
       );
     } catch (error) {
       const durationMs = Date.now() - startTime;
@@ -506,12 +529,14 @@ export class StreamProcessor {
     promptId: string,
     startTime: number,
     hookRestrictedAllowedTools: string[] | undefined,
+    rawTokenDeltaBridge: RawTokenDeltaBridge | null,
   ): Promise<AsyncGenerator<ModelStreamChunk>> {
     const convertedStream = this._convertIContentStream(
       streamResponse,
       requestPayload,
       { promptId, startTime, attemptIndex: this.currentAttemptIndex },
       hookRestrictedAllowedTools,
+      rawTokenDeltaBridge,
     );
 
     const firstChunk = await convertedStream.next();
@@ -639,12 +664,18 @@ export class StreamProcessor {
       attemptIndex?: number;
     },
     hookRestrictedAllowedTools?: string[],
+    rawTokenDeltaBridge?: RawTokenDeltaBridge | null,
   ): AsyncGenerator<ModelStreamChunk> {
     let lastIContent: IContent | undefined;
     // Constructed at generator-body start (first pull — the provider call
     // boundary), so provider_request_ms covers the stream lifecycle alone
     // and excludes send-seam estimation (#3257).
     const timing = new StreamTimingTracker();
+    // The provider stream is only iterated inside this generator body, so
+    // attach always happens before any provider code can fire a raw delta.
+    // A null bridge means no attempt context threaded a sink (#3493): the
+    // tracker then runs on visible-chunk timing alone.
+    rawTokenDeltaBridge?.attach(timing);
 
     // The caller iterates this generator after _sendProviderRequest returned,
     // so a mid-stream failure never re-enters its try/catch; clear the failed

--- a/packages/agents/src/core/StreamProcessor.ts
+++ b/packages/agents/src/core/StreamProcessor.ts
@@ -127,9 +127,10 @@ export class StreamProcessor {
 
   /**
    * Raw token-delta bridge for the attempt in flight (#3493). Null when no
-   * attempt is in flight; minted fresh per attempt in
-   * makeApiCallAndProcessStream so an abandoned attempt's stream cannot feed
-   * the next attempt's tracker. The sink rides request metadata, which the
+   * attempt is in flight; minted fresh per attempt at the retry boundary in
+   * _executeStreamApiCall — where retryWithBackoff re-invokes the apiCall
+   * closure — so an abandoned attempt's stream cannot feed the next
+   * attempt's tracker. The sink rides request metadata, which the
    * providers layer treats as optional — an absent sink simply means "no raw
    * signal" and visible-chunk timing applies.
    */
@@ -171,7 +172,6 @@ export class StreamProcessor {
   ): Promise<AsyncGenerator<ModelStreamChunk>> {
     this.currentPromptEnvelopeEstimate = null;
     this.currentAttemptIndex = attemptIndex ?? 0;
-    this.currentRawTokenDeltaBridge = new RawTokenDeltaBridge();
     const provider = this.providerResolver('stream');
 
     const providerBaseUrl = this.runtimeContext.state.baseUrl;
@@ -284,8 +284,18 @@ export class StreamProcessor {
     userContent: IContent | IContent[],
     provider: IProvider,
   ): Promise<AsyncGenerator<ModelStreamChunk>> {
-    const apiCall = () =>
-      this._buildAndSendStreamRequest(params, promptId, userContent, provider);
+    // retryWithBackoff re-invokes this closure once per attempt, so the
+    // bridge is minted here: each attempt's sink closure stays pointed at
+    // its own tracker even after a later attempt attaches its own (#3493).
+    const apiCall = () => {
+      this.currentRawTokenDeltaBridge = new RawTokenDeltaBridge();
+      return this._buildAndSendStreamRequest(
+        params,
+        promptId,
+        userContent,
+        provider,
+      );
+    };
 
     return retryWithBackoff(apiCall, {
       onPersistent429: () =>

--- a/packages/agents/src/core/TokenUsageLogger.rawTiming.test.ts
+++ b/packages/agents/src/core/TokenUsageLogger.rawTiming.test.ts
@@ -705,4 +705,83 @@ describe('TokenUsageLogger raw token-delta timing (#3493)', () => {
     // Fresh attempt-2 timing wins: three chunks, not attempt 1's single one.
     expect(success.chunk_count).toBe(3);
   });
+
+  // Inner retryWithBackoff retry: attempt 1 fires raw deltas then fails
+  // BEFORE its first chunk, so the failure lands inside the retry boundary
+  // and attempt 2 runs within the same makeApiCallAndProcessStream call.
+  // The retry's own generator fires attempt 1's captured sink at a known
+  // point — attach runs at generator-body start, before the first provider
+  // pull, so the stale call deterministically lands after the retry's
+  // tracker is attached. With a shared bridge that stale call stamps the
+  // retry's tracker (ttft ~0, generation spanning the stale-to-last-delta
+  // gap); with a per-attempt bridge the retry's window holds only its own
+  // deltas (ttft past the 80ms sleep, generation near one 15ms sleep).
+  it('keeps retry timing free of a late raw delta from the abandoned attempt (#3493)', async () => {
+    let staleSink: (() => void) | undefined;
+    let attempt = 0;
+    const mockProvider = {
+      name: 'anthropic',
+      generateChatCompletion: vi
+        .fn()
+        .mockImplementation(async function* (options: {
+          metadata?: Record<string, unknown>;
+        }) {
+          attempt++;
+          if (attempt === 1) {
+            staleSink = rawDeltaSinkFrom(options.metadata);
+            staleSink?.();
+            await sleep(15);
+            staleSink?.();
+            // Fail before the first chunk so the error surfaces inside the
+            // retryWithBackoff boundary rather than ChatSession's outer retry.
+            throw new Error('Connection error.');
+          }
+          const sink = rawDeltaSinkFrom(options.metadata);
+          // Deterministic late callback from the abandoned attempt's stream.
+          staleSink?.();
+          await sleep(80);
+          sink?.();
+          await sleep(15);
+          sink?.();
+          yield {
+            speaker: 'ai',
+            blocks: [{ type: 'text', text: 'The answer is 4.' }],
+            metadata: {
+              usage: {
+                promptTokens: 5100,
+                completionTokens: 15,
+                totalTokens: 5115,
+              },
+            },
+          };
+        }),
+    };
+
+    const records = await runTurnReadRecords(
+      mockProvider,
+      'stale-sink-retry-session',
+      'stale-sink-retry-prompt',
+    );
+
+    expect(attempt).toBe(2);
+    expect(records).toHaveLength(1);
+    const success = records[0];
+    expect(success.attempt_outcome).toBe('success');
+    // One visible chunk, so the timing window can only come from raw deltas.
+    expect(success.chunk_count).toBe(1);
+    if (
+      typeof success.ttft_ms !== 'number' ||
+      typeof success.generation_ms !== 'number'
+    ) {
+      throw new Error('expected ttft_ms/generation_ms to be recorded');
+    }
+    // The retry's first own delta trails the stale call by a full 80ms
+    // sleep; a ttft under 50ms means the stale sink stamped the tracker.
+    expect(success.ttft_ms).toBeGreaterThanOrEqual(50);
+    // The retry's raw deltas span one 15ms sleep; a window that also
+    // covered the stale call would sit near 95ms. Both bounds keep ≥30ms
+    // of margin against scheduling noise.
+    expect(success.generation_ms).toBeGreaterThan(0);
+    expect(success.generation_ms).toBeLessThan(50);
+  });
 });

--- a/packages/agents/src/core/TokenUsageLogger.rawTiming.test.ts
+++ b/packages/agents/src/core/TokenUsageLogger.rawTiming.test.ts
@@ -1,0 +1,708 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  StreamEventType,
+  type StreamEvent,
+} from '@vybestack/llxprt-code-core/core/chatSessionTypes.js';
+import { ChatSession } from './chatSession.js';
+import {
+  TokenUsageLogger,
+  type SerializedTokenUsageRecord,
+} from './TokenUsageLogger.js';
+import {
+  createAgentRuntimeState,
+  type AgentRuntimeState,
+} from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
+import { createAgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/createAgentRuntimeContext.js';
+import {
+  createProviderAdapterFromManager,
+  createTelemetryAdapterFromConfig,
+  createToolRegistryViewFromRegistry,
+} from '@vybestack/llxprt-code-core/runtime/runtimeAdapters.js';
+import { RAW_TOKEN_DELTA_SINK_KEY } from '@vybestack/llxprt-code-providers';
+import { createTokenSyncTestFixture } from './chatSession-tokenSync-helpers.js';
+
+function makeTempLogPath(): string {
+  return path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'token-usage-raw-')),
+    'usage.jsonl',
+  );
+}
+
+function isSerializedTokenUsageRecord(
+  value: unknown,
+): value is SerializedTokenUsageRecord {
+  if (typeof value !== 'object' || value === null) return false;
+  if (!('ts' in value) || typeof value.ts !== 'string') return false;
+  if (!('prompt_id' in value) || typeof value.prompt_id !== 'string')
+    return false;
+  if (!('provider' in value) || typeof value.provider !== 'string')
+    return false;
+  if (!('model' in value) || typeof value.model !== 'string') return false;
+  if (
+    !('estimated_tokens' in value) ||
+    typeof value.estimated_tokens !== 'number'
+  )
+    return false;
+  if (!('estimator' in value) || typeof value.estimator !== 'string')
+    return false;
+  if (
+    !('tiktoken_tokens' in value) ||
+    (typeof value.tiktoken_tokens !== 'number' &&
+      value.tiktoken_tokens !== null)
+  )
+    return false;
+  if (
+    !('tiktoken_estimation_failed' in value) ||
+    typeof value.tiktoken_estimation_failed !== 'boolean'
+  )
+    return false;
+  if (
+    !('actual_prompt_tokens' in value) ||
+    typeof value.actual_prompt_tokens !== 'number'
+  )
+    return false;
+  if (!('cached_tokens' in value) || typeof value.cached_tokens !== 'number')
+    return false;
+  return (
+    'effective_actual_tokens' in value &&
+    typeof value.effective_actual_tokens === 'number'
+  );
+}
+
+function readJsonl(filePath: string): SerializedTokenUsageRecord[] {
+  const raw = fs.readFileSync(filePath, 'utf-8').trim();
+  if (raw.length === 0) return [];
+  return raw.split('\n').map((line) => {
+    const parsed: unknown = JSON.parse(line);
+    if (!isSerializedTokenUsageRecord(parsed)) {
+      throw new Error('Invalid token usage JSONL record');
+    }
+    return parsed;
+  });
+}
+
+type ProviderManagerStub = {
+  getActiveProvider: unknown;
+};
+
+/** Type predicate: the mock provider manager shape used across this file. */
+function isProviderManagerStub(
+  manager: unknown,
+): manager is ProviderManagerStub {
+  return (
+    typeof manager === 'object' &&
+    manager !== null &&
+    'getActiveProvider' in manager
+  );
+}
+
+function providerAdapterFromStub(manager: unknown) {
+  if (!isProviderManagerStub(manager)) {
+    throw new Error('provider manager stub must expose getActiveProvider()');
+  }
+  // The stub implements only the member the adapter consumes at runtime;
+  // bridged to the structural contract the same way the token-sync fixture
+  // bridges its own mocks.
+  return createProviderAdapterFromManager(
+    manager as unknown as Parameters<
+      typeof createProviderAdapterFromManager
+    >[0],
+  );
+}
+
+/** Real-time sleep between simulated deltas (timer-based, Bun-agnostic). */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Builds the runtime-context view every test in this file uses: a ChatSession
+ * facing the given provider stub, backed by the token-sync fixture services.
+ */
+function buildTokenSyncView(
+  fixture: ReturnType<typeof createTokenSyncTestFixture>,
+  mockProvider: unknown,
+  sessionId: string,
+) {
+  const { mockConfig, historyService, providerRuntimeSnapshot } = fixture;
+  const runtimeState: AgentRuntimeState = createAgentRuntimeState({
+    runtimeId: fixture.runtimeSetup.runtime.runtimeId ?? 'raw-timing-runtime',
+    provider: 'anthropic',
+    model: 'claude-3-5-sonnet-20241022',
+    sessionId,
+  });
+  const providerManager = {
+    getActiveProvider: vi.fn(() => mockProvider),
+  };
+  mockConfig.getProviderManager = vi.fn().mockReturnValue(providerManager);
+  return createAgentRuntimeContext({
+    state: runtimeState,
+    history: historyService,
+    settings: {
+      compressionThreshold: 0.8,
+      contextLimit: 200000,
+      preserveThreshold: 0.2,
+      telemetry: { enabled: true, target: null },
+    },
+    provider: providerAdapterFromStub(mockConfig.getProviderManager()),
+    telemetry: createTelemetryAdapterFromConfig(mockConfig),
+    tools: createToolRegistryViewFromRegistry(),
+    providerRuntime: providerRuntimeSnapshot,
+  });
+}
+
+/** Reads the raw token-delta sink the agents layer threads into metadata. */
+function rawDeltaSinkFrom(
+  metadata: Record<string, unknown> | undefined,
+): (() => void) | undefined {
+  return metadata?.[RAW_TOKEN_DELTA_SINK_KEY] as (() => void) | undefined;
+}
+
+/** Collects the text a consumer actually receives from a ChatSession stream. */
+async function collectConsumedText(
+  stream: AsyncGenerator<StreamEvent>,
+): Promise<string> {
+  let text = '';
+  for await (const event of stream) {
+    if (event.type !== StreamEventType.CHUNK) continue;
+    for (const block of event.value.content.blocks) {
+      if (block.type === 'text' && typeof block.text === 'string') {
+        text += block.text;
+      }
+    }
+  }
+  return text;
+}
+
+describe('TokenUsageLogger raw token-delta timing (#3493)', () => {
+  let logFile: string;
+
+  beforeEach(() => {
+    logFile = makeTempLogPath();
+  });
+
+  afterEach(() => {
+    const dir = path.dirname(logFile);
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch (error) {
+      // Temp dir cleanup is best-effort; failure here does not affect test outcomes
+      process.stderr.write(`Failed to clean up temp dir: ${String(error)}\n`);
+    }
+  });
+
+  // A reasoning-style buffered stream: raw deltas arrive at the transport
+  // while the visible layer defers everything into one terminal chunk. With
+  // a single visible chunk, visible-only timing stamps first and last token
+  // at the same instant, so generation_ms is omitted entirely. A positive
+  // generation_ms can therefore only come from the raw deltas.
+  it('derives ttft/generation from raw token deltas for a single-chunk stream (#3493)', async () => {
+    const fixture = createTokenSyncTestFixture();
+    const mockContentGenerator = fixture.mockContentGenerator;
+    const historyService = fixture.historyService;
+
+    const mockProvider = {
+      name: 'anthropic',
+      generateChatCompletion: vi
+        .fn()
+        .mockImplementation(async function* (options: {
+          metadata?: Record<string, unknown>;
+        }) {
+          const sink = rawDeltaSinkFrom(options.metadata);
+          sink?.();
+          await sleep(15);
+          sink?.();
+          await sleep(15);
+          sink?.();
+          yield {
+            speaker: 'ai',
+            blocks: [{ type: 'text', text: 'The answer is 4.' }],
+            metadata: {
+              usage: {
+                promptTokens: 5000,
+                completionTokens: 15,
+                totalTokens: 5015,
+              },
+            },
+          };
+        }),
+    };
+
+    const view = buildTokenSyncView(
+      fixture,
+      mockProvider,
+      'raw-timing-session',
+    );
+
+    const chat = new ChatSession(view, mockContentGenerator, {}, []);
+
+    const realLogger = new TokenUsageLogger(true, logFile);
+    chat.setTokenUsageLoggerForTesting(realLogger);
+
+    const promptId = 'raw-timing-prompt';
+    realLogger.recordEstimate(promptId, {
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet-20241022',
+      estimatedTokens: 150,
+      estimator: 'anthropic-char',
+      tiktokenTokens: 140,
+    });
+
+    const stream = await chat.sendMessageStream(
+      { message: 'What is 2+2?' },
+      promptId,
+    );
+    for await (const _event of stream) {
+      // consume
+    }
+
+    await historyService.waitForTokenUpdates();
+
+    const records = readJsonl(logFile);
+    expect(records).toHaveLength(1);
+    const record = records[0];
+    expect(record.chunk_count).toBe(1);
+    expect(record.generation_ms).toBeGreaterThan(0);
+    if (
+      typeof record.ttft_ms !== 'number' ||
+      typeof record.generation_ms !== 'number' ||
+      typeof record.provider_request_ms !== 'number'
+    ) {
+      throw new Error(
+        'expected ttft_ms/generation_ms/provider_request_ms to be recorded',
+      );
+    }
+    expect(record.ttft_ms).toBeGreaterThanOrEqual(0);
+    expect(record.ttft_ms + record.generation_ms).toBeLessThanOrEqual(
+      record.provider_request_ms,
+    );
+  });
+
+  // AC-3: visible-chunk stamping must stay the timing source when the
+  // provider never fires the raw sink (mirrors the #3257 expectations).
+  it('keeps visible-chunk timing when no raw signal arrives (#3493 AC-3)', async () => {
+    const fixture = createTokenSyncTestFixture();
+    const mockContentGenerator = fixture.mockContentGenerator;
+    const historyService = fixture.historyService;
+
+    const mockProvider = {
+      name: 'anthropic',
+      generateChatCompletion: vi.fn().mockImplementation(async function* () {
+        yield { speaker: 'ai', blocks: [{ type: 'text', text: 'The ' }] };
+        await sleep(15);
+        yield { speaker: 'ai', blocks: [{ type: 'text', text: 'answer ' }] };
+        await sleep(15);
+        yield {
+          speaker: 'ai',
+          blocks: [{ type: 'text', text: 'is 4.' }],
+          metadata: {
+            usage: {
+              promptTokens: 5000,
+              completionTokens: 15,
+              totalTokens: 5015,
+            },
+          },
+        };
+      }),
+    };
+
+    const view = buildTokenSyncView(
+      fixture,
+      mockProvider,
+      'visible-fallback-session',
+    );
+
+    const chat = new ChatSession(view, mockContentGenerator, {}, []);
+
+    const realLogger = new TokenUsageLogger(true, logFile);
+    chat.setTokenUsageLoggerForTesting(realLogger);
+
+    const promptId = 'visible-fallback-prompt';
+    realLogger.recordEstimate(promptId, {
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet-20241022',
+      estimatedTokens: 150,
+      estimator: 'anthropic-char',
+      tiktokenTokens: 140,
+    });
+
+    const stream = await chat.sendMessageStream(
+      { message: 'What is 2+2?' },
+      promptId,
+    );
+    for await (const _event of stream) {
+      // consume
+    }
+
+    await historyService.waitForTokenUpdates();
+
+    const records = readJsonl(logFile);
+    expect(records).toHaveLength(1);
+    const record = records[0];
+    expect(record.ttft_ms).toBeGreaterThanOrEqual(0);
+    expect(record.generation_ms).toBeGreaterThan(0);
+    expect(record.provider_request_ms).toBeGreaterThan(0);
+    expect(record.chunk_count).toBe(3);
+  });
+
+  // The sink rides the same internal metadata channel as the logical
+  // request id and must never leak into the consumer-visible stream.
+  it('threads the sink on internal metadata only and leaves visible chunks untouched (#3493)', async () => {
+    const fixture = createTokenSyncTestFixture();
+    const mockContentGenerator = fixture.mockContentGenerator;
+    const historyService = fixture.historyService;
+
+    const providerOptions: Array<{
+      metadata?: Record<string, unknown>;
+    }> = [];
+    const providerText = 'The answer is 4.';
+    const mockProvider = {
+      name: 'anthropic',
+      generateChatCompletion: vi
+        .fn()
+        .mockImplementation(async function* (options: {
+          metadata?: Record<string, unknown>;
+        }) {
+          providerOptions.push(options);
+          const sink = rawDeltaSinkFrom(options.metadata);
+          sink?.();
+          await sleep(15);
+          sink?.();
+          yield {
+            speaker: 'ai',
+            blocks: [{ type: 'text', text: providerText }],
+            metadata: {
+              usage: {
+                promptTokens: 5000,
+                completionTokens: 15,
+                totalTokens: 5015,
+              },
+            },
+          };
+        }),
+    };
+
+    const view = buildTokenSyncView(
+      fixture,
+      mockProvider,
+      'sink-channel-session',
+    );
+
+    const chat = new ChatSession(view, mockContentGenerator, {}, []);
+
+    const realLogger = new TokenUsageLogger(true, logFile);
+    chat.setTokenUsageLoggerForTesting(realLogger);
+
+    const promptId = 'sink-channel-prompt';
+    realLogger.recordEstimate(promptId, {
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet-20241022',
+      estimatedTokens: 150,
+      estimator: 'anthropic-char',
+      tiktokenTokens: 140,
+    });
+
+    const stream = await chat.sendMessageStream(
+      { message: 'What is 2+2?' },
+      promptId,
+    );
+    const consumedText = await collectConsumedText(stream);
+
+    await historyService.waitForTokenUpdates();
+
+    expect(providerOptions).toHaveLength(1);
+    const metadata = providerOptions[0].metadata;
+    expect(metadata?.['__logicalRequestId']).toBe(promptId);
+    expect(typeof metadata?.[RAW_TOKEN_DELTA_SINK_KEY]).toBe('function');
+    expect(consumedText).toBe(providerText);
+  });
+
+  /** Drives one full turn against the given provider stub and reads back the serialized records. */
+  async function runTurnReadRecords(
+    mockProvider: unknown,
+    sessionId: string,
+    promptId: string,
+  ): Promise<SerializedTokenUsageRecord[]> {
+    const fixture = createTokenSyncTestFixture();
+    const view = buildTokenSyncView(fixture, mockProvider, sessionId);
+    const chat = new ChatSession(view, fixture.mockContentGenerator, {}, []);
+
+    const realLogger = new TokenUsageLogger(true, logFile);
+    chat.setTokenUsageLoggerForTesting(realLogger);
+
+    realLogger.recordEstimate(promptId, {
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet-20241022',
+      estimatedTokens: 150,
+      estimator: 'anthropic-char',
+      tiktokenTokens: 140,
+    });
+
+    const stream = await chat.sendMessageStream(
+      { message: 'What is 2+2?' },
+      promptId,
+    );
+    for await (const _event of stream) {
+      // consume
+    }
+
+    await fixture.historyService.waitForTokenUpdates();
+    return readJsonl(logFile);
+  }
+
+  // A tool-call turn buffered into a single terminal chunk: raw argument
+  // fragments fire at the transport while the visible layer defers the whole
+  // call. With one visible chunk the visible-only window is zero, so a
+  // positive generation_ms can only come from the raw deltas — tool-call-only
+  // turns get real generation timing too.
+  it('derives generation timing for a buffered tool-call-only stream (#3493)', async () => {
+    const mockProvider = {
+      name: 'anthropic',
+      generateChatCompletion: vi
+        .fn()
+        .mockImplementation(async function* (options: {
+          metadata?: Record<string, unknown>;
+        }) {
+          const sink = rawDeltaSinkFrom(options.metadata);
+          sink?.();
+          await sleep(15);
+          sink?.();
+          await sleep(15);
+          sink?.();
+          yield {
+            speaker: 'ai',
+            blocks: [
+              {
+                type: 'tool_call',
+                id: 'call-1',
+                name: 'read_file',
+                parameters: { path: 'a.txt' },
+              },
+            ],
+            metadata: {
+              usage: {
+                promptTokens: 5000,
+                completionTokens: 15,
+                totalTokens: 5015,
+              },
+            },
+          };
+        }),
+    };
+
+    const records = await runTurnReadRecords(
+      mockProvider,
+      'tool-call-buffered-session',
+      'tool-call-buffered-prompt',
+    );
+
+    expect(records).toHaveLength(1);
+    const record = records[0];
+    expect(record.chunk_count).toBe(1);
+    expect(record.generation_ms).toBeGreaterThan(0);
+  });
+
+  // Buffered text flushed late: raw content deltas arrive early while the
+  // provider holds the visible text back. The generation window must track
+  // the raw deltas and end BEFORE the late flush, proving the window
+  // measures generation rather than visible emission.
+  it('ends the raw-derived generation window before a late buffered flush (#3493)', async () => {
+    const holdMs = 120;
+    const mockProvider = {
+      name: 'anthropic',
+      generateChatCompletion: vi
+        .fn()
+        .mockImplementation(async function* (options: {
+          metadata?: Record<string, unknown>;
+        }) {
+          const sink = rawDeltaSinkFrom(options.metadata);
+          sink?.();
+          await sleep(20);
+          sink?.();
+          await sleep(20);
+          sink?.();
+          await sleep(holdMs); // provider buffers the text before flushing
+          yield {
+            speaker: 'ai',
+            blocks: [{ type: 'text', text: 'The answer is 4.' }],
+            metadata: {
+              usage: {
+                promptTokens: 5000,
+                completionTokens: 15,
+                totalTokens: 5015,
+              },
+            },
+          };
+        }),
+    };
+
+    const records = await runTurnReadRecords(
+      mockProvider,
+      'buffered-late-session',
+      'buffered-late-prompt',
+    );
+
+    expect(records).toHaveLength(1);
+    const record = records[0];
+    expect(record.chunk_count).toBe(1);
+    if (
+      typeof record.ttft_ms !== 'number' ||
+      typeof record.generation_ms !== 'number' ||
+      typeof record.provider_request_ms !== 'number'
+    ) {
+      throw new Error(
+        'expected ttft_ms/generation_ms/provider_request_ms to be recorded',
+      );
+    }
+    expect(record.generation_ms).toBeGreaterThan(0);
+    // The last raw delta precedes the 120ms hold while provider_request_ms
+    // includes it, so the gap is at least the hold; a 50ms bound cannot flake.
+    expect(
+      record.provider_request_ms - (record.ttft_ms + record.generation_ms),
+    ).toBeGreaterThanOrEqual(50);
+  });
+
+  // An ordinary text stream interleaves raw deltas with visible chunks; the
+  // recorded shape must match the visible-only fallback expectations, so the
+  // raw signal does not distort the common case.
+  it('records ordinary-stream timing when raw deltas interleave visible chunks (#3493)', async () => {
+    const mockProvider = {
+      name: 'anthropic',
+      generateChatCompletion: vi
+        .fn()
+        .mockImplementation(async function* (options: {
+          metadata?: Record<string, unknown>;
+        }) {
+          const sink = rawDeltaSinkFrom(options.metadata);
+          sink?.();
+          yield { speaker: 'ai', blocks: [{ type: 'text', text: 'The ' }] };
+          await sleep(15);
+          sink?.();
+          yield { speaker: 'ai', blocks: [{ type: 'text', text: 'answer ' }] };
+          await sleep(15);
+          sink?.();
+          yield {
+            speaker: 'ai',
+            blocks: [{ type: 'text', text: 'is 4.' }],
+            metadata: {
+              usage: {
+                promptTokens: 5000,
+                completionTokens: 15,
+                totalTokens: 5015,
+              },
+            },
+          };
+        }),
+    };
+
+    const records = await runTurnReadRecords(
+      mockProvider,
+      'ordinary-stream-session',
+      'ordinary-stream-prompt',
+    );
+
+    expect(records).toHaveLength(1);
+    const record = records[0];
+    expect(record.chunk_count).toBe(3);
+    expect(record.ttft_ms).toBeGreaterThanOrEqual(0);
+    expect(record.generation_ms).toBeGreaterThan(0);
+    expect(record.provider_request_ms).toBeGreaterThan(0);
+  });
+
+  // A failed attempt that already streamed raw deltas must keep that partial
+  // raw timing on its abandoned-attempt record, and the retry must record
+  // fresh timing of its own (mirrors the #3257 abandoned/success pair; the
+  // raw deltas make the abandoned generation window strictly positive where
+  // the visible-only record omitted it).
+  it('keeps partial raw timing on an abandoned attempt and fresh timing on the retry (#3493)', async () => {
+    let attempt = 0;
+    const mockProvider = {
+      name: 'anthropic',
+      generateChatCompletion: vi
+        .fn()
+        .mockImplementation(async function* (options: {
+          metadata?: Record<string, unknown>;
+        }) {
+          attempt++;
+          if (attempt === 1) {
+            const sink = rawDeltaSinkFrom(options.metadata);
+            sink?.();
+            await sleep(15);
+            sink?.();
+            await sleep(15);
+            sink?.();
+            yield {
+              speaker: 'ai',
+              blocks: [{ type: 'text', text: 'partial' }],
+              metadata: {
+                usage: {
+                  promptTokens: 5000,
+                  completionTokens: 5,
+                  totalTokens: 5005,
+                },
+              },
+            };
+            throw new Error('Connection error.');
+          }
+          yield { speaker: 'ai', blocks: [{ type: 'text', text: 'The ' }] };
+          await sleep(15);
+          yield { speaker: 'ai', blocks: [{ type: 'text', text: 'answer ' }] };
+          await sleep(15);
+          yield {
+            speaker: 'ai',
+            blocks: [{ type: 'text', text: 'is 4.' }],
+            metadata: {
+              usage: {
+                promptTokens: 5100,
+                completionTokens: 15,
+                totalTokens: 5115,
+              },
+            },
+          };
+        }),
+    };
+
+    const records = await runTurnReadRecords(
+      mockProvider,
+      'abandoned-raw-timing-session',
+      'abandoned-raw-timing-prompt',
+    );
+
+    expect(attempt).toBe(2);
+    expect(records).toHaveLength(2);
+
+    const abandoned = records.find((r) => r.attempt_outcome === 'abandoned');
+    expect(abandoned).toBeDefined();
+    if (abandoned === undefined) throw new Error('no abandoned record');
+    expect(abandoned.attempt_index).toBe(0);
+    expect(typeof abandoned.ttft_ms).toBe('number');
+    expect(abandoned.ttft_ms).toBeGreaterThanOrEqual(0);
+    // One visible chunk means a zero visible-only window; a positive
+    // generation window here can only come from the raw deltas.
+    expect(abandoned.generation_ms).toBeGreaterThan(0);
+    expect(typeof abandoned.provider_request_ms).toBe('number');
+    expect(abandoned.provider_request_ms).toBeGreaterThanOrEqual(0);
+    expect(abandoned.chunk_count).toBe(1);
+
+    const success = records.find((r) => r.attempt_outcome !== 'abandoned');
+    expect(success).toBeDefined();
+    if (success === undefined) throw new Error('no success record');
+    expect(success.attempt_index).toBe(1);
+    expect(typeof success.ttft_ms).toBe('number');
+    expect(success.ttft_ms).toBeGreaterThanOrEqual(0);
+    expect(success.generation_ms).toBeGreaterThan(0);
+    expect(typeof success.provider_request_ms).toBe('number');
+    expect(success.provider_request_ms).toBeGreaterThanOrEqual(0);
+    // Fresh attempt-2 timing wins: three chunks, not attempt 1's single one.
+    expect(success.chunk_count).toBe(3);
+  });
+});

--- a/packages/agents/src/core/streamTelemetryLogger.timing.test.ts
+++ b/packages/agents/src/core/streamTelemetryLogger.timing.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { StreamTimingTracker } from './streamTelemetryLogger.js';
+
+function textChunk(text: string): IContent {
+  return { speaker: 'ai', blocks: [{ type: 'text', text }] };
+}
+
+function emptyTextChunk(): IContent {
+  return { speaker: 'ai', blocks: [{ type: 'text', text: '' }] };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+describe('StreamTimingTracker raw token-delta timing (issue #3493)', () => {
+  it('visible token-bearing chunks stamp first/last timing when no raw delta arrives (fallback path)', async () => {
+    const tracker = new StreamTimingTracker();
+    await delay(15);
+    tracker.recordChunk(textChunk('Hello'));
+    const afterFirst = tracker.measure();
+    await delay(15);
+    tracker.recordChunk(textChunk(' world'));
+    const final = tracker.measure();
+
+    const firstStamp = afterFirst.firstTokenMs;
+    if (firstStamp === null) {
+      throw new Error('visible token-bearing chunk must stamp firstTokenMs');
+    }
+    expect(afterFirst.lastTokenMs).toBe(firstStamp);
+    expect(final.firstTokenMs).toBe(firstStamp);
+    expect(final.lastTokenMs).toBeGreaterThan(firstStamp);
+    expect(final.chunkCount).toBe(2);
+  });
+
+  it('a raw delta before any visible chunk sets firstTokenMs and a later visible chunk does not overwrite the window', async () => {
+    const tracker = new StreamTimingTracker();
+    await delay(15);
+    tracker.recordRawTokenDelta();
+    const rawWindow = tracker.measure();
+    await delay(15);
+    tracker.recordChunk(textChunk('deferred visible emission'));
+    const final = tracker.measure();
+
+    const rawFirst = rawWindow.firstTokenMs;
+    const rawLast = rawWindow.lastTokenMs;
+    if (rawFirst === null || rawLast === null) {
+      throw new Error(
+        'raw token delta must stamp firstTokenMs and lastTokenMs',
+      );
+    }
+    expect(final.firstTokenMs).toBe(rawFirst);
+    expect(final.lastTokenMs).toBe(rawLast);
+    expect(final.chunkCount).toBe(1);
+  });
+
+  it('the last raw delta defines lastTokenMs even when a visible token-bearing chunk arrives strictly after it', async () => {
+    const tracker = new StreamTimingTracker();
+    await delay(15);
+    tracker.recordRawTokenDelta();
+    const firstRawWindow = tracker.measure();
+    await delay(15);
+    tracker.recordRawTokenDelta();
+    const lastRawWindow = tracker.measure();
+    await delay(15);
+    tracker.recordChunk(textChunk('reasoning buffer flush'));
+    const final = tracker.measure();
+
+    const firstRaw = firstRawWindow.firstTokenMs;
+    const lastRaw = lastRawWindow.lastTokenMs;
+    if (firstRaw === null || lastRaw === null) {
+      throw new Error(
+        'raw token deltas must stamp firstTokenMs and lastTokenMs',
+      );
+    }
+    expect(lastRaw).toBeGreaterThan(firstRaw);
+    expect(final.firstTokenMs).toBe(firstRaw);
+    expect(final.lastTokenMs).toBe(lastRaw);
+    expect(final.chunkCount).toBe(1);
+  });
+
+  it('visible chunks still advance chunkCount after raw timing has stamped the attempt', () => {
+    const tracker = new StreamTimingTracker();
+    tracker.recordRawTokenDelta();
+    const rawWindow = tracker.measure();
+    tracker.recordChunk(textChunk('one'));
+    tracker.recordChunk(textChunk('two'));
+    tracker.recordChunk(textChunk('three'));
+    const final = tracker.measure();
+
+    expect(final.chunkCount).toBe(3);
+    expect(final.firstTokenMs).toBe(rawWindow.firstTokenMs);
+    expect(final.lastTokenMs).toBe(rawWindow.lastTokenMs);
+  });
+
+  it('non-token-bearing visible chunks count toward chunkCount without stamping timing (no raw deltas)', async () => {
+    const tracker = new StreamTimingTracker();
+    tracker.recordChunk(emptyTextChunk());
+    await delay(15);
+    tracker.recordChunk(emptyTextChunk());
+    const final = tracker.measure();
+
+    expect(final.chunkCount).toBe(2);
+    expect(final.firstTokenMs).toBeNull();
+    expect(final.lastTokenMs).toBeNull();
+  });
+
+  it('non-token-bearing visible chunks count toward chunkCount without moving a raw-stamped window', async () => {
+    const tracker = new StreamTimingTracker();
+    tracker.recordRawTokenDelta();
+    const rawWindow = tracker.measure();
+    await delay(15);
+    tracker.recordChunk(emptyTextChunk());
+    tracker.recordChunk(emptyTextChunk());
+    const final = tracker.measure();
+
+    expect(final.chunkCount).toBe(2);
+    expect(final.firstTokenMs).toBe(rawWindow.firstTokenMs);
+    expect(final.lastTokenMs).toBe(rawWindow.lastTokenMs);
+  });
+
+  it('providerRequestMs spans the full stream lifecycle regardless of which timing source stamped the window', async () => {
+    const visibleOnly = new StreamTimingTracker();
+    await delay(15);
+    visibleOnly.recordChunk(textChunk('visible'));
+    await delay(15);
+    const visibleMeasurement = visibleOnly.measure();
+
+    const rawStamped = new StreamTimingTracker();
+    await delay(15);
+    rawStamped.recordRawTokenDelta();
+    await delay(15);
+    rawStamped.recordChunk(textChunk('terminal combined chunk'));
+    const rawMeasurement = rawStamped.measure();
+
+    const visibleLast = visibleMeasurement.lastTokenMs;
+    const rawLast = rawMeasurement.lastTokenMs;
+    if (visibleLast === null || rawLast === null) {
+      throw new Error('both timing sources must stamp lastTokenMs');
+    }
+    expect(visibleMeasurement.providerRequestMs).toBeGreaterThan(visibleLast);
+    expect(rawMeasurement.providerRequestMs).toBeGreaterThan(rawLast);
+  });
+});

--- a/packages/agents/src/core/streamTelemetryLogger.ts
+++ b/packages/agents/src/core/streamTelemetryLogger.ts
@@ -70,16 +70,40 @@ function isTokenBearingChunk(chunk: IContent): boolean {
  * generator execution begins (the provider call boundary), fed every raw
  * chunk before any conversion or hook processing, and read out at stream
  * end. Excludes send-seam estimation, which runs before the provider call.
+ *
+ * Timing source precedence (issue #3493): firstTokenMs/lastTokenMs are
+ * stamped from raw token deltas via recordRawTokenDelta whenever that
+ * signal arrives, falling back to visible token-bearing chunks when it
+ * does not. Once a raw delta has stamped the attempt, visible chunks still
+ * count toward chunkCount but must not move the token window, because
+ * deferred visible emissions (a terminal combined chunk, a buffered-text
+ * flush) trail the final raw delta. This mirrors the providers-layer
+ * AttemptRecorder rule from issue #3473 (`rawTimingStamped` guarding
+ * `recordTokenBearingChunk` after `recordTimingOnly`), so both layers
+ * agree on the same token window.
  */
 export class StreamTimingTracker {
   private readonly startMs = performance.now();
   private firstTokenMs: number | null = null;
   private lastTokenMs: number | null = null;
   private chunkCount = 0;
+  private rawTimingStamped = false;
+
+  /**
+   * Record a raw token-delta timing signal for this attempt (issue #3493).
+   * Stamps firstTokenMs/lastTokenMs without touching chunkCount, and makes
+   * the raw stamps authoritative over later visible-chunk stamps.
+   */
+  recordRawTokenDelta(): void {
+    const now = performance.now() - this.startMs;
+    this.firstTokenMs ??= now;
+    this.lastTokenMs = now;
+    this.rawTimingStamped = true;
+  }
 
   recordChunk(chunk: IContent): void {
     this.chunkCount++;
-    if (isTokenBearingChunk(chunk)) {
+    if (!this.rawTimingStamped && isTokenBearingChunk(chunk)) {
       const now = performance.now() - this.startMs;
       this.firstTokenMs ??= now;
       this.lastTokenMs = now;
@@ -93,6 +117,28 @@ export class StreamTimingTracker {
       providerRequestMs: performance.now() - this.startMs,
       chunkCount: this.chunkCount,
     };
+  }
+}
+
+/**
+ * Stable indirection between request metadata and the per-attempt tracker
+ * (issue #3493). Request metadata is built in _buildStreamChatOptions
+ * before the provider call, while the tracker only comes into existence at
+ * the generator-body start of _convertIContentStream — the provider-call
+ * boundary that keeps provider_request_ms free of send-seam estimation
+ * (#3257). The bridge is threaded into metadata first and attached to the
+ * tracker when that boundary is crossed, so the sink identity stays stable
+ * across the two moments. `notify` is an arrow-function property so it can
+ * be passed as a bare function value without losing `this`.
+ */
+export class RawTokenDeltaBridge {
+  private tracker: StreamTimingTracker | null = null;
+  /** Stable sink threaded into request metadata before the tracker exists. */
+  readonly notify = (): void => {
+    this.tracker?.recordRawTokenDelta();
+  };
+  attach(tracker: StreamTimingTracker): void {
+    this.tracker = tracker;
   }
 }
 

--- a/packages/providers/src/__tests__/attemptLifecycle.rawDeltaGuard.test.ts
+++ b/packages/providers/src/__tests__/attemptLifecycle.rawDeltaGuard.test.ts
@@ -14,11 +14,16 @@
  * makes resolveRawTokenDeltaNotifier call .bind on a non-function and throw
  * a TypeError at request time, failing the whole request instead of
  * degrading to visible-chunk timing.
+ *
+ * Issue #3493 adds a caller-supplied sink on a separate metadata key. The
+ * raw signal must fan out to both consumers (observer hook first, then the
+ * caller sink), and a malformed consumer must never disable the other.
  */
 
 import { describe, it, expect } from 'bun:test';
 import {
   ATTEMPT_LIFECYCLE_KEY,
+  RAW_TOKEN_DELTA_SINK_KEY,
   getAttemptLifecycleObserver,
   resolveRawTokenDeltaNotifier,
 } from '../logging/attemptLifecycle.js';
@@ -68,5 +73,86 @@ describe('issue #3473: lifecycle observer guard for the raw-delta hook', () => {
   it('resolves no notifier when no observer is present in metadata', () => {
     expect(resolveRawTokenDeltaNotifier(undefined)).toBeUndefined();
     expect(resolveRawTokenDeltaNotifier({})).toBeUndefined();
+  });
+});
+
+describe('issue #3493: raw token-delta sink fan-out', () => {
+  it('resolves a notifier that fires a caller-supplied sink when only the sink is present', () => {
+    let sinkFired = 0;
+    const metadata = {
+      [RAW_TOKEN_DELTA_SINK_KEY]: () => {
+        sinkFired++;
+      },
+    };
+
+    const notifier = resolveRawTokenDeltaNotifier(metadata);
+    expect(notifier).toBeTypeOf('function');
+    notifier?.();
+    expect(sinkFired).toBe(1);
+  });
+
+  it('fans one raw delta out to the observer hook and the caller sink, each exactly once, observer first', () => {
+    const calls: string[] = [];
+    const metadata = {
+      [ATTEMPT_LIFECYCLE_KEY]: {
+        onAttemptStart: () => {},
+        onAttemptEnd: () => {},
+        onRawTokenDelta: () => {
+          calls.push('observer');
+        },
+      },
+      [RAW_TOKEN_DELTA_SINK_KEY]: () => {
+        calls.push('sink');
+      },
+    };
+
+    const notifier = resolveRawTokenDeltaNotifier(metadata);
+    expect(notifier).toBeTypeOf('function');
+    notifier?.();
+    expect(calls).toEqual(['observer', 'sink']);
+  });
+
+  it('ignores a present-but-non-function sink beside a valid observer hook', () => {
+    let observerFired = 0;
+    const metadata = {
+      [ATTEMPT_LIFECYCLE_KEY]: {
+        onAttemptStart: () => {},
+        onAttemptEnd: () => {},
+        onRawTokenDelta: () => {
+          observerFired++;
+        },
+      },
+      [RAW_TOKEN_DELTA_SINK_KEY]: 'not-a-function',
+    };
+
+    const notifier = resolveRawTokenDeltaNotifier(metadata);
+    expect(notifier).toBeTypeOf('function');
+    notifier?.();
+    expect(observerFired).toBe(1);
+  });
+
+  it('ignores a present-but-non-function sink and resolves no notifier when no observer is present', () => {
+    const metadata = { [RAW_TOKEN_DELTA_SINK_KEY]: 42 };
+
+    expect(resolveRawTokenDeltaNotifier(metadata)).toBeUndefined();
+  });
+
+  it('still resolves a working sink notifier when the observer onRawTokenDelta is malformed', () => {
+    let sinkFired = 0;
+    const metadata = {
+      [ATTEMPT_LIFECYCLE_KEY]: {
+        onAttemptStart: () => {},
+        onAttemptEnd: () => {},
+        onRawTokenDelta: 'malformed',
+      },
+      [RAW_TOKEN_DELTA_SINK_KEY]: () => {
+        sinkFired++;
+      },
+    };
+
+    const notifier = resolveRawTokenDeltaNotifier(metadata);
+    expect(notifier).toBeTypeOf('function');
+    notifier?.();
+    expect(sinkFired).toBe(1);
   });
 });

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -123,6 +123,9 @@ export { PROVIDER_CONFIG_KEYS } from './providerConfigKeys.js';
 // Callers (e.g. the agents layer) thread their logical request id through
 // options metadata so provider-attempt records join caller-side registries.
 export { LOGICAL_REQUEST_ID_KEY } from './logging/attemptLifecycle.js';
+// Callers thread a raw token-delta sink so caller-side timing consumers
+// observe raw generation deltas.
+export { RAW_TOKEN_DELTA_SINK_KEY } from './logging/attemptLifecycle.js';
 
 // --- Provider utilities ---
 export {

--- a/packages/providers/src/logging/attemptLifecycle.ts
+++ b/packages/providers/src/logging/attemptLifecycle.ts
@@ -103,6 +103,18 @@ export const ATTEMPT_LIFECYCLE_KEY = '__attemptLifecycle';
 export const LOGICAL_REQUEST_ID_KEY = '__logicalRequestId';
 
 /**
+ * Metadata key carrying an internal, caller-supplied () => void sink
+ * notified at each raw token-bearing delta (issue #3493). It is a separate
+ * key from ATTEMPT_LIFECYCLE_KEY because LoggingProviderWrapper overwrites
+ * that key with its own AttemptRecorder (see LoggingProviderWrapper.ts
+ * ~lines 264-270, which spreads caller metadata then assigns its own
+ * recorder), so a caller-side timing consumer needs a channel that
+ * survives the wrapper's metadata spread. Internal plumbing; never sent
+ * on the wire.
+ */
+export const RAW_TOKEN_DELTA_SINK_KEY = '__rawTokenDeltaSink';
+
+/**
  * Extract the logical request id from GenerateChatOptions metadata.
  * Returns a non-empty string when present, otherwise undefined.
  */
@@ -133,18 +145,42 @@ export function getAttemptLifecycleObserver(
 /**
  * Resolve the raw token-delta timing notifier from GenerateChatOptions
  * metadata (issue #3473). Providers call this once per request and invoke
- * the returned notifier at each raw token-bearing delta. Returns undefined
- * when no observer (or no timing hook) is present, leaving attempt timing
- * to visible-chunk stamping.
+ * the returned notifier at each raw token-bearing delta. The single raw
+ * signal fans out to every usable consumer (issue #3493): the lifecycle
+ * observer's bound onRawTokenDelta hook first, then the caller sink at
+ * RAW_TOKEN_DELTA_SINK_KEY. A present-but-non-function consumer is
+ * malformed external input and is ignored, never allowed to throw at
+ * resolve time. Returns undefined when neither consumer is usable,
+ * leaving attempt timing to visible-chunk stamping.
  */
 export function resolveRawTokenDeltaNotifier(
   metadata: Record<string, unknown> | undefined,
 ): (() => void) | undefined {
   const observer = getAttemptLifecycleObserver(metadata);
-  if (observer?.onRawTokenDelta === undefined) {
-    return undefined;
+  const observerHook =
+    observer?.onRawTokenDelta !== undefined
+      ? observer.onRawTokenDelta.bind(observer)
+      : undefined;
+  const rawSink = metadata?.[RAW_TOKEN_DELTA_SINK_KEY];
+  const sink = isRawTokenDeltaSink(rawSink) ? rawSink : undefined;
+  if (observerHook !== undefined && sink !== undefined) {
+    return () => {
+      observerHook();
+      sink();
+    };
   }
-  return observer.onRawTokenDelta.bind(observer);
+  return observerHook ?? sink;
+}
+
+/**
+ * True when a metadata value is a usable raw token-delta sink. A
+ * present-but-non-function sink is malformed external input, in the same
+ * spirit as isOptionalFunctionHook: metadata is genuinely external input
+ * and throwing there fails the whole request instead of degrading timing,
+ * so it is ignored instead.
+ */
+function isRawTokenDeltaSink(value: unknown): value is () => void {
+  return typeof value === 'function';
 }
 
 /**

--- a/project-plans/issue-3493-agents-raw-timing/plan.md
+++ b/project-plans/issue-3493-agents-raw-timing/plan.md
@@ -1,0 +1,180 @@
+# Issue #3493 — StreamTimingTracker misses raw reasoning and tool-call timing
+
+## Problem
+
+`StreamTimingTracker` (`packages/agents/src/core/streamTelemetryLogger.ts`) stamps
+`firstTokenMs`/`lastTokenMs` from the post-provider `IContent` chunks yielded to the
+agents layer. Classic OpenAI reasoning streams buffer raw reasoning deltas and
+tool-call argument fragments and only yield a visible chunk much later (often a single
+terminal combined chunk). The agents-layer token-usage turn record therefore reports
+`ttft_ms` and `generation_ms` measured from visible emission, not from generation.
+
+Issue #3473 (merged as PR #3494) fixed the equivalent problem for provider/session
+telemetry by adding an optional `onRawTokenDelta()` hook on `AttemptLifecycleObserver`.
+Providers resolve it once per request via `resolveRawTokenDeltaNotifier(metadata)` and
+call it at each raw token-bearing delta. The only observer installed on that channel is
+the `AttemptRecorder` created inside `LoggingProviderWrapper`, which overwrites
+`metadata[ATTEMPT_LIFECYCLE_KEY]`. The signal never reaches the agents layer.
+
+## Intended timing source (the decision this issue asks for)
+
+Agents-layer turn records measure the **raw generation window** when the provider
+reports raw token deltas, and fall back to visible-chunk stamping when it does not.
+`StreamTimingTracker` stays the single agents-layer measurement point — it is fed a
+better input rather than being shadowed by a parallel tracker or by re-deriving the
+provider's numbers. Precedence exactly mirrors
+`AttemptRecorder.recordTokenBearingChunk`/`recordTimingOnly`: once a raw delta has
+stamped an attempt, later visible chunks update volume (`chunkCount`) but must not move
+first/last token timestamps, because deferred visible emissions trail the final raw
+delta.
+
+## Acceptance criteria
+
+**AC-1 — Raw deltas drive agents-layer timing.**
+When the provider emits raw token deltas for an attempt, the `StreamTimingMeasurement`
+attached to the turn record derives `firstTokenMs` from the first raw delta and
+`lastTokenMs` from the last raw delta, both relative to the same stream-start origin
+used today. `ttft_ms` and `generation_ms` in the token-usage record follow.
+
+**AC-2 — Raw stamps are authoritative over visible chunks.**
+After the first raw delta, visible token-bearing chunks still increment `chunkCount`
+but never overwrite `firstTokenMs`/`lastTokenMs`. Same rule as the provider recorder,
+so agents-layer and provider/session telemetry cannot disagree about the window.
+
+**AC-3 — Unchanged fallback.**
+With no raw-delta signal (providers that never call the hook), timing is stamped from
+visible token-bearing chunks exactly as before this change. `providerRequestMs` remains
+the full stream-lifecycle elapsed time and `chunkCount` remains the visible chunk count
+in every case.
+
+**AC-4 — Visible stream and retry/load-balancing semantics preserved.**
+The raw signal travels only on the internal metadata channel. The consumer-visible
+chunk sequence (order, content, count) is identical with and without a raw-delta
+source. Each agents-layer attempt measures into a fresh tracker, and `attachStreamTiming`
+still writes all four keys so a retry fully replaces the previous attempt's timing.
+The failed-attempt path (stream error, empty stream) still attaches partial timing.
+
+### Boundary cases
+
+| Case | Expected |
+| --- | --- |
+| Reasoning-only stream (raw reasoning deltas, single terminal visible chunk) | ttft from first raw reasoning delta |
+| Tool-call-only stream (raw argument fragments, tool_call yielded at end) | ttft from first raw fragment; window ends at last fragment |
+| Buffered text (raw content deltas held, flushed late) | ttft from first raw delta, not from the flush |
+| Ordinary text (raw delta per visible chunk) | unchanged numbers |
+| No raw-delta source | visible-chunk stamping (AC-3) |
+| Raw deltas but zero visible chunks (EmptyStreamError path) | raw timing still attached to the abandoned-attempt record |
+| Malformed sink value in metadata (present, not a function) | ignored; degrade to visible-chunk stamping, no throw |
+
+## Design
+
+Add one internal metadata channel so the same raw signal fans out to both consumers
+instead of creating a second measurement:
+
+1. `packages/providers/src/logging/attemptLifecycle.ts`
+   - New key `RAW_TOKEN_DELTA_SINK_KEY = '__rawTokenDeltaSink'` carrying an optional
+     caller-supplied `() => void`.
+   - `resolveRawTokenDeltaNotifier(metadata)` returns a notifier that invokes the
+     lifecycle observer's `onRawTokenDelta` (when present) **and** the caller sink
+     (when present and a function), returning `undefined` when neither exists.
+     Guarded like `isOptionalFunctionHook`: a present non-function sink is ignored.
+   - No provider call sites change — `OpenAIProvider` already resolves the notifier
+     once per request, and `LoggingProviderWrapper` spreads caller metadata, so the
+     sink survives the recorder installation.
+   - Export the key from `packages/providers/src/index.ts` next to
+     `LOGICAL_REQUEST_ID_KEY`.
+
+2. `packages/agents/src/core/streamTelemetryLogger.ts`
+   - `StreamTimingTracker` gains `recordRawTokenDelta()` (stamps first/last, marks raw
+     timing authoritative) and `recordChunk()` keeps counting chunks but skips timing
+     once raw-stamped.
+   - The tracker's `startMs` origin is unchanged (stream-lifecycle start).
+
+3. `packages/agents/src/core/StreamProcessor.ts`
+   - `_sendProviderRequest` creates the tracker before `provider.generateChatCompletion`
+     and threads `RAW_TOKEN_DELTA_SINK_KEY` into request metadata bound to it, then
+     passes the tracker into `_convertIContentStream` instead of constructing one there.
+   - The tracker's clock still starts at the provider-call boundary so
+     `provider_request_ms` keeps excluding send-seam estimation (#3257). If construction
+     order cannot preserve that origin, the tracker starts its clock explicitly at
+     generator-body start and the sink is a stable indirection to it.
+
+## Test plan (behavioral, written first)
+
+New: `packages/agents/src/core/StreamProcessor.rawTiming.test.ts`
+Drives `StreamProcessor` with a fake provider that reads
+`metadata[RAW_TOKEN_DELTA_SINK_KEY]`, fires raw deltas on a controlled clock, then
+yields visible chunks later. Captures the record written through `TokenUsageLogger`.
+
+- reasoning-only: raw deltas at t0..t1, single terminal visible chunk at t2 →
+  `ttft_ms` ≈ t0, `generation_ms` ≈ t1 - t0 (not t2 - t2).
+- tool-call-only: raw argument fragments then one terminal `tool_call` chunk → same shape.
+- buffered text: raw deltas then a late flush → window from raw deltas.
+- ordinary text: raw delta immediately before each visible chunk → window matches
+  visible timing (no regression).
+- no sink consumed by the provider → visible-chunk timing preserved (AC-3).
+- visible chunk sequence asserted identical across the raw/no-raw variants (AC-4).
+- error path: raw deltas then a thrown stream error → partial timing still attached.
+
+New/extended provider-side unit coverage in
+`packages/providers/src/__tests__/attemptLifecycle.rawDeltaGuard.test.ts`:
+sink-only metadata, observer-plus-sink fan-out, malformed sink ignored, neither present
+→ `undefined`.
+
+Extended `packages/agents/src/core/streamTelemetryLogger` coverage for the tracker's
+precedence rule (raw stamp wins, chunkCount still advances).
+
+## Verification
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`,
+plus the `stepfun-37` startup smoke.
+
+## Out of scope
+
+Provider-side timing formulas, session `/stats` aggregation, non-OpenAI providers
+adopting the raw-delta hook, and any change to retry, load-balancing, or compression
+behavior.
+
+## Review outcomes
+
+Verification on the candidate head: lint, typecheck, format and build all exit 0; the
+`stepfun-37` startup smoke passes; the suite reports 9298 passed / 1 failed, where the
+single failure is `packages/cli/src/utils/sandbox-entrypoint.test.ts` snapshotting the
+real home config directory while a concurrent sibling checkout wrote
+`~/.llxprt/code-rs-sessions/`. That test passes in isolation and is unrelated to this
+change.
+
+### Triaged findings
+
+- **Reject** (OCR, low): reuse `isOptionalFunctionHook` for the sink guard instead of
+  the new `isRawTokenDeltaSink`. `isOptionalFunctionHook` returns `boolean`, not a type
+  predicate, so the suggested form needs an unchecked cast. The type-predicate guard is
+  the safer shape.
+- **Defer** (medium): the agents-layer tests drive the sink from a fake provider rather
+  than composing `LoggingProviderWrapper` with a real classic OpenAI stream fixture. The
+  review separately traced that production path end to end and found no point where the
+  sink is dropped, through `prepareAtSendSeam`, `optionsNormalizer`,
+  `LoggingProviderWrapper`, `BaseProviderNormalization`, `RetryOrchestrator` and the
+  load-balancer options builder.
+
+### Open scope question: inner-attempt raw window
+
+`RetryOrchestrator.runRetryRequest` derives `attemptOptions` from the same
+`requestOptions.metadata` on every loop iteration, so every provider-internal retry and
+load-balancer failover attempt shares one sink. The lifecycle observer receives fresh
+`onAttemptStart`/`onAttemptEnd` boundaries and `AttemptRecorder` keeps a separate window
+per attempt; the agents bridge does not.
+
+Consequence: when an inner attempt emits raw reasoning or tool fragments, yields no
+visible chunk and then fails, its first raw delta stamps `ttft_ms` while the successful
+retry ends the window, so `generation_ms` absorbs the failed attempt and its backoff.
+Before this change a raw-only failed attempt contributed nothing to agents timing, so
+this is a narrow new gap rather than inherited behavior, and it cuts against the
+"consistent with provider/session telemetry" criterion.
+
+Closing it requires attempt identity on the sink, which changes the metadata contract
+(for example the sink becomes a factory resolved once per provider invocation, returning
+a per-attempt stamper that resets the tracker's raw window) plus a `beginRawAttempt()`
+on the tracker and behavioral tests through `RetryOrchestrator` and load-balancer
+failover. That is new public contract surface beyond this plan, so it is held for an
+explicit scope decision rather than implemented here.


### PR DESCRIPTION
## TLDR

The agents-layer `StreamTimingTracker` stamped `ttft_ms` and `generation_ms` from post-provider visible `IContent` chunks. Classic OpenAI reasoning streams buffer raw reasoning deltas and tool-call argument fragments and only yield a visible chunk much later, so token-usage turn records measured visible emission rather than generation. A buffered turn that ends in one combined chunk put first and last token at the same instant, which suppressed `generation_ms` entirely.

Issue #3473 already carried the raw signal to provider telemetry, but its only consumer was the `AttemptRecorder` that `LoggingProviderWrapper` installs, and the wrapper overwrites `metadata[ATTEMPT_LIFECYCLE_KEY]`, so a caller-side consumer could not ride that key. This adds a separate metadata channel that survives the wrapper's spread and fans the one raw event out to both consumers.

Reviewers should look hardest at the bridge lifetime in `StreamProcessor` and at whether `provider_request_ms` still excludes send-seam estimation.

## Dive Deeper

**Timing source.** Raw token deltas drive agents-layer timing when the provider reports them; visible-chunk stamping remains the fallback when it does not. `StreamTimingTracker` stays the single agents-layer measurement point, fed a better input rather than shadowed by a parallel tracker or by re-deriving the provider's numbers.

**One signal, two consumers.** `RAW_TOKEN_DELTA_SINK_KEY` is a new metadata key carrying a caller-supplied `() => void`. `resolveRawTokenDeltaNotifier` now returns a notifier that invokes the lifecycle observer's bound `onRawTokenDelta` and then the caller sink, `undefined` when neither is usable. No provider call sites changed: `OpenAIProvider` already resolves the notifier once per request. A present-but-non-function sink is ignored rather than allowed to throw at resolve time, matching the existing `isOptionalFunctionHook` precedent, because request metadata is an external boundary and throwing there would fail the whole request instead of degrading timing.

**Precedence mirrors the provider recorder.** `recordRawTokenDelta()` stamps first/last token and marks raw timing authoritative. `recordChunk()` still counts every visible chunk but stops moving the token window once raw timing has stamped the attempt, because deferred visible emissions (a terminal combined chunk, a buffered-text flush) trail the final raw delta. This is the same rule as `AttemptRecorder.rawTimingStamped` guarding `recordTokenBearingChunk` after `recordTimingOnly`, so the two layers cannot disagree about a single attempt's window.

**Why a bridge.** Request metadata is built in `_buildStreamChatOptions`, which runs before the provider call and can run more than once during prompt-envelope enforcement. The tracker is constructed at the generator-body start of `_convertIContentStream`, and that construction site is what keeps `provider_request_ms` free of send-seam estimation (#3257). `RawTokenDeltaBridge` holds the stable sink identity across those two moments; the tracker construction site is deliberately unmoved. A fresh bridge per attempt, minted in `makeApiCallAndProcessStream` beside the other per-attempt resets, keeps an abandoned attempt's stream from feeding the next attempt's tracker, and `_sendProviderRequest` captures it into a local rather than letting the generator read the instance field.

**Known gap, tracked separately.** `RetryOrchestrator` reuses the same `requestOptions.metadata` for every provider-internal attempt, so one agents tracker spans retry and load-balancer failover attempts while `AttemptRecorder` keeps separate per-attempt windows. A raw-only inner attempt that fails can therefore pull `ttft_ms` early and inflate `generation_ms` with backoff. Closing that needs attempt identity on the sink, which changes the metadata contract, so it is filed as #3509 rather than expanded into this PR. The triage record is in `project-plans/issue-3493-agents-raw-timing/plan.md`.

## Reviewer Test Plan

The behavior is observable in the token-usage JSONL log, so the fastest check is the automated coverage:

```
bun test packages/agents/src/core/TokenUsageLogger.rawTiming.test.ts --timeout 30000
bun test packages/agents/src/core/streamTelemetryLogger.timing.test.ts
bun test packages/providers/src/__tests__/attemptLifecycle.rawDeltaGuard.test.ts
bun test packages/providers/src/__tests__/rawTimingTransport.retryBoundary.test.ts
bun test packages/agents/src/core/TokenUsageLogger.integration.test.ts --timeout 30000
```

Note the `--timeout 30000`: the repo runner applies a 30s per-test timeout, while a bare `bun test` uses bun's 5s default and will falsely time out the retry/backoff cases.

The discriminating assertion to look at is the single-visible-chunk case. With one visible chunk, visible-only timing puts first and last token at the same instant, and `TokenUsageLogger._generationWindowMs` emits `generation_ms` only when the window is strictly positive. A positive `generation_ms` there can only come from raw deltas, so those tests fail if the wiring is reverted.

For a live check, run a turn against a classic OpenAI-format reasoning model with token usage logging enabled and compare `ttft_ms`/`generation_ms` in the turn record against the session `/stats` output. They should now agree on a buffered reasoning turn instead of the turn record collapsing to a near-zero window.

To confirm nothing visible changed, run any ordinary streaming turn and check the output text and chunk sequence are unaffected; `chunk_count` should still equal the number of visible chunks.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build` all clean, plus the `stepfun-37` startup smoke. The suite reported one failure in `packages/cli/src/utils/sandbox-entrypoint.test.ts`, which snapshots the real home config directory and was disturbed by a concurrent sibling checkout writing `~/.llxprt/code-rs-sessions/`; it passes in isolation and is unrelated to this change.

## Linked issues / bugs

Fixes #3493

Follow-up filed during review: #3509

Builds on #3473 (PR #3494), which added the provider-side raw token-delta hook this change consumes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved streaming performance metrics, including more accurate time-to-first-token and generation timing.
  - Timing now remains reliable for buffered responses, tool-call-only streams, delayed output, and retry attempts.
  - Preserved fallback timing based on visible streamed content when detailed token timing is unavailable.
  - Improved handling of streaming telemetry so token timing signals remain isolated from content displayed to consumers.
  - Improved consistency of timing data across repeated or interrupted streaming attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->