### PR TITLE
fix(agents): retain and enforce the scope-local output emitter in non-interactive subagents (Fixes #3526)

### DIFF
--- a/packages/agents/src/core/StreamProcessor.ts
+++ b/packages/agents/src/core/StreamProcessor.ts
@@ -60,7 +60,10 @@ import {
   LOGICAL_REQUEST_ID_KEY,
   RAW_TOKEN_DELTA_SINK_KEY,
 } from '@vybestack/llxprt-code-providers';
-import { canonicalizeToolName } from './toolGovernance.js';
+import {
+  canonicalizeToolName,
+  SCOPE_LOCAL_EMIT_TOOL_NAME,
+} from './toolGovernance.js';
 import {
   buildRequestContentsResult,
   contentForTelemetryPreservingUsage,
@@ -604,7 +607,20 @@ export class StreamProcessor {
     const toolConfig = modifiedConfig?.toolConfig as unknown;
     const allowedFunctions = extractAllowedFunctionNames(toolConfig);
     if (allowedFunctions !== undefined) {
-      const allowedNames = new Set(allowedFunctions.map(canonicalizeToolName));
+      const emitterName = canonicalizeToolName(SCOPE_LOCAL_EMIT_TOOL_NAME);
+      const hasScopeLocalEmitter = toolsFromConfig.some(
+        (toolGroup) =>
+          toolGroup.functionDeclarations?.some(
+            (declaration) =>
+              canonicalizeToolName(declaration.name) === emitterName,
+          ) === true,
+      );
+      const effectiveAllowedFunctions = hasScopeLocalEmitter
+        ? Array.from(new Set([...allowedFunctions, SCOPE_LOCAL_EMIT_TOOL_NAME]))
+        : allowedFunctions;
+      const allowedNames = new Set(
+        effectiveAllowedFunctions.map(canonicalizeToolName),
+      );
       const filteredTools = toolsFromConfig
         .map((toolGroup) => ({
           ...toolGroup,
@@ -617,7 +633,10 @@ export class StreamProcessor {
             : [],
         }))
         .filter((g) => g.functionDeclarations.length > 0) as ToolGroupArray;
-      return { tools: filteredTools, allowedFunctionNames: allowedFunctions };
+      return {
+        tools: filteredTools,
+        allowedFunctionNames: effectiveAllowedFunctions,
+      };
     }
 
     return { tools: toolsFromConfig, allowedFunctionNames: undefined };

--- a/packages/agents/src/core/subagent.issue3526.test.ts
+++ b/packages/agents/src/core/subagent.issue3526.test.ts
@@ -1,0 +1,741 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { automock } from '@vybestack/llxprt-code-test-utils';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'bun:test';
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type {
+  ContentBlock,
+  IContent,
+} from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type {
+  RuntimeProvider as IProvider,
+  RuntimeToolDeclaration,
+} from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
+import type {
+  RuntimeGenerateChatOptions as GenerateChatOptions,
+  RuntimeProviderToolset,
+} from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProviderChat.js';
+import type {
+  AgentRuntimeContext,
+  AgentRuntimeProviderAdapter,
+  ToolRegistryView,
+} from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import {
+  ContextState,
+  SubagentTerminateMode,
+  type OutputConfig,
+} from '@vybestack/llxprt-code-core/core/subagentTypes.js';
+import { ToolErrorType } from '@vybestack/llxprt-code-tools/types/tool-error.js';
+import { SubAgentScope } from './subagent.js';
+import { executeToolCall } from './nonInteractiveToolExecutor.js';
+import {
+  createCompletedToolCallResponse,
+  createMockConfig,
+  createRuntimeOverrides,
+  createStatelessRuntimeBundle,
+  defaultModelConfig,
+  defaultRunConfig,
+} from './subagent-test-helpers.js';
+
+const realNonInteractiveToolExecutorModule = {
+  ...(await import('./nonInteractiveToolExecutor.js')),
+};
+void vi.mock('./nonInteractiveToolExecutor.js', () =>
+  automock(realNonInteractiveToolExecutorModule),
+);
+
+const { readTodos, TodoStoreMock } = (() => {
+  const readTodos = vi.fn(async () => []);
+  const TodoStoreMock = vi.fn(() => ({ readTodos }));
+  return { readTodos, TodoStoreMock };
+})();
+const toolsModule = { ...(await import('@vybestack/llxprt-code-tools')) };
+void vi.mock('@vybestack/llxprt-code-tools', () => ({
+  ...toolsModule,
+  LocalTodoStore: TodoStoreMock,
+}));
+
+const OUTPUT_CONFIG: OutputConfig = {
+  outputs: {
+    alpha: 'first value',
+    beta: 'second value',
+    gamma: 'third value',
+    delta: 'fourth value',
+  },
+};
+
+const EXPECTED_EMIT_SCHEMA = {
+  type: 'object',
+  properties: {
+    emit_variable_name: {
+      description: 'This is the name of the variable to be returned.',
+      type: 'string',
+    },
+    emit_variable_value: {
+      description: 'This is the _value_ to be returned for this variable.',
+      type: 'string',
+    },
+  },
+  required: ['emit_variable_name', 'emit_variable_value'],
+};
+
+type HookMode =
+  | { readonly enabled: false }
+  | {
+      readonly enabled: true;
+      readonly allowedFunctionNames?: readonly string[];
+    };
+
+interface RuntimeHarness {
+  readonly requests: GenerateChatOptions[];
+  readonly scope: SubAgentScope;
+}
+
+type CompletedToolCallFixture = Omit<
+  ReturnType<typeof createCompletedToolCallResponse>,
+  'status'
+> & {
+  readonly status: 'success' | 'error' | 'cancelled';
+};
+
+function mockCompletedToolCall(response: CompletedToolCallFixture): void {
+  const mockedExecutor = executeToolCall as Mock<
+    () => Promise<CompletedToolCallFixture>
+  >;
+  mockedExecutor.mockResolvedValueOnce(response);
+}
+
+function mockSuccessfulPause(callId: string, toolName = 'todo_pause'): void {
+  mockCompletedToolCall(
+    createCompletedToolCallResponse({
+      callId,
+      responseParts: [
+        {
+          type: 'tool_response',
+          callId,
+          toolName,
+          result: { message: 'Paused' },
+        },
+      ],
+    }),
+  );
+}
+
+function mockCancelledPause(callId: string): void {
+  const cancellationMessage = 'Tool call cancelled by user.';
+  mockCompletedToolCall({
+    ...createCompletedToolCallResponse({
+      callId,
+      responseParts: [
+        {
+          type: 'tool_response',
+          callId,
+          toolName: 'todo_pause',
+          result: { error: cancellationMessage },
+          error: cancellationMessage,
+        },
+      ],
+    }),
+    status: 'cancelled',
+  });
+}
+
+function toolCall(
+  name: string,
+  parameters: Readonly<Record<string, unknown>>,
+  id = name,
+): ContentBlock {
+  return { type: 'tool_call', id, name, parameters };
+}
+
+function emitCall(
+  name: keyof typeof OUTPUT_CONFIG.outputs,
+  value: string,
+): ContentBlock {
+  return toolCall(
+    'self_emitvalue',
+    { emit_variable_name: name, emit_variable_value: value },
+    `emit-${name}`,
+  );
+}
+
+function nativeEmissions(
+  entries: ReadonlyArray<readonly [keyof typeof OUTPUT_CONFIG.outputs, string]>,
+): IContent {
+  return {
+    speaker: 'ai',
+    blocks: entries.map(([name, value]) => emitCall(name, value)),
+  };
+}
+
+function hermesEmissions(
+  entries: ReadonlyArray<readonly [keyof typeof OUTPUT_CONFIG.outputs, string]>,
+): IContent {
+  const text = entries
+    .map(
+      ([name, value]) =>
+        `<tool_call>\n${JSON.stringify({ name: 'self_emitvalue', arguments: { emit_variable_name: name, emit_variable_value: value } })}\n</tool_call>`,
+    )
+    .join('\n');
+  return { speaker: 'ai', blocks: [{ type: 'text', text }] };
+}
+
+function stopped(text = 'Done.'): IContent {
+  return { speaker: 'ai', blocks: [{ type: 'text', text }] };
+}
+
+function declarationsFrom(
+  options: GenerateChatOptions,
+): RuntimeToolDeclaration[] {
+  if (options.tools === undefined) {
+    throw new Error('Expected provider request tool declarations.');
+  }
+  return options.tools.flatMap((group) => group.functionDeclarations);
+}
+
+function requestText(options: GenerateChatOptions): string {
+  return options.contents
+    .flatMap((content) => content.blocks)
+    .map((block) => {
+      if (block.type === 'text') return block.text;
+      if (block.type !== 'tool_response') return '';
+      return JSON.stringify(block.result);
+    })
+    .join('\n');
+}
+
+function findMissingOutputNudge(
+  requests: readonly GenerateChatOptions[],
+): GenerateChatOptions {
+  const request = requests.find((candidate) =>
+    requestText(candidate).includes('not emitted'),
+  );
+  if (request === undefined) {
+    throw new Error('Expected a missing-output nudge request.');
+  }
+  return request;
+}
+
+function createHookConfig(config: Config, mode: HookMode): Config {
+  const hookConfig = Object.create(config) as Config;
+  Object.defineProperties(hookConfig, {
+    getEnableHooks: { value: () => mode.enabled },
+    getHookSystem: {
+      value: () => {
+        if (!mode.enabled) return undefined;
+        return {
+          initialize: async () => undefined,
+          isInitialized: () => true,
+          fireBeforeToolSelectionEvent: async () => ({
+            applyToolConfigModifications: () =>
+              mode.allowedFunctionNames === undefined
+                ? { toolConfig: {} }
+                : {
+                    toolConfig: {
+                      allowedFunctionNames: [...mode.allowedFunctionNames],
+                    },
+                  },
+          }),
+          fireBeforeModelEvent: async () => undefined,
+          fireAfterModelEvent: async () => undefined,
+        };
+      },
+    },
+  });
+  return hookConfig;
+}
+
+async function createHarness(params: {
+  readonly responses: readonly IContent[];
+  readonly hookMode?: HookMode;
+  readonly toolConfig?: { readonly tools: readonly string[] };
+  readonly outputConfig?: OutputConfig | null;
+}): Promise<RuntimeHarness> {
+  const { config, toolRegistry } = await createMockConfig();
+  const requests: GenerateChatOptions[] = [];
+  let responseIndex = 0;
+  function generateChatCompletion(
+    options: GenerateChatOptions,
+  ): AsyncIterableIterator<IContent>;
+  function generateChatCompletion(
+    content: IContent[],
+    tools?: RuntimeProviderToolset,
+    signal?: AbortSignal,
+  ): AsyncIterableIterator<IContent>;
+  function generateChatCompletion(
+    input: GenerateChatOptions | IContent[],
+  ): AsyncIterableIterator<IContent> {
+    return (async function* () {
+      if (Array.isArray(input)) {
+        throw new Error('Expected request options from the runtime.');
+      }
+      requests.push(input);
+      const response = params.responses[responseIndex] ?? stopped();
+      responseIndex += 1;
+      yield response;
+    })();
+  }
+  const provider: IProvider = {
+    name: 'gemini',
+    getModels: async () => [],
+    getDefaultModel: () => defaultModelConfig.model,
+    getServerTools: () => [],
+    invokeServerTool: vi.fn(),
+    generateChatCompletion,
+  };
+  const providerAdapter: AgentRuntimeProviderAdapter = {
+    getActiveProvider: () => provider,
+    getProviderByName: () => provider,
+    setActiveProvider: vi.fn(),
+  };
+  const toolsView: ToolRegistryView = {
+    listToolNames: () => ['read_file', 'run_shell_command', 'todo_pause'],
+    getToolMetadata: (name) => ({
+      name,
+      description: `${name} description`,
+      parameterSchema: { type: 'object', properties: {} },
+    }),
+  };
+  const baseBundle = createStatelessRuntimeBundle({
+    providerAdapter,
+    toolRegistry,
+    toolsView,
+    history: new HistoryService(),
+  });
+  const hookConfig = createHookConfig(
+    config,
+    params.hookMode ?? { enabled: false },
+  );
+  const runtimeContext: AgentRuntimeContext = {
+    ...baseBundle.runtimeContext,
+    providerRuntime: {
+      ...baseBundle.runtimeContext.providerRuntime,
+      config: hookConfig,
+    },
+  };
+  const runtimeBundle = { ...baseBundle, runtimeContext };
+  const { overrides } = createRuntimeOverrides({ runtimeBundle, toolRegistry });
+  const toolConfig = params.toolConfig
+    ? { tools: [...params.toolConfig.tools] }
+    : undefined;
+  const scope = await SubAgentScope.create(
+    'issue3526-agent',
+    config,
+    { systemPrompt: 'Complete the task and emit each required output.' },
+    defaultModelConfig,
+    defaultRunConfig,
+    toolConfig,
+    params.outputConfig === null
+      ? undefined
+      : (params.outputConfig ?? OUTPUT_CONFIG),
+    overrides,
+  );
+  return { requests, scope };
+}
+
+const FOUR_VALUES = [
+  ['alpha', 'A'],
+  ['beta', 'B'],
+  ['gamma', 'C'],
+  ['delta', 'D'],
+] as const;
+
+describe('non-interactive scope-local output emitter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    readTodos.mockResolvedValue([]);
+  });
+
+  it.each([
+    [
+      'no whitelist with hooks disabled',
+      undefined,
+      { enabled: false } as const,
+    ],
+    [
+      'empty whitelist with hooks disabled',
+      { tools: [] as const },
+      { enabled: false } as const,
+    ],
+    [
+      'hook without allowedFunctionNames',
+      undefined,
+      { enabled: true } as const,
+    ],
+  ])(
+    'provides one correctly shaped emitter for %s',
+    async (_name, toolConfig, hookMode) => {
+      const harness = await createHarness({
+        responses: [nativeEmissions(FOUR_VALUES), stopped()],
+        toolConfig,
+        hookMode,
+      });
+
+      await harness.scope.runNonInteractive(new ContextState());
+
+      const emitters = declarationsFrom(harness.requests[0]).filter(
+        (declaration) => declaration.name === 'self_emitvalue',
+      );
+      expect(emitters).toStrictEqual([
+        expect.objectContaining({
+          name: 'self_emitvalue',
+          parametersJsonSchema: EXPECTED_EMIT_SCHEMA,
+        }),
+      ]);
+    },
+  );
+
+  it.each([
+    ['ordinary allowlist', ['read_file'] as const, ['read_file']],
+    [
+      'allowlist omitting emitter',
+      ['run_shell_command'] as const,
+      ['run_shell_command'],
+    ],
+    ['empty allowlist', [] as const, []],
+  ])(
+    'retains the emitter while filtering ordinary tools for %s',
+    async (_name, allowedFunctionNames, expectedOrdinaryNames) => {
+      const harness = await createHarness({
+        responses: [nativeEmissions(FOUR_VALUES), stopped()],
+        hookMode: { enabled: true, allowedFunctionNames },
+      });
+
+      await harness.scope.runNonInteractive(new ContextState());
+
+      const names = declarationsFrom(harness.requests[0]).map(
+        (declaration) => declaration.name,
+      );
+      expect(names.filter((name) => name === 'self_emitvalue')).toHaveLength(1);
+      expect(names.filter((name) => name !== 'self_emitvalue')).toStrictEqual(
+        expectedOrdinaryNames,
+      );
+    },
+  );
+
+  it('completes four native emissions with GOAL after one provider request', async () => {
+    const harness = await createHarness({
+      responses: [nativeEmissions(FOUR_VALUES)],
+    });
+
+    await harness.scope.runNonInteractive(new ContextState());
+
+    expect(harness.scope.output.emitted_vars).toStrictEqual({
+      alpha: 'A',
+      beta: 'B',
+      gamma: 'C',
+      delta: 'D',
+    });
+    expect(harness.scope.output.terminate_reason).toBe(
+      SubagentTerminateMode.GOAL,
+    );
+    expect(harness.requests).toHaveLength(1);
+    expect(harness.requests.map(requestText).join('\n')).not.toContain(
+      'not emitted',
+    );
+  });
+
+  it('completes four Hermes emissions with GOAL after one provider request', async () => {
+    const harness = await createHarness({
+      responses: [hermesEmissions(FOUR_VALUES)],
+    });
+
+    await harness.scope.runNonInteractive(new ContextState());
+
+    expect(harness.scope.output.emitted_vars).toStrictEqual({
+      alpha: 'A',
+      beta: 'B',
+      gamma: 'C',
+      delta: 'D',
+    });
+    expect(harness.scope.output.terminate_reason).toBe(
+      SubagentTerminateMode.GOAL,
+    );
+    expect(harness.requests).toHaveLength(1);
+    expect(harness.requests.map(requestText).join('\n')).not.toContain(
+      'not emitted',
+    );
+  });
+
+  it('terminates on the provider request containing the final partial emissions', async () => {
+    const harness = await createHarness({
+      responses: [
+        nativeEmissions(FOUR_VALUES.slice(0, 2)),
+        stopped('Waiting.'),
+        nativeEmissions(FOUR_VALUES.slice(2)),
+      ],
+    });
+
+    await harness.scope.runNonInteractive(new ContextState());
+
+    const nudgeRequest = findMissingOutputNudge(harness.requests);
+    expect(requestText(nudgeRequest)).toContain('gamma, delta');
+    expect(requestText(nudgeRequest)).not.toContain('alpha, beta');
+    expect(
+      declarationsFrom(nudgeRequest).filter(
+        (declaration) => declaration.name === 'self_emitvalue',
+      ),
+    ).toHaveLength(1);
+    expect(
+      harness.requests.map(
+        (request) =>
+          declarationsFrom(request).filter(
+            (declaration) => declaration.name === 'self_emitvalue',
+          ).length,
+      ),
+    ).toStrictEqual([1, 1, 1]);
+    expect(harness.requests).toHaveLength(3);
+    expect(harness.scope.output.terminate_reason).toBe(
+      SubagentTerminateMode.GOAL,
+    );
+    expect(harness.scope.output.emitted_vars).toStrictEqual({
+      alpha: 'A',
+      beta: 'B',
+      gamma: 'C',
+      delta: 'D',
+    });
+  });
+
+  it('stops immediately with ERROR after a successful case-insensitive todo_pause', async () => {
+    const harness = await createHarness({
+      responses: [
+        {
+          speaker: 'ai',
+          blocks: [
+            toolCall('TODO_PAUSE', { reason: 'blocked' }, 'pause-success'),
+          ],
+        },
+      ],
+    });
+
+    mockSuccessfulPause('pause-success', 'TODO_PAUSE');
+
+    await harness.scope.runNonInteractive(new ContextState());
+
+    expect(harness.scope.output.terminate_reason).toBe(
+      SubagentTerminateMode.ERROR,
+    );
+    expect(harness.scope.output.final_message).toContain(
+      'todo_pause before completing required outputs: alpha, beta, gamma, delta',
+    );
+    expect(harness.requests).toHaveLength(1);
+    expect(harness.requests.map(requestText).join('\n')).not.toContain(
+      'not emitted',
+    );
+  });
+
+  it.each([
+    ['no output configuration', null],
+    ['an empty output map', { outputs: {} } satisfies OutputConfig],
+  ])(
+    'reports GOAL when successful todo_pause has %s',
+    async (_name, outputConfig) => {
+      const harness = await createHarness({
+        responses: [
+          {
+            speaker: 'ai',
+            blocks: [
+              toolCall(
+                'todo_pause',
+                { reason: 'complete' },
+                'pause-no-outputs',
+              ),
+            ],
+          },
+        ],
+        outputConfig,
+      });
+      mockSuccessfulPause('pause-no-outputs');
+
+      await harness.scope.runNonInteractive(new ContextState());
+
+      expect(harness.scope.output.terminate_reason).toBe(
+        SubagentTerminateMode.GOAL,
+      );
+      expect(harness.requests).toHaveLength(1);
+    },
+  );
+
+  it('does not treat an inherited emitted_vars property as a completed output before todo_pause', async () => {
+    const harness = await createHarness({
+      responses: [
+        {
+          speaker: 'ai',
+          blocks: [
+            toolCall(
+              'todo_pause',
+              { reason: 'blocked' },
+              'pause-inherited-key',
+            ),
+          ],
+        },
+      ],
+      outputConfig: { outputs: { toString: 'required value' } },
+    });
+    mockSuccessfulPause('pause-inherited-key');
+
+    await harness.scope.runNonInteractive(new ContextState());
+
+    expect(harness.scope.output.terminate_reason).toBe(
+      SubagentTerminateMode.ERROR,
+    );
+    expect(harness.scope.output.final_message).toContain('toString');
+  });
+
+  it('reports GOAL when successful todo_pause follows the final required emissions', async () => {
+    const harness = await createHarness({
+      responses: [
+        {
+          speaker: 'ai',
+          blocks: [
+            ...FOUR_VALUES.map(([name, value]) => emitCall(name, value)),
+            toolCall('TODO_PAUSE', { reason: 'complete' }, 'pause-complete'),
+          ],
+        },
+      ],
+    });
+
+    mockSuccessfulPause('pause-complete', 'TODO_PAUSE');
+
+    await harness.scope.runNonInteractive(new ContextState());
+
+    expect(harness.scope.output.emitted_vars).toStrictEqual({
+      alpha: 'A',
+      beta: 'B',
+      gamma: 'C',
+      delta: 'D',
+    });
+    expect(harness.scope.output.terminate_reason).toBe(
+      SubagentTerminateMode.GOAL,
+    );
+    expect(harness.requests).toHaveLength(1);
+  });
+
+  it('does not count shell output as declared output emission', async () => {
+    const harness = await createHarness({
+      responses: [
+        {
+          speaker: 'ai',
+          blocks: [
+            toolCall(
+              'run_shell_command',
+              { command: 'printf "alpha=A beta=B gamma=C delta=D"' },
+              'shell-output',
+            ),
+          ],
+        },
+        stopped('Shell command completed.'),
+        nativeEmissions(FOUR_VALUES),
+        stopped(),
+      ],
+    });
+    mockCompletedToolCall(
+      createCompletedToolCallResponse({
+        callId: 'shell-output',
+        responseParts: [
+          { type: 'text', text: 'alpha=A beta=B gamma=C delta=D' },
+        ],
+      }),
+    );
+
+    await harness.scope.runNonInteractive(new ContextState());
+
+    expect(requestText(findMissingOutputNudge(harness.requests))).toContain(
+      'alpha, beta, gamma, delta',
+    );
+    expect(harness.scope.output.terminate_reason).toBe(
+      SubagentTerminateMode.GOAL,
+    );
+    expect(harness.scope.output.emitted_vars).toStrictEqual({
+      alpha: 'A',
+      beta: 'B',
+      gamma: 'C',
+      delta: 'D',
+    });
+  });
+
+  it('returns a cancelled todo_pause result to the model and continues', async () => {
+    const harness = await createHarness({
+      responses: [
+        {
+          speaker: 'ai',
+          blocks: [toolCall('todo_pause', {}, 'pause-cancelled')],
+        },
+        nativeEmissions(FOUR_VALUES),
+      ],
+    });
+    mockCancelledPause('pause-cancelled');
+
+    await harness.scope.runNonInteractive(new ContextState());
+
+    expect(requestText(harness.requests[1])).toContain('cancelled');
+    expect(harness.requests).toHaveLength(2);
+    expect(harness.scope.output.terminate_reason).toBe(
+      SubagentTerminateMode.GOAL,
+    );
+    expect(harness.scope.output.emitted_vars).toStrictEqual({
+      alpha: 'A',
+      beta: 'B',
+      gamma: 'C',
+      delta: 'D',
+    });
+  });
+
+  it.each([
+    ['failed', 'pause rejected', new Error('pause rejected'), undefined],
+    [
+      'malformed',
+      'reason is required',
+      undefined,
+      ToolErrorType.INVALID_TOOL_PARAMS,
+    ],
+  ])(
+    'returns a %s todo_pause failure to the model and continues',
+    async (_name, errorMessage, error, errorType) => {
+      const harness = await createHarness({
+        responses: [
+          {
+            speaker: 'ai',
+            blocks: [toolCall('todo_pause', {}, 'pause-failure')],
+          },
+          nativeEmissions(FOUR_VALUES),
+          stopped(),
+        ],
+      });
+      mockCompletedToolCall(
+        createCompletedToolCallResponse({
+          callId: 'pause-failure',
+          responseParts: [
+            {
+              type: 'tool_response',
+              callId: 'pause-failure',
+              toolName: 'todo_pause',
+              result: { error: errorMessage },
+              error: errorMessage,
+            },
+          ],
+          error,
+          errorType,
+        }),
+      );
+
+      await harness.scope.runNonInteractive(new ContextState());
+
+      expect(requestText(harness.requests[1])).toContain(errorMessage);
+      expect(harness.scope.output.terminate_reason).toBe(
+        SubagentTerminateMode.GOAL,
+      );
+      expect(harness.scope.output.emitted_vars).toStrictEqual({
+        alpha: 'A',
+        beta: 'B',
+        gamma: 'C',
+        delta: 'D',
+      });
+    },
+  );
+});

--- a/packages/agents/src/core/subagent.issue3526.test.ts
+++ b/packages/agents/src/core/subagent.issue3526.test.ts
@@ -30,6 +30,7 @@ import {
   SubagentTerminateMode,
   type OutputConfig,
 } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
+import { MockTool } from '@vybestack/llxprt-code-core/test-utils/mock-tool.js';
 import { ToolErrorType } from '@vybestack/llxprt-code-tools/types/tool-error.js';
 import { SubAgentScope } from './subagent.js';
 import { executeToolCall } from './nonInteractiveToolExecutor.js';
@@ -103,11 +104,40 @@ type CompletedToolCallFixture = Omit<
   readonly status: 'success' | 'error' | 'cancelled';
 };
 
+const MOCK_TOOL = new MockTool('mock_tool');
+const MOCK_INVOCATION = MOCK_TOOL.build({});
+
+function completeToolCallFixture(
+  response: CompletedToolCallFixture,
+): Awaited<ReturnType<typeof executeToolCall>> {
+  const completedResponse = {
+    ...response.response,
+    resultDisplay: undefined,
+  };
+  if (response.status === 'success') {
+    return {
+      ...response,
+      status: 'success',
+      response: completedResponse,
+      tool: MOCK_TOOL,
+      invocation: MOCK_INVOCATION,
+    };
+  }
+  if (response.status === 'cancelled') {
+    return {
+      ...response,
+      status: 'cancelled',
+      response: completedResponse,
+      tool: MOCK_TOOL,
+      invocation: MOCK_INVOCATION,
+    };
+  }
+  return { ...response, status: 'error', response: completedResponse };
+}
+
 function mockCompletedToolCall(response: CompletedToolCallFixture): void {
-  const mockedExecutor = executeToolCall as Mock<
-    () => Promise<CompletedToolCallFixture>
-  >;
-  mockedExecutor.mockResolvedValueOnce(response);
+  const mockedExecutor = executeToolCall as Mock<typeof executeToolCall>;
+  mockedExecutor.mockResolvedValueOnce(completeToolCallFixture(response));
 }
 
 function mockSuccessfulPause(callId: string, toolName = 'todo_pause'): void {

--- a/packages/agents/src/core/subagent.runNonInteractive-execution.test.ts
+++ b/packages/agents/src/core/subagent.runNonInteractive-execution.test.ts
@@ -255,7 +255,6 @@ describe('subagent.ts', () => {
               },
             },
           ],
-          'stop',
         ]),
       );
 
@@ -276,17 +275,7 @@ describe('subagent.ts', () => {
       expect(scope.output.terminate_reason).toBe(SubagentTerminateMode.GOAL);
       expect(scope.output.emitted_vars).toStrictEqual({ result: 'Success!' });
       expect(scope.output.final_message).toContain('result=Success');
-      expect(mockSendMessageStream).toHaveBeenCalledTimes(2);
-
-      const secondCallArgs = mockSendMessageStream.mock.calls[1][0];
-      expect(secondCallArgs.message).toHaveLength(1);
-      expect(secondCallArgs.message[0]).toMatchObject({
-        type: 'tool_response',
-      });
-      expect(secondCallArgs.message[0].toolName).toBe('self_emitvalue');
-      expect(secondCallArgs.message[0].result.message).toBe(
-        'Emitted variable result successfully',
-      );
+      expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
     });
 
     it('should execute external tools and provide the response to the model', async () => {
@@ -638,7 +627,6 @@ describe('subagent.ts', () => {
               },
             },
           ],
-          'stop',
         ]),
       );
 
@@ -666,7 +654,7 @@ describe('subagent.ts', () => {
       expect(scope.output.emitted_vars).toStrictEqual({
         required_var: 'Here it is',
       });
-      expect(mockSendMessageStream).toHaveBeenCalledTimes(3);
+      expect(mockSendMessageStream).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/agents/src/core/subagentExecution.ts
+++ b/packages/agents/src/core/subagentExecution.ts
@@ -307,8 +307,9 @@ export async function checkGoalCompletion(
     return null;
   }
 
+  const emittedOutputKeys = Object.keys(ctx.output.emitted_vars);
   const remainingVars = Object.keys(ctx.outputConfig.outputs).filter(
-    (key) => !(key in ctx.output.emitted_vars),
+    (key) => !emittedOutputKeys.includes(key),
   );
 
   if (remainingVars.length === 0) {

--- a/packages/agents/src/core/subagentNonInteractive.issue3526.test.ts
+++ b/packages/agents/src/core/subagentNonInteractive.issue3526.test.ts
@@ -1,0 +1,262 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'bun:test';
+import type {
+  ContentBlock,
+  IContent,
+} from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import {
+  toModelStreamChunk,
+  type ToolDeclaration,
+} from '@vybestack/llxprt-code-core/llm-types/index.js';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+import { GemmaToolCallParser } from '@vybestack/llxprt-code-core/parsers/TextToolCallParser.js';
+import {
+  SubagentTerminateMode,
+  type OutputConfig,
+  type OutputObject,
+} from '@vybestack/llxprt-code-core/core/subagentTypes.js';
+import { ChatSession, StreamEventType } from './chatSession.js';
+import { executeNonInteractiveRun } from './subagentNonInteractive.js';
+import {
+  checkGoalCompletion,
+  type ExecutionLoopContext,
+} from './subagentExecution.js';
+import { getScopeLocalFuncDefs } from './subagentRuntimeSetup.js';
+import {
+  createMockConfig,
+  createStatelessRuntimeBundle,
+  defaultRunConfig,
+} from './subagent-test-helpers.js';
+
+const { readTodos, TodoStoreMock } = (() => {
+  const readTodos = vi.fn(async () => []);
+  const TodoStoreMock = vi.fn(() => ({ readTodos }));
+  return { readTodos, TodoStoreMock };
+})();
+const toolsModule = { ...(await import('@vybestack/llxprt-code-tools')) };
+void vi.mock('@vybestack/llxprt-code-tools', () => ({
+  ...toolsModule,
+  LocalTodoStore: TodoStoreMock,
+}));
+
+const OUTPUT_CONFIG: OutputConfig = {
+  outputs: {
+    alpha: 'first value',
+    beta: 'second value',
+    gamma: 'third value',
+    delta: 'fourth value',
+  },
+};
+
+const FOUR_VALUES = [
+  ['alpha', 'A'],
+  ['beta', 'B'],
+  ['gamma', 'C'],
+  ['delta', 'D'],
+] as const;
+
+function toolCall(
+  name: string,
+  parameters: Readonly<Record<string, unknown>>,
+  id = name,
+): ContentBlock {
+  return { type: 'tool_call', id, name, parameters };
+}
+
+function nativeEmissions(): IContent {
+  return {
+    speaker: 'ai',
+    blocks: FOUR_VALUES.map(([name, value]) =>
+      toolCall(
+        'self_emitvalue',
+        { emit_variable_name: name, emit_variable_value: value },
+        `emit-${name}`,
+      ),
+    ),
+  };
+}
+
+function hermesEmissions(): IContent {
+  const text = FOUR_VALUES.map(
+    ([name, value]) =>
+      `<tool_call>\n${JSON.stringify({ name: 'self_emitvalue', arguments: { emit_variable_name: name, emit_variable_value: value } })}\n</tool_call>`,
+  ).join('\n');
+  return { speaker: 'ai', blocks: [{ type: 'text', text }] };
+}
+
+function stopped(): IContent {
+  return { speaker: 'ai', blocks: [{ type: 'text', text: 'Done.' }] };
+}
+
+async function runDirectNonInteractive(params: {
+  readonly outputConfig: OutputConfig;
+  readonly declarations: readonly ToolDeclaration[];
+  readonly responses: readonly IContent[];
+  readonly emittedVars?: Readonly<Record<string, string>>;
+}): Promise<{ readonly output: OutputObject; readonly requestCount: number }> {
+  const { config } = await createMockConfig();
+  const baseBundle = createStatelessRuntimeBundle();
+  const output: OutputObject = {
+    terminate_reason: SubagentTerminateMode.ERROR,
+    emitted_vars: { ...params.emittedVars },
+  };
+  const logger = new DebugLogger('issue3526-test');
+  const execCtx: ExecutionLoopContext = {
+    output,
+    subagentId: 'direct-issue3526-agent',
+    runConfig: defaultRunConfig,
+    outputConfig: params.outputConfig,
+    textToolParser: new GemmaToolCallParser(),
+    toolsView: baseBundle.runtimeContext.tools,
+    logger,
+  };
+  let requestCount = 0;
+  const chat = {
+    sendMessageStream: async () => {
+      const response = params.responses[requestCount] ?? stopped();
+      requestCount += 1;
+      return (async function* () {
+        yield {
+          type: StreamEventType.CHUNK,
+          value: toModelStreamChunk(response),
+        };
+      })();
+    },
+  } as unknown as ChatSession;
+
+  await executeNonInteractiveRun(
+    chat,
+    [...params.declarations],
+    new AbortController(),
+    [{ speaker: 'human', blocks: [{ type: 'text', text: 'start' }] }],
+    Date.now(),
+    execCtx,
+    {
+      output,
+      subagentId: 'direct-issue3526-agent',
+      name: 'direct-issue3526-agent',
+      runtimeContext: baseBundle.runtimeContext,
+      logger,
+      config,
+      runConfig: defaultRunConfig,
+      outputConfig: params.outputConfig,
+      toolExecutorContext: config,
+    },
+    () => undefined,
+  );
+
+  return { output, requestCount };
+}
+
+describe('issue 3526 non-interactive emitter completion invariants', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    readTodos.mockResolvedValue([]);
+  });
+
+  it('resolves raw Hermes emitter calls without an ordinary registry entry', async () => {
+    const { output, requestCount } = await runDirectNonInteractive({
+      outputConfig: OUTPUT_CONFIG,
+      declarations: getScopeLocalFuncDefs(OUTPUT_CONFIG),
+      responses: [hermesEmissions()],
+    });
+
+    expect(output.emitted_vars).toStrictEqual({
+      alpha: 'A',
+      beta: 'B',
+      gamma: 'C',
+      delta: 'D',
+    });
+    expect(requestCount).toBe(1);
+  });
+
+  it('uses a callable emitter when duplicate effective declarations are present', async () => {
+    const emitterDeclarations = getScopeLocalFuncDefs(OUTPUT_CONFIG);
+
+    const { output, requestCount } = await runDirectNonInteractive({
+      outputConfig: OUTPUT_CONFIG,
+      declarations: [...emitterDeclarations, ...emitterDeclarations],
+      responses: [nativeEmissions()],
+    });
+
+    expect(output.terminate_reason).toBe(SubagentTerminateMode.GOAL);
+    expect(output.emitted_vars).toStrictEqual({
+      alpha: 'A',
+      beta: 'B',
+      gamma: 'C',
+      delta: 'D',
+    });
+    expect(requestCount).toBe(1);
+  });
+
+  it('fails once without nudging when required outputs lack an effective emitter', async () => {
+    const { output, requestCount } = await runDirectNonInteractive({
+      outputConfig: OUTPUT_CONFIG,
+      declarations: [
+        {
+          name: 'read_file',
+          description: 'Read a file',
+          parametersJsonSchema: { type: 'object', properties: {} },
+        },
+      ],
+      responses: [
+        {
+          speaker: 'ai',
+          blocks: [toolCall('read_file', { file_path: 'report.md' })],
+        },
+      ],
+      emittedVars: { alpha: 'A', beta: 'B' },
+    });
+
+    expect(output.terminate_reason).toBe(SubagentTerminateMode.ERROR);
+    expect(output.final_message).toContain('self_emitvalue');
+    expect(output.final_message).toContain('gamma, delta');
+    expect(output.emitted_vars).toStrictEqual({ alpha: 'A', beta: 'B' });
+    expect(requestCount).toBe(1);
+  });
+
+  it('fails missing-emitter provisioning when a required key exists only on the prototype', async () => {
+    const outputConfig: OutputConfig = {
+      outputs: { toString: 'required value' },
+    };
+
+    const { output } = await runDirectNonInteractive({
+      outputConfig,
+      declarations: [],
+      responses: [stopped()],
+    });
+
+    expect(output.terminate_reason).toBe(SubagentTerminateMode.ERROR);
+    expect(output.final_message).toContain('toString');
+  });
+
+  it('nudges for a required key that exists only on the emitted_vars prototype', async () => {
+    const output: OutputObject = {
+      terminate_reason: SubagentTerminateMode.ERROR,
+      emitted_vars: {},
+    };
+
+    const nextMessages = await checkGoalCompletion(
+      {
+        output,
+        outputConfig: { outputs: { toString: 'required value' } },
+        subagentId: 'prototype-key-agent',
+        logger: new DebugLogger('issue3526-test'),
+      },
+      null,
+      0,
+    );
+
+    expect(nextMessages?.[0]?.blocks).toStrictEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('toString'),
+      }),
+    ]);
+  });
+});

--- a/packages/agents/src/core/subagentNonInteractive.issue3526.test.ts
+++ b/packages/agents/src/core/subagentNonInteractive.issue3526.test.ts
@@ -172,6 +172,7 @@ describe('issue 3526 non-interactive emitter completion invariants', () => {
       gamma: 'C',
       delta: 'D',
     });
+    expect(output.terminate_reason).toBe(SubagentTerminateMode.GOAL);
     expect(requestCount).toBe(1);
   });
 
@@ -220,7 +221,7 @@ describe('issue 3526 non-interactive emitter completion invariants', () => {
     expect(requestCount).toBe(1);
   });
 
-  it('fails missing-emitter provisioning when a required key exists only on the prototype', async () => {
+  it('fails missing-emitter provisioning when the required output key is named toString', async () => {
     const outputConfig: OutputConfig = {
       outputs: { toString: 'required value' },
     };
@@ -235,7 +236,7 @@ describe('issue 3526 non-interactive emitter completion invariants', () => {
     expect(output.final_message).toContain('toString');
   });
 
-  it('nudges for a required key that exists only on the emitted_vars prototype', async () => {
+  it('nudges when the required output key named toString has not been emitted', async () => {
     const output: OutputObject = {
       terminate_reason: SubagentTerminateMode.ERROR,
       emitted_vars: {},

--- a/packages/agents/src/core/subagentNonInteractive.ts
+++ b/packages/agents/src/core/subagentNonInteractive.ts
@@ -61,6 +61,10 @@ import {
   processFunctionCalls,
   buildTodoCompletionPrompt,
 } from './subagentToolProcessing.js';
+import {
+  canonicalizeToolName,
+  SCOPE_LOCAL_EMIT_TOOL_NAME,
+} from './toolGovernance.js';
 
 // ---------------------------------------------------------------------------
 // Run context — carries all collaborators the non-interactive path needs
@@ -351,6 +355,38 @@ async function readStreamToCompletion(
 // Turn execution
 // ---------------------------------------------------------------------------
 
+function hasEffectiveEmitter(
+  toolsList: readonly ToolDeclaration[],
+  hookRestrictedAllowedTools: readonly string[] | undefined,
+): boolean {
+  const emitterName = canonicalizeToolName(SCOPE_LOCAL_EMIT_TOOL_NAME);
+  const emitterDeclared = toolsList.some(
+    (declaration) => canonicalizeToolName(declaration.name) === emitterName,
+  );
+  const emitterAllowed =
+    hookRestrictedAllowedTools === undefined ||
+    hookRestrictedAllowedTools.some(
+      (name) => canonicalizeToolName(name) === emitterName,
+    );
+  return emitterDeclared && emitterAllowed;
+}
+
+function resolveNonInteractiveToolName(
+  rawName: string | undefined,
+  toolsView: ExecutionLoopContext['toolsView'],
+  effectiveEmitterAvailable: boolean,
+): string | null {
+  if (
+    effectiveEmitterAvailable &&
+    rawName !== undefined &&
+    canonicalizeToolName(rawName) ===
+      canonicalizeToolName(SCOPE_LOCAL_EMIT_TOOL_NAME)
+  ) {
+    return SCOPE_LOCAL_EMIT_TOOL_NAME;
+  }
+  return resolveToolName(rawName, toolsView);
+}
+
 /**
  * Execute a single non-interactive turn: send the message, consume the
  * stream, and parse any textual tool calls.
@@ -367,7 +403,11 @@ export async function runNonInteractiveTurn(
   config: Config,
   logger: DebugLogger,
   output: OutputObject,
-): Promise<{ functionCalls: ToolCallBlock[]; textResponse: string }> {
+): Promise<{
+  functionCalls: ToolCallBlock[];
+  textResponse: string;
+  effectiveEmitterAvailable: boolean;
+}> {
   const blocks = currentMessages[0]?.blocks ?? [];
   const messageParams = {
     message: blocks,
@@ -399,9 +439,18 @@ export async function runNonInteractiveTurn(
     output,
   );
   if (abortController.signal.aborted === true) {
-    return { functionCalls: [], textResponse: '' };
+    return {
+      functionCalls: [],
+      textResponse: '',
+      effectiveEmitterAvailable: false,
+    };
   }
   recordTurnOutputTokens(execCtx, reportedOutputTokens, outputCharacterCount);
+
+  const effectiveEmitterAvailable = hasEffectiveEmitter(
+    toolsList,
+    hookRestrictedAllowedTools,
+  );
 
   let functionCalls = rawCalls;
   if (parseableTextResponse) {
@@ -409,13 +458,22 @@ export async function runNonInteractiveTurn(
       parseableTextResponse,
       functionCalls,
       execCtx,
-      resolveToolName,
+      (rawName, toolsView) =>
+        resolveNonInteractiveToolName(
+          rawName,
+          toolsView,
+          effectiveEmitterAvailable,
+        ),
       hookRestrictedAllowedTools,
     );
     functionCalls = result.functionCalls;
   }
 
-  return { functionCalls, textResponse };
+  return {
+    functionCalls,
+    textResponse,
+    effectiveEmitterAvailable,
+  };
 }
 
 /**
@@ -429,16 +487,53 @@ export async function dispatchNonInteractiveTurnResult(
   currentTurn: number,
   execCtx: ExecutionLoopContext,
   ctx: NonInteractiveRunContext,
+  effectiveEmitterAvailable: boolean,
 ): Promise<IContent[] | null> {
+  const requiredOutputKeys = Object.keys(ctx.outputConfig?.outputs ?? {});
+  const emittedOutputKeys = Object.keys(ctx.output.emitted_vars);
+  const missingOutputKeys = requiredOutputKeys.filter(
+    (key) => !emittedOutputKeys.includes(key),
+  );
+  if (missingOutputKeys.length > 0 && !effectiveEmitterAvailable) {
+    const errorMessage =
+      `Required tool ${SCOPE_LOCAL_EMIT_TOOL_NAME} is unavailable while required outputs are missing: ` +
+      `${missingOutputKeys.join(', ')}.`;
+    ctx.output.terminate_reason = SubagentTerminateMode.ERROR;
+    ctx.output.final_message = errorMessage;
+    ctx.logger.warn(
+      () =>
+        `Subagent ${ctx.subagentId} cannot complete output emission: ${errorMessage}`,
+    );
+    return null;
+  }
   if (functionCalls.length > 0) {
-    return processFunctionCalls(functionCalls, abortController, promptId, {
-      output: ctx.output,
-      subagentId: ctx.subagentId,
-      logger: ctx.logger,
-      toolExecutorContext: ctx.toolExecutorContext,
-      config: ctx.config,
-      messageBus: ctx.messageBus,
-    });
+    const nextMessages = await processFunctionCalls(
+      functionCalls,
+      abortController,
+      promptId,
+      {
+        output: ctx.output,
+        ...(ctx.outputConfig === undefined
+          ? {}
+          : { outputConfig: ctx.outputConfig }),
+        subagentId: ctx.subagentId,
+        logger: ctx.logger,
+        toolExecutorContext: ctx.toolExecutorContext,
+        config: ctx.config,
+        messageBus: ctx.messageBus,
+      },
+    );
+    const emittedKeysAfterToolCalls = Object.keys(ctx.output.emitted_vars);
+    const completedDeclaredOutputs =
+      requiredOutputKeys.length > 0 &&
+      requiredOutputKeys.every((key) =>
+        emittedKeysAfterToolCalls.includes(key),
+      );
+    if (completedDeclaredOutputs) {
+      ctx.output.terminate_reason = SubagentTerminateMode.GOAL;
+      return null;
+    }
+    return nextMessages;
   }
   const todoReminder = await buildTodoCompletionPrompt(
     ctx.runtimeContext,
@@ -496,19 +591,20 @@ async function runNonInteractiveLoopIteration(
     () => `Subagent ${ctx.subagentId} turn=${currentTurn} promptId=${promptId}`,
   );
 
-  const { functionCalls } = await runNonInteractiveTurn(
-    chat,
-    currentMessages,
-    toolsList,
-    abortController,
-    currentTurn,
-    sessionId,
-    ctx.subagentId,
-    execCtx,
-    ctx.config,
-    ctx.logger,
-    ctx.output,
-  );
+  const { functionCalls, effectiveEmitterAvailable } =
+    await runNonInteractiveTurn(
+      chat,
+      currentMessages,
+      toolsList,
+      abortController,
+      currentTurn,
+      sessionId,
+      ctx.subagentId,
+      execCtx,
+      ctx.config,
+      ctx.logger,
+      ctx.output,
+    );
   if (abortController.signal.aborted === true) return { action: 'abort' };
 
   // Only the output budget is re-checked here. Re-checking the turn and time
@@ -527,6 +623,7 @@ async function runNonInteractiveLoopIteration(
     currentTurn,
     execCtx,
     ctx,
+    effectiveEmitterAvailable,
   );
   // `processFunctionCalls` returns `[]` (an empty, truthy array) when no
   // tool calls were executed. `!nextMessages` only catches null/undefined,

--- a/packages/agents/src/core/subagentToolProcessing.ts
+++ b/packages/agents/src/core/subagentToolProcessing.ts
@@ -41,11 +41,13 @@ import { debugLogger } from '@vybestack/llxprt-code-core/utils/debugLogger.js';
 import { toolFailureMarker } from '@vybestack/llxprt-code-core/utils/generateContentResponseUtilities.js';
 import {
   SubagentTerminateMode,
+  type OutputConfig,
   type OutputObject,
 } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
 import type { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import { createSchedulerConfig } from './subagentRuntimeSetup.js';
 import { isToolNameRestricted } from './hookToolRestrictions.js';
+import { SCOPE_LOCAL_EMIT_TOOL_NAME } from './toolGovernance.js';
 
 // ---------------------------------------------------------------------------
 // Pure helpers
@@ -445,11 +447,53 @@ export function buildPartsFromCompletedCalls(
 
 export interface ProcessFunctionCallsContext {
   output: OutputObject;
+  outputConfig?: OutputConfig;
   subagentId: string;
   logger: DebugLogger;
   toolExecutorContext: ToolExecutionConfig;
   config: Config;
   messageBus?: MessageBus;
+}
+
+interface NonInteractiveToolExecutionResult {
+  readonly status: CompletedToolCall['status'];
+  readonly response: ToolCallResponseInfo;
+}
+
+function isSuccessfulTodoPause(
+  toolName: string,
+  result: NonInteractiveToolExecutionResult,
+): boolean {
+  return (
+    toolName.toLowerCase() === 'todo_pause' &&
+    result.status === 'success' &&
+    result.response.error === undefined &&
+    result.response.errorType === undefined
+  );
+}
+
+function getMissingRequiredOutputKeys(
+  ctx: ProcessFunctionCallsContext,
+): string[] {
+  const emittedOutputKeys = Object.keys(ctx.output.emitted_vars);
+  return Object.keys(ctx.outputConfig?.outputs ?? {}).filter(
+    (key) => !emittedOutputKeys.includes(key),
+  );
+}
+
+function terminateAfterSuccessfulTodoPause(
+  ctx: ProcessFunctionCallsContext,
+): void {
+  const missingOutputKeys = getMissingRequiredOutputKeys(ctx);
+  if (missingOutputKeys.length === 0) {
+    ctx.output.terminate_reason = SubagentTerminateMode.GOAL;
+    return;
+  }
+
+  ctx.output.terminate_reason = SubagentTerminateMode.ERROR;
+  ctx.output.final_message =
+    'Subagent paused via todo_pause before completing required outputs: ' +
+    `${missingOutputKeys.join(', ')}.`;
 }
 
 export async function processFunctionCalls(
@@ -488,15 +532,21 @@ export async function processFunctionCalls(
           `Subagent ${ctx.subagentId} executing tool '${requestInfo.name}' with args=${JSON.stringify(requestInfo.args)}`,
       );
 
-      const toolResponse = await executeNonInteractiveTool(
+      const executionResult = await executeNonInteractiveTool(
         functionCall,
         requestInfo,
         callId,
         abortController,
         ctx,
       );
+      const toolResponse = executionResult.response;
 
       logToolResult(functionCall, toolResponse, ctx);
+
+      if (isSuccessfulTodoPause(functionCall.name, executionResult)) {
+        terminateAfterSuccessfulTodoPause(ctx);
+        return [];
+      }
 
       if (isFatalToolError(toolResponse.errorType)) {
         const fatalMessage = buildToolUnavailableMessage(
@@ -574,31 +624,34 @@ async function executeNonInteractiveTool(
   callId: string,
   abortController: AbortController,
   ctx: ProcessFunctionCallsContext,
-): Promise<ToolCallResponseInfo> {
-  if (functionCall.name === 'self_emitvalue') {
+): Promise<NonInteractiveToolExecutionResult> {
+  if (functionCall.name === SCOPE_LOCAL_EMIT_TOOL_NAME) {
     const valName = String(requestInfo.args['emit_variable_name']);
     const valVal = String(requestInfo.args['emit_variable_value']);
     ctx.output.emitted_vars[valName] = valVal;
 
     const successMessage = `Emitted variable ${valName} successfully`;
     return {
-      callId,
-      responseParts: [
-        {
-          type: 'tool_response',
-          callId,
-          toolName: requestInfo.name,
-          result: {
-            emit_variable_name: valName,
-            emit_variable_value: valVal,
-            message: successMessage,
+      status: 'success',
+      response: {
+        callId,
+        responseParts: [
+          {
+            type: 'tool_response',
+            callId,
+            toolName: requestInfo.name,
+            result: {
+              emit_variable_name: valName,
+              emit_variable_value: valVal,
+              message: successMessage,
+            },
           },
-        },
-      ],
-      resultDisplay: successMessage,
-      error: undefined,
-      errorType: undefined,
-      agentId: requestInfo.agentId,
+        ],
+        resultDisplay: successMessage,
+        error: undefined,
+        errorType: undefined,
+        agentId: requestInfo.agentId,
+      },
     };
   }
 
@@ -613,7 +666,7 @@ async function executeNonInteractiveTool(
     abortController.signal,
     { messageBus: ctx.messageBus },
   );
-  return completed.response;
+  return { status: completed.status, response: completed.response };
 }
 
 function logToolResult(

--- a/packages/agents/src/core/toolGovernance.ts
+++ b/packages/agents/src/core/toolGovernance.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export const SCOPE_LOCAL_EMIT_TOOL_NAME = 'self_emitvalue';
+
 export {
   buildSubagentExcludedToolNames,
   buildToolGovernance,

--- a/project-plans/issue3526.md
+++ b/project-plans/issue3526.md
@@ -1,0 +1,59 @@
+# Issue 3526 Plan
+
+## Accepted behavior
+
+1. A non-interactive subagent with declared outputs sends exactly one callable `self_emitvalue` declaration on every provider request while required outputs are missing.
+2. `BeforeToolSelection` allowlists continue to filter ordinary tools, but cannot remove the required scope-local `self_emitvalue` declaration.
+3. Four native `self_emitvalue` calls populate four declared outputs and terminate with `GOAL` without a follow-up nudge.
+4. Supported textual Hermes `self_emitvalue` calls resolve to the same scope-local handler and complete a four-output task.
+5. The runtime verifies that effective provider declarations contain `self_emitvalue` before sending a missing-output nudge.
+6. If required outputs remain and internal provisioning leaves the effective emitter absent, execution terminates once with `ERROR`. The error identifies `self_emitvalue` and the missing keys, preserves partial `emitted_vars`, and sends no nudge or additional provider request.
+7. A successful case-insensitive `todo_pause` stops immediately without a later provider request or nudge. If required outputs remain, termination uses the existing `ERROR` mode, includes the missing keys in `final_message`, and does not report `GOAL`. If the same batch completed all required outputs first, or no outputs are required, termination reports `GOAL`.
+8. A failed or malformed `todo_pause` remains nonterminal and returns its failure to the model.
+
+## Scope boundaries
+
+- Exercise no whitelist, empty whitelist, a populated ordinary-tool whitelist, hooks disabled, a hook without `allowedFunctionNames`, an allowlist that omits `self_emitvalue`, and an empty allowlist where each case adds behavioral evidence.
+- Preserve existing behavior when no outputs are declared or the output map is empty.
+- Missing-output nudges identify only missing keys after partial emission.
+- Support output calls received together or across provider turns.
+- Do not treat shell output as declared output emission.
+- Preserve cancellation, timeout, output-budget, and max-turn behavior.
+- Do not change unknown-output or duplicate-output validation.
+- Do not add a public abstraction or termination enum.
+- Do not modify dependencies, workflows, agent memory, quality tooling, or `.llxprt`.
+- Stop implementation if satisfying the behavior requires an unplanned subsystem or public API change.
+
+## Test-first sequence and behavioral mapping
+
+| Evidence | Failing behavioral test | Implementation response |
+| --- | --- | --- |
+| A | Drive a real non-interactive runtime with four declared outputs and inspect the provider-bound request for exactly one correctly shaped `self_emitvalue`. Repeat only the setup variants needed to cover no whitelist, hooks disabled, and a hook without `allowedFunctionNames`. | Preserve one required scope-local declaration in the effective provider tool set while outputs are missing. |
+| B | Drive `BeforeToolSelection` with populated and empty ordinary allowlists, including an allowlist that omits `self_emitvalue`; assert ordinary tools are filtered while one emitter remains. | Separate required scope-local declaration retention from ordinary-tool allowlist filtering. |
+| C | Return four native emitter calls from provider infrastructure; assert four values, `GOAL`, and no follow-up nudge or request. | Route all native calls through the existing scope-local emitter and recognize completion in the same turn. |
+| D | Return four supported Hermes textual emitter calls; assert the same outputs and completion behavior. | Resolve textual emitter calls against the scope-local declaration before ordinary registry lookup. |
+| E | Drive a deliberate internal effective-emitter absence after partial emission; assert one specific `ERROR`, named missing keys, preserved partial values, no nudge, and no extra provider turn. | Add a fail-fast runtime invariant before missing-output nudging. |
+| F | Emit two of four outputs, assert the nudge names only the remaining two, then emit those outputs and assert completion. | Derive nudge content from the remaining output keys and retain the emitter for the next request. |
+| G | Return a successful mixed-case `todo_pause` while outputs remain; assert immediate `ERROR` termination with no later request or nudge and no `GOAL`. In a paired case, emit the final values before the pause in the same batch and assert immediate `GOAL`. | Treat successful non-interactive pause as terminal and derive `GOAL` versus `ERROR` from whether declared outputs are complete. |
+| H | Return failed and malformed `todo_pause` results; assert the failure is included in the next model turn and execution continues. | Keep unsuccessful pause calls on the existing nonterminal tool-result path. |
+
+Focused tests run after each red and green step. Final focused verification is logged under `tmp/verify3526/` and covers every touched agents file, focused ESLint, the agents package typecheck, and formatting. The foreground orchestrator owns the later full repository verification cycle.
+
+## Review-finding triage
+
+| Review finding | Classification | Reason and resolution |
+| --- | --- | --- |
+| 1. Successful `todo_pause` forced `ERROR` after the same batch emitted every required output. | **Blocker-Fix** | This violated accepted same-batch completion behavior. `processFunctionCalls` now determines missing required keys after earlier calls in the batch have executed and reports `GOAL` when none remain. The four-output same-batch behavior test passes. |
+| 2. Effective-emitter validation required exactly one declaration instead of callable presence. | **In-scope-Fix** | The runtime invariant needs at least one callable declaration. Provisioning still produces exactly one declaration per provider request, while the validation now uses presence and does not misreport duplicate effective declarations as absence. |
+| 3 and 7. Emitter name and normalization were duplicated, with the follow-up repeating the normalization concern. | **In-scope-Fix** | These are the same maintainability finding. The touched paths now share `SCOPE_LOCAL_EMIT_TOOL_NAME` from `toolGovernance.ts` and use `canonicalizeToolName` for effective-declaration and Hermes-resolution comparisons. Pre-existing user-facing instruction strings remain unchanged. |
+| 4. `todo_pause` termination in `ERROR` lacked a useful `final_message`. | **In-scope-Fix** | Callers need the terminal reason and missing keys. The successful pause error path now sets a message naming `todo_pause` and only the missing required outputs before finalization. |
+| 5. Prototype-chain properties in `emitted_vars` could satisfy required output keys. | **In-scope-Fix** | This produced false completion and made the touched pause and missing-emitter paths disagree with required-output checks. A bounded consistency correction uses own-property membership in `processFunctionCalls`, `dispatchNonInteractiveTurnResult`, and `checkGoalCompletion`. It does not alter unknown-output or duplicate-output validation. Tests cover pause termination, fail-fast missing-emitter termination, and the normal missing-output nudge for a prototype-name key. |
+| 6 and 8. Successful `todo_pause` reported `ERROR` for no output configuration or an empty output map, with finding 8 restating the same vacuous-completion defect. | **Blocker-Fix** | These are the same termination bug and violate preserved output-less behavior. Completion now uses the missing-key set directly, so zero required keys produce `GOAL`. Separate behavior cases cover absent and empty output configurations. |
+| 9. A tool-call batch that emitted every required value still sent its tool responses to the provider, so `GOAL` depended on a later no-tool response and could be replaced by `MAX_TURNS`. | **Blocker-Fix** | After processing a batch, dispatch now checks only a nonempty declared output set. If every declared key has been emitted, it sets `GOAL` and returns no continuation message. Native and Hermes four-value tests now require exactly one provider request, and the partial-emission test requires termination on request three, which contains the final values. The no-output and still-missing-output continuation tests pass. |
+| 10. Cancelled `todo_pause` calls had no response `error` or `errorType`, so non-interactive execution treated scheduler status `cancelled` as success and terminated. | **Blocker-Fix** | The local execution result now carries `CompletedToolCall.status`, and pause termination requires `status === 'success'` in addition to absent response errors. A cancelled-result behavior test uses the scheduler cancellation response shape, verifies the failure reaches the next provider request, and completes only after that request emits the required values. Successful, failed-error, malformed, and cancellation-neighbor tests pass. |
+
+No finding was rejected or deferred. Every accepted change is limited to issue 3526 completion, emitter availability, and required-key membership behavior.
+
+## Prior verification-log disposition
+
+`tmp/verify3526/npm-test-post-review.log` ends with the vscode companion summary and an explicit `Exit Code: 0` record. It therefore contains completion evidence for that prior full `npm run test` invocation. The final focused commands for this continuation are recorded separately and do not replace the foreground orchestrator's requested repository-wide verification.

--- a/project-plans/issue3526.md
+++ b/project-plans/issue3526.md
@@ -54,6 +54,27 @@ Focused tests run after each red and green step. Final focused verification is l
 
 No finding was rejected or deferred. Every accepted change is limited to issue 3526 completion, emitter availability, and required-key membership behavior.
 
+## PR 3539 remediation triage
+
+| Finding | Classification | Verification and disposition |
+| --- | --- | --- |
+| 1. Missing or null `self_emitvalue` arguments are coerced to strings. | **Defer** | Malformed emitter argument validation is outside the accepted issue behavior. Follow-up issue #3540 tracks this policy. Production behavior is unchanged here. |
+| 2. The `executeToolCall` mock erases the real callable signature, with duplicate reports also requesting argument assertions. | **In-scope-Fix** for typing; **Reject** for interaction assertions | The cast uses a zero-argument function type even though the real function requires execution context and request parameters. Type the mock as `Mock<typeof executeToolCall>`. Do not assert mock calls because `dev-docs/RULES.md` prohibits mock verification. One edit resolves both duplicate reports. |
+| 3. The provider fake advertises an `IContent[]` overload but rejects that call shape. | **Reject** | `RuntimeProvider` requires both the options overload and the legacy `IContent[]` overload. Removing the overload would make the fake incompatible with the interface, while implementing an unused legacy path would add behavior unrelated to this test. |
+| 4. Add a nullish fallback around `Object.keys(ctx.output.emitted_vars)`. | **Reject** | `OutputObject.emitted_vars` is a required, non-null `Record<string, string>`. A fallback would hide an internal invariant violation rather than fix an allowed input case. |
+| 5. Execute non-emitter calls queued in a turn where the required emitter is missing. | **Reject** | Accepted behavior makes missing emitter provisioning a terminal infrastructure failure. No queued side effects or later provider work should run after that invariant fails. |
+| 6. Canonicalize aliases such as `todoPause` or `functions.todo_pause` for successful pause detection. | **Reject** | Existing pause policy in the agent loop and continuation service recognizes the exact `todo_pause` name case-insensitively. Alias expansion was not accepted for issue 3526. |
+| 7. Preserve accumulated tool responses and execute calls after a successful `todo_pause`. | **Reject** | Successful pause is intentionally terminal. It stops the batch immediately, and no later provider turn consumes a response transcript. |
+| 8. Extract a shared `isScopeLocalEmitterName` helper. | **Reject** | The implementation already shares the emitter constant and general name normalizer. Another abstraction was not planned and is outside the accepted scope. |
+| 9. Extract duplicate issue-test fixtures. | **Reject** | Fixture refactoring is unrelated to the accepted behavior and is not required for the narrow test-quality corrections. |
+| 10. Extract a shared missing-required-output helper across three production sites. | **Reject** | The review did not demonstrate a current behavioral inconsistency. A new abstraction for possible future drift is outside scope. |
+| 11. Two test names claim a property exists only on a prototype. | **In-scope-Fix** | Both tests use an own required-output key named `toString` and verify that inherited membership on an empty emitted-output object does not count as emission. Rename the tests to state that behavior accurately. |
+| 12. A direct-runtime successful four-output test lacks an explicit `GOAL` assertion. | **In-scope-Fix** | The Hermes direct-runtime case verifies values and request count but not termination mode. Add the behavioral `GOAL` assertion using the existing import. |
+| 13. Add docstrings to satisfy a coverage warning. | **Reject** | Docstring coverage is outside issue scope, and repository guidance requires comments only when they add necessary context. |
+| 14. CLI sandbox node-modules preflight expected a symlink path but received its contained target path. | **Defer** | This is an external CI observation in an unrelated CLI shard. The failed job was rerun. No agents or issue-3526 behavior is changed for it. |
+
+This remediation has no additional Blocker-Fix findings. Accepted edits are limited to the three test-quality corrections in findings 2, 11, and 12.
+
 ## Prior verification-log disposition
 
 `tmp/verify3526/npm-test-post-review.log` ends with the vscode companion summary and an explicit `Exit Code: 0` record. It therefore contains completion evidence for that prior full `npm run test` invocation. The final focused commands for this continuation are recorded separately and do not replace the foreground orchestrator's requested repository-wide verification.


### PR DESCRIPTION
## TLDR

Fixes non-interactive subagents becoming trapped in repeated completion prompts when required outputs remain but the scope-local `self_emitvalue` declaration is unavailable.

The change keeps the emitter callable through tool-selection filtering, routes native and Hermes-formatted calls to the same local handler, completes immediately after the final required values are emitted, and fails once with a specific error if emitter provisioning is broken. Successful `todo_pause` calls now stop the subagent without another completion prompt.

## Dive Deeper

`self_emitvalue` is a scope-local protocol tool rather than an ordinary registry tool. The normal setup added it, but `BeforeToolSelection` could later remove it when applying an ordinary-tool allowlist. Textual Hermes calls also attempted ordinary registry resolution, where the scope-local emitter does not exist. The completion loop could not distinguish missing output values from missing emitter provisioning, so it kept asking the model to call an unavailable tool.

This PR:

- preserves one required `self_emitvalue` declaration after `BeforeToolSelection` filtering without restoring unrelated ordinary tools;
- shares the scope-local emitter name and normalization across filtering and call resolution;
- resolves native and supported Hermes calls through the local emitter handler;
- tracks effective emitter availability for each non-interactive turn;
- terminates with `ERROR`, naming the missing output keys, when required outputs remain without a callable emitter;
- recognizes completion in the same function-call batch that emits the final required values, avoiding an unnecessary provider request and possible `MAX_TURNS` result;
- treats successful `todo_pause` as terminal, returning `GOAL` when outputs are complete and `ERROR` with the missing keys otherwise;
- preserves failed, malformed, and cancelled pause results as nonterminal tool responses;
- checks required outputs against own properties so prototype-chain names cannot falsely satisfy the output contract.

The issue plan in `project-plans/issue3526.md` records the accepted behavior, scope boundaries, behavioral evidence, and review-finding classifications. All local review findings were resolved. PR review produced three in-scope test-quality fixes, which are included in this change. Malformed emitter validation was deferred to #3540. Other PR suggestions were rejected, with reasons recorded in the issue plan.

Local verification on macOS passed on the final candidate:

- `npm run test`
- full-tree ESLint over `.` with `NODE_OPTIONS=--max-old-space-size=20480`
- `npm run typecheck`
- `npm run format`
- `npm run build`
- `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`
- issue-focused test-audit scan with no findings in the added tests

The standard `npm run lint` wrapper forced ESLint back to its fixed 12 GB heap and exited 134 from heap exhaustion before reporting lint findings. `scripts/run-lint.ts` uses the same full-tree `eslint .` target for a normal local run. Running that target directly with a 20 GB heap completed successfully without changing rules, files, or target coverage.

## Reviewer Test Plan

1. Run `bun test packages/agents/src/core/subagent.issue3526.test.ts packages/agents/src/core/subagentNonInteractive.issue3526.test.ts packages/agents/src/core/subagent.runNonInteractive-execution.test.ts`.
2. Verify a four-output subagent receives exactly one `self_emitvalue` declaration when hooks are disabled and when a tool-selection allowlist omits the emitter.
3. Verify four native emitter calls and four Hermes-formatted emitter calls each produce `GOAL` after one provider request.
4. Verify partial emission prompts only for remaining keys and completes on the response containing the final values.
5. Verify deliberately missing emitter provisioning returns one `ERROR` naming `self_emitvalue` and the missing keys without another request.
6. Verify successful `todo_pause` stops immediately, while failed, malformed, and cancelled pauses continue with their tool result.
7. Run the repository test, lint, typecheck, format, and build checks.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3526

Related tooling failure observed during delegated implementation: #3535

Follow-up malformed emitter argument validation: #3540

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved non-interactive subagent output completion and validation.
  - Preserved the local output emitter when tool restrictions are applied.
  - Correctly handles missing, duplicate, inherited, or unavailable output emitters.
  - Added reliable pause handling, including success, failure, cancellation, and malformed results.
  - Prevented unnecessary follow-up model requests after output emission.

- **Tests**
  - Added comprehensive coverage for emitter filtering, output completion, nudging, pause behavior, and edge cases involving output names and declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->