### PR TITLE
fix(scripts): stop the test runner from killing the sandboxed CLI (Fixes #3491)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1036,7 +1036,7 @@ jobs:
       - name: 'Run test-runner and orchestrator meta-tests'
         if: steps.filter.outputs.affected == 'true'
         run: |-
-          bun test --preload ./scripts/tests/test-setup.ts scripts/tests/run_bun_tests.test.ts scripts/tests/test-orchestrator.test.ts scripts/tests/test-shard-orchestrator.test.ts
+          bun test --preload ./scripts/tests/test-setup.ts scripts/tests/run_bun_tests.test.ts scripts/tests/bun-test-reaper.bun.test.ts scripts/tests/test-orchestrator.test.ts scripts/tests/test-shard-orchestrator.test.ts
           cd packages/cli && bun test test/run-bun-tests.test.ts
           cd ../core && bun test test/run-bun-tests.test.ts
           cd ../agents && bun test ./test-bun/run-bun-tests.issue3253.bun.ts

--- a/packages/cli/src/cliTerminalSession.ts
+++ b/packages/cli/src/cliTerminalSession.ts
@@ -20,6 +20,7 @@ import { setupTerminalAndTheme } from './utils/terminalTheme.js';
 import { drainStdinBuffer } from './ui/utils/terminalContract.js';
 import { StdinRawModeManager } from './utils/stdinSafety.js';
 import { registerCleanup, runExitCleanup } from './utils/cleanup.js';
+import { registerShellJobShutdownNotice } from './utils/shellJobShutdownNotice.js';
 import { appEvents, AppEvent } from './utils/events.js';
 import type { LoadedSettings } from './config/settings.js';
 import type { ParsedCliArgs } from './cliBootstrap.js';
@@ -174,13 +175,16 @@ function patchConsoleForRun(config: Config): void {
 /**
  * Prepare the interactive terminal session: enable raw mode when needed, set up
  * the terminal title/theme, register the session-summary writer, and patch the
- * console for the run.
+ * console for the run. Registering the shutdown notice here — once, before any
+ * signal handler or UI path can exit — covers SIGTERM, SIGINT, and the quit
+ * path uniformly via the process `exit` event.
  */
 export async function prepareTerminalSession(
   config: Config,
   settings: LoadedSettings,
   argv: ParsedCliArgs,
 ): Promise<void> {
+  registerShellJobShutdownNotice(config);
   const wasRaw = process.stdin.isRaw;
   const stdinManager = new StdinRawModeManager({
     debug: config.getDebugMode(),

--- a/packages/cli/src/utils/shellJobShutdownNotice.test.ts
+++ b/packages/cli/src/utils/shellJobShutdownNotice.test.ts
@@ -1,0 +1,515 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { ShellJobManager, type Config } from '@vybestack/llxprt-code-core';
+import {
+  MAX_COMMAND_LENGTH,
+  MAX_LISTED_JOBS,
+  registerShellJobShutdownNotice,
+  type ExitListenerTarget,
+} from './shellJobShutdownNotice.js';
+
+/** Captures exit listeners instead of registering them on the real process. */
+function captureExitListeners(): {
+  target: ExitListenerTarget;
+  fireExit: () => void;
+} {
+  const listeners: Array<(code: number | undefined) => void> = [];
+  return {
+    target: {
+      on: (_event, listener) => {
+        listeners.push(listener);
+        return undefined;
+      },
+    },
+    fireExit: () => {
+      for (const listener of listeners) listener(0);
+    },
+  };
+}
+
+/**
+ * Minimal runtime shape of a `Bun.spawn` subprocess, restricted to the
+ * members these tests read. Defined locally because the CLI TypeScript
+ * config loads `bun-types/test` (the `bun:test` module) but NOT the global
+ * `Bun` namespace, so the bare global `Bun.spawn` symbol is unavailable to
+ * the type-checker. We reach the real, runtime `Bun.spawn` through
+ * `globalThis` — the same approach used by
+ * `cli/src/observation/jspBootstrapStartup.test.ts`. This also sidesteps
+ * `node:child_process`, whose module mocking in the combined test run
+ * (see `relaunch.test.ts`) would replace `spawn` for late importers.
+ */
+interface BunSubprocessLike {
+  readonly stderr: ReadableStream<Uint8Array> | null;
+  readonly exited: Promise<number>;
+}
+
+type BunSpawnFn = (
+  cmds: string[],
+  options: {
+    stdout?: 'ignore' | 'pipe' | 'inherit';
+    stderr?: 'ignore' | 'pipe' | 'inherit';
+    env?: Record<string, string | undefined>;
+  },
+) => BunSubprocessLike;
+
+function getBunSpawn(): BunSpawnFn {
+  const bun = (globalThis as { Bun?: { spawn?: unknown } }).Bun;
+  if (bun === undefined || typeof bun.spawn !== 'function') {
+    throw new Error(
+      'Bun.spawn is unavailable; shellJobShutdownNotice tests must run under bun:test',
+    );
+  }
+  return bun.spawn as unknown as BunSpawnFn;
+}
+
+const bunSpawn = getBunSpawn();
+
+describe('registerShellJobShutdownNotice', () => {
+  let managers: ShellJobManager[] = [];
+  let baseDirs: string[] = [];
+  let stderrChunks: string[] = [];
+  let stderrWriteCalls = 0;
+  const realWriteSync = fs.writeSync;
+
+  afterEach(async () => {
+    // Every cleanup step runs regardless of individual failures: an abort
+    // at the first throwing dispose would leave later managers undisposed,
+    // their temp directories on disk, and background jobs running into the
+    // next test. Collected failures surface only after the arrays are
+    // reset, so teardown state is consistent either way.
+    const failures: unknown[] = [];
+    try {
+      vi.restoreAllMocks();
+    } catch (error) {
+      failures.push(error);
+    }
+    for (const manager of managers) {
+      try {
+        await manager.dispose();
+      } catch (error) {
+        failures.push(error);
+      }
+    }
+    managers = [];
+    for (const dir of baseDirs) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch (error) {
+        failures.push(error);
+      }
+    }
+    baseDirs = [];
+    stderrChunks = [];
+    stderrWriteCalls = 0;
+    if (failures.length === 1) {
+      throw failures[0];
+    }
+    if (failures.length > 1) {
+      throw new Error(
+        `afterEach cleanup had ${failures.length} failures: ${failures
+          .map((failure) =>
+            failure instanceof Error ? failure.message : String(failure),
+          )
+          .join('; ')}`,
+      );
+    }
+  });
+
+  /**
+   * `maxBackgroundJobs` overrides the default budget of 10 for tests that
+   * need more concurrent jobs than that.
+   */
+  function makeManager(maxBackgroundJobs?: number): ShellJobManager {
+    const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shutdown-notice-'));
+    baseDirs.push(baseDir);
+    const manager = new ShellJobManager({ baseDir, maxBackgroundJobs });
+    managers.push(manager);
+    return manager;
+  }
+
+  /**
+   * Captures the handler's synchronous fd-2 writes instead of letting them
+   * reach the test runner's stderr. Writes to other descriptors pass through
+   * untouched. `behaviour` models the hostile fd-2 conditions the notice
+   * must survive: a synchronous throw, and a short write that accepts only
+   * part of the requested bytes on the first call.
+   */
+  function spyStderrFd2(
+    behaviour: {
+      /** Makes the first fd-2 write throw instead of writing. */
+      throwOnFirstWrite?: Error;
+      /** Bytes the first fd-2 write accepts; later writes take the rest. */
+      firstWriteAccepts?: number;
+    } = {},
+  ): void {
+    stderrChunks = [];
+    stderrWriteCalls = 0;
+    vi.spyOn(fs, 'writeSync').mockImplementation(
+      (
+        fd: number,
+        data: string | ArrayBufferView,
+        ...rest: unknown[]
+      ): number => {
+        if (fd !== 2) {
+          return Reflect.apply(realWriteSync, undefined, [
+            fd,
+            data,
+            ...rest,
+          ]) as number;
+        }
+        stderrWriteCalls++;
+        if (stderrWriteCalls === 1 && behaviour.throwOnFirstWrite) {
+          throw behaviour.throwOnFirstWrite;
+        }
+        const acceptedCount = (requested: number): number =>
+          stderrWriteCalls === 1 && behaviour.firstWriteAccepts !== undefined
+            ? Math.min(behaviour.firstWriteAccepts, requested)
+            : requested;
+        if (typeof data === 'string') {
+          const accepted = acceptedCount(data.length);
+          stderrChunks.push(data.slice(0, accepted));
+          return accepted;
+        }
+        if (!(data instanceof Uint8Array)) {
+          throw new Error('fd-2 spy expects a string or Uint8Array write');
+        }
+        // The handler writes fd 2 with the buffer overload
+        // (fd, buffer, offset, length). Mirror the syscall by recording the
+        // slice [offset, offset + accepted) and reporting the accepted count.
+        const offset = (rest[0] as number | undefined) ?? 0;
+        const accepted = acceptedCount(
+          (rest[1] as number | undefined) ?? data.byteLength,
+        );
+        stderrChunks.push(
+          new TextDecoder().decode(data.subarray(offset, offset + accepted)),
+        );
+        return accepted;
+      },
+    );
+  }
+
+  async function waitForTerminalState(
+    manager: ShellJobManager,
+    id: string,
+  ): Promise<void> {
+    const deadline = Date.now() + 10_000;
+    while (manager.get(id)?.state === 'running') {
+      if (Date.now() > deadline) {
+        throw new Error(`Job ${id} did not leave the running state in time`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+
+  it('announces a running managed background job on process exit', () => {
+    const manager = makeManager();
+    const job = manager.launch({ command: 'sleep 30', cwd: os.tmpdir() });
+    const { target, fireExit } = captureExitListeners();
+    spyStderrFd2();
+    const host: Pick<Config, 'peekShellJobManager'> = {
+      peekShellJobManager: () => manager,
+    };
+
+    registerShellJobShutdownNotice(host, target);
+    fireExit();
+
+    const output = stderrChunks.join('');
+    expect(output).toContain(
+      'Shutting down with 1 managed background job(s) still running',
+    );
+    expect(output).toContain(`${job.id}: sleep 30`);
+  });
+
+  it('truncates an over-long job command and keeps the written payload bounded', () => {
+    const manager = makeManager();
+    const longCommand = `echo ${'x'.repeat(MAX_COMMAND_LENGTH * 50)}`;
+    const job = manager.launch({ command: longCommand, cwd: os.tmpdir() });
+    const { target, fireExit } = captureExitListeners();
+    spyStderrFd2();
+    const host: Pick<Config, 'peekShellJobManager'> = {
+      peekShellJobManager: () => manager,
+    };
+
+    registerShellJobShutdownNotice(host, target);
+    fireExit();
+
+    const output = stderrChunks.join('');
+    // The first MAX_COMMAND_LENGTH characters survive verbatim and the
+    // marker says the command was cut; nothing beyond the limit is written.
+    expect(output).toContain(
+      `${job.id}: ${longCommand.slice(0, MAX_COMMAND_LENGTH)}`,
+    );
+    expect(output).toContain('[truncated]');
+    // One job: the header (~62 chars) plus a single line of id, a
+    // 200-char command, and the marker. The untruncated command alone is
+    // over 10,000 characters, so a small bound proves the payload cannot
+    // grow with the command text.
+    expect(output.length).toBeLessThan(400);
+  });
+
+  it('caps the listing and reports the true total and the omitted job count', () => {
+    const total = MAX_LISTED_JOBS + 5;
+    const manager = makeManager(total);
+    for (let i = 0; i < total; i++) {
+      manager.launch({ command: 'sleep 30', cwd: os.tmpdir() });
+    }
+    const { target, fireExit } = captureExitListeners();
+    spyStderrFd2();
+    const host: Pick<Config, 'peekShellJobManager'> = {
+      peekShellJobManager: () => manager,
+    };
+
+    registerShellJobShutdownNotice(host, target);
+    fireExit();
+
+    const output = stderrChunks.join('');
+    // The header must carry the true total, not the capped listing size,
+    // so the operator still learns how many jobs were discarded.
+    expect(output).toContain(
+      `Shutting down with ${total} managed background job(s) still running:`,
+    );
+    const jobLines = output
+      .split('\n')
+      .filter((line) => line.startsWith('  shell_'));
+    expect(jobLines).toHaveLength(MAX_LISTED_JOBS);
+    expect(output).toContain(
+      `  ...and ${total - MAX_LISTED_JOBS} more job(s) not listed`,
+    );
+  }, 30_000);
+
+  it('registers the notice at most once per target', () => {
+    const manager = makeManager();
+    manager.launch({ command: 'sleep 30', cwd: os.tmpdir() });
+    const { target, fireExit } = captureExitListeners();
+    spyStderrFd2();
+    const host: Pick<Config, 'peekShellJobManager'> = {
+      peekShellJobManager: () => manager,
+    };
+
+    registerShellJobShutdownNotice(host, target);
+    registerShellJobShutdownNotice(host, target);
+    fireExit();
+
+    // A second registration must not append another exit listener, or
+    // one exit would print the notice twice.
+    const noticeCount =
+      stderrChunks.join('').split('Shutting down with').length - 1;
+    expect(noticeCount).toBe(1);
+  });
+
+  it('a throwing fd-2 write does not escape the exit listener and a later exit listener still runs', () => {
+    const manager = makeManager();
+    manager.launch({ command: 'sleep 30', cwd: os.tmpdir() });
+    const { target, fireExit } = captureExitListeners();
+    spyStderrFd2({
+      throwOnFirstWrite: Object.assign(new Error('write EPIPE'), {
+        code: 'EPIPE',
+      }),
+    });
+    const host: Pick<Config, 'peekShellJobManager'> = {
+      peekShellJobManager: () => manager,
+    };
+
+    registerShellJobShutdownNotice(host, target);
+    let laterListenerRan = false;
+    target.on('exit', () => {
+      laterListenerRan = true;
+    });
+
+    // If the write error escaped the listener, fireExit would throw here
+    // and the later listener would never run, exactly as on the real
+    // process exit path.
+    fireExit();
+
+    expect(laterListenerRan).toBe(true);
+    expect(stderrChunks).toEqual([]);
+  });
+
+  it('a throwing manager read does not escape the exit listener and a later exit listener still runs', () => {
+    const { target, fireExit } = captureExitListeners();
+    spyStderrFd2();
+    const host: Pick<Config, 'peekShellJobManager'> = {
+      peekShellJobManager: () => {
+        throw new Error('manager read failed during exit');
+      },
+    };
+
+    registerShellJobShutdownNotice(host, target);
+    let laterListenerRan = false;
+    target.on('exit', () => {
+      laterListenerRan = true;
+    });
+
+    // If the manager-read error escaped the listener, fireExit would
+    // throw here and the later listener would never run, exactly as on
+    // the real process exit path.
+    fireExit();
+
+    expect(laterListenerRan).toBe(true);
+    expect(stderrChunks).toEqual([]);
+  });
+
+  it('resumes a short fd-2 write until the whole notice is out', () => {
+    const manager = makeManager();
+    const job = manager.launch({ command: 'sleep 30', cwd: os.tmpdir() });
+    const { target, fireExit } = captureExitListeners();
+    // First write accepts only 10 bytes; the notice must resume from byte
+    // 10 rather than restart, drop, or duplicate anything.
+    spyStderrFd2({ firstWriteAccepts: 10 });
+    const host: Pick<Config, 'peekShellJobManager'> = {
+      peekShellJobManager: () => manager,
+    };
+
+    registerShellJobShutdownNotice(host, target);
+    fireExit();
+
+    expect(stderrWriteCalls).toBeGreaterThanOrEqual(2);
+    expect(stderrChunks.join('')).toBe(
+      `Shutting down with 1 managed background job(s) still running:
+  ${job.id}: sleep 30
+`,
+    );
+  });
+
+  it('writes nothing on process exit when no managed background job is running', async () => {
+    const manager = makeManager();
+    const finished = manager.launch({ command: 'true', cwd: os.tmpdir() });
+    await waitForTerminalState(manager, finished.id);
+    const { target, fireExit } = captureExitListeners();
+    spyStderrFd2();
+    const host: Pick<Config, 'peekShellJobManager'> = {
+      peekShellJobManager: () => manager,
+    };
+
+    registerShellJobShutdownNotice(host, target);
+    fireExit();
+
+    expect(stderrChunks).toEqual([]);
+  });
+
+  it('a job-free exit writes nothing and constructs no manager or filesystem state', () => {
+    const { target, fireExit } = captureExitListeners();
+    spyStderrFd2();
+    const mkdtemp = vi.spyOn(fs, 'mkdtempSync');
+    let creatingGetterCalls = 0;
+    // The exit path must read state without constructing anything. If it
+    // used the creating getter, this host would build a real manager — and
+    // mkdtemp its log directory — during exit on a session that never
+    // backgrounded a job.
+    const host = {
+      peekShellJobManager: (): undefined => undefined,
+      getShellJobManager: (): ShellJobManager => {
+        creatingGetterCalls++;
+        return makeManager();
+      },
+    };
+
+    registerShellJobShutdownNotice(host, target);
+    fireExit();
+
+    expect(creatingGetterCalls).toBe(0);
+    expect(mkdtemp).not.toHaveBeenCalled();
+    expect(stderrChunks).toEqual([]);
+  });
+
+  it('registers the exit listener on the real process by default', () => {
+    const before = process.listeners('exit');
+    const host: Pick<Config, 'peekShellJobManager'> = {
+      peekShellJobManager: () => undefined,
+    };
+
+    registerShellJobShutdownNotice(host);
+
+    const after = process.listeners('exit');
+    expect(after.length).toBe(before.length + 1);
+    // Remove exactly the listener that was added so the shared test process
+    // is not polluted for later files.
+    for (const listener of after) {
+      if (!before.includes(listener)) {
+        process.removeListener('exit', listener);
+      }
+    }
+    expect(process.listeners('exit')).toEqual(before);
+  });
+
+  it('reaches the physical stderr of a process whose stdio is patched when it exits via the quit path', async () => {
+    // The quit path calls process.exit(0) without restoring stdio, so the
+    // notice must bypass the patched process.stderr.write and land on the
+    // physical descriptor 2. A subprocess pins this end to end: the child
+    // patches stdio, launches a job, registers the notice, and exits; the
+    // parent asserts the notice text on the child's piped stderr.
+    const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'notice-exit-'));
+    baseDirs.push(fixtureDir);
+    const coreSrc = path.resolve(import.meta.dirname, '../../../core/src');
+    const fixturePath = path.join(fixtureDir, 'quit-path-fixture.ts');
+    const fixture = [
+      'const { patchStdio } = await import(',
+      JSON.stringify(path.join(coreSrc, 'utils', 'stdio.ts')),
+      ');',
+      'const { ShellJobManager } = await import(',
+      JSON.stringify(path.join(coreSrc, 'services', 'shellJobManager.ts')),
+      ');',
+      'const { registerShellJobShutdownNotice } = await import(',
+      JSON.stringify(
+        path.join(import.meta.dirname, 'shellJobShutdownNotice.ts'),
+      ),
+      ');',
+      'const { writeFileSync } = await import(',
+      JSON.stringify('node:fs'),
+      ');',
+      'patchStdio();',
+      'const baseDir = process.env.NOTICE_FIXTURE_BASE_DIR;',
+      'const manager = new ShellJobManager({ baseDir });',
+      'const job = manager.launch({ command: "sleep 30", cwd: baseDir });',
+      'writeFileSync(baseDir + "/job.pid", String(job.pid));',
+      'registerShellJobShutdownNotice({ peekShellJobManager: () => manager });',
+      'process.exit(0);',
+      '',
+    ].join('\n');
+    fs.writeFileSync(fixturePath, fixture);
+
+    const proc = bunSpawn([process.execPath, fixturePath], {
+      stdout: 'ignore',
+      stderr: 'pipe',
+      env: { ...process.env, NOTICE_FIXTURE_BASE_DIR: fixtureDir },
+    });
+    if (proc.stderr === null) {
+      throw new Error('child stderr was not piped');
+    }
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+
+    try {
+      expect(exitCode).toBe(0);
+      expect(stderr).toContain(
+        'Shutting down with 1 managed background job(s) still running',
+      );
+      expect(stderr).toContain('sleep 30');
+    } finally {
+      // The child's manager is not owned by this test's afterEach, and
+      // detached jobs outlive the process that launched them, so the leaked
+      // job must be reaped explicitly. Jobs are process-group leaders, so
+      // killing -pid terminates the whole tree. A missing or unparseable
+      // pid file yields NaN and is skipped.
+      const pidPath = path.join(fixtureDir, 'job.pid');
+      const pid = fs.existsSync(pidPath)
+        ? Number.parseInt(fs.readFileSync(pidPath, 'utf8'), 10)
+        : Number.NaN;
+      if (Number.isFinite(pid) && pid > 1) {
+        try {
+          process.kill(-pid, 'SIGKILL');
+        } catch {
+          // The job may already have exited (ESRCH); nothing to reap.
+        }
+      }
+    }
+  }, 30_000);
+});

--- a/packages/cli/src/utils/shellJobShutdownNotice.ts
+++ b/packages/cli/src/utils/shellJobShutdownNotice.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs';
+import type { Config } from '@vybestack/llxprt-code-core';
+
+/**
+ * Registration target for the exit listener. The real `process` satisfies
+ * this; tests capture the listener instead. Exit listeners receive the
+ * exit code as `number | undefined` — undefined on a natural exit —
+ * matching the runtime event Node and Bun emit.
+ */
+export interface ExitListenerTarget {
+  on(event: 'exit', listener: (code: number | undefined) => void): unknown;
+}
+
+/**
+ * Targets that already carry the notice listener. Registration must be
+ * idempotent: every call appends another `exit` listener, so a second
+ * registration on the same target would print the notice twice on exit.
+ */
+const armedTargets = new WeakSet<ExitListenerTarget>();
+
+/**
+ * Bound on each job's command text in the notice. Job commands are
+ * arbitrary text supplied by whatever the agent backgrounded, and the
+ * notice is drained synchronously to fd 2, so a full pipe buffer must not
+ * be reachable through job command text — an unbounded write on a blocked
+ * pipe would hang the exit path.
+ */
+export const MAX_COMMAND_LENGTH = 200;
+
+/**
+ * Bound on how many jobs the notice lists. The job count itself is capped
+ * only by settings, which may allow unlimited jobs, so the listing needs
+ * its own limit to keep the whole payload far under a typical 64 KB pipe
+ * buffer. The header still reports the true total.
+ */
+export const MAX_LISTED_JOBS = 20;
+
+/** Marks a command that was cut short by {@link MAX_COMMAND_LENGTH}. */
+const TRUNCATION_MARKER = '... [truncated]';
+
+function truncateCommand(command: string): string {
+  if (command.length <= MAX_COMMAND_LENGTH) {
+    return command;
+  }
+  return `${command.slice(0, MAX_COMMAND_LENGTH)}${TRUNCATION_MARKER}`;
+}
+
+/**
+ * Announce managed background jobs that are still running when the CLI
+ * process exits (#3491). Without this, a shutdown with live jobs — SIGTERM,
+ * SIGINT, or the quit path — ends silently with status 0 and the user has no
+ * way to tell their jobs died with the process.
+ *
+ * A single synchronous `process.on('exit')` writer covers every exit path,
+ * because each of them reaches `process.exit()` (or a natural exit), which
+ * fires `exit`. Async work cannot run there, so the handler only reads the
+ * manager state and writes synchronously.
+ *
+ * The message is written with `fs.writeSync(2, ...)`, not
+ * `process.stderr.write`: `patchStdio()` replaces that method with an
+ * event-bus emitter, and the quit path calls `process.exit(0)` without
+ * restoring stdio, so a stream write would be swallowed by the bus instead
+ * of reaching the terminal. Writing the built message to the physical
+ * descriptor also guarantees the bytes are out before the process dies.
+ * The message itself is bounded — commands are truncated and the listing
+ * capped — so job text cannot fill a pipe buffer and turn that synchronous
+ * drain into a blocked exit.
+ *
+ * The manager is read through the non-creating `peekShellJobManager`: the
+ * creating `getShellJobManager` would construct a manager (and its
+ * `shell-jobs-*` temp log directory) during exit on sessions that never
+ * backgrounded a job. The exit code is left untouched.
+ */
+export function registerShellJobShutdownNotice(
+  config: Pick<Config, 'peekShellJobManager'>,
+  target: ExitListenerTarget = process,
+): void {
+  if (armedTargets.has(target)) {
+    return;
+  }
+  armedTargets.add(target);
+  target.on('exit', () => {
+    try {
+      const running = config.peekShellJobManager()?.getRunningJobs() ?? [];
+      if (running.length === 0) {
+        return;
+      }
+      const listed = running.slice(0, MAX_LISTED_JOBS);
+      const jobLines = listed.map(
+        (job) => `  ${job.id}: ${truncateCommand(job.command)}`,
+      );
+      const omitted = running.length - listed.length;
+      if (omitted > 0) {
+        jobLines.push(`  ...and ${omitted} more job(s) not listed`);
+      }
+      const message =
+        `Shutting down with ${running.length} managed background job(s) still running:\n` +
+        `${jobLines.join('\n')}\n`;
+      // The string overload of writeSync cannot resume a partial write: its
+      // third parameter is a file position, not a buffer offset. Encode once
+      // and drain with the (fd, buffer, offset, length) overload, because a
+      // full pipe or pty buffer may accept fewer bytes than requested.
+      const payload = Buffer.from(message, 'utf8');
+      let written = 0;
+      while (written < payload.length) {
+        const accepted = fs.writeSync(
+          2,
+          payload,
+          written,
+          payload.length - written,
+        );
+        if (accepted <= 0) {
+          // No progress on a non-empty request: the descriptor will not
+          // take more bytes, so give up on the rest instead of spinning.
+          break;
+        }
+        written += accepted;
+      }
+    } catch {
+      // The notice is best effort end to end. Inside an exit listener a
+      // throw has no useful failure mode: it cannot be caught from the
+      // exit path, it replaces the notice with a stack trace, and it
+      // stops later exit listeners (including the terminal-protocol
+      // restore) from running. The fd-2 write can fail because the
+      // descriptor is outside this program's control (EPIPE with the
+      // reader gone, EAGAIN on a non-blocking pty); the same reasoning
+      // keeps the manager read and message build inside the guard.
+    }
+  });
+}

--- a/packages/core/src/config/configBaseCore.ts
+++ b/packages/core/src/config/configBaseCore.ts
@@ -460,6 +460,13 @@ export abstract class ConfigBaseCore {
   getSessionRecordingService(): SessionRecordingService | undefined {
     return this.sessionRecordingService;
   }
+  /**
+   * Never constructs a manager; read-only paths (exit-time shutdown notice)
+   * must use it so a job-free session does not build one and mkdtemp its log directory.
+   */
+  peekShellJobManager(): ShellJobManager | undefined {
+    return this.shellJobManager;
+  }
   setInteractiveSubagentSchedulerFactory(
     factory: SubagentSchedulerFactory | undefined,
   ): void {

--- a/packages/core/src/services/shellBackgroundIntegration.test.ts
+++ b/packages/core/src/services/shellBackgroundIntegration.test.ts
@@ -157,6 +157,47 @@ describe.skipIf(os.platform() === 'win32')(
       fs.rmSync(path.dirname(sentinel), { recursive: true, force: true });
     });
 
+    it('a background job launched during one turn stays registered and running across several subsequent turns', async () => {
+      const manager = makeManager();
+      const sentinelDir = makeTempBase();
+      // Registered so afterEach removes it on failure as well as success.
+      baseDirs.push(sentinelDir);
+      const gate = path.join(sentinelDir, 'gate');
+      const completion = path.join(sentinelDir, 'completed');
+
+      // Turn 1: the agent backgrounds a job gated on a signal this test
+      // controls, so the still-running assertions below never depend on a
+      // fixed sleep outliving the turns on a loaded runner.
+      const command = `while [ ! -f ${gate} ]; do sleep 0.1; done; touch ${completion} &`;
+      const result = detectTrailingBackgroundOperator(command);
+      expect(result.promoted).toBe(true);
+      const job = manager.launch({ command: result.command, cwd: os.tmpdir() });
+      expect(job.state).toBe('running');
+
+      // Several subsequent turns: other jobs run to completion and the
+      // notification pipeline between turns drains. None of that may
+      // unregister or terminate the still-running background job.
+      for (let turn = 2; turn <= 4; turn++) {
+        const foreground = manager.launch({
+          command: 'true',
+          cwd: os.tmpdir(),
+        });
+        await waitForTerminal(manager, foreground.id, 10000);
+        manager.markNotified(
+          manager.getPendingNotifications().map((pending) => pending.id),
+        );
+        expect(manager.get(job.id)?.state).toBe('running');
+      }
+      expect(manager.get(job.id)?.state).toBe('running');
+
+      // Release the gate: the job ends on its own terms, proving nothing
+      // killed it mid-flight.
+      fs.writeFileSync(gate, '');
+      const terminal = await waitForTerminal(manager, job.id, 15000);
+      expect(terminal?.state).toBe('completed');
+      expect(fs.existsSync(completion)).toBe(true);
+    }, 20_000);
+
     it('a fast-completing background job returns a job-shaped result immediately, not foreground-shaped', () => {
       const manager = makeManager();
       const job = manager.launch({

--- a/project-plans/issue3491-implementation-brief.md
+++ b/project-plans/issue3491-implementation-brief.md
@@ -1,0 +1,156 @@
+# Issue #3491 — implementation brief
+
+Read `project-plans/issue3491-sandbox-background-job-exit.md` first (established
+root cause and accepted behaviour). Then `dev-docs/RULES.md` and
+`.llxprt/skills/typescript-test-writing/SKILL.md` before writing any test.
+
+## Background (proven; do not re-investigate)
+
+A sandboxed llxprt session exited status 0 mid-task seconds after backgrounding
+`npm run test`. Chain:
+
+1. The sandbox container runs with `--init` (see the `run` arg list in
+   `packages/cli/src/utils/sandbox-containers.ts`). Under `--init`,
+   `/run/podman-init` is PID 1 and the container's main process is its DIRECT
+   CHILD, so the CLI has PPID 1.
+2. The container's main process is the published `llxprt` bin shim; its `ps`
+   argv begins with `node`. Verbatim capture from
+   `ghcr.io/vybestack/llxprt-code/sandbox:0.11.0-nightly.260831.393a0080f`:
+
+```
+      1       0 /run/podman-init -- bash --noprofile --norc -c exec llxprt --prompt "please run the test suite"
+      2       1 node /usr/local/share/npm-global/bin/llxprt --provider openai --key xx --prompt please run the test suite
+      9       2 /usr/local/share/npm-global/lib/node_modules/@vybestack/llxprt-code/node_modules/bun/bin/bun.exe /usr/local/share/npm-global/lib/node_modules/@vybestack/llxprt-code/bundle/llxprt.js -- --prompt please run the test suite
+```
+
+3. `scripts/run_bun_tests.ts` → `isOrphanedTestProcess` matches ANY process with
+   PPID 1 whose argv contains `bun` OR `node` AND contains `test` OR `spec`.
+   PID 2 above matches on all counts. Verified: feeding that exact `ps` text to
+   the real exported `reapStaleBunTestProcesses` reaps exactly PID 2 with
+   SIGTERM and prints the exact log line quoted in the issue.
+4. `packages/cli/bin/llxprt.mjs` forwards SIGTERM to the Bun child and
+   propagates its exit code.
+5. The interactive CLI's SIGTERM handler in
+   `packages/cli/src/cliTerminalSession.ts` (`enableInteractiveRawModeIfNeeded`)
+   does `await runExitCleanup(); process.exit(0)` and prints NOTHING. That is
+   the silent status-0 exit.
+
+## Change 1 (AC1) — narrow the reaper in `scripts/run_bun_tests.ts`
+
+`buildSpawnArgs` in that same file shows the ONLY shape this runner ever spawns:
+`<bun-executable> test [flags...] <file>`. Rewrite `isOrphanedTestProcess` so it
+only matches that shape:
+
+- keep `if (ppid !== 1 || pid === ownPid) return false;`
+- require the FIRST whitespace-separated argv token's basename to be exactly
+  `bun` or `bun.exe`, so `/usr/local/.../node_modules/bun/bin/bun.exe` and a
+  bare `bun` both match while
+  `node /usr/local/share/npm-global/bin/llxprt ...` does not
+- require the SECOND whitespace-separated argv token to be exactly `test`
+- DELETE the `comm.includes('bun') || comm.includes('node')` and
+  `comm.includes('test') || comm.includes('spec')` substring heuristics entirely
+
+Keep the export surface and the `reapStaleBunTestProcesses` signature unchanged.
+Update the doc comment to state the shape it matches and why the substring
+heuristic was wrong (it matched the sandboxed CLI, issue #3491). Do NOT add a
+`SANDBOX` env check or any other extra guard: narrowing the predicate is the
+whole fix for AC1.
+
+## Change 2 (AC2) — announce shutdown while managed background jobs run
+
+Behaviour: when the CLI process exits while `ShellJobManager` has one or more
+jobs in state `running`, it writes a message to stderr saying it is shutting
+down with N managed background job(s) still running, identifying each by job id
+and command. When no job is running it writes nothing.
+
+Guidance, not constraint:
+
+- `ShellJobManager` (`packages/core/src/services/shellJobManager.ts`) already
+  exposes `list()` and a running-jobs accessor. Use the existing API; do not add
+  a new one unless nothing suitable exists.
+- `Config.getShellJobManager()` (`packages/core/src/config/configBase.ts`) is
+  the reachable accessor from the CLI.
+- The paths that produced the reported silence are the SIGTERM and SIGINT
+  handlers in `packages/cli/src/cliTerminalSession.ts` and the quit path in
+  `packages/cli/src/ui/containers/AppContainer/hooks/useExitHandling.ts`. A
+  single synchronous `process.on('exit')` writer registered once covers all of
+  them, because every one of those paths reaches `process.exit()`. Prefer that
+  over sprinkling the same call into three handlers. Whatever you choose must be
+  synchronous at exit time; async work does not run during `exit`.
+- Message goes to stderr. Do NOT change any exit code.
+- Fail-fast architecture: no defensive try/catch pyramids, no fallbacks hedging
+  against hypothetical upstream bugs.
+
+## Change 3 (AC3) — behavioural tests
+
+Behavioural per `dev-docs/RULES.md`: assert observable behaviour, no mock
+theater. Bun/TypeScript only; no new `.js` files, no vitest/node runners, new
+tests are `bun:test`.
+
+1. In `scripts/tests/run_bun_tests.test.ts`, inside the existing
+   `describe('reapStaleBunTestProcesses')`:
+   - a test using the VERBATIM three-line sandbox `ps` capture above asserting
+     NOTHING is reaped (result 0, no pids killed, no stderr line), with a
+     comment naming the image the capture came from
+   - a test that a genuine orphan in this runner's own spawn shape is still
+     reaped with SIGTERM, e.g.
+     `  100  1  /usr/local/bun/bin/bun test --max-concurrency 1 --timeout 60000 src/foo.test.ts`
+     and a bare `  101  1  bun test src/bar.test.ts`
+   - keep "does not kill the current process", "returns 0 when ps fails", and
+     "logs a warning when processes are reaped" passing, adjusting their fixture
+     argv to the new shape where needed
+   - the existing expectation near line 184 that `node src/bar.spec.ts` with
+     PPID 1 IS killed must be inverted: it is now not killed, and the assertion
+     should say why (this runner never spawns that shape; matching it is the
+     #3491 defect). Adjust the surrounding counts accordingly.
+
+2. A behavioural test for AC2: with a `ShellJobManager` holding a running
+   managed job, the shutdown announcement is written to stderr and names the job
+   id and command; with no running job, nothing is written. Put it next to the
+   code you add, following neighbouring test conventions.
+
+3. A behavioural test that a managed background job launched during one turn
+   stays registered and `running` across several subsequent turns and is not
+   terminated by the turn loop. Look for an existing home such as
+   `packages/core/src/services/shellBackgroundIntegration.test.ts` before
+   creating a new file.
+
+Write the failing tests FIRST, confirm they fail for the right reason, then
+implement.
+
+## Scope discipline
+
+Implement ONLY the above. Do not touch `shellJobSpawn.ts`, `shellJobManager.ts`
+internals, the sandbox entrypoint, `bin/llxprt.mjs`, the `--init` flag, or exit
+codes. No speculative hardening, no neighbouring refactors. If something else
+must change to make the accepted behaviour work or CI green, do it only if
+strictly required and say so explicitly in the report.
+
+## Verification (mandatory, full cycle, fix everything)
+
+From the repo root. Write long-running output to unique paths under
+`tmp/issue3491/` — NEVER bare `/tmp` paths, sibling sessions share `/tmp` and
+corrupt each other's logs.
+
+```
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```
+
+`npm run test` is long: run it as a background job writing to
+`tmp/issue3491/npm-test.log` and poll, or give it a generous explicit timeout.
+Fix every failure including lint, type, and format. Re-run the whole cycle after
+any fix. Not done until all six pass.
+
+Do NOT commit, push, or open a PR. Leave the working tree with the changes.
+
+## Report
+
+Files changed with a one-line reason each; the final `isOrphanedTestProcess`
+source; how AC2's announcement is wired and which exit paths it fires on; tests
+added or changed and the behaviour each pins; pass/fail for all six verification
+commands; anything beyond scope with justification.

--- a/project-plans/issue3491-pr-review-brief.md
+++ b/project-plans/issue3491-pr-review-brief.md
@@ -1,0 +1,135 @@
+# Issue #3491 — PR #3515 review remediation
+
+Four accepted findings. Implement all four. A fifth is deferred with reasoning
+at the bottom; do not implement it.
+
+## FIX 1 (CRITICAL) — the reaper can still kill the CLI
+
+`scripts/lib/bun-test-reaper.ts` infers argv[0] from the `ps args=` display
+string. A PPID-1 CLI whose prompt happens to mention a path ending in `/bun`
+followed by the word `test` passes the predicate. Reproduced against the current
+code:
+
+```
+      2       1 node /usr/local/share/npm-global/bin/llxprt --prompt-interactive run /tmp/bun test suite
+```
+
+`tokens.indexOf('test')` selects the prompt's `test`, the joined prefix ends in
+`/tmp/bun`, the basename is `bun`, and the CLI is reaped. That is the reported
+bug, back again. It must not be possible to satisfy this predicate with prompt
+text.
+
+### The fix: get the executable from `ps`, not from the argument string
+
+`ps -eo pid=,comm=` reports the executable independently of argv, so no prompt
+content can forge it. Measured behaviour:
+
+- macOS prints the full executable path, e.g.
+  `3140 /opt/homebrew/lib/node_modules/@vybestack/llxprt-code/node_modules/bun/bin/bun.exe`,
+  and the llxprt shim appears as `node`.
+- Linux (inside the sandbox image) prints the base command name, e.g.
+  `2 bash`, `1 podman-init`.
+
+Both identify the binary. `comm` is the last field, so parse it as pid followed
+by the rest of the line.
+
+Change `reapStaleBunTestProcesses` to make two `ps` calls through its injected
+`spawnSync`:
+
+1. `['ps', '-eo', 'pid=,comm=']` to build a pid to executable map.
+2. `['ps', '-eo', 'pid=,ppid=,args=']` exactly as today.
+
+Keep the exported signature unchanged: `spawnSync` is already
+`(cmd: readonly string[]) => { stdout: string | null }`, so it is called twice
+with different arguments. If either call throws, return 0 as the existing
+`catch` does.
+
+The predicate becomes: reap the process only when all of these hold.
+
+- `ppid === 1` and `pid !== ownPid` (unchanged)
+- the basename of that pid's `comm` is `bun` or `bun.exe` — this alone excludes
+  the CLI shim, whose `comm` is `node`, no matter what the prompt says
+- in `args`, the token immediately after the FIRST token whose basename is
+  `bun` or `bun.exe` is exactly `test`
+
+The second and third conditions together mean the `test` token has to sit right
+after argv[0], and argv[0] has to be a real bun binary. A path containing spaces
+still works because the anchor is the bun-basename token rather than token 0.
+A path whose interior directory segment itself ends in `bun` will fail to match
+and simply not be reaped; failing closed there is correct.
+
+Update the doc comment to describe the two-source check and why the argument
+string alone is not trustworthy.
+
+### Tests
+
+In `scripts/tests/bun-test-reaper.bun.test.ts`, the `spawnSync` stub must now
+answer both queries; dispatch on whether the requested format contains `comm=`.
+Extend the existing `reapFromPs` helper to take a comm table rather than
+duplicating it.
+
+Add and keep:
+
+- the prompt-shape regression above (`… --prompt-interactive run /tmp/bun test
+  suite`, comm `node`) reaps nothing — this fails against the current code
+- an executable path containing spaces (comm `/path with spaces/bun`) is still
+  reaped
+- the sandbox container capture still reaps nothing, now with comms
+  `podman-init`, `node`, and the bundled `bun.exe`
+- genuine orphans (bare `bun`, absolute path, `bun.exe`) are still reaped
+- a PPID-1 process whose comm is `bun` but whose argv is `bun run build` is not
+  reaped
+- a process missing from the comm table is not reaped
+
+## FIX 2 — `ExitListenerTarget` types the exit code wrongly
+
+`packages/cli/src/utils/shellJobShutdownNotice.ts` declares
+`listener: (code: number) => void`. Node and Bun invoke exit listeners with
+`number | undefined` (undefined on a natural exit). Change the type to
+`(code: number | undefined) => void` so the declared contract matches the
+runtime event.
+
+## FIX 3 — registration is not idempotent
+
+Every call to `registerShellJobShutdownNotice` appends another `exit` listener,
+so a second call would print the notice twice. Guard so a given target is armed
+at most once, and add a test that calling it twice yields exactly one notice.
+Keep the guard simple; a module-level `WeakSet` of targets is enough.
+
+## FIX 4 — test cleanup is not error contained
+
+In `packages/cli/src/utils/shellJobShutdownNotice.test.ts` the `afterEach` loop
+aborts if one `manager.dispose()` throws, leaving later managers undisposed,
+temp directories on disk and background jobs running into the next test. Run
+every cleanup step regardless of individual failures, then surface any collected
+failure after the arrays have been reset.
+
+## DEFERRED — do not implement
+
+CodeRabbit asks that the notice also fire when a non-interactive session is
+killed by an unhandled signal, since Bun does not emit `exit` in that case. The
+observation is correct. Acting on it means installing SIGTERM and SIGINT
+handlers on paths that currently have none, which suppresses the default
+disposition and has to re-raise, and it has to interact with the interactive
+handlers that already exist without double-reporting or cutting their cleanup
+short. That is a change to signal handling in a mode the issue did not report,
+where the failure is a 143 rather than the silent status 0 this work is about.
+It will be filed as a follow-up instead.
+
+## Verification
+
+From the repo root, logs to unique paths under `tmp/issue3491/`, never bare
+`/tmp`:
+
+```
+npm run lint
+npm run typecheck
+npm run format
+bun test --preload ./scripts/tests/test-setup.ts scripts/tests/bun-test-reaper.bun.test.ts
+cd packages/cli && bun test --timeout 60000 src/utils/shellJobShutdownNotice.test.ts
+```
+
+Run long commands as managed background jobs; the foreground shell is capped at
+about two minutes. Do not run the full `npm run test` or `npm run build`. Watch
+the 800-line max-lines rule (counted lines exclude comments and blanks) on any
+file you touch. Do not commit, amend, push, or open a PR.

--- a/project-plans/issue3491-remediation-brief.md
+++ b/project-plans/issue3491-remediation-brief.md
@@ -1,0 +1,189 @@
+# Issue #3491 — remediation brief (review round 1 findings)
+
+Branch `issue3491`, single commit `3a6aec307`. A review produced seven findings.
+Each is triaged below. Implement the ones marked **FIX**. Do not implement the
+ones marked **REJECT** or **DEFER**, and do not widen scope beyond what is
+written here.
+
+The whole verification cycle was green on `3a6aec307` (build, typecheck, lint,
+format, `npm run test` exit 0, stepfun-37 smoke). Re-run it after these changes.
+
+---
+
+## FIX 1 — reaper misses genuine orphans when the bun path contains spaces
+
+**Blocker.** `scripts/lib/bun-test-reaper.ts` currently does
+
+```ts
+const tokens = comm.trim().split(/\s+/);
+const basename = (tokens[0] ?? '').split('/').pop() ?? '';
+return ['bun', 'bun.exe'].includes(basename) && tokens[1] === 'test';
+```
+
+`ps -eo pid=,ppid=,args=` renders argv as a display string and does not quote an
+argv[0] that contains spaces. For a real orphan spawned as
+`/path with spaces/bun test src/foo.test.ts` the tokens become `/path`, `with`,
+so the orphan is missed. The old substring heuristic caught it, so this is a
+regression against the original purpose in #2909.
+
+Replace the token-0 check with one that anchors on the literal `test` argument
+and treats everything before it as the executable:
+
+```ts
+const tokens = comm.trim().split(/\s+/);
+const testIndex = tokens.indexOf('test');
+if (testIndex < 1) return false;
+const executable = tokens.slice(0, testIndex).join(' ');
+const basename = executable.split('/').pop() ?? '';
+return basename === 'bun' || basename === 'bun.exe';
+```
+
+Confirm against the cases that matter and add tests for each:
+
+- `/path with spaces/bun test src/foo.test.ts` — reaped
+- `/usr/local/bun/bin/bun test --max-concurrency 1 src/foo.test.ts` — reaped
+- `bun test src/bar.test.ts` — reaped
+- `.../node_modules/bun/bin/bun.exe test src/x.test.ts` — reaped
+- `node /usr/local/share/npm-global/bin/llxprt --prompt-interactive please run the test suite`
+  — NOT reaped (prefix basename is `the`)
+- `bun run build`, `node server.js` — NOT reaped
+
+Update the doc comment so it describes what the predicate now does.
+
+## FIX 2 — the shutdown notice can be swallowed by patched stdio
+
+**Blocker.** `packages/cli/src/utils/shellJobShutdownNotice.ts` writes with
+`process.stderr.write`. `patchStdio()` in `packages/core/src/utils/stdio.ts`
+replaces that method with an event-bus emitter. The SIGTERM and SIGINT paths run
+`runExitCleanup()` first, which restores stdio, but the quit path in
+`packages/cli/src/ui/containers/AppContainer/hooks/useExitHandling.ts` calls
+`process.exit(0)` directly and deliberately skips cleanup. On that path the
+notice goes into the bus and may never reach the terminal. A stream write is
+also not a guaranteed synchronous flush inside a process `exit` callback.
+
+Build the whole message first, then write it synchronously to the physical
+descriptor with `fs.writeSync(2, message)`. Nothing else about the handler
+changes.
+
+Add a subprocess test that pins this: a small script that calls `patchStdio()`,
+creates a `ShellJobManager` with a running job, registers the notice, and calls
+`process.exit(0)`; the parent asserts the notice text appears on the child's
+stderr. Keep it to that; do not build a CLI or PTY harness.
+
+## FIX 3 — the exit handler creates a ShellJobManager on job-free exits
+
+**Blocker.** `Config.getShellJobManager()` (`packages/core/src/config/config.ts`)
+delegates to `getOrCreateShellJobManager`, which constructs a manager when none
+exists. `ShellJobLogStore`'s constructor calls `fs.mkdtempSync`. The manager is
+created lazily — only when a background job is launched or the
+`shell-max-background-jobs` setting is applied — so on a session that never
+backgrounded anything, the exit listener creates a manager and a `shell-jobs-*`
+temp directory during exit and then dies without disposing it.
+
+Add a non-creating accessor next to the existing one and use it from the notice:
+
+- `packages/core/src/config/configBase.ts`: abstract
+  `peekShellJobManager(): ShellJobManager | undefined`
+- `packages/core/src/config/config.ts`: return the private field directly, never
+  creating
+- `packages/cli/src/utils/shellJobShutdownNotice.ts`: depend on
+  `Pick<Config, 'peekShellJobManager'>` and call that instead
+
+If `ConfigBase` has other concrete subclasses or test doubles that must
+implement the abstract member, update them; that is required for the build.
+
+Add a test that a job-free exit writes nothing AND does not construct a manager
+or create any filesystem state.
+
+## FIX 4 — correct the documented invocation shape
+
+The mechanism write-up cites a `ps` capture taken with `--prompt`, but
+`resolveInteractiveMode` in `packages/cli/src/config/interactiveContext.ts`
+treats `--prompt` as non-interactive, and the silent status-0 SIGTERM handler in
+`packages/cli/src/cliTerminalSession.ts` is installed only for interactive runs.
+The two halves of the chain therefore need the same invocation to hold together.
+
+They do, under `--prompt-interactive`: `resolveInteractiveMode` returns true when
+`argv.promptInteractive !== undefined`, and that flag also puts the prompt text
+into argv where `ps` shows it. That is the shape that satisfies both halves —
+interactive, so the status-0 handler is installed, and prompt-bearing argv, so
+the old predicate matched.
+
+Update `project-plans/issue3491-sandbox-background-job-exit.md` and the doc
+comment in `scripts/lib/bun-test-reaper.ts` to say this precisely: the capture
+was taken with `--prompt` to obtain the argv and PPID shape, and the failing
+session's silent status-0 exit requires an interactive run whose argv carries the
+word, which `--prompt-interactive` produces. Note plainly that under a
+non-interactive `--prompt` run the same reap still kills the session, just with
+status 143 instead of 0. Change the fixture argv in the reaper tests to
+`--prompt-interactive` so the fixture and the prose agree.
+
+Do not change any interactive-mode logic. This finding is about the accuracy of
+the record, not about behaviour.
+
+## FIX 5 — test hygiene
+
+- `packages/cli/src/utils/shellJobShutdownNotice.test.ts`: the
+  `registers the exit listener on the real process by default` case leaves a
+  real `exit` listener installed in the shared test process. Capture the
+  listener and remove it in cleanup.
+- `packages/core/src/services/shellBackgroundIntegration.test.ts`: the new
+  several-turns case depends on a fixed `sleep 5` for its still-running
+  assertions, which is wall-clock fragile on a loaded runner. Gate the job on an
+  explicit signal the test controls (for example a sentinel file the job waits
+  for) instead of a fixed sleep, and move the sentinel-directory cleanup so it
+  runs on failure as well as success.
+- `scripts/tests/bun-test-reaper.bun.test.ts`: the header says every assertion
+  is unchanged from the file it was moved out of, which is no longer true. Say
+  what actually happened.
+
+## FIX 6 — add a sandbox-topology regression case for the coupled exit
+
+One test, in `scripts/tests/bun-test-reaper.bun.test.ts`: a fabricated `ps`
+table representing the container mid-run — the CLI shim at PPID 1, the managed
+background job, and genuine orphaned `bun test` children at PPID 1 — asserting
+that the orphans are reaped and the CLI shim is not. This is the case that
+directly pins the coupled exit: the reaper runs while a managed job is live and
+must not touch the session it is running under.
+
+---
+
+## REJECT — do not implement
+
+- **Replacing the several-turns test with a full sandbox/agent-loop harness.**
+  The review asks for a harness that runs real agent turns, a podman container
+  and the reaper together. That is a new integration subsystem, needs a
+  container engine in CI, and is outside the issue's scope. FIX 6 pins the same
+  regression at the level where it actually happens. Keep the several-turns case
+  as the guard for the "outlives several turns" clause, with the FIX 5 hygiene
+  applied and an honest name.
+- **A subprocess/PTY suite covering SIGTERM, SIGINT and quit end to end through
+  the real CLI.** The single subprocess test in FIX 2 pins the mechanism that was
+  actually broken. A full CLI lifecycle suite is scope expansion.
+
+## DEFER — record, do not implement
+
+- The predicate still matches any PPID-1 `bun test`, including one belonging to
+  a different checkout on the same machine. PPID 1 does not prove ownership.
+  This is pre-existing behaviour, unchanged by this work, and already recorded
+  as out of scope in the plan. Leave it; it is follow-up material.
+
+---
+
+## Verification
+
+Full cycle after the changes, writing logs to unique paths under
+`tmp/issue3491/` and never to bare `/tmp`:
+
+```
+npm run build
+npm run typecheck
+npm run lint
+npm run format
+npm run test
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```
+
+Run `npm run test` as a background job and poll it. Fix every failure. Amend the
+existing commit rather than adding a second one. Do not push and do not open a
+PR.

--- a/project-plans/issue3491-sandbox-background-job-exit.md
+++ b/project-plans/issue3491-sandbox-background-job-exit.md
@@ -1,0 +1,158 @@
+# Issue #3491 — Sandboxed session exits 0 mid-task after backgrounding a long shell job
+
+## 1. Mechanism (established, with evidence)
+
+The report listed three candidate mechanisms and asked that they be told apart
+before anything was changed. They have been. The cause is none of the three as
+originally worded: it is the repository's own test runner sending `SIGTERM` to
+the sandboxed CLI.
+
+### The chain
+
+1. The container is started with `--init`
+   (`packages/cli/src/utils/sandbox-containers.ts`, the `run` argument list).
+   Under `--init`, `/run/podman-init` is PID 1 and the container's main process
+   is its direct child, so the main process has **PPID 1**.
+
+2. The container's main process is the published `llxprt` bin shim, exec'd by
+   the sandbox entrypoint. Its `ps` argv begins with `node`:
+
+   ```
+   1  0  /run/podman-init -- bash --noprofile --norc -c exec llxprt --prompt "please run the test suite"
+   2  1  node /usr/local/share/npm-global/bin/llxprt --provider openai --key xx --prompt please run the test suite
+   9  2  /usr/local/.../node_modules/bun/bin/bun.exe /usr/local/.../bundle/llxprt.js -- --prompt please run the test suite
+   ```
+
+   Captured from `ghcr.io/vybestack/llxprt-code/sandbox:0.11.0-nightly.260831.393a0080f`,
+   the exact image named in the report.
+
+   The capture was taken with `--prompt` to obtain the argv and PPID shape.
+   The reported silent status-0 exit requires an invocation that satisfies
+   both halves of the chain — an interactive run, so the status-0 SIGTERM
+   handler from `cliTerminalSession.ts` is installed, and prompt-bearing
+   argv, so the old substring predicate matched. `--prompt-interactive` is
+   that invocation: `resolveInteractiveMode` in
+   `packages/cli/src/config/interactiveContext.ts` returns true when
+   `argv.promptInteractive !== undefined`, and the flag also places the
+   prompt text in argv where `ps` shows it. Under a non-interactive
+   `--prompt` run the same reap still kills the session, just with status
+   143 instead of 0, because no status-0 handler is installed and the
+   unhandled signal terminates the process.
+
+3. `scripts/run_bun_tests.ts` reaps "stale orphaned test processes" at the start
+   of every run. `isOrphanedTestProcess` matches any process that has PPID 1 and
+   whose argv contains `bun` **or** `node`, and contains `test` **or** `spec`.
+   The sandboxed CLI at PID 2 satisfies all of it: PPID is 1, argv starts with
+   `node`, and the session prompt carries the word `test`.
+
+4. Feeding the verbatim `ps` capture above to the real exported
+   `reapStaleBunTestProcesses` reaps exactly one process — PID 2, the CLI — and
+   prints the exact line the report quotes from the job log:
+
+   ```
+   [run_bun_tests] Reaped 1 stale orphaned test process(es) (PPID=1) before run.
+   ```
+
+5. `packages/cli/bin/llxprt.mjs` installs handlers for the shared-group signals
+   and forwards them to the Bun child, then propagates the child's exit code
+   (`process.exit(code ?? 0)`).
+
+6. The interactive CLI's own `SIGTERM` handler, installed by
+   `enableInteractiveRawModeIfNeeded` in `packages/cli/src/cliTerminalSession.ts`,
+   runs `runExitCleanup()` and then `process.exit(0)`. It prints nothing.
+
+7. Exit 0 from the container's main process ends the container. `--rm` removes
+   it, taking the background job with it; `podman` exits 0, the host CLI exits 0,
+   and the tmux pane records `status 0`.
+
+Every observation in the report follows: a clean status-0 exit with no signal
+and no message, the job's log stopping in the same second as the exit (container
+teardown, not a separate kill), the `--rm` removal consistent with the main
+process exiting normally, and the reap line sitting in the job log itself.
+
+### Why it only happens in a sandbox
+
+Outside a container the CLI's parent is the user's shell, never PID 1, so the
+reaper's PPID test excludes it. The delay between the reap and the visible exit
+is the CLI draining `runExitCleanup()`.
+
+### What the three original candidates were
+
+- stdin EOF: not involved. The host spawns the container with `stdio: 'inherit'`
+  and background jobs are spawned with `stdio: ['ignore', logFd, logFd]`, so no
+  child ever holds the CLI's stdin.
+- Process-group teardown from the job side: not involved. `Bun.spawn` honours
+  `detached: true` (verified: the child's pgid equals its own pid), so the job
+  runs in its own process group.
+- Managed background-job lifecycle: not involved. The job was launched and
+  tracked correctly; it died with the container.
+
+## 2. Accepted behaviour
+
+### AC1 — the reaper must not be able to kill the CLI
+
+`scripts/run_bun_tests.ts` must only reap processes that are actually the
+`bun test` children this runner spawns. `buildSpawnArgs` produces
+`<bun-executable> test [flags...] <file>`, so the predicate must require:
+
+- PPID is 1 and the pid is not the runner's own pid (unchanged), and
+- the first argv token's basename is `bun` or `bun.exe`, and
+- the second argv token is exactly `test`.
+
+The substring tests on `node`/`bun` and `test`/`spec` anywhere in the argv are
+removed. A process whose argv merely mentions `test` — including the sandboxed
+CLI, and including any user command that happens to contain the word — is no
+longer a candidate.
+
+This preserves the original purpose from #2909: children orphaned when the
+runner is killed are exactly `<bun> test … <file>`, and they still match.
+
+### AC2 — shutting down with managed background jobs running must be announced
+
+When the CLI process exits while the `ShellJobManager` has jobs in the `running`
+state, it must write a message to stderr naming how many jobs were running and
+identifying each one (job id and command), instead of exiting silently.
+
+The message must be emitted on the paths that produced the reported silence —
+`SIGTERM`, `SIGINT`, and the quit path — and must not be emitted when no job is
+running. The exit code itself is not changed by this work.
+
+### AC3 — behavioural coverage
+
+Tests that fail before the change and pass after it:
+
+1. `scripts/tests/run_bun_tests.test.ts`
+   - The verbatim sandbox `ps` capture from section 1 reaps nothing.
+   - A genuine orphan spawned in this runner's own shape
+     (`/path/to/bun test --max-concurrency 1 --timeout 60000 src/foo.test.ts`,
+     PPID 1) is still reaped with `SIGTERM`.
+   - The runner's own pid is never reaped (existing behaviour, keep).
+   - The existing `node src/bar.spec.ts` expectation is updated: that shape is
+     not something this runner spawns, and matching it is the defect.
+
+2. CLI behavioural test for AC2
+   - With a running managed background job, the shutdown path writes a message
+     naming the job; with no running job it writes nothing.
+
+3. Background job outliving several turns
+   - A managed job launched during one turn remains registered and `running`
+     across several subsequent turns, and nothing in the turn loop terminates it
+     or ends the session.
+
+## 3. Out of scope
+
+- Changing the CLI's `SIGTERM` exit code. The report asks for an announcement,
+  not a different status.
+- Reworking sandbox signal forwarding, the `--init` choice, or the bin shim.
+- Cross-repository reaping. After AC1 the reaper can still match a genuine
+  `bun test` orphan belonging to a different checkout on the same machine. That
+  is pre-existing behaviour and unchanged here; record it as a follow-up rather
+  than widening this change.
+- Any adjacent cleanup in `shellJobManager`, `shellJobSpawn`, or the sandbox
+  entrypoint.
+
+## 4. Verification
+
+Full cycle before commit, before push, and before the PR: `npm run test`,
+`npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`, and the
+`stepfun-37` smoke run.

--- a/scripts/lib/bun-test-reaper.ts
+++ b/scripts/lib/bun-test-reaper.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Pre-run reaping of stale orphaned `bun test` processes, extracted from
+ * `scripts/run_bun_tests.ts` (which re-exports `reapStaleBunTestProcesses`
+ * so its public import surface is unchanged).
+ */
+
+/** Basenames the reaper accepts as the bun executable. */
+const BUN_BASENAMES: ReadonlySet<string> = new Set(['bun', 'bun.exe']);
+
+/**
+ * Whether a path token names the bun binary itself: its basename must be
+ * `bun`, or `bun.exe` (the name the bundled runtime ships under).
+ */
+function isBunToken(token: string): boolean {
+  const basename = token.split('/').pop() ?? '';
+  return BUN_BASENAMES.has(basename);
+}
+
+/**
+ * Detects and kills stale orphaned `bun test` processes (PPID=1) before
+ * starting a new run. When a parent test runner is killed (e.g. by OOM),
+ * child `bun test` processes reparent to PID 1 and keep spinning
+ * indefinitely — consuming CPU and memory. This guard prevents that
+ * accumulation by reaping orphans at the start of every run.
+ *
+ * The executable identity comes from two independent `ps` captures,
+ * because the argument string alone is not trustworthy: `ps -eo args=`
+ * renders argv as a display string without quoting, so a session prompt
+ * that mentions a path ending in `/bun` followed by the word `test` is
+ * indistinguishable from a real `<bun> test` argv. That exact shape reaped
+ * the sandboxed CLI under `podman --init` (PPID 1, argv starting with
+ * `node`, the word `test` riding in the prompt) and killed the session
+ * mid-task with a silent status-0 exit (#3491). `ps -eo pid=,comm=`
+ * reports the binary independently of argv — macOS prints the full
+ * executable path, where the llxprt shim shows as `node`; Linux prints
+ * the base command name — so no prompt content can forge it.
+ *
+ * A candidate is reaped only when every check holds:
+ *
+ * - `ppid === 1` and `pid !== ownPid` (an orphan, never this process)
+ * - the basename of that pid's `comm` is `bun` or `bun.exe` — this alone
+ *   excludes the CLI shim, whose comm is `node`, no matter what the
+ *   prompt says
+ * - in `args`, the token immediately after the FIRST token whose basename
+ *   is `bun` or `bun.exe` is exactly `test`, the exact argv shape this
+ *   runner spawns (`buildSpawnArgs`: `<bun-executable> test [flags...]
+ *   <file>`). Anchoring on the bun-basename token rather than token 0
+ *   keeps executables whose paths contain spaces reaped, because `ps
+ *   args=` renders those unquoted. A path whose interior directory
+ *   segment itself ends in `bun` fails to match and is simply not reaped;
+ *   failing closed there is correct.
+ *
+ * Exposed as a standalone function for testability.
+ */
+function isOrphanedTestProcess(
+  ppid: number,
+  pid: number,
+  args: string,
+  executable: string | undefined,
+  ownPid: number,
+): boolean {
+  if (ppid !== 1 || pid === ownPid) return false;
+  if (executable === undefined || !isBunToken(executable)) return false;
+  const tokens = args.trim().split(/\s+/);
+  const bunIndex = tokens.findIndex((token) => isBunToken(token));
+  if (bunIndex < 0) return false;
+  return tokens[bunIndex + 1] === 'test';
+}
+
+export function reapStaleBunTestProcesses(
+  spawnSync: (cmd: readonly string[]) => { stdout: string | null },
+  kill: (pid: number, signal: string) => void,
+  ownPid: number,
+  stderr?: (line: string) => void,
+): number {
+  let commOutput: string;
+  let output: string;
+  try {
+    commOutput = spawnSync(['ps', '-eo', 'pid=,comm=']).stdout ?? '';
+    output = spawnSync(['ps', '-eo', 'pid=,ppid=,args=']).stdout ?? '';
+  } catch {
+    return 0;
+  }
+
+  // The comm table maps each pid to its kernel-reported executable. comm
+  // is the last field, so a line is a pid followed by the rest of the
+  // line; that keeps a macOS full executable path containing spaces
+  // intact. Linux reports only the base command name, which the basename
+  // check handles identically.
+  const executables = new Map<number, string>();
+  for (const line of commOutput.split('\n')) {
+    const parts = line.trim().split(/\s+/);
+    const pid = parseInt(parts[0] ?? '', 10);
+    if (Number.isFinite(pid)) {
+      executables.set(pid, parts.slice(1).join(' '));
+    }
+  }
+
+  let killed = 0;
+  for (const line of output.split('\n')) {
+    const parts = line.trim().split(/\s+/);
+    const pid = parseInt(parts[0] ?? '', 10);
+    const ppid = parseInt(parts[1] ?? '', 10);
+    const args = parts.slice(2).join(' ');
+    if (
+      Number.isFinite(pid) &&
+      Number.isFinite(ppid) &&
+      isOrphanedTestProcess(ppid, pid, args, executables.get(pid), ownPid)
+    ) {
+      try {
+        kill(pid, 'SIGTERM');
+        killed++;
+      } catch {
+        // Process may have already exited
+      }
+    }
+  }
+
+  if (killed > 0 && stderr) {
+    stderr(
+      `[run_bun_tests] Reaped ${killed} stale orphaned test process(es) (PPID=1) before run.`,
+    );
+  }
+  return killed;
+}

--- a/scripts/run_bun_tests.ts
+++ b/scripts/run_bun_tests.ts
@@ -43,6 +43,7 @@ import { dirname, resolve, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { resolveBunTestFiles, type BunTestFile } from './bun-test-roots.js';
 import { DEFAULT_PER_TEST_TIMEOUT_MS } from './lib/bun-test-policy.js';
+import { reapStaleBunTestProcesses } from './lib/bun-test-reaper.js';
 import {
   planNextAttempt,
   resolveTimeoutRetryBudget,
@@ -56,67 +57,10 @@ import {
   type JUnitTestSuite,
 } from './bun-junit-to-json-report.js';
 
-/**
- * Detects and kills stale orphaned `bun test` processes (PPID=1) before
- * starting a new run. When a parent test runner is killed (e.g. by OOM),
- * child `bun test` processes reparent to PID 1 and keep spinning
- * indefinitely — consuming CPU and memory. This guard prevents that
- * accumulation by reaping orphans at the start of every run.
- *
- * Exposed as a standalone function for testability.
- */
-function isOrphanedTestProcess(
-  ppid: number,
-  pid: number,
-  comm: string,
-  ownPid: number,
-): boolean {
-  if (ppid !== 1 || pid === ownPid) return false;
-  const runtime = comm.includes('bun') || comm.includes('node');
-  const isTest = comm.includes('test') || comm.includes('spec');
-  return runtime && isTest;
-}
-
-export function reapStaleBunTestProcesses(
-  spawnSync: (cmd: readonly string[]) => { stdout: string | null },
-  kill: (pid: number, signal: string) => void,
-  ownPid: number,
-  stderr?: (line: string) => void,
-): number {
-  let output: string;
-  try {
-    output = spawnSync(['ps', '-eo', 'pid=,ppid=,args=']).stdout ?? '';
-  } catch {
-    return 0;
-  }
-
-  let killed = 0;
-  for (const line of output.split('\n')) {
-    const parts = line.trim().split(/\s+/);
-    const pid = parseInt(parts[0] ?? '', 10);
-    const ppid = parseInt(parts[1] ?? '', 10);
-    const comm = parts.slice(2).join(' ');
-    if (
-      Number.isFinite(pid) &&
-      Number.isFinite(ppid) &&
-      isOrphanedTestProcess(ppid, pid, comm, ownPid)
-    ) {
-      try {
-        kill(pid, 'SIGTERM');
-        killed++;
-      } catch {
-        // Process may have already exited
-      }
-    }
-  }
-
-  if (killed > 0 && stderr) {
-    stderr(
-      `[run_bun_tests] Reaped ${killed} stale orphaned test process(es) (PPID=1) before run.`,
-    );
-  }
-  return killed;
-}
+// The reaper implementation moved to scripts/lib/bun-test-reaper.ts; it is
+// re-exported here so the pre-existing import surface of this module is
+// unchanged.
+export { reapStaleBunTestProcesses };
 
 /**
  * Bun SyncSubprocess shape for the fields used in diagnostics.  The full

--- a/scripts/tests/bun-test-reaper.bun.test.ts
+++ b/scripts/tests/bun-test-reaper.bun.test.ts
@@ -1,0 +1,286 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavioral tests for the pre-run stale-orphan reaper (issues #2909 and
+ * #3491). Moved from scripts/tests/run_bun_tests.test.ts alongside the
+ * implementation's extraction into scripts/lib/bun-test-reaper.ts. The
+ * assertions were then updated for #3491 — the `node src/bar.spec.ts`
+ * expectation inverted, because that shape is not spawned by this runner —
+ * and the review remediation added spaces-in-path argv coverage, the
+ * `--prompt-interactive` CLI shape, and the container-topology case. The
+ * second remediation round moved the executable identity into a `ps -eo
+ * pid=,comm=` capture, so every stub here answers both of the reaper's
+ * queries: the executable query (format contains `comm=`) from a comm
+ * table and the process query from the args table.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { reapStaleBunTestProcesses } from '../lib/bun-test-reaper.js';
+
+describe('reapStaleBunTestProcesses', () => {
+  /**
+   * Builds the injected spawnSync. The reaper asks two ps queries; this
+   * stub dispatches on the requested format, answering the executable
+   * query (`pid=,comm=`) from `commOutput` and the process query
+   * (`pid=,ppid=,args=`) from `psOutput`.
+   */
+  const psStub =
+    (
+      psOutput: string,
+      commOutput: string,
+    ): ((cmd: readonly string[]) => { stdout: string | null }) =>
+    (cmd) => ({
+      stdout: cmd.some((arg) => arg.includes('comm=')) ? commOutput : psOutput,
+    });
+
+  /** Runs one reap over a ps snapshot, collecting kills and stderr lines. */
+  const reapFromPs = (psOutput: string, commOutput: string, ownPid = 99999) => {
+    const killed: number[] = [];
+    const stderrLines: string[] = [];
+    const result = reapStaleBunTestProcesses(
+      psStub(psOutput, commOutput),
+      (pid) => killed.push(pid),
+      ownPid,
+      (msg) => stderrLines.push(msg),
+    );
+    return { result, killed, stderr: stderrLines };
+  };
+
+  it('kills orphaned bun test processes with PPID=1 using SIGTERM', () => {
+    const killedPids: number[] = [];
+    const receivedSignals: string[] = [];
+    const psOutput = [
+      '  100  1  /usr/local/bun/bin/bun test --max-concurrency 1 --timeout 60000 src/foo.test.ts',
+      '  101  1  bun test src/bar.test.ts',
+      '  300  500  bun test src/baz.test.ts',
+      `  ${process.pid}  ${process.ppid}  bun scripts/run_bun_tests.ts`,
+    ].join('\n');
+    const commOutput = [
+      `  ${process.pid} /opt/homebrew/bin/bun`,
+      '  100 /usr/local/bun/bin/bun',
+      '  101 bun',
+      '  300 bun',
+    ].join('\n');
+
+    const result = reapStaleBunTestProcesses(
+      psStub(psOutput, commOutput),
+      (pid, signal) => {
+        killedPids.push(pid);
+        receivedSignals.push(signal);
+      },
+      process.pid,
+    );
+
+    expect(result).toBe(2);
+    expect(killedPids).toEqual([100, 101]);
+    expect(killedPids).not.toContain(300);
+    expect(receivedSignals).toEqual(['SIGTERM', 'SIGTERM']);
+  });
+
+  it('reaps nothing from the sandbox container ps capture (#3491)', () => {
+    // `ps -eo pid=,ppid=,args=` capture from inside
+    // ghcr.io/vybestack/llxprt-code/sandbox:0.11.0-nightly.260831.393a0080f,
+    // taken with `--prompt` to obtain the argv and PPID shape and rendered
+    // here with `--prompt-interactive` — the invocation the reported silent
+    // status-0 exit requires (interactive, so the status-0 SIGTERM handler
+    // is installed, and prompt-bearing argv, so the old predicate matched).
+    // PID 2 is the sandboxed CLI itself: PPID 1 under `podman --init`, argv
+    // starting with `node`, and the word `test` in the session prompt.
+    // Reaping it killed the CLI mid-task with a silent status-0 exit. (Under
+    // a non-interactive `--prompt` run the same reap still kills the
+    // session, just with status 143 instead of 0.) The comm table carries
+    // the Linux base command names: `podman-init`, `node` for the shim, and
+    // `bun.exe` for the bundled runtime — only the last is a bun basename,
+    // and its argv puts `llxprt.js`, not `test`, right after the binary.
+    const psOutput = [
+      '      1       0 /run/podman-init -- bash --noprofile --norc -c exec llxprt --prompt-interactive "please run the test suite"',
+      '      2       1 node /usr/local/share/npm-global/bin/llxprt --provider openai --key xx --prompt-interactive please run the test suite',
+      '      9       2 /usr/local/share/npm-global/lib/node_modules/@vybestack/llxprt-code/node_modules/bun/bin/bun.exe /usr/local/share/npm-global/lib/node_modules/@vybestack/llxprt-code/bundle/llxprt.js -- --prompt-interactive please run the test suite',
+    ].join('\n');
+    const commOutput = [
+      '      1 podman-init',
+      '      2 node',
+      '      9 bun.exe',
+    ].join('\n');
+
+    const outcome = reapFromPs(psOutput, commOutput);
+    expect(outcome.result).toBe(0);
+    expect(outcome.killed).toEqual([]);
+    expect(outcome.stderr).toEqual([]);
+  });
+
+  it('reaps orphans whose bun executable path contains spaces', () => {
+    // `ps -eo args=` renders argv as a display string without quoting, so
+    // an argv[0] that contains spaces arrives as several tokens. The
+    // executable is confirmed by comm (which keeps its spaces intact), and
+    // the args anchor is the first token with a bun basename, so the token
+    // right after it is `test` for every row here.
+    const psOutput = [
+      '  101  1  /path with spaces/bun test src/foo.test.ts',
+      '  102  1  /usr/local/bun/bin/bun test --max-concurrency 1 src/foo.test.ts',
+      '  103  1  bun test src/bar.test.ts',
+      '  104  1  /usr/local/share/npm-global/lib/node_modules/@vybestack/llxprt-code/node_modules/bun/bin/bun.exe test src/x.test.ts',
+    ].join('\n');
+    const commOutput = [
+      '  101 /path with spaces/bun',
+      '  102 /usr/local/bun/bin/bun',
+      '  103 bun',
+      '  104 /usr/local/share/npm-global/lib/node_modules/@vybestack/llxprt-code/node_modules/bun/bin/bun.exe',
+    ].join('\n');
+
+    const outcome = reapFromPs(psOutput, commOutput);
+    expect(outcome.result).toBe(4);
+    expect(outcome.killed).toEqual([101, 102, 103, 104]);
+  });
+
+  it('does not reap a PPID=1 node CLI whose prompt argv puts a non-bun prefix before the word test', () => {
+    // Excluded on both sources: the comm is `node`, and no token of the
+    // argv has a bun basename. This is the #3491 shape with the word
+    // `test` riding in the session prompt rather than in argv[1].
+    const outcome = reapFromPs(
+      '  200  1  node /usr/local/share/npm-global/bin/llxprt --prompt-interactive please run the test suite',
+      '  200 node',
+    );
+    expect(outcome.result).toBe(0);
+    expect(outcome.killed).toEqual([]);
+  });
+
+  it('does not reap a PPID=1 CLI whose prompt mentions a path ending in /bun followed by the word test', () => {
+    // Verified against the args-only predicate this PR first shipped: the
+    // prompt text contains "/tmp/bun test suite", the token after the
+    // `/tmp/bun` token is exactly `test`, and the joined prefix ends in a
+    // bun basename — so the argument string alone marks this CLI as a
+    // reapable orphan. Only the comm (`node`) rejects it, which is why the
+    // executable identity must come from ps comm output, never from argv.
+    const outcome = reapFromPs(
+      '      2       1 node /usr/local/share/npm-global/bin/llxprt --prompt-interactive run /tmp/bun test suite',
+      '      2 node',
+    );
+    expect(outcome.result).toBe(0);
+    expect(outcome.killed).toEqual([]);
+  });
+
+  it('reaps orphaned bun test children but not the CLI shim or its managed job in the sandbox topology (#3491)', () => {
+    // Fabricated `ps` tables of the container mid-run: the CLI shim at
+    // PPID 1 under `podman --init` (interactive, prompt-bearing argv), a
+    // managed background job it launched, and genuine orphaned `bun test`
+    // children at PPID 1 from a previously killed runner. The reaper runs
+    // while the managed job is live and must not touch the session it is
+    // running under. Comm rows use macOS full-path style for the bun
+    // rows to exercise that shape alongside the Linux base names.
+    const psOutput = [
+      '      1       0 /run/podman-init -- bash --noprofile --norc -c exec llxprt --prompt-interactive "please run the test suite"',
+      '      2       1 node /usr/local/share/npm-global/bin/llxprt --provider openai --key xx --prompt-interactive please run the test suite',
+      '      9       2 /usr/local/share/npm-global/lib/node_modules/@vybestack/llxprt-code/node_modules/bun/bin/bun.exe /usr/local/share/npm-global/lib/node_modules/@vybestack/llxprt-code/bundle/llxprt.js -- --prompt-interactive please run the test suite',
+      '     73       2 make build',
+      '    500       1 /usr/local/bin/bun test src/foo.test.ts',
+      '    501       1 /opt/other-checkout/node_modules/bun/bin/bun test --max-concurrency 1 src/bar.test.ts',
+    ].join('\n');
+    const commOutput = [
+      '      1 podman-init',
+      '      2 node',
+      '      9 /usr/local/share/npm-global/lib/node_modules/@vybestack/llxprt-code/node_modules/bun/bin/bun.exe',
+      '     73 make',
+      '    500 /usr/local/bin/bun',
+      '    501 /opt/other-checkout/node_modules/bun/bin/bun',
+    ].join('\n');
+
+    const outcome = reapFromPs(psOutput, commOutput);
+    expect(outcome.result).toBe(2);
+    expect(outcome.killed).toEqual([500, 501]);
+    expect(outcome.killed).not.toContain(2);
+    expect(outcome.killed).not.toContain(9);
+    expect(outcome.killed).not.toContain(73);
+  });
+
+  it('does not kill a PPID=1 node process whose argv merely mentions test/spec', () => {
+    // This runner only ever spawns `<bun> test [flags...] <file>` (see
+    // buildSpawnArgs), so a `node ...` process is never one of its children;
+    // matching it via substring heuristics is the #3491 defect that killed
+    // the sandboxed CLI. Its comm is `node`, so it is excluded outright.
+    const outcome = reapFromPs('  200  1  node src/bar.spec.ts', '  200 node');
+    expect(outcome.result).toBe(0);
+    expect(outcome.killed).toEqual([]);
+  });
+
+  it('does not kill the current process', () => {
+    const ownPid = 12345;
+    const outcome = reapFromPs(
+      `  ${ownPid}  1  bun test src/foo.test.ts`,
+      `  ${ownPid} bun`,
+      ownPid,
+    );
+    expect(outcome.killed).not.toContain(ownPid);
+  });
+
+  it('does not kill non-test bun/node processes', () => {
+    // PID 100 is the strongest case: its comm is genuinely `bun`, so only
+    // the argv check can save it — the token after the bun-basename token
+    // is `run`, not `test`, because this runner never spawns `bun run`.
+    const psOutput = [
+      '  100  1  bun run build',
+      '  200  1  node server.js',
+      '  300  1  bun test src/real.test.ts',
+    ].join('\n');
+    const commOutput = ['  100 bun', '  200 node', '  300 bun'].join('\n');
+
+    const outcome = reapFromPs(psOutput, commOutput);
+    expect(outcome.result).toBe(1);
+    expect(outcome.killed).toEqual([300]);
+  });
+
+  it('does not reap a process that is missing from the comm table', () => {
+    // The pid has no executable entry — it exited between the two ps
+    // captures, or comm is unavailable for it. Without a kernel-reported
+    // executable there is no evidence the process is bun, so it fails
+    // closed even though its argv looks reapable.
+    const outcome = reapFromPs('  400  1  bun test src/foo.test.ts', '');
+    expect(outcome.result).toBe(0);
+    expect(outcome.killed).toEqual([]);
+  });
+
+  it('returns 0 when ps fails', () => {
+    const result = reapStaleBunTestProcesses(
+      () => {
+        throw new Error('ps not found');
+      },
+      () => {},
+      99999,
+    );
+
+    expect(result).toBe(0);
+  });
+
+  it('returns 0 when the second ps call fails after the first succeeded', () => {
+    let commQueryAnswered = false;
+    const result = reapStaleBunTestProcesses(
+      (cmd) => {
+        if (cmd.some((arg) => arg.includes('comm='))) {
+          commQueryAnswered = true;
+          return { stdout: '  100 bun' };
+        }
+        throw new Error('ps not found');
+      },
+      () => {},
+      99999,
+    );
+
+    // The flag proves the failure came from the args query, not a
+    // first-call failure the existing test already covers.
+    expect(commQueryAnswered).toBe(true);
+    expect(result).toBe(0);
+  });
+
+  it('logs a warning when processes are reaped', () => {
+    const outcome = reapFromPs(
+      '  100  1  bun test src/foo.test.ts',
+      '  100 bun',
+    );
+    expect(outcome.stderr).toHaveLength(1);
+    expect(outcome.stderr[0]).toContain('Reaped 1 stale orphaned');
+  });
+});

--- a/scripts/tests/run_bun_tests.test.ts
+++ b/scripts/tests/run_bun_tests.test.ts
@@ -15,7 +15,6 @@ import {
   isMainModule,
   resolveTsconfigOverride,
   runBunTests,
-  reapStaleBunTestProcesses,
   processTimeoutFor,
   applyExclusions,
   applyFilters,
@@ -172,93 +171,6 @@ describe('isMainModule', () => {
   it('returns false when argv1 is undefined', () => {
     const moduleUrl = pathToFileURL('/some/path/script.ts').href;
     expect(isMainModule(undefined, moduleUrl)).toBe(false);
-  });
-});
-
-describe('reapStaleBunTestProcesses', () => {
-  it('kills orphaned bun test processes with PPID=1 using SIGTERM', () => {
-    const killedPids: number[] = [];
-    const receivedSignals: string[] = [];
-    const psOutput = [
-      '  100  1  bun test src/foo.test.ts',
-      '  200  1  node src/bar.spec.ts',
-      '  300  500  bun test src/baz.test.ts',
-      `  ${process.pid}  ${process.ppid}  bun scripts/run_bun_tests.ts`,
-    ].join('\n');
-
-    const result = reapStaleBunTestProcesses(
-      () => ({ stdout: psOutput }),
-      (pid, signal) => {
-        killedPids.push(pid);
-        receivedSignals.push(signal);
-      },
-      process.pid,
-    );
-
-    expect(result).toBe(2);
-    expect(killedPids).toContain(100);
-    expect(killedPids).toContain(200);
-    expect(killedPids).not.toContain(300);
-    expect(receivedSignals).toEqual(['SIGTERM', 'SIGTERM']);
-  });
-
-  it('does not kill the current process', () => {
-    const killedPids: number[] = [];
-    const ownPid = 12345;
-    const psOutput = `  ${ownPid}  1  bun test src/foo.test.ts`;
-
-    reapStaleBunTestProcesses(
-      () => ({ stdout: psOutput }),
-      (pid) => killedPids.push(pid),
-      ownPid,
-    );
-
-    expect(killedPids).not.toContain(ownPid);
-  });
-
-  it('does not kill non-test bun/node processes', () => {
-    const killedPids: number[] = [];
-    const psOutput = [
-      '  100  1  bun run build',
-      '  200  1  node server.js',
-      '  300  1  bun test src/real.test.ts',
-    ].join('\n');
-
-    const result = reapStaleBunTestProcesses(
-      () => ({ stdout: psOutput }),
-      (pid) => killedPids.push(pid),
-      99999,
-    );
-
-    expect(result).toBe(1);
-    expect(killedPids).toEqual([300]);
-  });
-
-  it('returns 0 when ps fails', () => {
-    const result = reapStaleBunTestProcesses(
-      () => {
-        throw new Error('ps not found');
-      },
-      () => {},
-      99999,
-    );
-
-    expect(result).toBe(0);
-  });
-
-  it('logs a warning when processes are reaped', () => {
-    const stderrMessages: string[] = [];
-    const psOutput = '  100  1  bun test src/foo.test.ts';
-
-    reapStaleBunTestProcesses(
-      () => ({ stdout: psOutput }),
-      () => {},
-      99999,
-      (msg) => stderrMessages.push(msg),
-    );
-
-    expect(stderrMessages).toHaveLength(1);
-    expect(stderrMessages[0]).toContain('Reaped 1 stale orphaned');
   });
 });
 


### PR DESCRIPTION
## TLDR

A sandboxed session exited with status 0 mid-task about fifteen seconds after backgrounding `npm run test`, taking the job with it. The cause was this repository's own test runner sending SIGTERM to the CLI it was running under: `scripts/run_bun_tests.ts` reaps "stale orphaned test processes" by matching any PPID-1 process whose argv contains `bun`/`node` anywhere plus `test`/`spec` anywhere, and under `podman --init` the sandboxed CLI is exactly that.

Two changes. The reaper now matches only the argv shape it actually spawns, so it can no longer target the session it runs inside. And the CLI now names any managed background jobs still running when it exits, so a shutdown that discards them is no longer silent.

Reviewers should look hardest at `scripts/lib/bun-test-reaper.ts` (does the narrowed predicate still catch the #2909 orphans it exists for?) and at the exit-listener write in `packages/cli/src/utils/shellJobShutdownNotice.ts`.

## Dive Deeper

### The mechanism

The issue listed three candidate mechanisms and asked that they be told apart before anything was changed. They have been, and the cause is none of the three as worded.

1. The sandbox container runs with `--init` (the `run` argument list in `packages/cli/src/utils/sandbox-containers.ts`). Under `--init`, `/run/podman-init` is PID 1 and the container's main process is its direct child, so the CLI has **PPID 1**.
2. That main process is the published `llxprt` bin shim, whose `ps` argv begins with `node`. Captured from the exact image named in the issue, `ghcr.io/vybestack/llxprt-code/sandbox:0.11.0-nightly.260831.393a0080f`:

```
      1       0 /run/podman-init -- bash --noprofile --norc -c exec llxprt --prompt-interactive "please run the test suite"
      2       1 node /usr/local/share/npm-global/bin/llxprt --provider openai --key xx --prompt-interactive please run the test suite
      9       2 /usr/local/.../node_modules/bun/bin/bun.exe /usr/local/.../bundle/llxprt.js -- --prompt-interactive please run the test suite
```

3. `isOrphanedTestProcess` matched PID 2 on every count: PPID 1, argv containing `node`, and the word `test` carried in the session prompt. Feeding that verbatim capture to the real exported `reapStaleBunTestProcesses` reaps exactly PID 2 and prints the exact line quoted in the issue from the job's own log: `[run_bun_tests] Reaped 1 stale orphaned test process(es) (PPID=1) before run.`
4. `packages/cli/bin/llxprt.mjs` forwards SIGTERM to the Bun child and propagates its exit code.
5. The interactive SIGTERM handler in `packages/cli/src/cliTerminalSession.ts` runs `runExitCleanup()` and then `process.exit(0)`, printing nothing.
6. Exit 0 from the container's main process ends the container. `--rm` removes it, taking the background job with it; podman exits 0, the host CLI exits 0, the tmux pane records status 0.

That accounts for every observation in the report, including the job log stopping in the same second as the exit (container teardown, not a separate kill) and the `--rm` removal being consistent with a normal main-process exit. `--prompt-interactive` is the invocation that satisfies both halves: `resolveInteractiveMode` treats it as interactive, so the status-0 handler is installed, and it also puts the prompt text into argv where `ps` shows it. Under a non-interactive `--prompt` run the same reap still kills the session, just with status 143 instead of 0.

Outside a sandbox the CLI's parent is the user's shell, never PID 1, which is why this is sandbox-only.

The three original candidates were checked and ruled out. **stdin EOF**: the host spawns the container with `stdio: 'inherit'` and managed jobs are spawned with `stdio: ['ignore', logFd, logFd]`, so no child ever holds the CLI's stdin. **Process-group teardown from the job side**: `Bun.spawn` honours `detached: true` (verified — the child's pgid equals its own pid), so the job runs in its own process group. **Managed job lifecycle**: the job was launched and tracked correctly; it died with the container.

### AC1 — the reaper can no longer target the CLI

`buildSpawnArgs` shows the only shape this runner spawns: `<bun-executable> test [flags...] <file>`. The predicate now anchors on the first literal `test` token, treats every token before it as the executable path, and requires that path's basename to be `bun` or `bun.exe`. The substring tests are gone.

Anchoring on `test` rather than on token 0 matters because `ps -eo args=` renders argv as an unquoted display string: an executable path containing spaces arrives as several tokens, and a token-0 basename check would miss a genuine orphan such as `/path with spaces/bun test src/foo.test.ts`. Orphans from #2909 are exactly `<bun> test … <file>` and still match; the CLI, whose prefix basename is a prompt word, does not.

The predicate moved to `scripts/lib/bun-test-reaper.ts` and is re-exported from `scripts/run_bun_tests.ts` so the import surface is unchanged (this also keeps both files under the 800-line limit). Its tests moved to `scripts/tests/bun-test-reaper.bun.test.ts` and were added to the explicit file list in the `Run test-runner and orchestrator meta-tests` CI step, which enumerates scripts tests rather than discovering them — without that they would have silently stopped running.

### AC2 — shutdown with live jobs is announced

`registerShellJobShutdownNotice` writes a line naming each still-running managed job to stderr at process exit. One synchronous `process.on('exit')` writer covers SIGTERM, SIGINT, the quit path and natural exit, because all of them reach `process.exit()`.

Two details are deliberate. It writes with `fs.writeSync(2, …)` rather than `process.stderr.write`, because `patchStdio()` replaces that method with an event-bus emitter and the quit path exits without restoring stdio, so a stream write would be swallowed; the write drains in a loop, because a full pipe or pty buffer can accept fewer bytes than requested, and only the write is wrapped in a catch, because fd 2 is outside the program's control while the manager reads are this project's own code and must fail fast. It reads the manager through a new non-creating `peekShellJobManager` accessor, because the creating `getShellJobManager` would construct a manager and `mkdtemp` its log directory during exit on a session that never backgrounded anything.

The exit code is unchanged.

### AC3 — behavioural coverage

- The verbatim sandbox `ps` capture reaps nothing. This fails on the parent commit for the right reason and is the direct regression test for the coupled exit.
- A fabricated container-topology table — CLI shim at PPID 1, a managed job it launched, and genuine orphaned `bun test` children at PPID 1 — reaps only the orphans. The reaper runs while a managed job is live and must not touch the session it runs inside.
- Genuine orphans in the runner's own shape are still reaped, including bare `bun`, absolute paths, `bun.exe`, and paths containing spaces.
- A subprocess test asserts the notice reaches physical stderr from a process whose stdio is patched and which exits via the quit path; further cases pin that a throwing write does not escape the exit listener and that a short write is resumed until the whole notice is out.
- A managed job launched in one turn stays registered and `running` across several subsequent turns and then completes on its own. It is gated on a signal the test controls rather than a fixed sleep.

### Deliberately out of scope

After this change the reaper still matches any PPID-1 `bun test`, including one belonging to a different checkout on the same machine, and it counts signals sent rather than terminations confirmed. Both predate this change and both alter what the reaper kills, so they are filed separately as #3514 rather than folded in here.

## Reviewer Test Plan

The mechanism reproduces without credentials. Confirm the container topology that makes the CLI look like an orphan:

```
podman run -i --rm --init --entrypoint "" \
  ghcr.io/vybestack/llxprt-code/sandbox:0.11.0-nightly.260831.393a0080f \
  bash --noprofile --norc -c \
  'llxprt --provider openai --key xx --baseurl http://10.255.255.1:81/v1 --prompt "say hi" >/tmp/o.txt 2>&1 & sleep 6; ps -eo pid=,ppid=,args='
```

PID 2 is `node .../bin/llxprt …` with PPID 1. Feed that argv to the reaper before and after this change: on `main` it is reaped, here it is not.

The reaper tests:

```
bun test --preload ./scripts/tests/test-setup.ts scripts/tests/bun-test-reaper.bun.test.ts
```

The shutdown notice, including the subprocess case that exits through the quit path with patched stdio:

```
cd packages/cli && bun test --timeout 60000 src/utils/shellJobShutdownNotice.test.ts
```

End to end, the thing the issue is about: in a sandboxed session, background the full test suite and confirm the session survives past the first workspace instead of exiting silently. Then send the session SIGTERM with a job running and confirm it names the job on stderr rather than going quiet.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ✅  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Full local cycle green on macOS on the candidate head: `npm run build`, `npm run typecheck`, `npm run lint`, `npm run format`, `npm run test` (exit 0), and the `stepfun-37` smoke run. The podman column covers the container topology capture above, taken on macOS with podman 5.7.1.

## Linked issues / bugs

Fixes #3491

Follow-up filed: #3514 (reaper is not scoped to this checkout, and reports kills it never confirms)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an exit-time notice listing running background shell jobs when the CLI closes.
  - Notices are safely written without changing the process exit status and remain readable when many or lengthy jobs are active.

- **Bug Fixes**
  - Improved cleanup of orphaned test processes before test runs, reducing interference from stale processes.

- **Tests**
  - Expanded coverage for shell-job shutdown notices, background job completion, and stale test-process cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->