### PR TITLE
feat(providers): add Claude Fable 5.1 (claude-fable-5-1) support (Fixes #3531)

### DIFF
--- a/docs/providers/models-and-limits.md
+++ b/docs/providers/models-and-limits.md
@@ -127,14 +127,15 @@ system prompt, and project memory files.
 ### Anthropic API key (`anthropic` alias)
 
 Configured context-limit for current-generation models (`claude-opus-5`,
-`claude-opus-4-8`, `claude-fable-5`, `claude-sonnet-4-6`, `claude-sonnet-5`):
-**1,000,000 tokens**.
+`claude-opus-4-8`, `claude-fable-5-1`, `claude-fable-5`, `claude-sonnet-4-6`,
+`claude-sonnet-5`): **1,000,000 tokens**.
 
 Max output tokens configured: **128,000**.
 
 Reasoning is enabled by default for `claude-(opus|sonnet|haiku|fable)` models,
 with `reasoning.effort` set to **`high`** only for `claude-opus-5`,
-`claude-opus-4-8`, `claude-fable-5`, `claude-sonnet-4-6`, and `claude-sonnet-5`.
+`claude-opus-4-8`, `claude-fable-5-1`, `claude-fable-5`, `claude-sonnet-4-6`,
+and `claude-sonnet-5`.
 Other matching models (for example, `claude-haiku-4-5`) get reasoning enabled
 without a default effort. Temperature, `top_p`, and `top_k` are disallowed for
 all `claude-(opus|sonnet|haiku|fable)` models (reasoning models manage sampling
@@ -180,9 +181,9 @@ Recommended settings:
 ### Claude Code OAuth (`claudecode` alias)
 
 Same context and output limits as the `anthropic` alias for current-generation
-models. Available static models include: `claude-opus-5`, `claude-fable-5`,
-`claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-5`,
-`claude-sonnet-4-6`, and earlier versions.
+models. Available static models include: `claude-opus-5`, `claude-fable-5-1`,
+`claude-fable-5`, `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`,
+`claude-sonnet-5`, `claude-sonnet-4-6`, and earlier versions.
 
 See [Provider Setup Quick Reference](./quick-reference.md#subscription-and-oauth-providers)
 for OAuth setup instructions.

--- a/packages/agents/src/api/__tests__/registerProviders-oauth.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/registerProviders-oauth.behavior.test.ts
@@ -136,7 +136,7 @@ describe('registerProvidersOntoManager OAuth wiring (Issue #2410)', () => {
     return provider;
   }
 
-  it('registers the Claude Code alias with its subscription model catalog', async () => {
+  it('registers the Claude Code alias with its subscription model catalog @issue:3531', async () => {
     writeSettings({ oauthEnabledProviders: { claudecode: true } });
 
     const claudecode = await registerAndGet('claudecode');
@@ -144,9 +144,10 @@ describe('registerProvidersOntoManager OAuth wiring (Issue #2410)', () => {
     const ids = models.map((m) => m.id);
 
     expect(ids).toContain(OAUTH_ONLY_MODEL_ID);
+    expect(ids).toContain('claude-fable-5-1');
   });
 
-  it('keeps the Anthropic API-key alias separate from subscription models', async () => {
+  it('keeps the Anthropic API-key alias separate from subscription models @issue:3531', async () => {
     writeSettings({ oauthEnabledProviders: { claudecode: true } });
 
     const anthropic = await registerAndGet('anthropic');
@@ -154,5 +155,6 @@ describe('registerProvidersOntoManager OAuth wiring (Issue #2410)', () => {
     const ids = models.map((m) => m.id);
 
     expect(ids).not.toContain(OAUTH_ONLY_MODEL_ID);
+    expect(ids).not.toContain('claude-fable-5-1');
   });
 });

--- a/packages/core/src/core/legacy-model-limits.expected.txt
+++ b/packages/core/src/core/legacy-model-limits.expected.txt
@@ -29,6 +29,8 @@
     "claude-sonnet-5-latest": 200000,
     "claude-fable-5": 200000,
     "claude-fable-5-latest": 200000,
+    "claude-fable-5-1": 200000,
+    "claude-fable-5-1-latest": 200000,
     "claude-3-7-opus-20250115": 300000,
     "claude-3-7-sonnet-20250115": 300000,
     "claude-3-opus-20240229": 200000,

--- a/packages/core/src/core/model-limits.json
+++ b/packages/core/src/core/model-limits.json
@@ -29,6 +29,8 @@
     "claude-sonnet-5-latest": 200000,
     "claude-fable-5": 200000,
     "claude-fable-5-latest": 200000,
+    "claude-fable-5-1": 200000,
+    "claude-fable-5-1-latest": 200000,
     "claude-3-7-opus-20250115": 300000,
     "claude-3-7-sonnet-20250115": 300000,
     "claude-3-opus-20240229": 200000,

--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -156,6 +156,15 @@ describe('tokenLimit', () => {
       expect(tokenLimit('claude-fable-5-20260701')).toBe(200_000);
     });
 
+    // Claude Fable 5.1 keeps the same subscription-tier 200K default.
+    it('should return 200K (auth default) limit for claude-fable-5-1 @issue:3531', () => {
+      expect(tokenLimit('claude-fable-5-1')).toBe(200_000);
+    });
+
+    it('should return 200K limit for the claude-fable-5-1-latest alias @issue:3531', () => {
+      expect(tokenLimit('claude-fable-5-1-latest')).toBe(200_000);
+    });
+
     it('honors a user-supplied context limit override (e.g. /set or profile)', () => {
       expect(tokenLimit('claude-opus-4-8', 1_000_000)).toBe(1_000_000);
     });

--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -171,6 +171,23 @@ describe('tokenLimit', () => {
       expect(catalogData.exactLimits['claude-fable-5-1-latest']).toBe(200_000);
     });
 
+    it('should return 200K limit for a claude-fable-5-1 dated snapshot @issue:3531', () => {
+      expect(tokenLimit('claude-fable-5-1-20260815')).toBe(200_000);
+    });
+
+    it('resolves a dated claude-fable-5-1 snapshot through an ordered rule @issue:3531', () => {
+      // Returns undefined rather than defaultLimit when no rule matches, so
+      // this fails if the claude-fable-5 substring rule is dropped from the
+      // catalog even while the 200_000 default masks it in tokenLimit().
+      expect(
+        resolveOrderedRuleFromCatalog(
+          catalogData,
+          'claude-fable-5-1-20260815',
+          '',
+        ),
+      ).toBe(200_000);
+    });
+
     it('honors a user-supplied context limit override (e.g. /set or profile)', () => {
       expect(tokenLimit('claude-opus-4-8', 1_000_000)).toBe(1_000_000);
     });

--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -159,10 +159,16 @@ describe('tokenLimit', () => {
     // Claude Fable 5.1 keeps the same subscription-tier 200K default.
     it('should return 200K (auth default) limit for claude-fable-5-1 @issue:3531', () => {
       expect(tokenLimit('claude-fable-5-1')).toBe(200_000);
+      // Pins the catalog entry itself, since tokenLimit() above would also
+      // pass via the 200_000 defaultLimit fallthrough if the entry were
+      // dropped.
+      expect(catalogData.exactLimits['claude-fable-5-1']).toBe(200_000);
     });
 
     it('should return 200K limit for the claude-fable-5-1-latest alias @issue:3531', () => {
       expect(tokenLimit('claude-fable-5-1-latest')).toBe(200_000);
+      // Pins the catalog entry itself, per the claude-opus-5-latest pattern.
+      expect(catalogData.exactLimits['claude-fable-5-1-latest']).toBe(200_000);
     });
 
     it('honors a user-supplied context limit override (e.g. /set or profile)', () => {

--- a/packages/providers/src/anthropic/AnthropicApiExecution.ts
+++ b/packages/providers/src/anthropic/AnthropicApiExecution.ts
@@ -74,7 +74,9 @@ export function buildAnthropicCustomHeaders(params: {
     customHeaders = {
       ...customHeaders,
       'anthropic-beta': betaWithThinking,
-      'User-Agent': 'claude-cli/2.1.2 (external, cli)',
+      // Fable 5.1 and other subscription models reject clients below
+      // claude-cli 2.1.255; 2.1.257 is the released version that includes it.
+      'User-Agent': 'claude-cli/2.1.257 (external, cli)',
     };
   }
 

--- a/packages/providers/src/anthropic/AnthropicModelData.test.ts
+++ b/packages/providers/src/anthropic/AnthropicModelData.test.ts
@@ -266,6 +266,23 @@ describe('AnthropicModelData Claude Fable 5 @issue:2328', () => {
     it('is case-insensitive', () => {
       expect(isFable5('Claude-Fable-5')).toBe(true);
     });
+
+    it('returns true for the claude-fable-5-1 point release and its variants @issue:3531', () => {
+      expect(isFable5('claude-fable-5-1')).toBe(true);
+      expect(isFable5('claude-fable-5-1-latest')).toBe(true);
+      expect(isFable5('claude-fable-5-1-20260901')).toBe(true);
+    });
+
+    it('returns false for fable-5-1 near-misses @issue:3531', () => {
+      expect(isFable5('claude-fable-5-1-mini')).toBe(false);
+      expect(isFable5('claude-fable-5-11')).toBe(false);
+      expect(isFable5('claude-fable-50')).toBe(false);
+      expect(isFable5('claude-fable-51')).toBe(false);
+    });
+
+    it('is case-insensitive for fable-5-1 ids @issue:3531', () => {
+      expect(isFable5('CLAUDE-FABLE-5-1')).toBe(true);
+    });
   });
 
   describe('supportsAdaptiveThinking', () => {
@@ -277,6 +294,11 @@ describe('AnthropicModelData Claude Fable 5 @issue:2328', () => {
     it('returns false for models without adaptive thinking', () => {
       expect(supportsAdaptiveThinking('claude-opus-4-5')).toBe(false);
       expect(supportsAdaptiveThinking('claude-haiku-4-5')).toBe(false);
+    });
+
+    it('returns true for claude-fable-5-1 @issue:3531', () => {
+      expect(supportsAdaptiveThinking('claude-fable-5-1')).toBe(true);
+      expect(supportsAdaptiveThinking('claude-fable-5-1-20260901')).toBe(true);
     });
   });
 
@@ -290,6 +312,12 @@ describe('AnthropicModelData Claude Fable 5 @issue:2328', () => {
     it('is case-insensitive (routes through isFable5)', () => {
       expect(getMaxTokensForModel('Claude-Fable-5')).toBe(40000);
     });
+
+    it('returns 40000 for claude-fable-5-1 variants @issue:3531', () => {
+      expect(getMaxTokensForModel('claude-fable-5-1')).toBe(40000);
+      expect(getMaxTokensForModel('claude-fable-5-1-latest')).toBe(40000);
+      expect(getMaxTokensForModel('claude-fable-5-1-20260901')).toBe(40000);
+    });
   });
 
   describe('getContextWindowForModel', () => {
@@ -301,6 +329,14 @@ describe('AnthropicModelData Claude Fable 5 @issue:2328', () => {
 
     it('is case-insensitive (routes through isFable5)', () => {
       expect(getContextWindowForModel('Claude-Fable-5')).toBe(200000);
+    });
+
+    it('returns 200000 (auth default) for claude-fable-5-1 variants @issue:3531', () => {
+      expect(getContextWindowForModel('claude-fable-5-1')).toBe(200000);
+      expect(getContextWindowForModel('claude-fable-5-1-latest')).toBe(200000);
+      expect(getContextWindowForModel('claude-fable-5-1-20260901')).toBe(
+        200000,
+      );
     });
   });
 });

--- a/packages/providers/src/anthropic/AnthropicModelData.ts
+++ b/packages/providers/src/anthropic/AnthropicModelData.ts
@@ -189,11 +189,13 @@ export function isSonnet5(modelId: string): boolean {
 
 /**
  * Anchored Fable 5 identifier: matches the bare `claude-fable-5` alias, the
- * `claude-fable-5-latest` pointer, and dated snapshots
- * (`claude-fable-5-YYYYMMDD`), but NOT a future `claude-fable-50`. An anchored
- * regex is used instead of a substring test so version boundaries are exact.
+ * `claude-fable-5-latest` pointer, dated snapshots
+ * (`claude-fable-5-YYYYMMDD`), and the `claude-fable-5-1` point release with
+ * its own `-latest`/dated variants, but NOT a future `claude-fable-50`. An
+ * anchored regex is used instead of a substring test so version boundaries
+ * are exact.
  */
-const FABLE_5_PATTERN = /^claude-fable-5(-latest|-\d{8})?$/i;
+const FABLE_5_PATTERN = /^claude-fable-5(-1)?(-latest|-\d{8})?$/i;
 
 /**
  * Whether the model is Claude Fable 5. Adaptive thinking is always on and

--- a/packages/providers/src/anthropic/AnthropicProvider.issue3255.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.issue3255.test.ts
@@ -721,6 +721,39 @@ describe('Anthropic reasoning wire translation (issue #3255)', () => {
     );
   });
 
+  it('rejects a direct Fable 5.1 budget before transport instead of ignoring it @issue:3531', async () => {
+    const request = prepare({
+      model: 'claude-fable-5-1',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.budgetTokens': 6000,
+        'reasoning.effortWireFormat': 'anthropic',
+        'reasoning.enabledWireFormat': 'thinking',
+        'reasoning.enabledMap': { true: 'adaptive' },
+      },
+    });
+
+    await expect(request).rejects.toThrow(
+      "Model 'claude-fable-5-1' is adaptive-only: reasoning.budgetTokens cannot select budgeted thinking. Remove reasoning.budgetTokens to use adaptive thinking.",
+    );
+  });
+
+  it('rejects an anthropic-budget selection for Fable 5.1 before transport @issue:3531', async () => {
+    const request = prepare({
+      model: 'claude-fable-5-1',
+      modelBehavior: {
+        'reasoning.enabled': true,
+        'reasoning.effort': 'high',
+        'reasoning.effortWireFormat': 'anthropic-budget',
+        'reasoning.effortMap': { high: 8192 },
+      },
+    });
+
+    await expect(request).rejects.toThrow(
+      "Model 'claude-fable-5-1' is adaptive-only: the anthropic-budget effort format cannot emit budgeted thinking. Use the 'anthropic' effort format or remove reasoning.effortWireFormat=anthropic-budget.",
+    );
+  });
+
   it('reports only own reasoning properties and ignores inherited ones', () => {
     const body: Record<string, unknown> = Object.create({
       reasoning_effort: 'inherited',

--- a/packages/providers/src/anthropic/AnthropicProvider.oauth.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.oauth.test.ts
@@ -474,7 +474,7 @@ describe('AnthropicProvider', () => {
       expect(options).toBeDefined();
       expect(options?.headers).toBeDefined();
       expect(options?.headers?.['User-Agent']).toBe(
-        'claude-cli/2.1.2 (external, cli)',
+        'claude-cli/2.1.257 (external, cli)',
       );
     });
 

--- a/packages/providers/src/composition/aliases/anthropic.config
+++ b/packages/providers/src/composition/aliases/anthropic.config
@@ -21,7 +21,7 @@
       "unallowedParameters": ["temperature", "top_p", "top_k"]
     },
     {
-      "pattern": "claude-(opus-5|opus-4-8|fable-5|sonnet-4-6|sonnet-5)",
+      "pattern": "claude-(opus-5|opus-4-8|fable-5-1|fable-5|sonnet-4-6|sonnet-5)",
       "ephemeralSettings": {
         "reasoning.effort": "high",
         "context-limit": 1000000,

--- a/packages/providers/src/composition/aliases/claudecode.config
+++ b/packages/providers/src/composition/aliases/claudecode.config
@@ -19,7 +19,7 @@
       }
     },
     {
-      "pattern": "claude-(opus-5|opus-4-8|fable-5|sonnet-4-6|sonnet-5)",
+      "pattern": "claude-(opus-5|opus-4-8|fable-5-1|fable-5|sonnet-4-6|sonnet-5)",
       "ephemeralSettings": {
         "reasoning.effort": "high",
         "context-limit": 1000000,
@@ -59,6 +59,12 @@
     {
       "id": "claude-opus-5",
       "name": "Claude Opus 5",
+      "contextWindow": 1000000,
+      "maxOutputTokens": 128000
+    },
+    {
+      "id": "claude-fable-5-1",
+      "name": "Claude Fable 5.1",
       "contextWindow": 1000000,
       "maxOutputTokens": 128000
     },

--- a/packages/providers/src/composition/providerAliases.claudecode.factory.test.ts
+++ b/packages/providers/src/composition/providerAliases.claudecode.factory.test.ts
@@ -57,6 +57,7 @@ import type { ProviderAliasEntry } from './providerAliases.js';
 // drift (retired models, geometry changes) is caught here.
 const EXPECTED_CLAUDECODE_CATALOG = [
   { id: 'claude-opus-5', contextWindow: 1000000, maxOutputTokens: 128000 },
+  { id: 'claude-fable-5-1', contextWindow: 1000000, maxOutputTokens: 128000 },
   { id: 'claude-fable-5', contextWindow: 1000000, maxOutputTokens: 128000 },
   { id: 'claude-opus-4-8', contextWindow: 1000000, maxOutputTokens: 128000 },
   { id: 'claude-opus-4-7', contextWindow: 1000000, maxOutputTokens: 128000 },
@@ -175,6 +176,23 @@ describe('claudecode alias static models (@issue:2274)', () => {
 
     expect(ids).toContain('claude-sonnet-4-20250514');
     expect(ids).toContain('claude-fable-5');
+  });
+
+  it('lists claude-fable-5-1 grouped directly above claude-fable-5 (A3) @issue:3531', async () => {
+    const entry = findAliasEntry('claudecode');
+    const provider = createAnthropicAliasProvider(
+      entry,
+      STUB_OAUTH_MANAGER,
+      true,
+    );
+
+    const models = await provider!.getModels();
+    const ids = models.map((m) => m.id);
+
+    expect(ids).toContain('claude-fable-5-1');
+    expect(ids.indexOf('claude-fable-5-1')).toBeLessThan(
+      ids.indexOf('claude-fable-5'),
+    );
   });
 
   it('does NOT include retired claude-opus-4-1 or claude-opus-4-1-20250805 (A3)', async () => {

--- a/packages/providers/src/composition/providerAliases.modelDefaults.test.ts
+++ b/packages/providers/src/composition/providerAliases.modelDefaults.test.ts
@@ -642,6 +642,52 @@ describe('anthropic.config modelDefaults (Phase 02)', () => {
     expect(defaults['context-limit']).toBe(1000000);
   });
 
+  it('claude-fable-5-1 matches the broad Claude rule (reasoning defaults) @issue:3531', () => {
+    const entry = getAnthropicEntry();
+    const defaults = computeMatchedDefaults(
+      'claude-fable-5-1',
+      entry.config.modelDefaults!,
+    );
+    expect(defaults['reasoning.enabled']).toBe(true);
+    expect(defaults['reasoning.adaptiveThinking']).toBe(true);
+    expect(defaults['reasoning.includeInContext']).toBe(true);
+  });
+
+  it('rules merge in order — claude-fable-5-1 gets broad + 1M-context settings @issue:3531', () => {
+    const entry = getAnthropicEntry();
+    const defaults = computeMatchedDefaults(
+      'claude-fable-5-1',
+      entry.config.modelDefaults!,
+    );
+    // From the broad "claude-(opus|sonnet|haiku|fable)" rule
+    expect(defaults['reasoning.enabled']).toBe(true);
+    expect(defaults['reasoning.adaptiveThinking']).toBe(true);
+    expect(defaults['reasoning.includeInContext']).toBe(true);
+    // From the 1M-context rule, which names fable-5-1 explicitly (merged on
+    // top)
+    expect(defaults['reasoning.effort']).toBe('high');
+    expect(defaults['context-limit']).toBe(1000000);
+    expect(defaults['maxOutputTokens']).toBe(128000);
+  });
+
+  it('claudecode rules merge in order — claude-fable-5-1 gets broad + 1M-context settings @issue:3531', () => {
+    const entry = loadProviderAliasEntries().find(
+      (candidate) =>
+        candidate.alias === 'claudecode' && candidate.source === 'builtin',
+    );
+    expect(entry).toBeDefined();
+    const defaults = computeMatchedDefaults(
+      'claude-fable-5-1',
+      entry?.config.modelDefaults ?? [],
+    );
+    expect(defaults['reasoning.enabled']).toBe(true);
+    expect(defaults['reasoning.adaptiveThinking']).toBe(true);
+    expect(defaults['reasoning.includeInContext']).toBe(true);
+    expect(defaults['reasoning.effort']).toBe('high');
+    expect(defaults['context-limit']).toBe(1000000);
+    expect(defaults['maxOutputTokens']).toBe(128000);
+  });
+
   it('anthropic applies image-resize limits to Opus and Sonnet families only', () => {
     const entry = loadProviderAliasEntries().find(
       (candidate) =>

--- a/project-plans/issue3531/PLAN.md
+++ b/project-plans/issue3531/PLAN.md
@@ -1,0 +1,150 @@
+# Issue #3531: Add Claude Fable 5.1 (claude-fable-5-1) to provider configs and model lists
+
+Branch: `issue3531`. Researched from Anthropic platform docs (Fable 5.1 overview
+and What's new pages, published with the September 1, 2026 release).
+
+## Researched specs (evidence)
+
+| Spec | Value | Source |
+| --- | --- | --- |
+| Model ID | `claude-fable-5-1` (Bedrock: `anthropic.claude-fable-5-1`); no date suffix | Model IDs table |
+| Context window | 1M tokens, default and maximum, standard pricing across the window | Capabilities table |
+| Max output | 128K tokens | Capabilities table |
+| Thinking | Adaptive, always on. `budget_tokens` and `disabled` both 400. Unchanged from Fable 5 | "Unchanged from Claude Fable 5" |
+| Effort | Default `high`; accepts low/medium/high/xhigh/max | Effort docs |
+| Sampling | Non-default `temperature`/`top_p`/`top_k` return 400 | "Unchanged from Claude Fable 5" |
+| Forced tool use | `tool_choice` type `any`/`tool` returns 400. New vs Fable 5 | Breaking changes |
+| Prefill | Prefilling assistant response returns 400 | "Unchanged from Claude Fable 5" |
+| Caching | 1h cache writes $20/MTok supported; reads $0.25/MTok | Pricing table |
+| Tokenizer | Identical to Fable 5 (Opus 4.7-era tokenizer) | What's new |
+| Availability | Claude API all customers; client gate 2.1.251+ (server-enforced, live 400), staff-confirmed minimum 2.1.255, changelog adds in 2.1.257 | Issue comment (live error), anthropics/claude-code#91331, changelog |
+
+Two repo facts make most of this a parity exercise:
+
+1. `modelDefaults` rule matching in `providerAliases.ts` (line 63-64) is an
+   unanchored case-insensitive `RegExp.test`, so the existing alternation
+   `claude-(opus-5|opus-4-8|fable-5|sonnet-4-6|sonnet-5)` already matches
+   `claude-fable-5-1` as a prefix. The 1M `context-limit` and 128K
+   `maxOutputTokens` ephemeral defaults apply without pattern edits.
+2. The token estimator already resolves `claude-fable-5-1` through the #3485
+   point-release path to the fable-5 family calibration
+   (`claudePromptEstimator.test.ts` asserts `method: 'calibrated'` for
+   `claude-fable-5-1`). No tokenizer change is needed.
+
+The real gaps: the OAuth static catalog has no `claude-fable-5-1` entry, and
+`AnthropicModelData.ts` identity functions miss it, which breaks adaptive
+thinking classification, budget rejection, and subscription-tier geometry
+defaults for the new ID.
+
+## Behavior specification
+
+### REQ-1: OAuth static catalog includes Fable 5.1
+
+- GIVEN: the `claudecode` alias config
+- WHEN: `getModels()` is served from `staticModels`
+- THEN: `claude-fable-5-1` appears directly above `claude-fable-5` with
+  `contextWindow: 1000000` and `maxOutputTokens: 128000`
+
+### REQ-2: modelDefaults explicitly name fable-5-1
+
+- GIVEN: the `claudecode` and `anthropic` alias configs
+- WHEN: the 1M-context rule pattern is read
+- THEN: the alternation lists `fable-5-1` explicitly (matching still works by
+  prefix, but the config documents the model it intends)
+- NOTE: the explicit `fable-5-1` spelling is intentionally unpinned — no
+  removal-sensitive guard asserts its presence, because rule matching is
+  prefix-based and behavior is identical without it (readability-only edit,
+  review finding 3, accepted as-is)
+
+### REQ-3: AnthropicModelData recognizes fable-5-1
+
+- GIVEN: `claude-fable-5-1`, `claude-fable-5-1-latest`,
+  `claude-fable-5-1-YYYYMMDD` (real date), case-insensitive
+- WHEN: `isFable5` / `supportsAdaptiveThinking` / `getMaxTokensForModel` /
+  `getContextWindowForModel` are called
+- THEN: they behave exactly as for `claude-fable-5` (adaptive thinking true,
+  40000 max output default, 200000 context default), and near-misses
+  (`claude-fable-5-1-mini`, `claude-fable-50`, `claude-fable-51`) still miss
+
+### REQ-4: adaptive-only enforcement covers fable-5-1
+
+- GIVEN: a request pinned to `claude-fable-5-1` carrying
+  `reasoning.budgetTokens` (or `effortWireFormat: anthropic-budget`)
+- WHEN: the request is built
+- THEN: it is rejected before transport with the same adaptive-only error text
+  shape used for `claude-fable-5` (issue #3255 behavior)
+
+### REQ-5: core model limits list fable-5-1 explicitly
+
+- GIVEN: `model-limits.json`
+- WHEN: the exact map is read
+- THEN: `claude-fable-5-1` and `claude-fable-5-1-latest` are present at 200000,
+  matching the fable-5 entries (the substring rule already catches them; the
+  explicit entries mirror how fable-5 itself is listed), and the legacy limits
+  expected file agrees with the parity test
+
+### REQ-6: docs mention fable-5-1
+
+- GIVEN: `docs/providers/models-and-limits.md`
+- WHEN: the 1M-context model lists are read
+- THEN: `claude-fable-5-1` appears alongside the other 1M models
+
+### REQ-7: OAuth User-Agent meets the server-side Fable 5.1 client gate
+
+- GIVEN: an OAuth (`claudecode`) request to the Anthropic API
+- WHEN: headers are built by `buildAnthropicCustomHeaders`
+- THEN: `User-Agent` is `claude-cli/2.1.257 (external, cli)` (was 2.1.2)
+- Evidence ladder: a live request pinned to `claude-fable-5-1` returned 400
+  `claude_code_version_too_old` ("version 2.1.251 or newer is required", issue
+  comment, req_011CefZkUxiwi9ZmyKCHTJFq); Anthropic staff in
+  anthropics/claude-code#91331 confirmed 2.1.255 is the minimum CLI version
+  for Fable 5.1; the Claude Code changelog added Fable 5.1 in 2.1.257. The
+  User-Agent is the only version-bearing header in the request path. 2.1.257
+  is above all three stated minimums.
+
+## Out of scope (documented follow-ups, not this PR)
+
+- Promoting `claude-fable-5-1` to a sanctioned estimator identity (drops the
+  warn-once from the #3485 point-release path; estimation is already correct).
+- Fable 5.1 beta API surface: per-message effort, turn-scoped system messages,
+  `thinking.display: "updates"`.
+- `tool_choice` forced-tool-use restriction: the Anthropic provider never sends
+  `tool_choice` (verified by search), so no code change is required.
+
+## Phases
+
+Single-phase change (config + identity + tests + docs); no interface changes.
+
+P01: Update configs, AnthropicModelData pattern, model-limits.json, docs, and
+all affected tests (factory catalog, modelDefaults, AnthropicModelData, oauth
+sentinel, core token limits parity).
+
+## Verification
+
+Full cycle per the issue workflow:
+
+```bash
+npm run test
+npm run lint
+npm run typecheck
+npm run format
+npm run build
+bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
+```
+
+All green on the pre-remediation tree and re-run green after remediation
+(test/lint/typecheck/format/build EXIT 0; logs in tmp/verify3531/ and
+tmp/verify3531-remediation/, gitignored).
+
+## Review record
+
+- Round 1 (deepthinker): FAIL. HIGH — OAuth UA `claude-cli/2.1.2` below the
+  Fable 5.1 client gate (cited the live 400 on the issue). Remediated: bumped
+  to `claude-cli/2.1.257` in `AnthropicApiExecution.ts` + pinned test
+  (REQ-7). LOW — oauth sentinel test did not assert fable-5-1 absent from the
+  Anthropic API-key catalog. Remediated: both assertions added, tagged
+  @issue:3531. LOW — no removal-sensitive guard for the explicit fable-5-1
+  alternation spelling. Accepted as-is (REQ-2 NOTE: readability-only edit;
+  prefix matching makes behavior identical without it).
+- Round 2: verification-only re-run of the full cycle on the remediated tree
+  (green); no new findings sought, per the two-cycle cap.


### PR DESCRIPTION
## TLDR

Adds Claude Fable 5.1 (`claude-fable-5-1`, released 2026-09-01) at full parity with the existing Fable 5 configuration: OAuth static catalog entry, explicit `modelDefaults` alternation, identity matching in `AnthropicModelData`, core exact model limits, and docs. Fable 5.1 matches Fable 5 on every axis this repo configures (1M context, 128K output, adaptive-only thinking, effort default `high`, sampling params rejected), so most of the change is extending existing patterns to the new ID.

One behavioral fix rides along: the OAuth `User-Agent` moves from `claude-cli/2.1.2` to `claude-cli/2.1.257`. Anthropic rejects `claude-fable-5-1` requests from older clients with 400 `claude_code_version_too_old` — see the live error on the issue. Without the bump, the catalog would advertise a model the spoofed client cannot use.

## Dive Deeper

- **Catalog and defaults**: `claudecode.config` staticModels gains `claude-fable-5-1` (contextWindow 1000000, maxOutputTokens 128000) above `claude-fable-5`. Rule matching in `providerAliases.ts` is unanchored prefix matching, so the 1M-context rule already applied; the alternations in both configs now list `fable-5-1` explicitly for readability (intentionally unpinned by a removal guard — behavior is identical without it).
- **Identity**: `FABLE_5_PATTERN` becomes `/^claude-fable-5(-1)?(-latest|-\d{8})?$/i`, routing `claude-fable-5-1`, its `-latest` pointer, and dated snapshots through `supportsAdaptiveThinking`, the adaptive-only budget rejection (#3255 behavior), and the subscription-tier defaults (40K max output, 200K context — the 1M window is the advertised ceiling, applied via the config's `context-limit`). Near-misses (`claude-fable-5-1-mini`, `claude-fable-5-50`, `claude-fable-5-51`) stay excluded.
- **Estimator**: no change needed — the #3485 point-release path already resolves `claude-fable-5-1` to the fable-5 family calibration (tokenizer is identical per Anthropic).
- **Client gate evidence**: server error demands 2.1.251+; Anthropic staff in the Claude Code repo (issue 91331 on anthropics/claude-code) confirmed 2.1.255 is the minimum; the changelog added the model in 2.1.257. 2.1.257 satisfies all three. The `User-Agent` is the only version-bearing header in the OAuth request path.
- **Out of scope** (recorded on the issue and in `project-plans/issue3531/PLAN.md`): promoting fable-5-1 to a sanctioned estimator identity; Fable 5.1 beta API surface (per-message effort, turn-scoped system messages, `thinking.display: "updates"`); forced-tool-use restriction (this provider never sends `tool_choice`).

## Reviewer Test Plan

- `bun test packages/providers/src/anthropic/AnthropicModelData.test.ts packages/providers/src/anthropic/AnthropicProvider.issue3255.test.ts packages/providers/src/composition/providerAliases.claudecode.factory.test.ts packages/providers/src/composition/providerAliases.modelDefaults.test.ts packages/core/src/core/tokenLimits.test.ts packages/agents/src/api/__tests__/registerProviders-oauth.behavior.test.ts`
- With Claude Code OAuth configured, run `/model claude-fable-5-1` and send one turn: expect a normal response (the UA bump is what unblocks this; before it, the API returns 400 `claude_code_version_too_old`).
- Confirm `/model` lists Claude Fable 5.1 under the `claudecode` provider.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Full local cycle on macOS: test (406 files), lint, typecheck, format, build, and the stepfun-37 smoke all green. Windows/Linux coverage via CI.

## Linked issues / bugs

Fixes #3531

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Claude Fable 5.1 model, including base, latest, dated, and case-insensitive identifiers.
  * Made Claude Fable 5.1 available through the Claude Code provider.
  * Applied high reasoning defaults, adaptive thinking, and provider-specific context and output limits.

* **Bug Fixes**
  * Prevented subscription-only Claude Fable models from being selected through the Anthropic API-key provider.

* **Documentation**
  * Updated model availability and limits documentation for Claude Fable 5.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->