### PR TITLE
test(sandbox): isolate spawned children instead of hashing the real config dir (Fixes #3519)

### DIFF
--- a/packages/cli/src/utils/sandbox-entrypoint.test.ts
+++ b/packages/cli/src/utils/sandbox-entrypoint.test.ts
@@ -27,7 +27,6 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { spawnSync, type ChildProcess } from 'node:child_process';
-import { createHash } from 'node:crypto';
 import { EventEmitter } from 'node:events';
 import { entrypoint } from './sandbox-entrypoint.js';
 import {
@@ -35,6 +34,8 @@ import {
   wireCleanupHandlers,
 } from './sandbox-containers.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core';
+import { LLXPRT_PLATFORM_PATHS } from '@vybestack/llxprt-code-storage/config/path-resolver.js';
+import { STORAGE_ENV_KEYS } from '@vybestack/llxprt-code-storage/testing';
 
 // Hoisted mocks for auth module — used by AC12 setupCredentialProxy/wireCleanupHandlers tests
 const authMocks = {
@@ -55,13 +56,6 @@ const VALID_TOKEN = 'a'.repeat(64);
 const BASH_CAP_REF = '${' + 'LLXPRT_CAPABILITY_TOKEN-}';
 const realHome = os.homedir();
 let realHomeCapabilityArtifacts = new Set<string>();
-let realConfigDir = '';
-let realConfigSnapshot: DirectorySnapshot | undefined;
-
-interface DirectorySnapshot {
-  readonly exists: boolean;
-  readonly entries: readonly string[];
-}
 
 function legacyCapabilityArtifacts(home: string): string[] {
   return fs
@@ -70,70 +64,8 @@ function legacyCapabilityArtifacts(home: string): string[] {
     .sort();
 }
 
-function resolveRealConfigDir(): string {
-  const probe = spawnSync(
-    process.execPath,
-    [
-      '-e',
-      "import { Storage } from '@vybestack/llxprt-code-storage'; process.stdout.write(Storage.getGlobalConfigDir());",
-    ],
-    { encoding: 'utf8' },
-  );
-  const resolved = probe.stdout.trim();
-  if (probe.status !== 0 || resolved === '') {
-    throw new Error(
-      `Could not resolve the real CLI config directory: ${probe.stderr.trim()}`,
-    );
-  }
-  return resolved;
-}
-
-function snapshotDirectoryEntries(
-  directory: string,
-  relativeDirectory = '',
-): string[] {
-  const snapshot: string[] = [];
-  const entries = fs
-    .readdirSync(directory, { withFileTypes: true })
-    .sort((left, right) => left.name.localeCompare(right.name));
-
-  for (const entry of entries) {
-    const relativePath = path.join(relativeDirectory, entry.name);
-    const entryPath = path.join(directory, entry.name);
-    if (entry.isDirectory()) {
-      snapshot.push(`directory:${relativePath}`);
-      snapshot.push(...snapshotDirectoryEntries(entryPath, relativePath));
-    } else if (entry.isFile()) {
-      const hash = createHash('sha256')
-        .update(fs.readFileSync(entryPath))
-        .digest('hex');
-      snapshot.push(`file:${relativePath}:${hash}`);
-    } else if (entry.isSymbolicLink()) {
-      snapshot.push(
-        `symbolic-link:${relativePath}:${fs.readlinkSync(entryPath)}`,
-      );
-    } else {
-      snapshot.push(`other:${relativePath}`);
-    }
-  }
-
-  return snapshot;
-}
-
-function snapshotDirectory(directory: string): DirectorySnapshot {
-  if (!fs.existsSync(directory)) {
-    return { exists: false, entries: [] };
-  }
-  return {
-    exists: true,
-    entries: snapshotDirectoryEntries(directory),
-  };
-}
-
 beforeAll(() => {
   realHomeCapabilityArtifacts = new Set(legacyCapabilityArtifacts(realHome));
-  realConfigDir = resolveRealConfigDir();
-  realConfigSnapshot = snapshotDirectory(realConfigDir);
 });
 
 afterAll(() => {
@@ -141,9 +73,6 @@ afterAll(() => {
     (entry) => !realHomeCapabilityArtifacts.has(entry),
   );
   expect(newRealHomeArtifacts).toStrictEqual([]);
-  if (realConfigDir !== '' && realConfigSnapshot !== undefined) {
-    expect(snapshotDirectory(realConfigDir)).toStrictEqual(realConfigSnapshot);
-  }
 });
 
 function useTempDir(
@@ -180,6 +109,38 @@ function restoreOsTmpdir(): void {
   });
 }
 
+/**
+ * Produces the environment every spawned child runs with. spawnSync with an
+ * inherited environment snapshots the process's ORIGINAL environment (see
+ * packages/storage/src/config/assertTestStorageIsolation.ts), so the storage
+ * isolation preload's post-startup assignments never reach children and they
+ * resolve the real user config dir. Carrying the isolated roots explicitly
+ * closes that gap; the key list comes from STORAGE_ENV_KEYS so a future
+ * storage root cannot silently escape isolation.
+ */
+function withIsolatedStorageRoots(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const childEnv: NodeJS.ProcessEnv = { ...process.env, ...env };
+  for (const key of STORAGE_ENV_KEYS) {
+    const isolated = process.env[key];
+    if (isolated === undefined) {
+      throw new Error(
+        `${key} is unset: the storage isolation preload must run before this suite spawns children`,
+      );
+    }
+    childEnv[key] = isolated;
+  }
+  return childEnv;
+}
+
+/**
+ * Path form safe to compare across the macOS /var -> /private/var symlink:
+ * resolved through realpath when the path exists, plainly resolved otherwise
+ * (a fresh runner may not have created the platform default config dir).
+ */
+function comparablePath(target: string): string {
+  return fs.existsSync(target) ? fs.realpathSync(target) : path.resolve(target);
+}
+
 function runCmd(
   cmd: string[],
   env: NodeJS.ProcessEnv,
@@ -187,7 +148,7 @@ function runCmd(
 ): { stdout: string; stderr: string; exit: number } {
   const r = spawnSync(cmd[0], cmd.slice(1), {
     encoding: 'utf8',
-    env,
+    env: withIsolatedStorageRoots(env),
     cwd: options.cwd,
   });
   return { stdout: r.stdout, stderr: r.stderr, exit: r.status ?? -1 };
@@ -225,7 +186,25 @@ function writeStealer(sentinelPath: string): string {
   return file;
 }
 
-/** Installs a PATH-discoverable recorder that reads fd 3 and writes a JSON report. */
+/**
+ * Interpreter and module URL for the recorder's config-root probe. The
+ * recorder fixture runs under whatever `node` is on PATH (standing in for an
+ * installed CLI), and plain node can neither execute the TypeScript entry
+ * bun resolves for `@vybestack/llxprt-code-storage` nor depend on a built
+ * dist being present. The fixture therefore spawns this test process's bun
+ * — the same interpreter the direct-child isolation test below uses — to run
+ * the REAL resolver, `Storage.getGlobalConfigDir()`, in the recorder's own
+ * (post-entrypoint) environment.
+ */
+const RESOLVER_EXECUTABLE = process.execPath;
+const STORAGE_ENTRY_URL = import.meta.resolve('@vybestack/llxprt-code-storage');
+
+/**
+ * Installs a PATH-discoverable recorder that reads fd 3 and writes a JSON
+ * report. Besides the token/env/fd fields, the report carries `configDir`,
+ * the config root `Storage.getGlobalConfigDir()` resolves in the recorder's
+ * environment, and `configDirError` (resolver stderr) when that probe fails.
+ */
 function installRecorder(
   binDir: string,
   sentinelPath: string,
@@ -242,7 +221,8 @@ function installRecorder(
       'let token = "";',
       'try { const b = Buffer.alloc(256); const n = fs.readSync(fd, b, 0, 256, null); token = b.slice(0, n).toString("utf8"); } catch (e) {}',
       'try { fs.closeSync(fd); } catch (e) {}',
-      'const out = { tokenValid: /^[0-9a-f]{64}\\n$/.test(token), envToken: process.env.LLXPRT_CAPABILITY_TOKEN === undefined ? "UNSET" : "LEAKED", fdMarker: process.env.LLXPRT_CAPABILITY_FD };',
+      `const resolution = require("node:child_process").spawnSync(${JSON.stringify(RESOLVER_EXECUTABLE)}, ["-e", ${JSON.stringify(`import(${JSON.stringify(STORAGE_ENTRY_URL)}).then((m) => process.stdout.write(String(m.Storage.getGlobalConfigDir())))`)}], { encoding: "utf8" });`,
+      'const out = { tokenValid: /^[0-9a-f]{64}\\n$/.test(token), envToken: process.env.LLXPRT_CAPABILITY_TOKEN === undefined ? "UNSET" : "LEAKED", fdMarker: process.env.LLXPRT_CAPABILITY_FD, configDir: resolution.stdout || "", configDirError: resolution.status === 0 ? null : String(resolution.stderr || "") };',
       `fs.writeFileSync(${JSON.stringify(sentinelPath)}, JSON.stringify(out));`,
     ].join('\n'),
   );
@@ -297,6 +277,33 @@ describe('sandbox-entrypoint: trusted entrypoint security (AC2, AC3, F1, F7, F10
     };
   }
 
+  it('spawned children resolve the isolated config dir, not the real user config dir', () => {
+    const isolatedConfigHome = process.env.LLXPRT_CONFIG_HOME;
+    if (isolatedConfigHome === undefined) {
+      throw new Error(
+        'LLXPRT_CONFIG_HOME is unset: the storage isolation preload must run before this suite spawns children',
+      );
+    }
+    const probe = runCmd(
+      [
+        process.execPath,
+        '-e',
+        "import { Storage } from '@vybestack/llxprt-code-storage'; process.stdout.write(Storage.getGlobalConfigDir());",
+      ],
+      {},
+    );
+    if (probe.exit !== 0) {
+      throw new Error(`config dir probe failed: ${probe.stderr.trim()}`);
+    }
+    // macOS reports the temp root as /var/folders/... while realpath resolves
+    // /private/var/folders/...; resolve both sides before comparing.
+    const resolvedConfigDir = comparablePath(probe.stdout.trim());
+    expect(resolvedConfigDir).toBe(comparablePath(isolatedConfigHome));
+    expect(resolvedConfigDir).not.toBe(
+      comparablePath(LLXPRT_PLATFORM_PATHS.config),
+    );
+  });
+
   it.skipIf(process.platform === 'win32')(
     'captures and unsets the token; passes it on fd 3 to the final CLI (PATH recorder)',
     () => {
@@ -313,10 +320,31 @@ describe('sandbox-entrypoint: trusted entrypoint security (AC2, AC3, F1, F7, F10
         tokenValid: boolean;
         envToken: string;
         fdMarker: string;
+        configDir: string;
       }>(sentinel);
       expect(rec.tokenValid).toBe(true);
       expect(rec.envToken).toBe('UNSET');
       expect(rec.fdMarker).toBe('3');
+      // The direct-child test above proves `runCmd` injects the isolated
+      // root; this proves it SURVIVES the real generated entrypoint chain
+      // (`env -u BASH_ENV` -> `bash --noprofile --norc` -> `exec` recorder).
+      // A future entrypoint change that scrubs the child environment would
+      // otherwise drop the final CLI onto the user's platform config dir
+      // while the direct-child probe stays green. The recorder resolves the
+      // root with the real `Storage.getGlobalConfigDir()` in its own
+      // environment, so an empty `configDir` (probe failed) cannot pass
+      // vacuously either.
+      const isolatedConfigHome = process.env.LLXPRT_CONFIG_HOME;
+      if (isolatedConfigHome === undefined) {
+        throw new Error(
+          'LLXPRT_CONFIG_HOME is unset: the storage isolation preload must run before this suite spawns children',
+        );
+      }
+      const resolvedConfigDir = comparablePath(rec.configDir);
+      expect(resolvedConfigDir).toBe(comparablePath(isolatedConfigHome));
+      expect(resolvedConfigDir).not.toBe(
+        comparablePath(LLXPRT_PLATFORM_PATHS.config),
+      );
     },
   );
 


### PR DESCRIPTION
## TLDR

`sandbox-entrypoint.test.ts` resolved your real global config directory and, in `afterAll`, walked it recursively and SHA-256 hashed every file, comparing byte-for-byte against a `beforeAll` snapshot. On a developer machine that is 4,324 files and about 56 MB read and hashed twice per run, over conversation history, profiles, keys and oauth material. It also failed on writes it did not cause, so any concurrent llxprt process saving a profile or refreshing a token broke an unrelated test run.

This deletes the snapshot and fixes the underlying reason it existed: spawned children were not storage-isolated. They are now.

Reviewers should look hardest at the spawn sites, since forcing env into a shared funnel is the one way this could weaken an adversarial test.

## Dive Deeper

**Why the snapshot existed.** Not an oversight. `packages/storage/src/config/assertTestStorageIsolation.ts` documents the cause: under Bun, `spawnSync` with an inherited environment snapshots the process's ORIGINAL environment and does not carry `process.env` mutations made after startup. `isolateStorageRoots()` runs as a bunfig preload and assigns `LLXPRT_CONFIG_HOME` and the other three roots after the process starts, so children never received them and resolved the real config dir. Since this suite exists to exercise the REAL generated entrypoint, it spawns real processes, and the whole-directory hash was policing them from outside.

Verified rather than assumed: a probe preload alongside the existing one shows the parent correctly isolated at `/var/folders/.../llxprt-test-storage-*/config`, while a child spawned with inherited env resolves `/Users/.../Library/Preferences/llxprt-code`.

**The fix.** `withIsolatedStorageRoots` builds the child environment from `process.env`, then the caller's env, then force-applies every `STORAGE_ENV_KEYS` value from the parent. It is applied in `runCmd`, which an AST search confirms is the suite's only `spawnSync`; `runBash` delegates to it. The key list comes from the storage package rather than being retyped, so a future fifth root cannot silently escape, and a missing root throws instead of quietly falling back to the real directory.

Storage roots deliberately win over caller input: the suite invariant is that every spawned path is isolated, and no call site supplies one of those four keys.

**What replaces the tripwire.** Two assertions that prove isolation forward instead of detecting damage after the fact:

1. A direct child spawned through `runCmd` resolves the isolated root.
2. The existing happy-path recorder test now also asserts it, riding the real chain: `env -u BASH_ENV` to `bash --noprofile --norc` to `exec` of the PATH-discoverable recorder. The fixture recorder reports the root that `Storage.getGlobalConfigDir()` resolves in its own post-entrypoint environment, so this covers a future entrypoint change that scrubbed the child environment.

Both assert equality with the isolated root and, separately, inequality with `LLXPRT_PLATFORM_PATHS.config`, so neither can pass vacuously. Path comparison normalizes through `realpath` for the macOS `/var` versus `/private/var` symlink.

**Kept.** The narrow `$HOME` guard filtering `.llxprt-code-cap-` entries from #3440. It is cheap, targeted, and attributable to the code under test.

**Known and unchanged.** The generated entrypoint intentionally repins `LLXPRT_DATA_HOME`, `LLXPRT_CACHE_HOME` and `LLXPRT_LOG_HOME` to `$HOME`-relative values via its XDG pin stanza, so processes after that stanza keep config isolation but not the parent's exact data/cache/log roots. That is deliberate production behavior, the deleted tripwire never guarded those roots, and no current fixture uses them.

## Reviewer Test Plan

```
cd packages/cli && bun test --timeout 30000 src/utils/sandbox-entrypoint.test.ts
```

Note the explicit timeout: the repo runner applies 30s per test, while a bare `bun test` uses bun's 5s default.

To see the assertions bite, break isolation for the entrypoint chain by wrapping that one spawn as `['env', '-u', 'LLXPRT_CONFIG_HOME', '-u', 'LLXPRT_TEST_STORAGE_ISOLATED', ...cmd]`. Passing an override through `runCmd` will not work, because the funnel re-injects the roots, which is the point. The failure names the real fallback directory:

```
Expected: "/private/var/folders/.../llxprt-test-storage-gVEfem/config"
Received: "/Users/acoliver/Library/Preferences/llxprt-code"
```

To confirm the old behavior is gone, grep the file for `createHash`, `snapshotDirectory`, `resolveRealConfigDir`, `realConfigSnapshot`. All should be absent, and nothing should reference the real config dir.

The adversarial coverage is the part worth reading rather than running: check that `BASH_ENV` and the project `sandbox.bashrc` attacks still supply their own hostile environment. Only the four storage keys are forced, so the hostile `BASH_ENV` still reaches the child and is still stripped by the production `env -u BASH_ENV`, not by the test helper.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: full `npm run test` exits 0, plus lint, typecheck, format, build and the `stepfun-37` startup smoke. The sandbox suite reports 19 pass / 0 fail. The full suite passed while other llxprt instances were running on the same machine, which previously produced the false failure this PR removes.

## Linked issues / bugs

Fixes #3519

Preserves the guard added by #3460 (Fixes #3440), whose commit message noted that tests were themselves running the capability producer against the real home.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation that spawned processes use isolated configuration storage instead of the user’s real configuration directory.
  * Added coverage for configuration-directory resolution in both direct child processes and PATH-based execution scenarios.
  * Improved path comparisons on macOS to account for system symlink normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->