### PR TITLE
fix(sandbox): isolate macOS Podman dependencies (Fixes #3534)

### DIFF
--- a/integration-tests/sandboxNodeModulesIsolation.real.test.ts
+++ b/integration-tests/sandboxNodeModulesIsolation.real.test.ts
@@ -1175,6 +1175,371 @@ ${result.stderr ?? ''}
   };
 }
 
+interface SourceFailureFixture {
+  readonly root: string;
+  readonly storageRoot: string;
+  readonly preparationStarted: string;
+  readonly sourceEntrypointRan: string;
+  readonly responsesFile: string;
+  readonly nodeModulesSnapshot: ReadonlyMap<string, TreeEntry>;
+  readonly bunLock: Buffer;
+  readonly packageLock: Buffer;
+}
+
+interface BranchLaunch {
+  readonly child: ChildProcess;
+  readonly completion: Promise<LaunchResult>;
+  readonly output: () => { readonly stdout: string; readonly stderr: string };
+}
+
+function buildSourceFailureFixture(home: string): SourceFailureFixture {
+  const root = join(home, 'source-checkout');
+  const storageRoot = join(home, 'storage');
+  const preparationStarted = join(root, 'preparation-started.txt');
+  const sourceEntrypointRan = join(root, 'source-entrypoint-ran.txt');
+  const responsesFile = join(root, 'fake-responses.jsonl');
+  const nodeModules = join(root, 'node_modules');
+  const binDir = join(nodeModules, '.bin');
+  const hostToolDir = join(nodeModules, 'host-tool');
+
+  writeJsonFile(join(root, 'package.json'), {
+    name: 'issue3534-source-failure-fixture',
+    private: true,
+    workspaces: [],
+    scripts: { postinstall: 'sh ./fail-preparation.sh' },
+  });
+  writeTextFile(
+    join(root, 'bun.lock'),
+    JSON.stringify({
+      lockfileVersion: 1,
+      configVersion: 0,
+      workspaces: {
+        '': { name: 'issue3534-source-failure-fixture' },
+      },
+      packages: {},
+    }) + '\n',
+  );
+  writeJsonFile(join(root, 'package-lock.json'), {
+    name: 'issue3534-source-failure-fixture',
+    lockfileVersion: 3,
+  });
+  writeTextFile(join(hostToolDir, 'index.js'), 'host dependency marker\n');
+  mkdirSync(binDir, { recursive: true });
+  symlinkSync('../host-tool/index.js', join(binDir, 'host-tool'));
+  writeTextFile(join(nodeModules, 'host-marker.txt'), 'host node_modules\n');
+  writeTextFile(
+    join(root, 'packages', 'cli', 'index.ts'),
+    [
+      "import { writeFileSync } from 'node:fs';",
+      `writeFileSync(${JSON.stringify(sourceEntrypointRan)}, 'unexpected source execution\\n');`,
+    ].join('\n'),
+  );
+  writeScript(
+    join(root, 'fail-preparation.sh'),
+    [
+      "printf 'dependency preparation acquired resources\\n' > ./preparation-started.txt",
+      'sleep 3',
+      "printf 'induced dependency preparation failure\\n' >&2",
+      'exit 42',
+    ].join('\n'),
+  );
+  writeTextFile(
+    responsesFile,
+    JSON.stringify({
+      chunks: [
+        {
+          speaker: 'ai',
+          blocks: [{ type: 'text', text: 'must not execute' }],
+        },
+      ],
+    }) + '\n',
+  );
+  for (const dir of ['config', 'data', 'cache', 'log']) {
+    mkdirSync(join(storageRoot, dir), { recursive: true });
+  }
+
+  const nodeModulesSnapshot = snapshotTree(nodeModules);
+  if (nodeModulesSnapshot === undefined) {
+    throw new Error('source failure fixture node_modules was not created');
+  }
+  return {
+    root,
+    storageRoot,
+    preparationStarted,
+    sourceEntrypointRan,
+    responsesFile,
+    nodeModulesSnapshot,
+    bunLock: readFileSync(join(root, 'bun.lock')),
+    packageLock: readFileSync(join(root, 'package-lock.json')),
+  };
+}
+
+function entriesWithPrefix(root: string, prefix: string): string[] {
+  if (!existsSync(root)) return [];
+  return readdirSync(root)
+    .filter((entry) => entry.startsWith(prefix))
+    .map((entry) => join(root, entry))
+    .sort();
+}
+
+function podmanReverseTunnelPids(): number[] {
+  const output = execFileSync('ps', ['-axo', 'pid=,command='], {
+    encoding: 'utf8',
+    timeout: 10_000,
+  });
+  const pids: number[] = [];
+  for (const line of output.split(/\r?\n/)) {
+    const match = /^\s*(\d+)\s+(.+)$/.exec(line);
+    if (match === null) continue;
+    const command = match[2];
+    if (
+      command.includes('ssh ') &&
+      command.includes('ExitOnForwardFailure=yes') &&
+      command.includes(' -R ')
+    ) {
+      pids.push(Number(match[1]));
+    }
+  }
+  return pids.sort((left, right) => left - right);
+}
+
+function launchSourcePreparationFailure(
+  fixture: SourceFailureFixture,
+): BranchLaunch {
+  const childEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    NODE_ENV: 'development',
+    HOME: process.env.HOME,
+    NO_BROWSER: 'true',
+    LLXPRT_NO_BROWSER_AUTH: 'true',
+    CI: 'true',
+    SANDBOX_SET_UID_GID: 'false',
+    LLXPRT_CONFIG_HOME: join(fixture.storageRoot, 'config'),
+    LLXPRT_DATA_HOME: join(fixture.storageRoot, 'data'),
+    LLXPRT_CACHE_HOME: join(fixture.storageRoot, 'cache'),
+    LLXPRT_LOG_HOME: join(fixture.storageRoot, 'log'),
+    LLXPRT_FAKE_RESPONSES: fixture.responsesFile,
+    SANDBOX_FLAGS: '',
+    SANDBOX_MOUNTS: '',
+  };
+  delete childEnv.SSH_AUTH_SOCK;
+  const child = spawn(
+    process.execPath,
+    [
+      CLI_ENTRY,
+      '--yolo',
+      '--ide-mode',
+      'disable',
+      '--sandbox',
+      '--sandbox-engine',
+      'podman',
+      '--sandbox-image',
+      IMAGE,
+      '--provider',
+      'fake',
+      '--model',
+      'fake-model',
+      'This prompt must not reach the source entrypoint.',
+    ],
+    {
+      cwd: fixture.root,
+      env: childEnv,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: AGENT_SESSION_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
+    },
+  );
+  let stdout = '';
+  let stderr = '';
+  let spawnError = '';
+  child.stdout?.setEncoding('utf8');
+  child.stderr?.setEncoding('utf8');
+  child.stdout?.on('data', (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr?.on('data', (chunk: string) => {
+    stderr += chunk;
+  });
+  child.once('error', (error) => {
+    spawnError = error.message;
+  });
+  const completion = new Promise<LaunchResult>((resolve) => {
+    child.once('close', (status) => {
+      resolve({
+        status,
+        stdout,
+        stderr: stderr + (spawnError === '' ? '' : `\n${spawnError}`),
+      });
+    });
+  });
+  return {
+    child,
+    completion,
+    output: () => ({ stdout, stderr }),
+  };
+}
+
+function waitForPreparationStart(
+  launch: BranchLaunch,
+  markerPath: string,
+): Promise<void> {
+  return bounded(
+    new Promise<void>((resolve, reject) => {
+      const timer = setInterval(() => {
+        if (existsSync(markerPath)) {
+          clearInterval(timer);
+          resolve();
+          return;
+        }
+        if (
+          launch.child.exitCode !== null ||
+          launch.child.signalCode !== null
+        ) {
+          clearInterval(timer);
+          const output = launch.output();
+          reject(
+            new Error(
+              `Branch launcher exited before dependency preparation started.\n` +
+                `--- stdout ---\n${output.stdout}\n` +
+                `--- stderr ---\n${output.stderr}`,
+            ),
+          );
+        }
+      }, 100);
+    }),
+    120_000,
+    'source dependency preparation startup',
+  );
+}
+
+function describePodmanSourcePreparationFailure(): void {
+  const enabled =
+    process.platform === 'darwin' &&
+    process.env.LLXPRT_RUN_REAL_PODMAN_SOURCE_FAILURE === 'true' &&
+    ENGINES.includes('podman');
+  describe.skipIf(!enabled)(
+    'Sandbox source preparation failure cleanup (real Podman macOS) #3534',
+    () => {
+      it(
+        'uses inherited TMPDIR and releases every acquired resource without mutating host dependencies',
+        async () => {
+          const home = mkdtempSync(join(tmpdir(), 'issue3534-source-failure-'));
+          const fixture = buildSourceFailureFixture(home);
+          const sessionRoot = realpathSync(tmpdir());
+          const shortRuntimeRoot = '/tmp';
+          const containersBefore = queryDependencyResources(
+            'podman',
+            'container',
+          );
+          const volumesBefore = queryDependencyResources('podman', 'volume');
+          const sessionsBefore = entriesWithPrefix(
+            sessionRoot,
+            'llxprt-sandbox-',
+          );
+          const shortRuntimesBefore = entriesWithPrefix(
+            shortRuntimeRoot,
+            'lx-',
+          );
+          const tunnelsBefore = podmanReverseTunnelPids();
+          let launch: BranchLaunch | undefined;
+
+          try {
+            launch = launchSourcePreparationFailure(fixture);
+            await waitForPreparationStart(launch, fixture.preparationStarted);
+            const activeContainers = queryDependencyResources(
+              'podman',
+              'container',
+            ).filter((name) => !containersBefore.includes(name));
+            const activeVolumes = queryDependencyResources(
+              'podman',
+              'volume',
+            ).filter((name) => !volumesBefore.includes(name));
+            const activeSessions = entriesWithPrefix(
+              sessionRoot,
+              'llxprt-sandbox-',
+            ).filter((entry) => !sessionsBefore.includes(entry));
+            const activeShortRuntimes = entriesWithPrefix(
+              shortRuntimeRoot,
+              'lx-',
+            ).filter((entry) => !shortRuntimesBefore.includes(entry));
+            const activeTunnels = podmanReverseTunnelPids().filter(
+              (pid) => !tunnelsBefore.includes(pid),
+            );
+            const result = await bounded(
+              launch.completion,
+              AGENT_SESSION_TIMEOUT_MS + 10_000,
+              'source preparation failure launch',
+            );
+            const containersAfter = queryDependencyResources(
+              'podman',
+              'container',
+            );
+            const volumesAfter = queryDependencyResources('podman', 'volume');
+            const tunnelsAfter = podmanReverseTunnelPids();
+
+            expect(process.env.TMPDIR).toBeDefined();
+            expect(activeContainers.length).toBeGreaterThan(0);
+            expect(activeVolumes.length).toBeGreaterThan(0);
+            expect(activeSessions.length).toBeGreaterThan(0);
+            expect(activeShortRuntimes.length).toBeGreaterThan(0);
+            expect(activeTunnels.length).toBeGreaterThan(0);
+            expect(result.status).not.toBe(0);
+            expect(result.stderr).toContain(
+              'induced dependency preparation failure',
+            );
+            expect(result.stderr).toContain(
+              'Failed to prepare isolated Linux dependencies for LLxprt source development',
+            );
+            expect(existsSync(fixture.sourceEntrypointRan)).toBe(false);
+            expect(containersAfter).toStrictEqual(containersBefore);
+            expect(volumesAfter).toStrictEqual(volumesBefore);
+            for (const resourcePath of [
+              ...activeSessions,
+              ...activeShortRuntimes,
+            ]) {
+              expect(existsSync(resourcePath)).toBe(false);
+            }
+            for (const pid of activeTunnels) {
+              expect(tunnelsAfter).not.toContain(pid);
+            }
+            expect(
+              snapshotTree(join(fixture.root, 'node_modules')),
+            ).toStrictEqual(fixture.nodeModulesSnapshot);
+            expect(readFileSync(join(fixture.root, 'bun.lock'))).toStrictEqual(
+              fixture.bunLock,
+            );
+            expect(
+              readFileSync(join(fixture.root, 'package-lock.json')),
+            ).toStrictEqual(fixture.packageLock);
+          } finally {
+            try {
+              if (
+                launch !== undefined &&
+                launch.child.exitCode === null &&
+                launch.child.signalCode === null
+              ) {
+                launch.child.kill('SIGKILL');
+              }
+              if (launch !== undefined) {
+                await bounded(
+                  launch.completion,
+                  10_000,
+                  'source failure test process cleanup',
+                );
+              }
+            } finally {
+              if (process.env.ISSUE3534_KEEP_REAL_FIXTURE === undefined) {
+                rmSync(home, { recursive: true, force: true });
+              }
+            }
+          }
+        },
+        AGENT_SESSION_TIMEOUT_MS + 30_000,
+      );
+    },
+  );
+}
+
 // --- the real-engine suites ---------------------------------------------------
 
 function describeEngine(engine: string): void {
@@ -1644,5 +2009,6 @@ if (process.platform !== 'win32') {
   describeEngine('docker');
   describeEngine('podman');
   describeAbruptRecoveryEngine('docker');
+  describePodmanSourcePreparationFailure();
   describeAbruptRecoveryEngine('podman');
 }

--- a/packages/agents/src/core/__tests__/providerAgnosticNamingAllowlist.ts
+++ b/packages/agents/src/core/__tests__/providerAgnosticNamingAllowlist.ts
@@ -119,6 +119,8 @@ export const ALLOWED_GEMINI_PAIRS: readonly string[] = [
   'providers/src/__tests__/LoadBalancingProvider.delegation.test.ts::mockGeminiProvider',
   'providers/src/__tests__/LoadBalancingProvider.delegation.test.ts::mockGemini',
   'providers/src/composition/providerManagerInstance.oauthRegistration.test.ts::MockGeminiProvider',
+  'providers/src/composition/providerManagerInstance.oauthRegistration.test.ts::geminiCtorState',
+  'providers/src/composition/providerManagerInstance.oauthRegistration.test.ts::geminiCtor',
   'providers/src/composition/providerManagerInstance.schemaDefaults.test.ts::MockGeminiProvider',
 ];
 

--- a/packages/agents/src/core/__tests__/providerAgnosticNamingAllowlist.ts
+++ b/packages/agents/src/core/__tests__/providerAgnosticNamingAllowlist.ts
@@ -212,6 +212,7 @@ export const ALLOWED_IMPORT_TUPLES: readonly string[] = [
   'core/test/models/profiles.test.ts::./__fixtures__/mock-data.js::geminiModel::geminiModel',
   'core/test/models/transformer.test.ts::./__fixtures__/mock-data.js::geminiModel::geminiModel',
   'providers/src/fake/FakeProvider.ts::@vybestack/llxprt-code-core/llm-types/index.js::GeminiContent::GeminiContent',
+  'providers/src/composition/aliasProviderFactory.authOnly.test.ts::./aliasProviderFactory.js::createGeminiAliasProvider::createGeminiAliasProvider',
   'providers/src/composition/aliasProviderFactory.ts::../gemini/GeminiProvider.js::GeminiProvider::GeminiProvider',
   'providers/src/utils/providerRequestConversion.ts::../gemini/GeminiMessageConverter.js::convertHistoryToGeminiFormat::convertHistoryToGeminiFormat',
   'settings/src/profiles/__tests__/canonicalProfileRepair.test.ts::./canonicalProfileRepair.testHelpers.js::corruptCanonicalProfileNonGeminiModel::corruptCanonicalProfileNonGeminiModel',

--- a/packages/cli/src/utils/sandbox-containers.test.ts
+++ b/packages/cli/src/utils/sandbox-containers.test.ts
@@ -636,6 +636,74 @@ describe('#2902 sandbox privilege hardening', () => {
     expect(proxyArgs[userIdx + 1]).toBe('501:20');
   });
 });
+describe('#3501 sandbox proxy sidecar endpoint', () => {
+  let environmentSnapshot: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    environmentSnapshot = { ...process.env };
+    vi.resetAllMocks();
+    for (const key of NETWORK_ENV_KEYS) delete process.env[key];
+  });
+
+  afterEach(() => {
+    process.env = environmentSnapshot;
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Records the sidecar argv without launching anything: spawn throws
+   * immediately, so startProxyContainer rejects before any I/O while the
+   * call arguments remain observable.
+   */
+  async function captureProxySidecarArgv(): Promise<string[]> {
+    const spawnMock = childProcess.spawn as unknown as Mock<
+      typeof childProcess.spawn
+    >;
+    spawnMock.mockImplementation(() => {
+      throw new Error('proxy-argv-captured');
+    });
+    await expect(
+      startProxyContainer(CONFIG, 'echo proxy', '', 'test-image', '/workspace'),
+    ).rejects.toThrow('proxy-argv-captured');
+    const argv = spawnMock.mock.calls[0][1];
+    if (!Array.isArray(argv)) {
+      throw new Error('proxy sidecar was spawned without an argv');
+    }
+    return argv;
+  }
+
+  function publishedPortMapping(argv: readonly string[]): string {
+    const publishIndex = argv.indexOf('-p');
+    expect(publishIndex).toBeGreaterThanOrEqual(0);
+    return argv[publishIndex + 1];
+  }
+
+  it('publishes the documented default port when nothing configures a proxy', async () => {
+    expect(publishedPortMapping(await captureProxySidecarArgv())).toBe(
+      '8877:8877',
+    );
+  });
+
+  it('publishes the configured proxy port so the host readiness probe reaches the sidecar', async () => {
+    process.env.HTTPS_PROXY = 'http://localhost:49877';
+
+    expect(publishedPortMapping(await captureProxySidecarArgv())).toBe(
+      '49877:49877',
+    );
+  });
+
+  it('rejects a proxy endpoint with no resolvable port before starting the sidecar', async () => {
+    process.env.HTTPS_PROXY = 'localhost:8877';
+    const spawnMock = childProcess.spawn as unknown as Mock<
+      typeof childProcess.spawn
+    >;
+
+    await expect(
+      startProxyContainer(CONFIG, 'echo proxy', '', 'test-image', '/workspace'),
+    ).rejects.toBeInstanceOf(FatalSandboxError);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});
 
 // Parsing helpers that operate on the produced docker argv. They look only at
 // the real buildContainerRunArgs output — no mocks — so the assertions pin the

--- a/packages/cli/src/utils/sandbox-containers.ts
+++ b/packages/cli/src/utils/sandbox-containers.ts
@@ -55,6 +55,11 @@ import {
   cleanupCredentialSocketRuntime,
   createCredentialSocketRuntime,
 } from './sandbox-credential-runtime.js';
+import {
+  awaitSandboxProxyReady,
+  resolveSandboxProxyPort,
+  resolveSandboxProxyUrl,
+} from './sandbox-network-proxy.js';
 
 export { containerMountSources };
 
@@ -136,19 +141,6 @@ function rewriteProxyHostname(proxyUrl: string): string {
   } catch {
     return proxyUrl;
   }
-}
-
-function resolveProxyUrl(): string {
-  const candidates = [
-    process.env.HTTPS_PROXY,
-    process.env.https_proxy,
-    process.env.HTTP_PROXY,
-    process.env.http_proxy,
-  ];
-  return (
-    candidates.find((v): v is string => v !== undefined && v !== '') ??
-    'http://localhost:8877'
-  );
 }
 
 function isNonEmptyEnvValue(value: string | undefined): value is string {
@@ -431,7 +423,7 @@ export function setupContainerNetworking(
 ): string | undefined {
   const proxyCommand = process.env.LLXPRT_SANDBOX_PROXY_COMMAND;
   if (isNonEmptyEnvValue(proxyCommand)) {
-    const proxy = rewriteProxyHostname(resolveProxyUrl());
+    const proxy = rewriteProxyHostname(resolveSandboxProxyUrl(process.env));
     args.push('--env', `HTTPS_PROXY=${proxy}`);
     args.push('--env', `https_proxy=${proxy}`);
     args.push('--env', `HTTP_PROXY=${proxy}`);
@@ -767,6 +759,11 @@ export async function startProxyContainer(
   workdir: string,
   lifecycle?: SandboxLaunchLifecycle,
 ): Promise<ProxyContainerHandle> {
+  // The host probes this endpoint for readiness and the sandboxed child is
+  // handed the same port on the sidecar's hostname, so the published mapping
+  // has to follow the configured endpoint rather than a fixed number.
+  const proxyUrl = resolveSandboxProxyUrl(process.env);
+  const proxyPort = resolveSandboxProxyPort(proxyUrl);
   const proxyContainerArgs = [
     'run',
     '--rm',
@@ -778,7 +775,7 @@ export async function startProxyContainer(
     '--network',
     SANDBOX_PROXY_NAME,
     '-p',
-    '8877:8877',
+    `${proxyPort}:${proxyPort}`,
     '-v',
     `${process.cwd()}:${workdir}`,
     '--workdir',
@@ -823,10 +820,7 @@ export async function startProxyContainer(
   debugLogger.log('waiting for proxy to start ...');
   const PROXY_READY_TIMEOUT_MS = 30000;
   try {
-    await execAsync(
-      `timeout ${Math.floor(PROXY_READY_TIMEOUT_MS / 1000)} bash -c 'until curl -s http://localhost:8877; do sleep 0.25; done'`,
-      { timeout: PROXY_READY_TIMEOUT_MS + 5000 },
-    );
+    await awaitSandboxProxyReady(proxyUrl, PROXY_READY_TIMEOUT_MS);
   } catch (err) {
     stopProxyContainer();
     throw new FatalSandboxError(

--- a/packages/cli/src/utils/sandbox-containers.ts
+++ b/packages/cli/src/utils/sandbox-containers.ts
@@ -51,6 +51,10 @@ import {
 import { Storage } from '@vybestack/llxprt-code-storage';
 import type { DependencyVolumeLifecycle } from './sandbox-node-modules.js';
 import type { SandboxLaunchLifecycle } from './sandbox-lifecycle.js';
+import {
+  cleanupCredentialSocketRuntime,
+  createCredentialSocketRuntime,
+} from './sandbox-credential-runtime.js';
 
 export { containerMountSources };
 
@@ -650,7 +654,7 @@ function assertSupportedCredentialNetwork(config: SandboxConfig): void {
 
 async function startCredentialProxyForSandbox(
   config: SandboxConfig,
-  sessionTmpdir: string,
+  socketRuntimePath: string,
   sessionTmpdirCleanup: () => void,
 ): Promise<string> {
   try {
@@ -659,7 +663,7 @@ async function startCredentialProxyForSandbox(
     throwCredentialProxySetupError(error, sessionTmpdirCleanup);
   }
   try {
-    await createAndStartProxy({ socketPath: sessionTmpdir });
+    await createAndStartProxy({ socketPath: socketRuntimePath });
   } catch (error) {
     throwCredentialProxySetupError(
       new FatalSandboxError(
@@ -685,15 +689,15 @@ export async function setupCredentialProxy(
   credentialProxyBridgeResult: CredentialProxyBridgeResult | undefined;
   credentialProxyBridgeCleanup: (() => void) | undefined;
 }> {
-  const sessionTmpdirCleanup = (): void => {
-    fs.rmSync(sessionTmpdir, { recursive: true, force: true });
-  };
+  const socketRuntime = createCredentialSocketRuntime(config, sessionTmpdir);
+  const sessionTmpdirCleanup = (): void =>
+    cleanupCredentialSocketRuntime(socketRuntime, sessionTmpdir);
   // @plan:PLAN-20250214-CREDPROXY.P34 R25.1: Start credential proxy BEFORE spawning container
   let socketPath: string;
   try {
     socketPath = await startCredentialProxyForSandbox(
       config,
-      sessionTmpdir,
+      socketRuntime.path,
       sessionTmpdirCleanup,
     );
   } catch (error) {

--- a/packages/cli/src/utils/sandbox-credential-runtime.ts
+++ b/packages/cli/src/utils/sandbox-credential-runtime.ts
@@ -72,13 +72,24 @@ export function createCredentialSocketRuntime(
       );
     }
   } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    const initializationError =
+      error instanceof FatalSandboxError
+        ? error
+        : new FatalSandboxError(
+            `Failed to create a private Podman macOS credential socket runtime under '${PODMAN_DARWIN_SOCKET_RUNTIME_ROOT}': ${detail}`,
+          );
     if (runtimePath !== '') {
-      fs.rmSync(runtimePath, { recursive: true, force: true });
+      try {
+        fs.rmSync(runtimePath, { recursive: true, force: true });
+      } catch (cleanupError) {
+        throw new AggregateError(
+          [initializationError, cleanupError],
+          'Podman macOS credential socket runtime initialization and cleanup failed',
+        );
+      }
     }
-    if (error instanceof FatalSandboxError) throw error;
-    throw new FatalSandboxError(
-      `Failed to create a private Podman macOS credential socket runtime under '${PODMAN_DARWIN_SOCKET_RUNTIME_ROOT}': ${error instanceof Error ? error.message : String(error)}`,
-    );
+    throw initializationError;
   }
   return {
     path: runtimePath,

--- a/packages/cli/src/utils/sandbox-credential-runtime.ts
+++ b/packages/cli/src/utils/sandbox-credential-runtime.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  FatalSandboxError,
+  type SandboxConfig,
+} from '@vybestack/llxprt-code-core';
+
+const PODMAN_DARWIN_SOCKET_RUNTIME_ROOT = '/tmp';
+const PODMAN_DARWIN_SOCKET_RUNTIME_PREFIX = 'lx-';
+const DARWIN_UNIX_SOCKET_PATH_MAX_BYTES = 103;
+
+export interface CredentialSocketRuntime {
+  readonly path: string;
+  readonly cleanup: () => void;
+}
+
+export function cleanupCredentialSocketRuntime(
+  socketRuntime: CredentialSocketRuntime,
+  sessionTmpdir: string,
+): void {
+  const errors: unknown[] = [];
+  for (const cleanup of [
+    socketRuntime.cleanup,
+    () => fs.rmSync(sessionTmpdir, { recursive: true, force: true }),
+  ]) {
+    try {
+      cleanup();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length === 1) throw errors[0];
+  if (errors.length > 1) {
+    throw new AggregateError(
+      errors,
+      'Credential proxy session directory cleanup failed',
+    );
+  }
+}
+
+export function createCredentialSocketRuntime(
+  config: SandboxConfig,
+  sessionTmpdir: string,
+): CredentialSocketRuntime {
+  if (os.platform() !== 'darwin' || config.command !== 'podman') {
+    return { path: sessionTmpdir, cleanup: () => {} };
+  }
+
+  let runtimePath = '';
+  try {
+    runtimePath = fs.mkdtempSync(
+      path.join(
+        PODMAN_DARWIN_SOCKET_RUNTIME_ROOT,
+        PODMAN_DARWIN_SOCKET_RUNTIME_PREFIX,
+      ),
+    );
+    fs.chmodSync(runtimePath, 0o700);
+    const socketBasename = `${process.pid}-${'x'.repeat(22)}.sock`;
+    const longestSocketPath = path.join(runtimePath, socketBasename);
+    if (
+      Buffer.byteLength(longestSocketPath) > DARWIN_UNIX_SOCKET_PATH_MAX_BYTES
+    ) {
+      throw new FatalSandboxError(
+        `Podman macOS credential socket path '${longestSocketPath}' exceeds Darwin's ${DARWIN_UNIX_SOCKET_PATH_MAX_BYTES}-byte pathname limit.`,
+      );
+    }
+  } catch (error) {
+    if (runtimePath !== '') {
+      fs.rmSync(runtimePath, { recursive: true, force: true });
+    }
+    if (error instanceof FatalSandboxError) throw error;
+    throw new FatalSandboxError(
+      `Failed to create a private Podman macOS credential socket runtime under '${PODMAN_DARWIN_SOCKET_RUNTIME_ROOT}': ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  return {
+    path: runtimePath,
+    cleanup: () => {
+      fs.rmSync(runtimePath, { recursive: true, force: true });
+    },
+  };
+}

--- a/packages/cli/src/utils/sandbox-credential.test.ts
+++ b/packages/cli/src/utils/sandbox-credential.test.ts
@@ -338,3 +338,166 @@ describe('#1456 credential proxy network policy', () => {
     },
   );
 });
+
+describe('#3534 Podman credential socket runtime', () => {
+  let environmentSnapshot: NodeJS.ProcessEnv;
+  let fixtureRoot = '';
+  let sessionTmpdir = '';
+
+  beforeEach(() => {
+    environmentSnapshot = { ...process.env };
+    fixtureRoot = fs.mkdtempSync(path.join(realOsTmpdir(), 'issue3534-cred-'));
+    const longTmpRoot = path.join(
+      fixtureRoot,
+      'private',
+      'var',
+      'folders',
+      'abcdefghijklmnopqrstuvwxyz0123456789',
+      'T',
+    );
+    sessionTmpdir = path.join(longTmpRoot, 'llxprt-sandbox-session');
+    fs.mkdirSync(sessionTmpdir, { recursive: true, mode: 0o700 });
+    overrideOsTmpdir(longTmpRoot);
+    vi.spyOn(os, 'platform').mockReturnValue('darwin');
+    authMocks.getProxyCapabilityToken.mockReturnValue(CAPABILITY_TOKEN);
+    authMocks.stopProxy.mockResolvedValue(undefined);
+    bridgeMocks.setupCredentialProxyPodmanMacOS.mockResolvedValue({
+      cleanup: bridgeMocks.podmanCleanup,
+      entrypointPrefix: 'PODMAN_CREDENTIAL_BRIDGE',
+      containerSocketPath: '/tmp/podman-credential.sock',
+    });
+  });
+
+  afterEach(() => {
+    process.env = environmentSnapshot;
+    restoreOsTmpdir();
+    vi.restoreAllMocks();
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it('uses a private short socket directory despite a long normal temporary root and removes it on cleanup', async () => {
+    let socketRuntime = '';
+    let socketPath = '';
+    authMocks.createAndStartProxy.mockImplementation(
+      async (config: { socketPath: string }) => {
+        socketRuntime = config.socketPath;
+        socketPath = path.join(
+          socketRuntime,
+          `${process.pid}-${'n'.repeat(22)}.sock`,
+        );
+        fs.writeFileSync(socketPath, 'socket fixture');
+        return { stop: async (): Promise<void> => {} };
+      },
+    );
+    authMocks.getProxySocketPath.mockImplementation(() => socketPath);
+
+    const invocation = invokeCredentialSetup('podman', sessionTmpdir);
+    const result = await invocation.promise;
+
+    expect(socketRuntime.startsWith(sessionTmpdir)).toBe(false);
+    expect(Buffer.byteLength(socketPath)).toBeLessThanOrEqual(103);
+    expect(fs.statSync(socketRuntime).mode & 0o777).toBe(0o700);
+    expect(fs.existsSync(socketPath)).toBe(true);
+
+    result.credentialProxyBridgeCleanup?.();
+    expect(fs.existsSync(socketRuntime)).toBe(false);
+    expect(fs.existsSync(sessionTmpdir)).toBe(false);
+  });
+
+  it('removes the short socket directory and normal session directory when bridge setup fails', async () => {
+    let socketRuntime = '';
+    let socketPath = '';
+    authMocks.createAndStartProxy.mockImplementation(
+      async (config: { socketPath: string }) => {
+        socketRuntime = config.socketPath;
+        socketPath = path.join(
+          socketRuntime,
+          `${process.pid}-${'n'.repeat(22)}.sock`,
+        );
+        fs.writeFileSync(socketPath, 'socket fixture');
+        return { stop: async (): Promise<void> => {} };
+      },
+    );
+    authMocks.getProxySocketPath.mockImplementation(() => socketPath);
+    bridgeMocks.setupCredentialProxyPodmanMacOS.mockRejectedValue(
+      new FatalSandboxError('induced Podman bridge failure'),
+    );
+
+    const result = invokeCredentialSetup('podman', sessionTmpdir).promise;
+
+    await expect(result).rejects.toThrow('induced Podman bridge failure');
+    expect(socketRuntime).not.toBe('');
+    expect(fs.existsSync(socketRuntime)).toBe(false);
+    expect(fs.existsSync(sessionTmpdir)).toBe(false);
+  });
+
+  it('removes the normal session directory when short socket runtime removal fails and surfaces the failure', async () => {
+    let socketRuntime = '';
+    let socketPath = '';
+    authMocks.createAndStartProxy.mockImplementation(
+      async (config: { socketPath: string }) => {
+        socketRuntime = config.socketPath;
+        socketPath = path.join(
+          socketRuntime,
+          `${process.pid}-${'n'.repeat(22)}.sock`,
+        );
+        fs.writeFileSync(socketPath, 'socket fixture');
+        return { stop: async (): Promise<void> => {} };
+      },
+    );
+    authMocks.getProxySocketPath.mockImplementation(() => socketPath);
+    const result = await invokeCredentialSetup('podman', sessionTmpdir).promise;
+    const realRmSync = fs.rmSync.bind(fs);
+    const rmSpy = vi
+      .spyOn(fs, 'rmSync')
+      .mockImplementation((target, options) => {
+        if (target.toString() === socketRuntime) {
+          throw new Error('induced short runtime cleanup failure');
+        }
+        return realRmSync(target, options);
+      });
+    let cleanupError: unknown;
+
+    try {
+      result.credentialProxyBridgeCleanup?.();
+    } catch (error) {
+      cleanupError = error;
+    } finally {
+      rmSpy.mockRestore();
+    }
+
+    expect(cleanupError).toBeInstanceOf(AggregateError);
+    if (!(cleanupError instanceof AggregateError)) {
+      throw new Error('Expected credential cleanup to aggregate its failure');
+    }
+    expect(
+      cleanupError.errors.some(
+        (error: unknown) =>
+          error instanceof Error &&
+          error.message === 'induced short runtime cleanup failure',
+      ),
+    ).toBe(true);
+    expect(fs.existsSync(sessionTmpdir)).toBe(false);
+    realRmSync(socketRuntime, { recursive: true, force: true });
+  });
+
+  it('keeps installed Docker compatibility by using the normal session directory', async () => {
+    let socketRuntime = '';
+    const socketPath = path.join(sessionTmpdir, HOST_SOCKET_NAME);
+    authMocks.createAndStartProxy.mockImplementation(
+      async (config: { socketPath: string }) => {
+        socketRuntime = config.socketPath;
+        fs.writeFileSync(socketPath, 'socket fixture');
+        return { stop: async (): Promise<void> => {} };
+      },
+    );
+    authMocks.getProxySocketPath.mockReturnValue(socketPath);
+
+    const invocation = invokeCredentialSetup('docker', sessionTmpdir);
+    const result = await invocation.promise;
+
+    expect(socketRuntime).toBe(sessionTmpdir);
+    result.credentialProxyBridgeCleanup?.();
+    expect(fs.existsSync(sessionTmpdir)).toBe(false);
+  });
+});

--- a/packages/cli/src/utils/sandbox-credential.test.ts
+++ b/packages/cli/src/utils/sandbox-credential.test.ts
@@ -41,6 +41,7 @@ void vi.mock('./sandbox-podman.js', () => ({
 }));
 
 import { setupCredentialProxy } from './sandbox-containers.js';
+import { createCredentialSocketRuntime } from './sandbox-credential-runtime.js';
 
 const NETWORK_ENV_KEYS = ['LLXPRT_SANDBOX_NETWORK', 'SANDBOX_NETWORK'] as const;
 const CAPABILITY_TOKEN = 'a'.repeat(64);
@@ -479,6 +480,110 @@ describe('#3534 Podman credential socket runtime', () => {
     ).toBe(true);
     expect(fs.existsSync(sessionTmpdir)).toBe(false);
     realRmSync(socketRuntime, { recursive: true, force: true });
+  });
+
+  // The runtime root is the literal '/tmp', so a real mkdtemp there can never
+  // reach the boundary; only the runtime directory name is substituted, and
+  // the directory itself is real so the guard's own cleanup is observed.
+  it('rejects a 104-byte Darwin runtime socket path before starting the proxy or Podman bridge', async () => {
+    const socketBasename = `${process.pid}-${'x'.repeat(22)}.sock`;
+    const shortestRuntime = path.join('/tmp', `r${process.pid}`);
+    const shortestSocketPath = path.join(shortestRuntime, socketBasename);
+    const runtimePath =
+      shortestRuntime + 'r'.repeat(104 - Buffer.byteLength(shortestSocketPath));
+    const longestSocketPath = path.join(runtimePath, socketBasename);
+    fs.mkdirSync(runtimePath, { recursive: true, mode: 0o700 });
+    const mkdtempSpy = vi.spyOn(fs, 'mkdtempSync').mockReturnValue(runtimePath);
+
+    const invocation = invokeCredentialSetup('podman', sessionTmpdir);
+
+    try {
+      expect(Buffer.byteLength(longestSocketPath)).toBe(104);
+      await expect(invocation.promise).rejects.toThrowError(
+        /exceeds Darwin's 103-byte pathname limit/,
+      );
+      // The rejection names the boundary rather than the downstream
+      // "proxy started but did not produce a socket path" failure, so the
+      // guard ran while the runtime was being constructed. Nothing was
+      // wired for the container and the rejected runtime left nothing behind.
+      expect(fs.existsSync(runtimePath)).toBe(false);
+      expect(invocation.args).toStrictEqual([]);
+      expect(invocation.prefixes).toStrictEqual([]);
+    } finally {
+      mkdtempSpy.mockRestore();
+      fs.rmSync(runtimePath, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts a 103-byte Darwin runtime socket path and keeps the runtime', async () => {
+    const socketBasename = `${process.pid}-${'x'.repeat(22)}.sock`;
+    const shortestRuntime = path.join('/tmp', `r${process.pid}`);
+    const shortestSocketPath = path.join(shortestRuntime, socketBasename);
+    const runtimePath =
+      shortestRuntime + 'r'.repeat(103 - Buffer.byteLength(shortestSocketPath));
+    const longestSocketPath = path.join(runtimePath, socketBasename);
+    fs.mkdirSync(runtimePath, { recursive: true, mode: 0o700 });
+    const mkdtempSpy = vi.spyOn(fs, 'mkdtempSync').mockReturnValue(runtimePath);
+
+    try {
+      expect(Buffer.byteLength(longestSocketPath)).toBe(103);
+      const runtime = createCredentialSocketRuntime(
+        { command: 'podman', image: 'test' },
+        sessionTmpdir,
+      );
+      expect(runtime.path).toBe(runtimePath);
+      expect(fs.existsSync(runtimePath)).toBe(true);
+      runtime.cleanup();
+      expect(fs.existsSync(runtimePath)).toBe(false);
+    } finally {
+      mkdtempSpy.mockRestore();
+      fs.rmSync(runtimePath, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves runtime initialization and cleanup failures together', () => {
+    const runtimePath = path.join('/tmp', 'lx-initialization-failure');
+    const initializationFailure = new Error(
+      'induced runtime permission initialization failure',
+    );
+    const cleanupFailure = new Error('induced runtime cleanup failure');
+    const mkdtempSpy = vi.spyOn(fs, 'mkdtempSync').mockReturnValue(runtimePath);
+    const chmodSpy = vi.spyOn(fs, 'chmodSync').mockImplementation(() => {
+      throw initializationFailure;
+    });
+    const rmSpy = vi.spyOn(fs, 'rmSync').mockImplementation(() => {
+      throw cleanupFailure;
+    });
+    let thrown: unknown;
+
+    try {
+      createCredentialSocketRuntime(
+        { command: 'podman', image: 'test' },
+        sessionTmpdir,
+      );
+    } catch (error) {
+      thrown = error;
+    } finally {
+      mkdtempSpy.mockRestore();
+      chmodSpy.mockRestore();
+      rmSpy.mockRestore();
+    }
+
+    expect(thrown).toBeInstanceOf(AggregateError);
+    if (!(thrown instanceof AggregateError)) {
+      throw new Error('Expected runtime failures to be aggregated');
+    }
+    expect(thrown.errors).toHaveLength(2);
+    // The initialization failure survives the failing cleanup instead of
+    // being replaced by it, and the cleanup failure is carried alongside.
+    const preserved: unknown = thrown.errors[0];
+    expect(preserved).toBeInstanceOf(FatalSandboxError);
+    if (!(preserved instanceof FatalSandboxError)) {
+      throw new Error('Expected the initialization failure to be preserved');
+    }
+    expect(preserved.message).toContain(initializationFailure.message);
+    expect(preserved.message).toContain("under '/tmp'");
+    expect(thrown.errors[1]).toBe(cleanupFailure);
   });
 
   it('keeps installed Docker compatibility by using the normal session directory', async () => {

--- a/packages/cli/src/utils/sandbox-entrypoint.ts
+++ b/packages/cli/src/utils/sandbox-entrypoint.ts
@@ -37,6 +37,24 @@ function buildPathSuffix(
   return suffix;
 }
 
+function buildSourceDependencyPreparation(workdir: string): string | undefined {
+  if (!isSourceDevelopmentWorkdir(workdir)) return undefined;
+  return [
+    'if [ ! -f package.json ] || [ ! -f bun.lock ]; then',
+    '  echo "LLxprt source development requires package.json and bun.lock in the repository root" >&2',
+    '  exit 1',
+    'fi',
+    'if ! command -v bun >/dev/null 2>&1; then',
+    '  echo "LLxprt source development requires Bun in the sandbox image" >&2',
+    '  exit 1',
+    'fi',
+    'if ! bun install --no-save; then',
+    '  echo "Failed to prepare isolated Linux dependencies for LLxprt source development" >&2',
+    '  exit 1',
+    'fi',
+  ].join(NL);
+}
+
 function resolveCliCommand(workdir: string): string {
   const isDebugMode = isSandboxDebugModeEnabled(process.env.DEBUG);
   const debugPort = resolveDebugPort();
@@ -222,6 +240,10 @@ export function entrypoint(
 
   const quotedCliArgs = cliArgs.slice(2).map((arg) => quote([arg]));
   const cliCmd = resolveCliCommand(workdir);
+  const sourceDependencyPreparation = buildSourceDependencyPreparation(workdir);
+  if (sourceDependencyPreparation !== undefined) {
+    shellCmds.push(sourceDependencyPreparation);
+  }
 
   // STEP 3: re-open fd 3 with the scrubbed capability (only when present) and
   // exec the final CLI.

--- a/packages/cli/src/utils/sandbox-launch-release.test.ts
+++ b/packages/cli/src/utils/sandbox-launch-release.test.ts
@@ -78,6 +78,10 @@ void vi.mock('node:child_process', () => {
   };
 });
 
+/** The two mocked child_process entry points, named once for the routers. */
+type SpawnMock = Mock<typeof childProcess.spawn>;
+type ExecSyncMock = Mock<typeof childProcess.execSync>;
+
 const PODMAN_MACHINE_CONNECTION = JSON.stringify([
   {
     Name: 'podman-machine-default-root',
@@ -202,6 +206,7 @@ describe('#3469 launch resource release', () => {
   const trackedChildren: TrackedChild[] = [];
   const trackedServers: net.Server[] = [];
   const createdSessionTmpdirs: string[] = [];
+  const createdScenarioTmpdirs: string[] = [];
   let tmpdirSnapshot = new Set<string>();
   let proxyMarkerDir = '';
   /**
@@ -213,13 +218,17 @@ describe('#3469 launch resource release', () => {
   let proxyUrl = '';
 
   /**
-   * Session tmpdirs this test's own launches created. A whole-directory scan
-   * races against sibling test processes creating the same prefix; the
-   * recorded paths are exactly the ones this launch must release.
+   * Every directory this test recorded must be gone. Both collections are
+   * recorded rather than scanned because a whole-directory scan races against
+   * sibling test processes creating the same prefixes:
+   * `createdSessionTmpdirs` holds the session tmpdirs this test's own launches
+   * created, `createdScenarioTmpdirs` the timeout-shim and readiness-gate
+   * directories the proxied-launch scenario created. The non-empty check stops
+   * a scenario that acquired nothing from passing vacuously.
    */
-  function assertSessionTmpdirsReleased(): void {
-    expect(createdSessionTmpdirs.length).toBeGreaterThan(0);
-    for (const dir of createdSessionTmpdirs) {
+  function assertTmpdirsReleased(recorded: readonly string[]): void {
+    expect(recorded.length).toBeGreaterThan(0);
+    for (const dir of recorded) {
       expect(fs.existsSync(dir)).toBe(false);
     }
   }
@@ -382,9 +391,7 @@ describe('#3469 launch resource release', () => {
     onTunnel?: (child: ChildProcess) => void,
     sidecarGate?: ReadinessGate,
   ): void {
-    const spawnMock = childProcess.spawn as unknown as Mock<
-      typeof childProcess.spawn
-    >;
+    const spawnMock = childProcess.spawn as unknown as SpawnMock;
     spawnMock.mockImplementation(((
       command: string,
       args: string[],
@@ -467,9 +474,7 @@ describe('#3469 launch resource release', () => {
     nameLookup?: boolean;
     identityProbe?: boolean;
   }): void {
-    const execSyncMock = childProcess.execSync as unknown as Mock<
-      typeof childProcess.execSync
-    >;
+    const execSyncMock = childProcess.execSync as unknown as ExecSyncMock;
     execSyncMock.mockImplementation(((command: string) => {
       if (command.includes('system connection list')) {
         return Buffer.from(PODMAN_MACHINE_CONNECTION);
@@ -563,6 +568,7 @@ describe('#3469 launch resource release', () => {
         .filter((entry) => entry.startsWith('llxprt-sandbox-')),
     );
     createdSessionTmpdirs.length = 0;
+    createdScenarioTmpdirs.length = 0;
     const realMkdtempSync = fs.mkdtempSync;
     vi.spyOn(fs, 'mkdtempSync').mockImplementation(((
       prefix: string,
@@ -638,7 +644,7 @@ describe('#3469 launch resource release', () => {
     expect(stderr).not.toContain('Warning: failed to release');
     assertEngineEmpty();
     expect(leakedRunRoots()).toStrictEqual([]);
-    assertSessionTmpdirsReleased();
+    assertTmpdirsReleased(createdSessionTmpdirs);
   }, 30_000);
 
   it('releases a live port-forward tunnel when a later preparation step fails', async () => {
@@ -663,7 +669,7 @@ describe('#3469 launch resource release', () => {
     expect(stderr).not.toContain('Warning: failed to release');
     assertEngineEmpty();
     expect(leakedRunRoots()).toStrictEqual([]);
-    assertSessionTmpdirsReleased();
+    assertTmpdirsReleased(createdSessionTmpdirs);
   }, 30_000);
 
   it('stops the credential proxy and removes the session tmpdir when user setup fails', async () => {
@@ -683,7 +689,7 @@ describe('#3469 launch resource release', () => {
     expect(stderr).not.toContain('Warning: failed to release');
     assertEngineEmpty();
     expect(leakedRunRoots()).toStrictEqual([]);
-    assertSessionTmpdirsReleased();
+    assertTmpdirsReleased(createdSessionTmpdirs);
   }, 30_000);
 
   /**
@@ -714,6 +720,7 @@ describe('#3469 launch resource release', () => {
       { mode: 0o755 },
     );
     const gateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'issue3533-gate-'));
+    createdScenarioTmpdirs.push(shimDir, gateDir);
     const gate: ReadinessGate = {
       rejections: 0,
       acceptances: 0,
@@ -721,37 +728,39 @@ describe('#3469 launch resource release', () => {
     };
     const originalPath = process.env.PATH ?? '';
     const scenarioServers: net.Server[] = [];
-    // #3538 (deferred): the listener is acquired before the try/finally, so
-    // a bind failure still rejects the scenario with the bind error and the
-    // shim/gate cleanup below does not run for it.
-    scenarioServers.push(
-      (
-        await listenAt(proxyPort, (socket) => {
-          // #3533: readiness must reflect the engine record, not the
-          // listener bind. A reply before the fake engine persisted the
-          // sidecar lets the launch proceed to `network connect`, which
-          // finds no container. Destroying the connection keeps the
-          // production retry loop polling; a never-registering sidecar
-          // still runs into the readiness timeout.
-          if (!engine.containerNames().includes('llxprt-code-sandbox-proxy')) {
-            gate.rejections++;
-            // #3533: the first observed rejection releases the gated
-            // registration, so the request order is causal: no
-            // registration can precede an observed, rejected readiness
-            // request.
-            if (gate.rejections === 1) {
-              fs.writeFileSync(gate.releasePath, 'released\n');
-            }
-            socket.destroy();
-            return;
-          }
-          gate.acceptances++;
-          socket.end('HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n');
-        })
-      ).server,
-    );
-    process.env.PATH = `${shimDir}${path.delimiter}${process.env.PATH}`;
+    // #3538: the proxy-port bind sits inside the try, so a failed bind still
+    // rejects the scenario with the bind error and releases the shim and gate
+    // directories acquired before it.
     try {
+      scenarioServers.push(
+        (
+          await listenAt(proxyPort, (socket) => {
+            // #3533: readiness must reflect the engine record, not the
+            // listener bind. A reply before the fake engine persisted the
+            // sidecar lets the launch proceed to `network connect`, which
+            // finds no container. Destroying the connection keeps the
+            // production retry loop polling; a never-registering sidecar
+            // still runs into the readiness timeout.
+            if (
+              !engine.containerNames().includes('llxprt-code-sandbox-proxy')
+            ) {
+              gate.rejections++;
+              // #3533: the first observed rejection releases the gated
+              // registration, so the request order is causal: no
+              // registration can precede an observed, rejected readiness
+              // request.
+              if (gate.rejections === 1) {
+                fs.writeFileSync(gate.releasePath, 'released\n');
+              }
+              socket.destroy();
+              return;
+            }
+            gate.acceptances++;
+            socket.end('HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n');
+          })
+        ).server,
+      );
+      process.env.PATH = `${shimDir}${path.delimiter}${process.env.PATH}`;
       routeSpawns('throw', undefined, sidecar === 'gated' ? gate : undefined);
       routeExecSync({});
       const stderr = await captureStderr(async () => {
@@ -772,6 +781,8 @@ describe('#3469 launch resource release', () => {
         if (index >= 0) trackedServers.splice(index, 1);
         await new Promise<void>((resolve) => server.close(() => resolve()));
       }
+      // Only a scenario that really took the port waits for it to come back.
+      // A rejected bind never held it, so waiting would block on whoever does.
       if (scenarioServers.length > 0) {
         await awaitPortRebindable(proxyPort);
       }
@@ -830,7 +841,7 @@ describe('#3469 launch resource release', () => {
     expect(stderr).not.toContain('Warning: failed to release');
     expect(engine.volumeNames()).toStrictEqual([]);
     expect(leakedRunRoots()).toStrictEqual([]);
-    assertSessionTmpdirsReleased();
+    assertTmpdirsReleased(createdSessionTmpdirs);
   }, 60_000);
 
   it('network-connects a proxy sidecar whose registration the readiness gate releases only after a rejected pre-registration request', async () => {
@@ -853,8 +864,24 @@ describe('#3469 launch resource release', () => {
     expect(stderr).not.toContain('Warning: failed to release');
     expect(engine.volumeNames()).toStrictEqual([]);
     expect(leakedRunRoots()).toStrictEqual([]);
-    assertSessionTmpdirsReleased();
+    assertTmpdirsReleased(createdSessionTmpdirs);
   }, 60_000);
+
+  it('releases the proxied-launch scenario directories when the proxy port bind fails', async () => {
+    // #3538: hold the port the scenario is configured to bind, so its
+    // listener really fails to bind before any launch step runs.
+    await listenAt(proxyPort, (socket) => socket.destroy());
+
+    const failure = await runProxiedLaunchFailure().then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    // The bind error still reaches the caller, and the shim and gate
+    // directories acquired before the bind are released with it.
+    expect(errnoCode(failure)).toBe('EADDRINUSE');
+    assertTmpdirsReleased(createdScenarioTmpdirs);
+  }, 30_000);
 
   it('leaves no sidecar process-group descendants after repeated proxied launches', async () => {
     // #3533 remediation: the sidecar child leads a real process group that
@@ -930,9 +957,7 @@ describe('#3469 launch resource release', () => {
     };
     try {
       routeSpawns('throw', undefined, gate);
-      const spawnMock = childProcess.spawn as unknown as Mock<
-        typeof childProcess.spawn
-      >;
+      const spawnMock = childProcess.spawn as unknown as SpawnMock;
       const sidecar = spawnMock(
         'docker',
         [

--- a/packages/cli/src/utils/sandbox-launch-release.test.ts
+++ b/packages/cli/src/utils/sandbox-launch-release.test.ts
@@ -23,6 +23,7 @@ import path from 'node:path';
 import { PassThrough } from 'node:stream';
 import { Storage } from '@vybestack/llxprt-code-storage';
 import { useFakeEngine } from '../../test-utils/fake-dependency-engine-harness.js';
+import { allocateEphemeralPort } from '../../test-utils/ephemeral-port.js';
 import { runContainerSandbox } from './sandbox-exec.js';
 
 /**
@@ -203,6 +204,13 @@ describe('#3469 launch resource release', () => {
   const createdSessionTmpdirs: string[] = [];
   let tmpdirSnapshot = new Set<string>();
   let proxyMarkerDir = '';
+  /**
+   * #3501: the proxy endpoint this test owns. Allocated per test rather than
+   * shared as a fixed number, so a concurrent test process can never hold it
+   * and fail this fixture's binds and port waits.
+   */
+  let proxyPort = 0;
+  let proxyUrl = '';
 
   /**
    * Session tmpdirs this test's own launches created. A whole-directory scan
@@ -307,16 +315,16 @@ describe('#3469 launch resource release', () => {
   }
 
   /**
-   * #3533 CodeRabbit remediation: really binds the fixed port outside
-   * `trackedServers`, standing in for any owner of 8877 that teardown never
-   * registered as a tracked server, and releases it after `holdMs`.
+   * #3533 CodeRabbit remediation: really binds this fixture's proxy port
+   * outside `trackedServers`, standing in for any owner of it that teardown
+   * never registered as a tracked server, and releases it after `holdMs`.
    */
-  async function holdFixedPortUntracked(holdMs: number): Promise<() => void> {
+  async function holdProxyPortUntracked(holdMs: number): Promise<() => void> {
     const holder = net.createServer();
     await new Promise<void>((resolve, reject) => {
       holder.once('listening', () => resolve());
       holder.once('error', reject);
-      holder.listen(8877, '127.0.0.1');
+      holder.listen(proxyPort, '127.0.0.1');
     });
     const timer = setTimeout(() => holder.close(), holdMs);
     return () => {
@@ -326,9 +334,9 @@ describe('#3469 launch resource release', () => {
   }
 
   /**
-   * #3533 remediation: after heavy readiness-poll churn, closing the
-   * fixed-port listener can leave the port briefly unbindable; wait until a
-   * probe bind succeeds so the next scenario starts deterministically. If
+   * #3533 remediation: after heavy readiness-poll churn, closing the proxy
+   * listener can leave the port briefly unbindable; wait until a probe bind
+   * succeeds so the next scenario starts deterministically. If
    * the port does not come back within the deadline, fail fast here instead
    * of deferring the attribution to the next bind.
    */
@@ -494,11 +502,12 @@ describe('#3469 launch resource release', () => {
     }) as unknown as typeof childProcess.execSync);
   }
 
-  /** A real TCP listener; the sidecar readiness probe needs an HTTP reply. */
   /**
-   * Binds a real TCP listener. Port 0 binds an ephemeral port so concurrent
-   * test processes never race on a fixed one; the fixed 8877 sidecar case
-   * rejects with the bind error instead of failing downstream.
+   * Binds a real TCP listener; the sidecar readiness probe needs an HTTP
+   * reply. Port 0 asks the kernel for an ephemeral port, while the sidecar
+   * case passes this fixture's own proxy port because the configured proxy
+   * endpoint names it. Either way a bind failure rejects with the bind error
+   * instead of failing downstream.
    */
   async function listenAt(
     port: number,
@@ -521,7 +530,9 @@ describe('#3469 launch resource release', () => {
     return { server, port: await whenListening };
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    proxyPort = await allocateEphemeralPort();
+    proxyUrl = `http://127.0.0.1:${proxyPort}`;
     environmentSnapshot = { ...process.env };
     fixturePath = fs.mkdtempSync(path.join(os.tmpdir(), 'launch-3469-'));
     isolatedCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'issue3469-uc-'));
@@ -533,6 +544,12 @@ describe('#3469 launch resource release', () => {
     delete process.env.LLXPRT_SANDBOX_NETWORK;
     delete process.env.SANDBOX_NETWORK;
     delete process.env.LLXPRT_SANDBOX_PROXY_COMMAND;
+    // The proxy endpoint is resolved from these; a developer shell that
+    // exports one must not decide which port this fixture launches against.
+    delete process.env.HTTPS_PROXY;
+    delete process.env.https_proxy;
+    delete process.env.HTTP_PROXY;
+    delete process.env.http_proxy;
     delete process.env.SANDBOX_SET_UID_GID;
     delete process.env.SSH_AUTH_SOCK;
     delete process.env.SANDBOX_PORTS;
@@ -564,7 +581,7 @@ describe('#3469 launch resource release', () => {
    * port waiting can fail; the fixture is restored either way, and the
    * failure itself still propagates (fail fast, never swallow). Sidecar
    * teardown awaits what it terminated: every sidecar process group is
-   * proven gone (ESRCH), and the fixed port is proven rebindable whenever
+   * proven gone (ESRCH), and the proxy port is proven rebindable whenever
    * sidecar groups or tracked servers were released, so restoration never
    * completes while a group member or the port is still held.
    */
@@ -576,7 +593,7 @@ describe('#3469 launch resource release', () => {
         server.close();
       }
       if (terminatedGroups.length > 0 || servers.length > 0) {
-        await awaitPortRebindable(8877);
+        await awaitPortRebindable(proxyPort);
       }
       if (terminatedGroups.length > 0) {
         await expectProcessGroupsGone(terminatedGroups);
@@ -671,9 +688,10 @@ describe('#3469 launch resource release', () => {
 
   /**
    * Runs the proxied-network launch scenario: the proxy sidecar runs for
-   * real against the fake engine, the 8877 listener stands in for the
-   * sidecar's HTTP readiness endpoint, and the main container launch is
-   * injected to throw. With `sidecar: 'gated'` the sidecar child's engine
+   * real against the fake engine, a listener on this fixture's own proxy
+   * port stands in for the sidecar's HTTP readiness endpoint, and the main
+   * container launch is injected to throw. With `sidecar: 'gated'` the
+   * sidecar child's engine
    * registration waits for the readiness gate's release file, which the
    * gate creates only after it observed and rejected a pre-registration
    * readiness request (#3533). Returns the captured launch stderr and the
@@ -684,6 +702,9 @@ describe('#3469 launch resource release', () => {
   ): Promise<{ stderr: string; gate: ReadinessGate }> {
     process.env.LLXPRT_SANDBOX_NETWORK = 'proxied';
     process.env.LLXPRT_SANDBOX_PROXY_COMMAND = 'sleep 120';
+    // #3501: the production endpoint resolver reads this, so the launch
+    // publishes and probes exactly the port this fixture owns.
+    process.env.HTTPS_PROXY = proxyUrl;
     // macOS has no `timeout`; the readiness probe shells out to it. A shim
     // that drops the duration and executes the command keeps the probe real.
     const shimDir = fs.mkdtempSync(path.join(os.tmpdir(), 'issue3469-bin-'));
@@ -705,7 +726,7 @@ describe('#3469 launch resource release', () => {
     // shim/gate cleanup below does not run for it.
     scenarioServers.push(
       (
-        await listenAt(8877, (socket) => {
+        await listenAt(proxyPort, (socket) => {
           // #3533: readiness must reflect the engine record, not the
           // listener bind. A reply before the fake engine persisted the
           // sidecar lets the launch proceed to `network connect`, which
@@ -743,7 +764,7 @@ describe('#3469 launch resource release', () => {
       process.env.PATH = originalPath;
       fs.rmSync(shimDir, { recursive: true, force: true });
       fs.rmSync(gateDir, { recursive: true, force: true });
-      // #3533 remediation: the scenario owns its fixed-port listener so
+      // #3533 remediation: the scenario owns its proxy-port listener so
       // repeated scenarios (and the process-group regression loop) rebind
       // deterministically instead of racing the teardown sweep.
       for (const server of scenarioServers) {
@@ -752,7 +773,7 @@ describe('#3469 launch resource release', () => {
         await new Promise<void>((resolve) => server.close(() => resolve()));
       }
       if (scenarioServers.length > 0) {
-        await awaitPortRebindable(8877);
+        await awaitPortRebindable(proxyPort);
       }
     }
   }
@@ -791,6 +812,12 @@ describe('#3469 launch resource release', () => {
     const { stderr } = await runProxiedLaunchFailure();
     const { sidecarRun, networkConnect, sidecarRm, volumeRm } =
       sidecarReleaseOrder();
+    // #3501: the sidecar published the configured endpoint's port, which is
+    // the one the host readiness probe just reached.
+    const sidecarArgv = engine.invocations()[sidecarRun];
+    expect(sidecarArgv[sidecarArgv.indexOf('-p') + 1]).toBe(
+      `${proxyPort}:${proxyPort}`,
+    );
     // The sidecar really started: its container was recorded and connected
     // to the sandbox network before the launch failure, then removed again
     // (AC2), before the volumes.
@@ -917,7 +944,7 @@ describe('#3469 launch resource release', () => {
           '--network',
           'llxprt-code-sandbox-proxy',
           '-p',
-          '8877:8877',
+          `${proxyPort}:${proxyPort}`,
           engine.config.image,
           'sh',
           '-lc',
@@ -983,7 +1010,7 @@ describe('#3469 launch resource release', () => {
     await expectProcessGroupsGone([sleeperPid]);
   }, 20_000);
 
-  it('waits out the sidecar group and the fixed port before teardown ends', async () => {
+  it('waits out the sidecar group and the proxy port before teardown ends', async () => {
     // A real detached sidecar group: a group leader with a live shell
     // descendant, the shape routeSpawns records for the proxy sidecar.
     const sidecar = __actual.spawn('sh', ['-c', 'sleep 120'], {
@@ -993,18 +1020,18 @@ describe('#3469 launch resource release', () => {
     const sidecarPid = sidecar.pid;
     if (sidecarPid === undefined) throw new Error('sidecar got no pid');
     trackedChildren.push({ child: sidecar, groupLeader: true });
-    // 8877 is really owned by something teardown never tracked as a server,
-    // so only a sidecar-group-driven port wait can outlast it.
-    const releaseHolder = await holdFixedPortUntracked(1_500);
+    // The proxy port is really owned by something teardown never tracked as
+    // a server, so only a sidecar-group-driven port wait can outlast it.
+    const releaseHolder = await holdProxyPortUntracked(1_500);
     try {
       await restoreFixture();
       // Restoration returned, so the sidecar group is really ESRCH-gone and
-      // the fixed port is really rebindable right now.
+      // the proxy port is really rebindable right now.
       expect(processGroupAlive(sidecarPid)).toBe(false);
-      await awaitPortRebindable(8877, 250);
+      await awaitPortRebindable(proxyPort, 250);
     } finally {
       releaseHolder();
-      await awaitPortRebindable(8877, 5_000);
+      await awaitPortRebindable(proxyPort, 5_000);
     }
   }, 30_000);
 });

--- a/packages/cli/src/utils/sandbox-launch-release.test.ts
+++ b/packages/cli/src/utils/sandbox-launch-release.test.ts
@@ -214,7 +214,9 @@ describe('#3469 launch resource release', () => {
         return completedEngineProcess('');
       }
       if (command === 'ssh') {
-        const child = __actual.spawn('sleep', ['120'], { stdio: 'ignore' });
+        const child = __actual.spawn('sleep', ['120'], {
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
         trackedChildren.push(child);
         onTunnel?.(child);
         return child;

--- a/packages/cli/src/utils/sandbox-network-proxy.test.ts
+++ b/packages/cli/src/utils/sandbox-network-proxy.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { FatalSandboxError } from '@vybestack/llxprt-code-core';
+import {
+  DEFAULT_SANDBOX_PROXY_URL,
+  resolveSandboxProxyPort,
+  resolveSandboxProxyUrl,
+} from './sandbox-network-proxy.js';
+
+describe('resolveSandboxProxyUrl', () => {
+  it('falls back to the documented default when nothing configures a proxy', () => {
+    expect(resolveSandboxProxyUrl({})).toBe('http://localhost:8877');
+  });
+
+  it.each([
+    ['HTTPS_PROXY', 'http://localhost:1111'],
+    ['https_proxy', 'http://localhost:2222'],
+    ['HTTP_PROXY', 'http://localhost:3333'],
+    ['http_proxy', 'http://localhost:4444'],
+  ])('reads the proxy endpoint from %s', (key, url) => {
+    expect(resolveSandboxProxyUrl({ [key]: url })).toBe(url);
+  });
+
+  it('prefers HTTPS_PROXY over every later candidate', () => {
+    expect(
+      resolveSandboxProxyUrl({
+        HTTPS_PROXY: 'http://localhost:1111',
+        https_proxy: 'http://localhost:2222',
+        HTTP_PROXY: 'http://localhost:3333',
+        http_proxy: 'http://localhost:4444',
+      }),
+    ).toBe('http://localhost:1111');
+  });
+
+  it('skips an empty candidate and reads the next one', () => {
+    expect(
+      resolveSandboxProxyUrl({
+        HTTPS_PROXY: '',
+        https_proxy: '',
+        HTTP_PROXY: 'http://localhost:3333',
+      }),
+    ).toBe('http://localhost:3333');
+  });
+});
+
+describe('resolveSandboxProxyPort', () => {
+  it('resolves the default endpoint to the documented sandbox proxy port', () => {
+    expect(resolveSandboxProxyPort(DEFAULT_SANDBOX_PROXY_URL)).toBe(8877);
+  });
+
+  it('reads the explicit port of a configured endpoint', () => {
+    expect(resolveSandboxProxyPort('http://127.0.0.1:49213')).toBe(49213);
+  });
+
+  it.each([
+    ['http://localhost', 80],
+    ['https://localhost', 443],
+  ])('derives the scheme default port for %s', (url, port) => {
+    expect(resolveSandboxProxyPort(url)).toBe(port);
+  });
+
+  it('rejects an endpoint that is not a URL', () => {
+    expect(() => resolveSandboxProxyPort('localhost:8877')).toThrow(
+      FatalSandboxError,
+    );
+  });
+
+  it('names the offending value so the misconfiguration is actionable', () => {
+    expect(() => resolveSandboxProxyPort('not a url')).toThrowError(
+      /not a url/,
+    );
+  });
+
+  it('rejects a scheme that carries no default port', () => {
+    expect(() => resolveSandboxProxyPort('socks5://localhost')).toThrow(
+      FatalSandboxError,
+    );
+  });
+});

--- a/packages/cli/src/utils/sandbox-network-proxy.ts
+++ b/packages/cli/src/utils/sandbox-network-proxy.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Resolution of the sandbox network proxy endpoint (#3501).
+ *
+ * The network proxy (`LLXPRT_SANDBOX_PROXY_COMMAND`, unrelated to the
+ * credential proxy) is configured through the standard proxy environment
+ * variables. Every consumer of that endpoint — the host readiness probe, the
+ * published sidecar port, and the proxy variables handed to the sandboxed
+ * child — must agree on one URL and one port, so they all read it from here
+ * instead of repeating a hard-coded default.
+ */
+
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import { FatalSandboxError } from '@vybestack/llxprt-code-core';
+
+const execAsync = promisify(exec);
+
+/** Endpoint used when no proxy environment variable configures one. */
+export const DEFAULT_SANDBOX_PROXY_URL = 'http://localhost:8877';
+
+const PROXY_URL_ENV_KEYS = [
+  'HTTPS_PROXY',
+  'https_proxy',
+  'HTTP_PROXY',
+  'http_proxy',
+] as const;
+
+/**
+ * Carries the endpoint into the readiness shell through the environment
+ * rather than the command string, so a configured URL is never interpolated
+ * into nested shell quoting.
+ */
+const PROXY_READY_URL_ENV = 'LLXPRT_SANDBOX_PROXY_READY_URL';
+
+export function resolveSandboxProxyUrl(env: NodeJS.ProcessEnv): string {
+  const configured = PROXY_URL_ENV_KEYS.map((key) => env[key]).find(
+    (value): value is string => value !== undefined && value !== '',
+  );
+  return configured ?? DEFAULT_SANDBOX_PROXY_URL;
+}
+
+function schemeDefaultPort(protocol: string): number | undefined {
+  if (protocol === 'http:') return 80;
+  if (protocol === 'https:') return 443;
+  return undefined;
+}
+
+/**
+ * The port the sandbox proxy is reachable on. The host publishes it for the
+ * sidecar container and probes it for readiness, so an endpoint whose port
+ * cannot be determined is a fatal misconfiguration rather than a value to
+ * guess at.
+ */
+export function resolveSandboxProxyPort(proxyUrl: string): number {
+  let parsed: URL;
+  try {
+    parsed = new URL(proxyUrl);
+  } catch {
+    throw new FatalSandboxError(
+      `Sandbox proxy endpoint '${proxyUrl}' is not a valid URL. Set ` +
+        `HTTPS_PROXY or HTTP_PROXY to an absolute URL such as ` +
+        `${DEFAULT_SANDBOX_PROXY_URL}.`,
+    );
+  }
+  if (parsed.port !== '') return Number(parsed.port);
+  const schemePort = schemeDefaultPort(parsed.protocol);
+  if (schemePort === undefined) {
+    throw new FatalSandboxError(
+      `Sandbox proxy endpoint '${proxyUrl}' has no port and its scheme ` +
+        `'${parsed.protocol}' has no default port. Set HTTPS_PROXY or ` +
+        `HTTP_PROXY to an absolute URL such as ${DEFAULT_SANDBOX_PROXY_URL}.`,
+    );
+  }
+  return schemePort;
+}
+
+/**
+ * Polls the configured proxy endpoint until it answers or the timeout
+ * elapses. Rejects with the underlying process failure; callers classify it
+ * together with whatever they must release.
+ */
+export async function awaitSandboxProxyReady(
+  proxyUrl: string,
+  timeoutMs: number,
+): Promise<void> {
+  await execAsync(
+    `timeout ${Math.floor(timeoutMs / 1000)} bash -c ` +
+      `'until curl -s "$${PROXY_READY_URL_ENV}"; do sleep 0.25; done'`,
+    {
+      timeout: timeoutMs + 5000,
+      env: { ...process.env, [PROXY_READY_URL_ENV]: proxyUrl },
+    },
+  );
+}

--- a/packages/cli/src/utils/sandbox-node-modules-preflight.test.ts
+++ b/packages/cli/src/utils/sandbox-node-modules-preflight.test.ts
@@ -361,15 +361,21 @@ describe('#3450 bounded wrong-platform contamination preflight', () => {
 
   it('fails on a symlinked .node file through its contained target', () => {
     vi.spyOn(os, 'platform').mockReturnValue('darwin');
+    // The stored target deliberately does not end in `.node`: the walk also
+    // inspects regular `.node` files in place, so naming it `real-addon.node`
+    // would make the store copy a second, independent contamination source and
+    // the reported path would depend on `fs.readdirSync` order (which of `pkg`
+    // and `store` is visited first varies by filesystem). Leaving the symlink
+    // as the only trigger keeps the asserted path deterministic everywhere.
     writeBytes(
-      path.join(workdir, 'node_modules', 'store', 'real-addon.node'),
+      path.join(workdir, 'node_modules', 'store', 'real-addon.bin'),
       elfBytes(),
     );
     fs.mkdirSync(path.join(workdir, 'node_modules', 'pkg'), {
       recursive: true,
     });
     fs.symlinkSync(
-      '../store/real-addon.node',
+      '../store/real-addon.bin',
       path.join(workdir, 'node_modules', 'pkg', 'addon.node'),
     );
 

--- a/packages/cli/src/utils/sandbox-node-modules.test.ts
+++ b/packages/cli/src/utils/sandbox-node-modules.test.ts
@@ -633,11 +633,7 @@ describe('#3450/#3468 private per-run dependency mounts', () => {
     expect(fs.existsSync(path.join(absentDir, 'kept.txt'))).toBe(true);
   });
 
-  it('keeps source-development launches unchanged: no preflight, no mounts, no storage, no engine calls', () => {
-    // NODE_ENV=development in a positively identified llxprt-code source
-    // checkout selects the excluded source-entrypoint path (#3455); it must
-    // keep the legacy single workspace bind, and even a recognized
-    // wrong-platform host tree must not stop it (#3450 F7).
+  it('isolates source-development dependencies without applying installed-mode host preflight', () => {
     fs.mkdirSync(path.join(workdir, 'packages', 'cli'), { recursive: true });
     fs.writeFileSync(
       path.join(workdir, 'packages', 'cli', 'index.ts'),
@@ -646,21 +642,39 @@ describe('#3450/#3468 private per-run dependency mounts', () => {
     const savedEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'development';
     try {
-      writeBytes(
-        path.join(workdir, 'node_modules', 'pkg', 'addon.node'),
-        elfBytes(),
+      const contaminatedHostFile = path.join(
+        workdir,
+        'node_modules',
+        'pkg',
+        'addon.node',
       );
+      writeBytes(contaminatedHostFile, elfBytes());
       const args: string[] = ['--volume', `${workdir}:${workdir}`];
       const lifecycle = addPrivateDependencyMounts(
         engine.config,
         args,
         workdir,
       );
-      lifecycle.recordMainContainerName('development-container');
-      lifecycle.release();
+      const mountValues = args.filter(
+        (token, index) => index > 0 && args[index - 1] === '--mount',
+      );
+      try {
+        expect(mountValues).toHaveLength(3);
+        expect(
+          mountValues.every((value) => value.startsWith('type=volume,src=')),
+        ).toBe(true);
+        expect(engine.volumeNames()).toHaveLength(3);
+        expect(
+          Buffer.compare(
+            fs.readFileSync(contaminatedHostFile),
+            Buffer.from(elfBytes()),
+          ),
+        ).toBe(0);
+        expect(privateRunRoots()).toStrictEqual([]);
+      } finally {
+        lifecycle.release();
+      }
 
-      expect(args).toStrictEqual(['--volume', `${workdir}:${workdir}`]);
-      expect(privateRunRoots()).toStrictEqual([]);
       expect(engine.volumeNames()).toStrictEqual([]);
       expect(engine.containerNames()).toStrictEqual([]);
     } finally {

--- a/packages/cli/src/utils/sandbox-node-modules.test.ts
+++ b/packages/cli/src/utils/sandbox-node-modules.test.ts
@@ -11,6 +11,7 @@ import path from 'node:path';
 import { FatalSandboxError } from '@vybestack/llxprt-code-core';
 import { Storage } from '@vybestack/llxprt-code-storage';
 import { useFakeEngine } from '../../test-utils/fake-dependency-engine-harness.js';
+import { getContainerPath } from './sandbox-env.js';
 import {
   addPrivateDependencyMounts,
   resolveProtectedNodeModulesDestinations,
@@ -658,8 +659,24 @@ describe('#3450/#3468 private per-run dependency mounts', () => {
       const mountValues = args.filter(
         (token, index) => index > 0 && args[index - 1] === '--mount',
       );
+      const protectedDestinations = [
+        path.join(workdir, 'node_modules'),
+        path.join(workdir, 'packages', 'nested', 'node_modules'),
+        path.join(workdir, 'packages', 'absent', 'node_modules'),
+      ];
+      const mountDestinations = mountValues.map((value) =>
+        value
+          .split(',')
+          .find((field) => field.startsWith('dst='))
+          ?.slice('dst='.length),
+      );
       try {
-        expect(mountValues).toHaveLength(3);
+        expect(resolveProtectedNodeModulesDestinations(workdir)).toStrictEqual(
+          protectedDestinations,
+        );
+        expect(mountDestinations).toStrictEqual(
+          protectedDestinations.map(getContainerPath),
+        );
         expect(
           mountValues.every((value) => value.startsWith('type=volume,src=')),
         ).toBe(true);

--- a/packages/cli/src/utils/sandbox-node-modules.ts
+++ b/packages/cli/src/utils/sandbox-node-modules.ts
@@ -25,11 +25,10 @@
  * one positioned follow-up read.
  *
  * The source-development path (#3455), a positively identified llxprt-code
- * source checkout under NODE_ENV=development, is excluded: it keeps the
- * legacy single workspace bind, because bootstrapping the source CLI needs
- * the repository's own dependencies. The same shared predicate selects the
- * source entrypoint command, so an arbitrary repository with ambient
- * NODE_ENV=development never bypasses the private volumes.
+ * source checkout under NODE_ENV=development, also receives fresh dependency
+ * volumes. Its trusted entrypoint prepares Linux dependencies in those mounts
+ * before executing checked-out TypeScript. Host preflight remains specific to
+ * installed mode because source dependencies are never read from the host.
  */
 
 import fs from 'node:fs';
@@ -512,8 +511,7 @@ export function planPrivateDependencyMounts(
   workspaceRoots: WorkspaceRoots,
 ): DependencyMountPlan {
   const roots = normalizeWorkspaceRoots(workspaceRoots);
-  if (isSourceDevelopmentWorkdir(roots[0])) return { enabled: false };
-
+  const sourceDevelopment = isSourceDevelopmentWorkdir(roots[0]);
   const destinations: string[] = [];
   const seenDestinations = new Set<string>();
   for (const workdir of roots) {
@@ -527,7 +525,9 @@ export function planPrivateDependencyMounts(
       if (seenDestinations.has(destination)) continue;
       seenDestinations.add(destination);
       assertDestinationChainIsDirectories(workdir, destination);
-      preflightProtectedTree(destination, workdir, workspaceRealRoot);
+      if (!sourceDevelopment) {
+        preflightProtectedTree(destination, workdir, workspaceRealRoot);
+      }
       destinations.push(destination);
     }
   }
@@ -562,10 +562,7 @@ export function addPrivateDependencyMounts(
 ): DependencyVolumeLifecycle {
   if (!planned.enabled) {
     debugLogger.log(
-      'Source-development launch (NODE_ENV=development in an llxprt-code ' +
-        'source checkout): keeping the shared workspace bind for the ' +
-        'source-entrypoint sandbox path; private dependency isolation is ' +
-        'installed-mode only.',
+      'No protected dependency destinations were discovered; skipping private dependency mounts.',
     );
     return noDependencyVolumeLifecycle();
   }

--- a/packages/cli/src/utils/sandbox-podman-diagnostics.test.ts
+++ b/packages/cli/src/utils/sandbox-podman-diagnostics.test.ts
@@ -9,7 +9,6 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { setupCredentialProxyPodmanMacOS } from './sandbox-podman.js';
 
 const DARWIN_SOCKET_PATH_MAX_BYTES = 103;
 const DIAGNOSTIC_MAX_BYTES = 4096;
@@ -21,15 +20,6 @@ function writeExecutable(filePath: string, content: string): void {
 
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
-}
-
-async function captureFailure(action: () => Promise<unknown>): Promise<string> {
-  try {
-    await action();
-  } catch (error) {
-    return error instanceof Error ? error.message : String(error);
-  }
-  throw new Error('Expected action to fail');
 }
 
 function processExists(pid: number): boolean {
@@ -44,10 +34,24 @@ function processExists(pid: number): boolean {
   }
 }
 
+/**
+ * Runs the real credential bridge in a fresh Bun process whose PATH is set
+ * through the child `env` so the fixture `podman` and `ssh` are the only ones
+ * reachable.
+ *
+ * Calling the bridge in-process instead is not deterministic: production
+ * resolves both binaries through child processes it spawns without an
+ * explicit `env` (`execSync` in `getPodmanMachineConnection`, `spawn('ssh')`),
+ * and a `process.env.PATH` mutation made inside a Bun test process is not
+ * guaranteed to reach them. On a host with a real Podman that reports no
+ * machine connections, the in-process form reached that Podman and failed in
+ * `getPodmanMachineConnection` before the fixture `ssh` ever ran.
+ */
 function invokeCredentialBridgeInFreshBun(
   fixtureRoot: string,
   originalPath: string,
   socketPath: string,
+  pollTimeoutMs = 1000,
 ): string {
   const runnerPath = path.join(fixtureRoot, 'invoke-credential-bridge.ts');
   const modulePath = path.join(import.meta.dirname, 'sandbox-podman.ts');
@@ -57,7 +61,7 @@ function invokeCredentialBridgeInFreshBun(
       `import { setupCredentialProxyPodmanMacOS } from ${JSON.stringify(modulePath)};`,
       `const socketPath = ${JSON.stringify(socketPath)};`,
       'try {',
-      '  await setupCredentialProxyPodmanMacOS([], socketPath, 1000);',
+      `  await setupCredentialProxyPodmanMacOS([], socketPath, ${String(pollTimeoutMs)});`,
       "  console.log('unexpected success');",
       '} catch (error) {',
       '  console.log(error instanceof Error ? error.message : String(error));',
@@ -90,9 +94,14 @@ describe('#3534 Podman tunnel startup diagnostics', () => {
 
   beforeEach(() => {
     fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'issue3534-ssh-'));
+    // Only used to build the child PATH; the host PATH is never mutated, so
+    // the fixture binaries are reachable exactly where they are needed.
     originalPath = process.env.PATH ?? '';
     podmanInvocationLog = path.join(fixtureRoot, 'podman-invocations.log');
     sshInvocationLog = path.join(fixtureRoot, 'ssh-invocations.log');
+    // The connection lookup is answered by this fixture rather than the host
+    // engine, so a machine-less environment (Linux CI) reaches the SSH path
+    // instead of failing early with "No Podman machine connections found".
     writeExecutable(
       path.join(fixtureRoot, 'podman'),
       [
@@ -108,15 +117,13 @@ describe('#3534 Podman tunnel startup diagnostics', () => {
         'esac',
       ].join('\n'),
     );
-    process.env.PATH = `${fixtureRoot}${path.delimiter}${originalPath}`;
   });
 
   afterEach(() => {
-    process.env.PATH = originalPath;
     fs.rmSync(fixtureRoot, { recursive: true, force: true });
   });
 
-  it('surfaces a late OpenSSH forwarding failure after draining chatty output and reaping the child', async () => {
+  it('surfaces a late OpenSSH forwarding failure after draining chatty output and reaping the child', () => {
     const sshPidPath = path.join(fixtureRoot, 'ssh.pid');
     writeExecutable(
       path.join(fixtureRoot, 'ssh'),
@@ -131,16 +138,24 @@ describe('#3534 Podman tunnel startup diagnostics', () => {
       ].join('\n'),
     );
 
-    const message = await captureFailure(() =>
-      setupCredentialProxyPodmanMacOS([], '/tmp/cred-proxy.sock', 3000),
+    const message = invokeCredentialBridgeInFreshBun(
+      fixtureRoot,
+      originalPath,
+      '/tmp/cred-proxy.sock',
+      3000,
     );
     const sshPid = Number(fs.readFileSync(sshPidPath, 'utf8').trim());
 
+    // The fixture Podman answered the connection lookup, so the diagnostic
+    // below came from the fixture ssh rather than an ambient host engine.
+    expect(fs.readFileSync(podmanInvocationLog, 'utf8')).toContain(
+      'system connection list',
+    );
     expect(message).toContain('late OpenSSH forwarding failure');
     expect(processExists(sshPid)).toBe(false);
   }, 10000);
 
-  it('retains exactly 4096 encoded bytes from an oversized OpenSSH diagnostic', async () => {
+  it('retains exactly 4096 encoded bytes from an oversized OpenSSH diagnostic', () => {
     writeExecutable(
       path.join(fixtureRoot, 'ssh'),
       [
@@ -153,13 +168,18 @@ describe('#3534 Podman tunnel startup diagnostics', () => {
       ].join('\n'),
     );
 
-    const message = await captureFailure(() =>
-      setupCredentialProxyPodmanMacOS([], '/tmp/cred-proxy.sock'),
+    const message = invokeCredentialBridgeInFreshBun(
+      fixtureRoot,
+      originalPath,
+      '/tmp/cred-proxy.sock',
     );
     const diagnosticMarker = ' SSH diagnostic: ';
     const markerIndex = message.indexOf(diagnosticMarker);
     const diagnostic = message.slice(markerIndex + diagnosticMarker.length);
 
+    expect(fs.readFileSync(podmanInvocationLog, 'utf8')).toContain(
+      'system connection list',
+    );
     expect(message).toContain(
       'Bad remote forwarding specification for credential socket',
     );

--- a/packages/cli/src/utils/sandbox-podman-diagnostics.test.ts
+++ b/packages/cli/src/utils/sandbox-podman-diagnostics.test.ts
@@ -1,0 +1,221 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setupCredentialProxyPodmanMacOS } from './sandbox-podman.js';
+
+const DARWIN_SOCKET_PATH_MAX_BYTES = 103;
+const DIAGNOSTIC_MAX_BYTES = 4096;
+
+function writeExecutable(filePath: string, content: string): void {
+  fs.writeFileSync(filePath, content);
+  fs.chmodSync(filePath, 0o755);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+async function captureFailure(action: () => Promise<unknown>): Promise<string> {
+  try {
+    await action();
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  throw new Error('Expected action to fail');
+}
+
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ESRCH') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function invokeCredentialBridgeInFreshBun(
+  fixtureRoot: string,
+  originalPath: string,
+  socketPath: string,
+): string {
+  const runnerPath = path.join(fixtureRoot, 'invoke-credential-bridge.ts');
+  const modulePath = path.join(import.meta.dirname, 'sandbox-podman.ts');
+  fs.writeFileSync(
+    runnerPath,
+    [
+      `import { setupCredentialProxyPodmanMacOS } from ${JSON.stringify(modulePath)};`,
+      `const socketPath = ${JSON.stringify(socketPath)};`,
+      'try {',
+      '  await setupCredentialProxyPodmanMacOS([], socketPath, 1000);',
+      "  console.log('unexpected success');",
+      '} catch (error) {',
+      '  console.log(error instanceof Error ? error.message : String(error));',
+      '}',
+    ].join('\n'),
+  );
+  const result = spawnSync(process.execPath, [runnerPath], {
+    cwd: fixtureRoot,
+    env: {
+      ...process.env,
+      PATH: `${fixtureRoot}${path.delimiter}${originalPath}`,
+    },
+    encoding: 'utf8',
+    timeout: 10000,
+  });
+  if (result.error !== undefined) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `Credential bridge runner failed with status ${String(result.status)}: ${result.stderr}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+describe('#3534 Podman tunnel startup diagnostics', () => {
+  let fixtureRoot = '';
+  let originalPath = '';
+  let podmanInvocationLog = '';
+  let sshInvocationLog = '';
+
+  beforeEach(() => {
+    fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'issue3534-ssh-'));
+    originalPath = process.env.PATH ?? '';
+    podmanInvocationLog = path.join(fixtureRoot, 'podman-invocations.log');
+    sshInvocationLog = path.join(fixtureRoot, 'ssh-invocations.log');
+    writeExecutable(
+      path.join(fixtureRoot, 'podman'),
+      [
+        '#!/bin/sh',
+        `printf '%s\\n' "$*" >> ${shellQuote(podmanInvocationLog)}`,
+        'case "$*" in',
+        "  *'system connection list'*)",
+        `    printf '%s\\n' '[{"Name":"default","URI":"ssh://core@localhost:12345/run/podman/podman.sock","Identity":"/tmp/key","Default":true}]'`,
+        '    ;;',
+        '  *)',
+        '    exit 1',
+        '    ;;',
+        'esac',
+      ].join('\n'),
+    );
+    process.env.PATH = `${fixtureRoot}${path.delimiter}${originalPath}`;
+  });
+
+  afterEach(() => {
+    process.env.PATH = originalPath;
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it('surfaces a late OpenSSH forwarding failure after draining chatty output and reaping the child', async () => {
+    const sshPidPath = path.join(fixtureRoot, 'ssh.pid');
+    writeExecutable(
+      path.join(fixtureRoot, 'ssh'),
+      [
+        '#!/bin/sh',
+        `printf '%s\\n' "$*" >> ${shellQuote(sshInvocationLog)}`,
+        `printf '%s\\n' "$$" > ${shellQuote(sshPidPath)}`,
+        'sleep 0.7',
+        "yes 'chatty tunnel output' | head -c 524288",
+        `printf 'late OpenSSH forwarding failure\\n' >&2`,
+        'exit 23',
+      ].join('\n'),
+    );
+
+    const message = await captureFailure(() =>
+      setupCredentialProxyPodmanMacOS([], '/tmp/cred-proxy.sock', 3000),
+    );
+    const sshPid = Number(fs.readFileSync(sshPidPath, 'utf8').trim());
+
+    expect(message).toContain('late OpenSSH forwarding failure');
+    expect(processExists(sshPid)).toBe(false);
+  }, 10000);
+
+  it('retains exactly 4096 encoded bytes from an oversized OpenSSH diagnostic', async () => {
+    writeExecutable(
+      path.join(fixtureRoot, 'ssh'),
+      [
+        '#!/bin/sh',
+        `printf '%s\\n' "$*" >> ${shellQuote(sshInvocationLog)}`,
+        `printf 'Bad remote forwarding specification for credential socket\\n' >&2`,
+        `printf '%05000d' 0 | tr '0' x >&2`,
+        `printf 'UNBOUNDED-TAIL\\n' >&2`,
+        'exit 23',
+      ].join('\n'),
+    );
+
+    const message = await captureFailure(() =>
+      setupCredentialProxyPodmanMacOS([], '/tmp/cred-proxy.sock'),
+    );
+    const diagnosticMarker = ' SSH diagnostic: ';
+    const markerIndex = message.indexOf(diagnosticMarker);
+    const diagnostic = message.slice(markerIndex + diagnosticMarker.length);
+
+    expect(message).toContain(
+      'Bad remote forwarding specification for credential socket',
+    );
+    expect(message).not.toContain('UNBOUNDED-TAIL');
+    expect(markerIndex).toBeGreaterThanOrEqual(0);
+    expect(Buffer.byteLength(diagnostic)).toBe(DIAGNOSTIC_MAX_BYTES);
+  }, 10000);
+
+  it('accepts a Darwin socket path of exactly 103 encoded bytes and starts Podman and SSH', async () => {
+    const socketPath = `/tmp/${'x'.repeat(DARWIN_SOCKET_PATH_MAX_BYTES - 5)}`;
+    writeExecutable(
+      path.join(fixtureRoot, 'ssh'),
+      [
+        '#!/bin/sh',
+        `printf '%s\\n' "$*" >> ${shellQuote(sshInvocationLog)}`,
+        `printf 'accepted-boundary reached OpenSSH\\n' >&2`,
+        'exit 23',
+      ].join('\n'),
+    );
+
+    const message = invokeCredentialBridgeInFreshBun(
+      fixtureRoot,
+      originalPath,
+      socketPath,
+    );
+
+    expect(Buffer.byteLength(socketPath)).toBe(DARWIN_SOCKET_PATH_MAX_BYTES);
+    expect(message).toContain('accepted-boundary reached OpenSSH');
+    expect(fs.readFileSync(podmanInvocationLog, 'utf8')).toContain(
+      'system connection list',
+    );
+    expect(fs.readFileSync(sshInvocationLog, 'utf8')).toContain(socketPath);
+  }, 10000);
+
+  it('rejects a Darwin socket path of 104 encoded bytes before starting Podman or SSH', async () => {
+    const socketPath = `/tmp/${'x'.repeat(DARWIN_SOCKET_PATH_MAX_BYTES - 4)}`;
+    writeExecutable(
+      path.join(fixtureRoot, 'ssh'),
+      [
+        '#!/bin/sh',
+        `printf '%s\\n' "$*" >> ${shellQuote(sshInvocationLog)}`,
+        'exit 23',
+      ].join('\n'),
+    );
+
+    const message = invokeCredentialBridgeInFreshBun(
+      fixtureRoot,
+      originalPath,
+      socketPath,
+    );
+
+    expect(Buffer.byteLength(socketPath)).toBe(
+      DARWIN_SOCKET_PATH_MAX_BYTES + 1,
+    );
+    expect(message).toMatch(/socket path.*104 bytes.*103-byte pathname limit/i);
+    expect(fs.existsSync(podmanInvocationLog)).toBe(false);
+    expect(fs.existsSync(sshInvocationLog)).toBe(false);
+  });
+});

--- a/packages/cli/src/utils/sandbox-podman.ts
+++ b/packages/cli/src/utils/sandbox-podman.ts
@@ -35,6 +35,24 @@ const CONTAINER_CREDENTIAL_PROXY_SOCK = '/tmp/llxprt-credential.sock';
 const SSH_TUNNEL_POLL_INTERVAL_MS = 200;
 const TUNNEL_PORT_MIN = 49152;
 const TUNNEL_PORT_SPAN = 16383;
+const DARWIN_UNIX_SOCKET_PATH_MAX_BYTES = 103;
+const SSH_STARTUP_OUTPUT_MAX_BYTES = 4096;
+const SSH_TERMINATE_TIMEOUT_MS = 1000;
+
+interface TunnelStartupMonitor {
+  readonly process: ChildProcess;
+  readonly failure: Promise<never>;
+  readonly isRunning: () => boolean;
+  readonly markReady: () => void;
+  readonly terminateAndReap: () => Promise<void>;
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
 function sampleTunnelPort(
   exclude: ReadonlySet<number> = new Set<number>(),
 ): number {
@@ -66,26 +84,204 @@ function buildPodmanSshBaseArgs(
   ];
 }
 
+function appendBoundedOutput(current: Buffer, chunk: Buffer | string): Buffer {
+  const remaining = SSH_STARTUP_OUTPUT_MAX_BYTES - current.byteLength;
+  if (remaining <= 0) return current;
+  const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+  return Buffer.concat([current, bytes.subarray(0, remaining)]);
+}
+
+function boundedUtf8Text(output: Buffer): string {
+  const chars: string[] = [];
+  let encodedBytes = 0;
+  for (const char of output.toString('utf8').trim()) {
+    const charBytes = Buffer.byteLength(char);
+    if (encodedBytes + charBytes > SSH_STARTUP_OUTPUT_MAX_BYTES) break;
+    chars.push(char);
+    encodedBytes += charBytes;
+  }
+  return chars.join('');
+}
+
+function startupFailureDetail(stderr: Buffer, stdout: Buffer): string {
+  const diagnostic = boundedUtf8Text(stderr) || boundedUtf8Text(stdout);
+  return diagnostic === '' ? '' : ` SSH diagnostic: ${diagnostic}`;
+}
+
+function waitForClose(
+  closePromise: Promise<void>,
+  timeoutMs: number,
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(false), timeoutMs);
+    void closePromise.then(() => {
+      clearTimeout(timer);
+      resolve(true);
+    });
+  });
+}
+
+async function terminateAndReapTunnel(
+  tunnelProcess: ChildProcess,
+  isClosed: () => boolean,
+  closePromise: Promise<void>,
+): Promise<void> {
+  const errors: unknown[] = [];
+  if (
+    !isClosed() &&
+    tunnelProcess.exitCode === null &&
+    tunnelProcess.signalCode === null
+  ) {
+    try {
+      tunnelProcess.kill('SIGTERM');
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (
+    !isClosed() &&
+    !(await waitForClose(closePromise, SSH_TERMINATE_TIMEOUT_MS))
+  ) {
+    try {
+      tunnelProcess.kill('SIGKILL');
+    } catch (error) {
+      errors.push(error);
+    }
+    if (!(await waitForClose(closePromise, SSH_TERMINATE_TIMEOUT_MS))) {
+      errors.push(
+        new Error('OpenSSH tunnel process did not close after SIGKILL'),
+      );
+    }
+  }
+  if (errors.length === 1) throw errors[0];
+  if (errors.length > 1) {
+    throw new AggregateError(errors, 'OpenSSH tunnel cleanup failed');
+  }
+}
+
+function monitorTunnelProcess(
+  tunnelProcess: ChildProcess,
+  failureMessage: string,
+): TunnelStartupMonitor {
+  let stdout: Buffer = Buffer.alloc(0);
+  let stderr: Buffer = Buffer.alloc(0);
+  let ready = false;
+  let closed = false;
+  let exitDescription = '';
+  let rejectFailure: ((error: Error) => void) | undefined;
+  let resolveClose: (() => void) | undefined;
+
+  const closePromise = new Promise<void>((resolve) => {
+    resolveClose = resolve;
+  });
+  const failure = new Promise<never>((_resolve, reject) => {
+    rejectFailure = reject;
+  });
+  const onStdout = (chunk: Buffer | string): void => {
+    stdout = appendBoundedOutput(stdout, chunk);
+  };
+  const onStderr = (chunk: Buffer | string): void => {
+    stderr = appendBoundedOutput(stderr, chunk);
+  };
+  const buildFailure = (): FatalSandboxError =>
+    new FatalSandboxError(
+      failureMessage + exitDescription + startupFailureDetail(stderr, stdout),
+    );
+
+  tunnelProcess.stdout?.on('data', onStdout);
+  tunnelProcess.stderr?.on('data', onStderr);
+  tunnelProcess.once('error', (error) => {
+    if (!ready) {
+      exitDescription = ` OpenSSH process error: ${error.message}.`;
+      rejectFailure?.(buildFailure());
+    }
+  });
+  tunnelProcess.once('exit', (code, signal) => {
+    if (!ready) {
+      exitDescription =
+        code === null
+          ? ` OpenSSH exited from signal ${signal ?? 'unknown'}.`
+          : ` OpenSSH exited with code ${String(code)}.`;
+    }
+  });
+  tunnelProcess.once('close', () => {
+    closed = true;
+    tunnelProcess.stdout?.removeListener('data', onStdout);
+    tunnelProcess.stderr?.removeListener('data', onStderr);
+    resolveClose?.();
+    if (!ready && exitDescription !== '') {
+      rejectFailure?.(buildFailure());
+    }
+  });
+
+  return {
+    process: tunnelProcess,
+    failure,
+    isRunning: () =>
+      !closed &&
+      tunnelProcess.exitCode === null &&
+      tunnelProcess.signalCode === null,
+    markReady: () => {
+      ready = true;
+    },
+    terminateAndReap: () =>
+      terminateAndReapTunnel(tunnelProcess, () => closed, closePromise),
+  };
+}
+
+async function terminateAfterFailure(
+  monitor: TunnelStartupMonitor,
+  failure: unknown,
+): Promise<never> {
+  try {
+    await monitor.terminateAndReap();
+  } catch (cleanupError) {
+    throw new AggregateError(
+      [failure, cleanupError],
+      'OpenSSH tunnel startup and cleanup failed',
+    );
+  }
+  throw failure;
+}
+
+async function waitForTunnelReadiness(
+  monitor: TunnelStartupMonitor,
+  readiness: (signal: AbortSignal) => Promise<void>,
+): Promise<ChildProcess> {
+  const abortController = new AbortController();
+  try {
+    await Promise.race([readiness(abortController.signal), monitor.failure]);
+    if (!monitor.isRunning()) {
+      await monitor.failure;
+    }
+    monitor.markReady();
+    return monitor.process;
+  } catch (error) {
+    abortController.abort();
+    return await terminateAfterFailure(monitor, error);
+  } finally {
+    abortController.abort();
+  }
+}
+
 /** Spawns an SSH process and waits up to 500ms for it to stabilize. */
 async function spawnAndWaitForTunnel(
   sshArgs: string[],
   failureMessage: string,
-): Promise<ChildProcess> {
+): Promise<TunnelStartupMonitor> {
   const tunnelProcess = spawn('ssh', sshArgs, {
     stdio: ['ignore', 'pipe', 'pipe'],
   });
-  const started = await new Promise<boolean>((resolve) => {
-    const handler = () => resolve(false);
-    tunnelProcess.on('error', handler);
-    setTimeout(() => {
-      tunnelProcess.removeListener('error', handler);
-      resolve(tunnelProcess.exitCode === null);
-    }, 500);
-  });
-  if (!started) {
-    throw new FatalSandboxError(failureMessage);
+  const monitor = monitorTunnelProcess(tunnelProcess, failureMessage);
+  try {
+    await Promise.race([delay(500), monitor.failure]);
+    if (!monitor.isRunning()) {
+      await monitor.failure;
+    }
+  } catch (error) {
+    return terminateAfterFailure(monitor, error);
   }
-  return tunnelProcess;
+  return monitor;
 }
 
 /** Polls Podman VM for a TCP port to become listen-ready. */
@@ -93,11 +289,10 @@ async function pollPodmanVmPortReady(
   tunnelPort: number,
   pollTimeoutMs: number,
   timeoutMessage: string,
-  tunnelProcess?: ChildProcess,
+  signal: AbortSignal,
 ): Promise<void> {
   const pollStart = Date.now();
-  let portReady = false;
-  while (Date.now() - pollStart < pollTimeoutMs) {
+  while (!signal.aborted && Date.now() - pollStart < pollTimeoutMs) {
     try {
       const result = execSync(
         `podman machine ssh -- ss -tln | grep -q ':${tunnelPort} ' && echo ok`,
@@ -106,24 +301,14 @@ async function pollPodmanVmPortReady(
         .toString()
         .trim();
       if (result === 'ok') {
-        portReady = true;
-        break;
+        return;
       }
     } catch {
       // Port not ready yet
     }
-    await new Promise((r) => setTimeout(r, SSH_TUNNEL_POLL_INTERVAL_MS));
+    await delay(SSH_TUNNEL_POLL_INTERVAL_MS);
   }
-  if (!portReady) {
-    if (tunnelProcess) {
-      try {
-        tunnelProcess.kill('SIGTERM');
-      } catch {
-        // ignore
-      }
-    }
-    throw new FatalSandboxError(timeoutMessage);
-  }
+  if (!signal.aborted) throw new FatalSandboxError(timeoutMessage);
 }
 
 function reservePodmanTunnelPort(options: PodmanTunnelOptions): number {
@@ -153,6 +338,12 @@ async function startPodmanReverseTunnel(
   pollTimeoutMs: number,
   options: PodmanTunnelOptions,
 ): Promise<PodmanReverseTunnelResult> {
+  const socketPathBytes = Buffer.byteLength(hostSocketPath);
+  if (socketPathBytes > DARWIN_UNIX_SOCKET_PATH_MAX_BYTES) {
+    throw new FatalSandboxError(
+      `Podman macOS reverse tunnel socket path '${hostSocketPath}' is ${socketPathBytes} bytes, exceeding Darwin's ${DARWIN_UNIX_SOCKET_PATH_MAX_BYTES}-byte pathname limit.`,
+    );
+  }
   const conn = getPodmanMachineConnection();
   const tunnelPort = reservePodmanTunnelPort(options);
   const sshArgs = buildPodmanReverseTunnelArgs(
@@ -160,15 +351,9 @@ async function startPodmanReverseTunnel(
     tunnelPort,
     hostSocketPath,
   );
-  const tunnelProcess = await spawnAndWaitForTunnel(
-    sshArgs,
-    startupFailureMessage,
-  );
-  await pollPodmanVmPortReady(
-    tunnelPort,
-    pollTimeoutMs,
-    timeoutMessage,
-    tunnelProcess,
+  const monitor = await spawnAndWaitForTunnel(sshArgs, startupFailureMessage);
+  const tunnelProcess = await waitForTunnelReadiness(monitor, (signal) =>
+    pollPodmanVmPortReady(tunnelPort, pollTimeoutMs, timeoutMessage, signal),
   );
   return { tunnelPort, tunnelProcess };
 }
@@ -328,21 +513,13 @@ export async function setupPortForwardingPodmanMacOS(
 ): Promise<PortForwardingResult> {
   const conn = getPodmanMachineConnection();
   const sshArgs = buildPodmanLocalTunnelArgs(conn, portsToForward);
-  const tunnelProcess = await spawnAndWaitForTunnel(
+  const monitor = await spawnAndWaitForTunnel(
     sshArgs,
     'Port forwarding SSH tunnel failed to start for Podman macOS. Ensure Podman machine is running: `podman machine start`. Check SSH connectivity: `podman machine ssh`.',
   );
-
-  try {
-    await pollLocalPortsReady(portsToForward, pollTimeoutMs);
-  } catch (error) {
-    try {
-      tunnelProcess.kill('SIGTERM');
-    } catch {
-      // ignore
-    }
-    throw error;
-  }
+  const tunnelProcess = await waitForTunnelReadiness(monitor, (signal) =>
+    pollLocalPortsReady(portsToForward, pollTimeoutMs, signal),
+  );
 
   const cleanup = createTunnelProcessCleanup(tunnelProcess);
   return { tunnelProcess, cleanup };
@@ -352,19 +529,35 @@ export async function setupPortForwardingPodmanMacOS(
 async function pollLocalPortsReady(
   portsToForward: string[],
   pollTimeoutMs: number,
+  signal: AbortSignal,
 ): Promise<void> {
   const pollPromises = portsToForward.map(
     (port) =>
       new Promise<void>((resolve, reject) => {
         const pollStart = Date.now();
-        let timedOut = false;
+        let settled = false;
         let currentSocket: net.Socket | undefined;
+        let retryTimer: NodeJS.Timeout | undefined;
 
-        const tryConnect = () => {
+        const settle = (result?: Error): void => {
+          if (settled) return;
+          settled = true;
+          currentSocket?.destroy();
+          if (retryTimer !== undefined) clearTimeout(retryTimer);
+          signal.removeEventListener('abort', abort);
+          if (result === undefined) resolve();
+          else reject(result);
+        };
+        const abort = (): void => settle();
+        signal.addEventListener('abort', abort, { once: true });
+
+        const tryConnect = (): void => {
+          if (signal.aborted) {
+            settle();
+            return;
+          }
           if (Date.now() - pollStart > pollTimeoutMs) {
-            timedOut = true;
-            currentSocket?.destroy();
-            reject(
+            settle(
               new FatalSandboxError(
                 `Port forwarding timed out waiting for port ${port} to be ready.`,
               ),
@@ -377,15 +570,10 @@ async function pollLocalPortsReady(
             port: parseInt(port, 10),
           });
           const socket = currentSocket;
-          socket.on('connect', () => {
-            socket.destroy();
-            if (!timedOut) {
-              resolve();
-            }
-          });
+          socket.on('connect', () => settle());
           socket.on('error', () => {
-            if (!timedOut) {
-              setTimeout(tryConnect, SSH_TUNNEL_POLL_INTERVAL_MS);
+            if (!settled) {
+              retryTimer = setTimeout(tryConnect, SSH_TUNNEL_POLL_INTERVAL_MS);
             }
           });
         };

--- a/packages/cli/src/utils/sandbox-proxy-integration.test.ts
+++ b/packages/cli/src/utils/sandbox-proxy-integration.test.ts
@@ -356,7 +356,7 @@ describe('Credential Proxy Integration - sandbox.ts', () => {
         'async function runSeatbeltSandbox',
       );
       const seatbeltEnd = sandboxSources.seatbelt.indexOf(
-        'function resolveProxyUrl',
+        'export function buildSeatbeltArgs',
       );
 
       expect(seatbeltStart).toBeGreaterThan(-1);

--- a/packages/cli/src/utils/sandbox-proxy-integration.test.ts
+++ b/packages/cli/src/utils/sandbox-proxy-integration.test.ts
@@ -11,11 +11,13 @@
  * @plan:PLAN-20250214-CREDPROXY.P34
  */
 
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect, vi } from 'bun:test';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { testRegex } from '../test-utils/regex.js';
+import { createCredentialSocketRuntime } from './sandbox-credential-runtime.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -163,8 +165,26 @@ describe('Credential Proxy Integration - sandbox.ts', () => {
       );
     });
 
-    it('passes sessionTmpdir to createAndStartProxy', () => {
-      expect(sandboxSource).toContain('socketPath: sessionTmpdir');
+    it('uses a separate short private credential runtime for Darwin Podman sessions', () => {
+      const sessionTmpdir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'proxy-integration-session-'),
+      );
+      const platformSpy = vi.spyOn(os, 'platform').mockReturnValue('darwin');
+      const runtime = createCredentialSocketRuntime(
+        { command: 'podman', image: 'test' },
+        sessionTmpdir,
+      );
+
+      try {
+        expect(runtime.path).not.toBe(sessionTmpdir);
+        expect(runtime.path.startsWith('/tmp/lx-')).toBe(true);
+        expect(fs.statSync(runtime.path).mode & 0o777).toBe(0o700);
+      } finally {
+        runtime.cleanup();
+        platformSpy.mockRestore();
+        fs.rmSync(sessionTmpdir, { recursive: true, force: true });
+      }
+      expect(fs.existsSync(runtime.path)).toBe(false);
     });
   });
 

--- a/packages/cli/src/utils/sandbox-seatbelt.test-helpers.ts
+++ b/packages/cli/src/utils/sandbox-seatbelt.test-helpers.ts
@@ -7,6 +7,10 @@
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { allocateEphemeralPort } from '../../test-utils/ephemeral-port.js';
+import { runSeatbeltSandbox } from './sandbox-seatbelt.js';
 
 const PROCESS_LISTENER_EVENTS = ['exit', 'SIGINT', 'SIGTERM'] as const;
 const CHILD_CLOSE_DRAIN_TURNS = 5;
@@ -103,13 +107,14 @@ export async function cleanupSeatbeltHarnessFixture(
   fixtureDir: string,
   restoreState: () => void,
   proxyPid: number | undefined,
+  proxyPort: number,
 ): Promise<void> {
   try {
     if (proxyPid !== undefined) {
       signalFixtureProcess(proxyPid, '-TERM');
       await waitForFixtureProcessExit(proxyPid);
     }
-    await assertSeatbeltProxyPortAvailable();
+    await assertSeatbeltProxyPortAvailable(proxyPort);
   } finally {
     await drainPendingChildCloseEvents();
     restoreSeatbeltHarnessFixture(fixtureDir, restoreState);
@@ -126,12 +131,20 @@ async function waitUntilStopped(pid: number): Promise<boolean> {
   return status !== 0;
 }
 
-export async function assertSeatbeltProxyPortAvailable(): Promise<void> {
+/**
+ * Asserts the harness really released the port its proxy fixture owned.
+ * Each harness allocates that port for itself (#3501); a shared fixed port
+ * made this bind fail with EADDRINUSE whenever a concurrent test process
+ * happened to hold it, failing tests whose own assertions had passed.
+ */
+export async function assertSeatbeltProxyPortAvailable(
+  port: number,
+): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     const server = net.createServer();
     const onError = (error: Error): void => reject(error);
     server.once('error', onError);
-    server.listen(8877, '127.0.0.1', () => {
+    server.listen(port, '127.0.0.1', () => {
       server.close((error) => {
         server.removeListener('error', onError);
         if (error) reject(error);
@@ -139,4 +152,272 @@ export async function assertSeatbeltProxyPortAvailable(): Promise<void> {
       });
     });
   });
+}
+
+export interface SeatbeltHarness {
+  readonly cwd: string;
+  readonly argsFile: string;
+  readonly envFile: string;
+  readonly sandboxMarker: string;
+  readonly proxyMarker: string;
+  readonly proxyCommand: string;
+  /** Loopback port this harness owns; its proxy fixture binds exactly it. */
+  readonly proxyPort: number;
+  /** Proxy endpoint the harness configures the production resolver with. */
+  readonly proxyUrl: string;
+  /** Every argv the readiness probe passed to the stubbed `curl`. */
+  readonly readinessProbeArgsFile: string;
+  readonly cleanup: () => Promise<void>;
+}
+
+/** Paths the fixture's stubs write to and the assertions read back. */
+interface SeatbeltFixtureFiles {
+  readonly argsFile: string;
+  readonly envFile: string;
+  readonly sandboxMarker: string;
+  readonly sandboxExitMarker: string;
+  readonly proxyMarker: string;
+  readonly proxyPidFile: string;
+  readonly proxyServer: string;
+  readonly readinessProbeArgsFile: string;
+}
+
+function seatbeltFixtureFiles(fixtureDir: string): SeatbeltFixtureFiles {
+  return {
+    argsFile: path.join(fixtureDir, 'args'),
+    envFile: path.join(fixtureDir, 'env'),
+    sandboxMarker: path.join(fixtureDir, 'sandbox-spawned'),
+    sandboxExitMarker: path.join(fixtureDir, 'sandbox-exit'),
+    proxyMarker: path.join(fixtureDir, 'proxy-listening'),
+    proxyPidFile: path.join(fixtureDir, 'proxy-pid'),
+    proxyServer: path.join(fixtureDir, 'proxy.cjs'),
+    readinessProbeArgsFile: path.join(fixtureDir, 'readiness-probe'),
+  };
+}
+
+function writeExecutable(filePath: string, content: string): void {
+  fs.writeFileSync(filePath, content, { mode: 0o755 });
+}
+
+/**
+ * A real HTTP proxy the launch starts through
+ * LLXPRT_SANDBOX_PROXY_COMMAND. It binds the port the harness owns, which is
+ * the port the configured proxy endpoint names, and exits once the sandbox
+ * stub has run.
+ */
+function writeProxyServerFixture(
+  files: SeatbeltFixtureFiles,
+  proxyPort: number,
+): void {
+  fs.writeFileSync(
+    files.proxyServer,
+    [
+      "const fs = require('node:fs');",
+      "const http = require('node:http');",
+      `const server = http.createServer((_request, response) => response.end('ok'));`,
+      `server.listen(${proxyPort}, '127.0.0.1', () => {`,
+      `  fs.writeFileSync(${JSON.stringify(files.proxyPidFile)}, String(process.pid));`,
+      `  fs.writeFileSync(${JSON.stringify(files.proxyMarker)}, 'listening');`,
+      `  const interval = setInterval(() => {`,
+      `    if (fs.existsSync(${JSON.stringify(files.sandboxMarker)})) {`,
+      `      clearInterval(interval);`,
+      `      fs.writeFileSync(${JSON.stringify(files.sandboxExitMarker)}, 'exit');`,
+      `      server.close(() => process.exit(0));`,
+      `    }`,
+      `  }, 10);`,
+      '});',
+      "process.on('SIGTERM', () => server.close(() => process.exit(0)));",
+    ].join('\n'),
+  );
+}
+
+/**
+ * PATH stubs the launch resolves instead of the real binaries: the sandbox
+ * itself, the `timeout` macOS does not ship, and a `curl` that records every
+ * readiness argv it was given before reporting the proxy up.
+ */
+function writeSeatbeltPathStubs(
+  fixtureDir: string,
+  files: SeatbeltFixtureFiles,
+): void {
+  writeExecutable(
+    path.join(fixtureDir, 'sandbox-exec'),
+    `#!/bin/sh\nprintf '%s\\n' "$@" > "${files.argsFile}"\nenv > "${files.envFile}"\ntouch "${files.sandboxMarker}"\nif [ -n "${'$'}{LLXPRT_SANDBOX_PROXY_COMMAND-}" ]; then attempts=0; while [ ! -f "${files.sandboxExitMarker}" ]; do attempts=$((attempts + 1)); [ "$attempts" -ge 1000 ] && exit 124; sleep 0.01; done; fi\n`,
+  );
+  writeExecutable(
+    path.join(fixtureDir, 'timeout'),
+    ['#!/bin/sh', 'shift', 'exec "$@"'].join('\n'),
+  );
+  writeExecutable(
+    path.join(fixtureDir, 'curl'),
+    `#!/bin/sh\nprintf '%s\\n' "$@" >> "${files.readinessProbeArgsFile}"\ncase "${'$'}{LLXPRT_SANDBOX_PROXY_COMMAND-}" in *proxy.cjs*) attempts=0; while [ ! -f "${files.proxyMarker}" ]; do attempts=$((attempts + 1)); [ "$attempts" -ge 1000 ] && exit 124; sleep 0.01; done;; esac\nexit 0\n`,
+  );
+}
+
+/**
+ * The launch signals process groups and can exit the runner outright; both
+ * are neutralized for the duration of the fixture and restored by the
+ * captured process state.
+ */
+function stubProcessTermination(): void {
+  Object.defineProperty(process, 'kill', {
+    configurable: true,
+    value: () => {
+      const error = new Error('kill ESRCH');
+      Object.assign(error, { code: 'ESRCH' });
+      throw error;
+    },
+    writable: true,
+  });
+  Object.defineProperty(process, 'exit', {
+    configurable: true,
+    value: () => undefined,
+    writable: true,
+  });
+}
+
+/**
+ * Installs the seatbelt launch fixture and returns the handles a test needs
+ * to observe it. The harness owns a loopback port of its own (#3501): its
+ * proxy fixture binds exactly that port and the caller configures production
+ * with the matching endpoint, so two test processes never contend for one.
+ */
+export async function createSeatbeltHarness(
+  cwd: string = process.cwd(),
+): Promise<SeatbeltHarness> {
+  // Allocated before anything is installed: a harness that cannot own a port
+  // has nothing to restore.
+  const proxyPort = await allocateEphemeralPort();
+  const restoreHarnessState = captureSeatbeltHarnessProcessState();
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'seatbelt-1456-'));
+
+  try {
+    const files = seatbeltFixtureFiles(fixtureDir);
+    writeProxyServerFixture(files, proxyPort);
+    writeSeatbeltPathStubs(fixtureDir, files);
+    process.env.PATH = `${fixtureDir}:${process.env.PATH ?? ''}`;
+    stubProcessTermination();
+
+    return {
+      cwd,
+      argsFile: files.argsFile,
+      envFile: files.envFile,
+      sandboxMarker: files.sandboxMarker,
+      proxyMarker: files.proxyMarker,
+      proxyCommand: `${JSON.stringify(process.execPath)} ${JSON.stringify(files.proxyServer)}`,
+      proxyPort,
+      proxyUrl: `http://127.0.0.1:${proxyPort}`,
+      readinessProbeArgsFile: files.readinessProbeArgsFile,
+      cleanup: async (): Promise<void> => {
+        const proxyPid = fs.existsSync(files.proxyPidFile)
+          ? Number(fs.readFileSync(files.proxyPidFile, 'utf8').trim())
+          : undefined;
+        await cleanupSeatbeltHarnessFixture(
+          fixtureDir,
+          restoreHarnessState,
+          proxyPid,
+          proxyPort,
+        );
+      },
+    };
+  } catch (error) {
+    restoreSeatbeltHarnessFixture(fixtureDir, restoreHarnessState);
+    throw error;
+  }
+}
+
+/**
+ * Deadline for a case that drives this harness.
+ *
+ * Every such case orchestrates real processes: a shell-spawned `sandbox-exec`
+ * stub, and for proxied modes a Node HTTP proxy plus the `timeout`/`bash`/
+ * `curl` readiness probe, each of which must then be proven gone at the OS
+ * level. That costs roughly 0.3-0.9s on an idle machine but 4.2-5.0s with four
+ * suites running at once (#3501), so the slowest case reached Bun's 5s default
+ * deadline before any assertion could fail. Once a case overruns, its orphaned
+ * continuation resolves `sandbox-exec` through the *next* case's PATH fixture
+ * and reads a directory that teardown already removed, which is how a single
+ * overrun turned into an `ENOENT` in an unrelated case. The deadline is
+ * therefore stated for the work these cases really do rather than inherited.
+ */
+export const SEATBELT_HARNESS_TIMEOUT_MS = 30_000;
+
+/**
+ * Process environment the harness owns for the duration of a case. `PATH`
+ * carries the fixture's stub directory, and the proxy endpoint variables are
+ * the production-facing configuration path for the proxy port, so the harness
+ * sets them itself instead of inheriting whatever the developer's shell
+ * exports (#3501).
+ */
+export const SEATBELT_HARNESS_ENV_KEYS = [
+  'SEATBELT_PROFILE',
+  'LLXPRT_SANDBOX_NETWORK',
+  'SANDBOX_NETWORK',
+  'LLXPRT_SANDBOX_PROXY_COMMAND',
+  'LLXPRT_CAPABILITY_TOKEN',
+  'LLXPRT_CAPABILITY_FD',
+  'LLXPRT_CREDENTIAL_SOCKET',
+  'HTTPS_PROXY',
+  'https_proxy',
+  'HTTP_PROXY',
+  'http_proxy',
+  'PATH',
+] as const;
+
+export type SeatbeltHarnessEnvironment = Partial<
+  Record<(typeof SEATBELT_HARNESS_ENV_KEYS)[number], string>
+>;
+
+export type SeatbeltHarnessEnvironmentSnapshot = Readonly<
+  Record<string, string | undefined>
+>;
+
+export function snapshotSeatbeltHarnessEnvironment(): SeatbeltHarnessEnvironmentSnapshot {
+  return Object.fromEntries(
+    SEATBELT_HARNESS_ENV_KEYS.map((key) => [key, process.env[key]]),
+  );
+}
+
+export function restoreSeatbeltHarnessEnvironment(
+  snapshot: SeatbeltHarnessEnvironmentSnapshot,
+): void {
+  for (const key of SEATBELT_HARNESS_ENV_KEYS) {
+    const value = snapshot[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function applyHarnessEnvironment(
+  environment: SeatbeltHarnessEnvironment,
+): void {
+  for (const key of SEATBELT_HARNESS_ENV_KEYS) {
+    if (key !== 'PATH') delete process.env[key];
+  }
+  Object.assign(
+    process.env,
+    Object.fromEntries(
+      SEATBELT_HARNESS_ENV_KEYS.flatMap((key) => {
+        const value = environment[key];
+        return value === undefined ? [] : [[key, value]];
+      }),
+    ),
+  );
+}
+
+/** Runs a real seatbelt launch against the harness's fixture. */
+export async function executeSeatbeltHarness(
+  harness: SeatbeltHarness,
+  environment: SeatbeltHarnessEnvironment,
+): Promise<number> {
+  // The harness configures its own proxy endpoint through the same variables
+  // a user would set, so production resolves the port this harness owns.
+  applyHarnessEnvironment({ HTTPS_PROXY: harness.proxyUrl, ...environment });
+  process.chdir(harness.cwd);
+  return runSeatbeltSandbox(
+    { command: 'sandbox-exec', image: 'test' },
+    [],
+    undefined,
+    [],
+  );
 }

--- a/packages/cli/src/utils/sandbox-seatbelt.test.ts
+++ b/packages/cli/src/utils/sandbox-seatbelt.test.ts
@@ -19,9 +19,13 @@ import {
 } from './sandbox-seatbelt.js';
 import {
   assertSeatbeltProxyPortAvailable,
-  captureSeatbeltHarnessProcessState,
-  cleanupSeatbeltHarnessFixture,
-  restoreSeatbeltHarnessFixture,
+  createSeatbeltHarness,
+  executeSeatbeltHarness,
+  restoreSeatbeltHarnessEnvironment,
+  snapshotSeatbeltHarnessEnvironment,
+  SEATBELT_HARNESS_TIMEOUT_MS,
+  type SeatbeltHarness,
+  type SeatbeltHarnessEnvironmentSnapshot,
 } from './sandbox-seatbelt.test-helpers.js';
 import { Storage } from '@vybestack/llxprt-code-storage';
 import { FatalSandboxError } from '@vybestack/llxprt-code-core';
@@ -482,164 +486,9 @@ describe('AC11: seatbelt spawn env carries no capability transport (#1954)', () 
   );
 });
 
-const ISSUE_1456_ENV_KEYS = [
-  'SEATBELT_PROFILE',
-  'LLXPRT_SANDBOX_NETWORK',
-  'SANDBOX_NETWORK',
-  'LLXPRT_SANDBOX_PROXY_COMMAND',
-  'LLXPRT_CAPABILITY_TOKEN',
-  'LLXPRT_CAPABILITY_FD',
-  'LLXPRT_CREDENTIAL_SOCKET',
-  'PATH',
-] as const;
 const PROXIED_PROFILE_ERROR =
   'Seatbelt proxied profile requires a non-empty LLXPRT_SANDBOX_PROXY_COMMAND.';
 const BUILTIN_PROFILE_DIRECTORY = __dirname;
-
-type Issue1456Environment = Partial<
-  Record<(typeof ISSUE_1456_ENV_KEYS)[number], string>
->;
-
-interface SeatbeltHarness {
-  readonly cwd: string;
-  readonly argsFile: string;
-  readonly envFile: string;
-  readonly sandboxMarker: string;
-  readonly proxyMarker: string;
-  readonly proxyCommand: string;
-  readonly cleanup: () => Promise<void>;
-}
-
-function restoreEnvironment(
-  snapshot: Readonly<Record<string, string | undefined>>,
-): void {
-  for (const key of ISSUE_1456_ENV_KEYS) {
-    const value = snapshot[key];
-    if (value === undefined) delete process.env[key];
-    else process.env[key] = value;
-  }
-}
-
-function applyEnvironment(environment: Issue1456Environment): void {
-  for (const key of ISSUE_1456_ENV_KEYS) {
-    if (key !== 'PATH') delete process.env[key];
-  }
-  Object.assign(
-    process.env,
-    Object.fromEntries(
-      ISSUE_1456_ENV_KEYS.flatMap((key) => {
-        const value = environment[key];
-        return value === undefined ? [] : [[key, value]];
-      }),
-    ),
-  );
-}
-
-function writeExecutable(filePath: string, content: string): void {
-  fs.writeFileSync(filePath, content, { mode: 0o755 });
-}
-
-function createSeatbeltHarness(cwd: string = process.cwd()): SeatbeltHarness {
-  const restoreHarnessState = captureSeatbeltHarnessProcessState();
-  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'seatbelt-1456-'));
-
-  try {
-    const argsFile = path.join(fixtureDir, 'args');
-    const envFile = path.join(fixtureDir, 'env');
-    const sandboxMarker = path.join(fixtureDir, 'sandbox-spawned');
-    const sandboxExitMarker = path.join(fixtureDir, 'sandbox-exit');
-    const proxyMarker = path.join(fixtureDir, 'proxy-listening');
-    const proxyPidFile = path.join(fixtureDir, 'proxy-pid');
-    const proxyServer = path.join(fixtureDir, 'proxy.cjs');
-
-    writeExecutable(
-      path.join(fixtureDir, 'sandbox-exec'),
-      `#!/bin/sh\nprintf '%s\\n' "$@" > "${argsFile}"\nenv > "${envFile}"\ntouch "${sandboxMarker}"\nif [ -n "${'$'}{LLXPRT_SANDBOX_PROXY_COMMAND-}" ]; then attempts=0; while [ ! -f "${sandboxExitMarker}" ]; do attempts=$((attempts + 1)); [ "$attempts" -ge 1000 ] && exit 124; sleep 0.01; done; fi\n`,
-    );
-    fs.writeFileSync(
-      proxyServer,
-      [
-        "const fs = require('node:fs');",
-        "const http = require('node:http');",
-        `const server = http.createServer((_request, response) => response.end('ok'));`,
-        `server.listen(8877, '127.0.0.1', () => {`,
-        `  fs.writeFileSync(${JSON.stringify(proxyPidFile)}, String(process.pid));`,
-        `  fs.writeFileSync(${JSON.stringify(proxyMarker)}, 'listening');`,
-        `  const interval = setInterval(() => {`,
-        `    if (fs.existsSync(${JSON.stringify(sandboxMarker)})) {`,
-        `      clearInterval(interval);`,
-        `      fs.writeFileSync(${JSON.stringify(sandboxExitMarker)}, 'exit');`,
-        `      server.close(() => process.exit(0));`,
-        `    }`,
-        `  }, 10);`,
-        '});',
-        "process.on('SIGTERM', () => server.close(() => process.exit(0)));",
-      ].join('\n'),
-    );
-    writeExecutable(
-      path.join(fixtureDir, 'timeout'),
-      ['#!/bin/sh', 'shift', 'exec "$@"'].join('\n'),
-    );
-    writeExecutable(
-      path.join(fixtureDir, 'curl'),
-      `#!/bin/sh\ncase "${'$'}{LLXPRT_SANDBOX_PROXY_COMMAND-}" in *proxy.cjs*) attempts=0; while [ ! -f "${proxyMarker}" ]; do attempts=$((attempts + 1)); [ "$attempts" -ge 1000 ] && exit 124; sleep 0.01; done;; esac\nexit 0\n`,
-    );
-    process.env.PATH = `${fixtureDir}:${process.env.PATH ?? ''}`;
-
-    Object.defineProperty(process, 'kill', {
-      configurable: true,
-      value: () => {
-        const error = new Error('kill ESRCH');
-        Object.assign(error, { code: 'ESRCH' });
-        throw error;
-      },
-      writable: true,
-    });
-    Object.defineProperty(process, 'exit', {
-      configurable: true,
-      value: () => undefined,
-      writable: true,
-    });
-
-    const proxyCommand = `${JSON.stringify(process.execPath)} ${JSON.stringify(proxyServer)}`;
-    const cleanup = async (): Promise<void> => {
-      const proxyPid = fs.existsSync(proxyPidFile)
-        ? Number(fs.readFileSync(proxyPidFile, 'utf8').trim())
-        : undefined;
-      await cleanupSeatbeltHarnessFixture(
-        fixtureDir,
-        restoreHarnessState,
-        proxyPid,
-      );
-    };
-    return {
-      cwd,
-      argsFile,
-      envFile,
-      sandboxMarker,
-      proxyMarker,
-      proxyCommand,
-      cleanup,
-    };
-  } catch (error) {
-    restoreSeatbeltHarnessFixture(fixtureDir, restoreHarnessState);
-    throw error;
-  }
-}
-
-async function executeSeatbeltHarness(
-  harness: SeatbeltHarness,
-  environment: Issue1456Environment,
-): Promise<number> {
-  applyEnvironment(environment);
-  process.chdir(harness.cwd);
-  return runSeatbeltSandbox(
-    { command: 'sandbox-exec', image: 'test' },
-    [],
-    undefined,
-    [],
-  );
-}
 
 function assertSelectedProfile(
   harness: SeatbeltHarness,
@@ -661,19 +510,17 @@ function assertScrubbedEnvironment(harness: SeatbeltHarness): void {
 }
 
 describe('#1456 Seatbelt network policy', () => {
-  let environmentSnapshot: Record<string, string | undefined>;
+  let environmentSnapshot: SeatbeltHarnessEnvironmentSnapshot;
   let originalCwd: string;
 
   beforeEach(() => {
-    environmentSnapshot = Object.fromEntries(
-      ISSUE_1456_ENV_KEYS.map((key) => [key, process.env[key]]),
-    );
+    environmentSnapshot = snapshotSeatbeltHarnessEnvironment();
     originalCwd = process.cwd();
   });
 
   afterEach(() => {
     process.chdir(originalCwd);
-    restoreEnvironment(environmentSnapshot);
+    restoreSeatbeltHarnessEnvironment(environmentSnapshot);
   });
 
   it.skipIf(process.platform === 'win32').each([
@@ -687,7 +534,7 @@ describe('#1456 Seatbelt network policy', () => {
   ])(
     'maps primary=%s and legacy=%s to %s',
     async (primary, legacy, profile) => {
-      const harness = createSeatbeltHarness();
+      const harness = await createSeatbeltHarness();
       try {
         await executeSeatbeltHarness(harness, {
           LLXPRT_SANDBOX_NETWORK: primary,
@@ -703,12 +550,13 @@ describe('#1456 Seatbelt network policy', () => {
         await harness.cleanup();
       }
     },
+    SEATBELT_HARNESS_TIMEOUT_MS,
   );
 
   it.skipIf(process.platform === 'win32')(
     'uses an empty explicit profile as automatic network selection',
     async () => {
-      const harness = createSeatbeltHarness();
+      const harness = await createSeatbeltHarness();
       try {
         await executeSeatbeltHarness(harness, {
           SEATBELT_PROFILE: '',
@@ -726,12 +574,13 @@ describe('#1456 Seatbelt network policy', () => {
         await harness.cleanup();
       }
     },
+    SEATBELT_HARNESS_TIMEOUT_MS,
   );
 
   it.skipIf(process.platform === 'win32')(
     'honors a conflicting non-empty explicit profile',
     async () => {
-      const harness = createSeatbeltHarness();
+      const harness = await createSeatbeltHarness();
       try {
         await executeSeatbeltHarness(harness, {
           SEATBELT_PROFILE: 'permissive-closed',
@@ -749,6 +598,7 @@ describe('#1456 Seatbelt network policy', () => {
         await harness.cleanup();
       }
     },
+    SEATBELT_HARNESS_TIMEOUT_MS,
   );
 
   it
@@ -764,7 +614,7 @@ describe('#1456 Seatbelt network policy', () => {
       );
       fs.mkdirSync(profileDirectory, { recursive: true });
       fs.writeFileSync(profilePath, '(version 1)\n(deny default)\n');
-      const harness = createSeatbeltHarness(cwd);
+      const harness = await createSeatbeltHarness(cwd);
       try {
         await executeSeatbeltHarness(harness, {
           SEATBELT_PROFILE: profile,
@@ -780,14 +630,15 @@ describe('#1456 Seatbelt network policy', () => {
         fs.rmSync(cwd, { recursive: true, force: true });
       }
     },
+    SEATBELT_HARNESS_TIMEOUT_MS,
   );
 
   it.skipIf(process.platform === 'win32')(
     'allocates both proxy listener and sandbox for valid proxied mode and scrubs child credentials',
     async () => {
-      await assertSeatbeltProxyPortAvailable();
-      const harness = createSeatbeltHarness();
+      const harness = await createSeatbeltHarness();
       try {
+        await assertSeatbeltProxyPortAvailable(harness.proxyPort);
         await executeSeatbeltHarness(harness, {
           LLXPRT_SANDBOX_NETWORK: 'proxied',
           LLXPRT_SANDBOX_PROXY_COMMAND: harness.proxyCommand,
@@ -809,6 +660,32 @@ describe('#1456 Seatbelt network policy', () => {
         await harness.cleanup();
       }
     },
+    SEATBELT_HARNESS_TIMEOUT_MS,
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'waits for readiness on the configured proxy endpoint, not a fixed port',
+    async () => {
+      const harness = await createSeatbeltHarness();
+      try {
+        await executeSeatbeltHarness(harness, {
+          LLXPRT_SANDBOX_NETWORK: 'proxied',
+          LLXPRT_SANDBOX_PROXY_COMMAND: harness.proxyCommand,
+        });
+
+        // The readiness probe really ran against the endpoint this harness
+        // owns; a hard-coded probe target would never name this port.
+        const probeArgv = fs.readFileSync(
+          harness.readinessProbeArgsFile,
+          'utf8',
+        );
+        expect(probeArgv.split('\n')).toContain(harness.proxyUrl);
+        expect(fs.existsSync(harness.proxyMarker)).toBe(true);
+      } finally {
+        await harness.cleanup();
+      }
+    },
+    SEATBELT_HARNESS_TIMEOUT_MS,
   );
 
   it.skipIf(process.platform === 'win32').each([
@@ -818,7 +695,7 @@ describe('#1456 Seatbelt network policy', () => {
   ])(
     'rejects automatic proxied mode with %s command before allocation',
     async (_label, command) => {
-      const harness = createSeatbeltHarness();
+      const harness = await createSeatbeltHarness();
       try {
         const result = executeSeatbeltHarness(harness, {
           LLXPRT_SANDBOX_NETWORK: 'proxied',
@@ -832,6 +709,7 @@ describe('#1456 Seatbelt network policy', () => {
         await harness.cleanup();
       }
     },
+    SEATBELT_HARNESS_TIMEOUT_MS,
   );
 
   it
@@ -839,7 +717,7 @@ describe('#1456 Seatbelt network policy', () => {
     .each(['permissive-proxied', 'restrictive-proxied'])(
     'rejects explicit built-in %s without a proxy command',
     async (profile) => {
-      const harness = createSeatbeltHarness();
+      const harness = await createSeatbeltHarness();
       try {
         const result = executeSeatbeltHarness(harness, {
           SEATBELT_PROFILE: profile,
@@ -852,6 +730,7 @@ describe('#1456 Seatbelt network policy', () => {
         await harness.cleanup();
       }
     },
+    SEATBELT_HARNESS_TIMEOUT_MS,
   );
 });
 

--- a/packages/cli/src/utils/sandbox-seatbelt.ts
+++ b/packages/cli/src/utils/sandbox-seatbelt.ts
@@ -9,9 +9,7 @@ import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { promisify } from 'node:util';
 import { quote } from 'shell-quote';
-import { exec } from 'node:child_process';
 import type { Config, SandboxConfig } from '@vybestack/llxprt-code-core';
 import {
   FatalSandboxError,
@@ -24,9 +22,11 @@ import {
   isSandboxDebugModeEnabled,
 } from './sandbox-env.js';
 import { canonicalizeExistingPath } from './sandbox-path-canonicalization.js';
+import {
+  awaitSandboxProxyReady,
+  resolveSandboxProxyUrl,
+} from './sandbox-network-proxy.js';
 import { Storage } from '@vybestack/llxprt-code-storage';
-
-const execAsync = promisify(exec);
 
 const BUILTIN_SEATBELT_PROFILES = [
   'permissive-open',
@@ -140,15 +140,6 @@ export async function runSeatbeltSandbox(
     stdinHadRawMode,
     cliConfig,
   );
-}
-function resolveProxyUrl(): string {
-  const candidates = [
-    process.env.HTTPS_PROXY,
-    process.env.https_proxy,
-    process.env.HTTP_PROXY,
-    process.env.http_proxy,
-  ];
-  return candidates.find((v): v is string => !!v) ?? 'http://localhost:8877';
 }
 
 export function buildSeatbeltArgs(
@@ -274,7 +265,7 @@ async function setupSeatbeltProxy(): Promise<SeatbeltProxySetup> {
     return { sandboxEnv };
   }
 
-  const proxy = resolveProxyUrl();
+  const proxy = resolveSandboxProxyUrl(process.env);
   sandboxEnv['HTTPS_PROXY'] = proxy;
   sandboxEnv['https_proxy'] = proxy;
   sandboxEnv['HTTP_PROXY'] = proxy;
@@ -305,10 +296,7 @@ async function setupSeatbeltProxy(): Promise<SeatbeltProxySetup> {
   debugLogger.log('waiting for proxy to start ...');
   const SEATBELT_PROXY_READY_TIMEOUT_MS = 30000;
   try {
-    await execAsync(
-      `timeout ${Math.floor(SEATBELT_PROXY_READY_TIMEOUT_MS / 1000)} bash -c 'until curl -s http://localhost:8877; do sleep 0.25; done'`,
-      { timeout: SEATBELT_PROXY_READY_TIMEOUT_MS + 5000 },
-    );
+    await awaitSandboxProxyReady(proxy, SEATBELT_PROXY_READY_TIMEOUT_MS);
   } catch (err) {
     const proxyPid = proxyProcess.pid;
     if (proxyPid !== undefined && proxyPid !== 0) {

--- a/packages/cli/src/utils/sandbox-source-development.test.ts
+++ b/packages/cli/src/utils/sandbox-source-development.test.ts
@@ -31,6 +31,7 @@ import { useFakeEngine } from '../../test-utils/fake-dependency-engine-harness.j
 
 /** The checked-out CLI source entrypoint a real llxprt-code checkout has. */
 const SOURCE_ENTRY = path.join('packages', 'cli', 'index.ts');
+const LOCKFILE_FIXTURE = '{}\n';
 
 function makeWorkspace(prefix: string): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -52,6 +53,11 @@ function seedSourceCheckout(workdir: string): void {
     path.join(workdir, SOURCE_ENTRY),
     '// checked-out CLI source entrypoint\n',
   );
+  fs.writeFileSync(
+    path.join(workdir, 'package.json'),
+    JSON.stringify({ name: 'llxprt-source-fixture', private: true }) + '\n',
+  );
+  fs.writeFileSync(path.join(workdir, 'bun.lock'), LOCKFILE_FIXTURE);
 }
 
 /** Saves/restores NODE_ENV around one test-controlled assignment. */
@@ -89,6 +95,11 @@ function installRecordingShims(binDir: string, recordPath: string): void {
       shimPath,
       [
         '#!/usr/bin/env bash',
+        'if [ "$(basename "$0")" = "bun" ] && [ "${1-}" = "install" ]; then',
+        '  printf \'%s\\n\' "$@" > ' + JSON.stringify(`${recordPath}.install`),
+        '  case " $* " in *" --no-save "*) ;; *) printf \'mutated by install\\n\' > bun.lock ;; esac',
+        '  exit "${ISSUE3534_BUN_INSTALL_EXIT:-0}"',
+        'fi',
         'printf \'%s\\n\' "$(basename "$0")" "$@" >> ' +
           JSON.stringify(recordPath),
       ].join('\n'),
@@ -173,7 +184,73 @@ describe('#3455 entrypoint command selection', () => {
           command: 'bun',
           args: ['./packages/cli/index.ts'],
         });
+        expect(fs.readFileSync(`${recordPath}.install`, 'utf8')).toBe(
+          'install\n--no-save\n',
+        );
+        expect(fs.readFileSync(path.join(repo, 'bun.lock'), 'utf8')).toBe(
+          LOCKFILE_FIXTURE,
+        );
       } finally {
+        restore();
+      }
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'fails before dependency preparation when the committed Bun lockfile is missing',
+    () => {
+      seedSourceCheckout(repo);
+      fs.rmSync(path.join(repo, 'bun.lock'));
+      const restore = setNodeEnv('development');
+      try {
+        const cmd = entrypoint(repo, ['llxprt', 'chat']);
+        const result = spawnSync(cmd[0], cmd.slice(1), {
+          encoding: 'utf8',
+          cwd: repo,
+          env: {
+            ...process.env,
+            BASH_ENV: '',
+            PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+          },
+        });
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain(
+          'requires package.json and bun.lock in the repository root',
+        );
+        expect(fs.existsSync(`${recordPath}.install`)).toBe(false);
+        expect(readShimInvocation(recordPath)).toBeUndefined();
+      } finally {
+        restore();
+      }
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'does not execute checked-out source when isolated dependency preparation fails',
+    () => {
+      seedSourceCheckout(repo);
+      const restore = setNodeEnv('development');
+      process.env.ISSUE3534_BUN_INSTALL_EXIT = '17';
+      try {
+        const cmd = entrypoint(repo, ['llxprt', 'chat']);
+        const result = spawnSync(cmd[0], cmd.slice(1), {
+          encoding: 'utf8',
+          cwd: repo,
+          env: {
+            ...process.env,
+            BASH_ENV: '',
+            PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+          },
+        });
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain(
+          'Failed to prepare isolated Linux dependencies for LLxprt source development',
+        );
+        expect(readShimInvocation(recordPath)).toBeUndefined();
+      } finally {
+        delete process.env.ISSUE3534_BUN_INSTALL_EXIT;
         restore();
       }
     },
@@ -289,14 +366,43 @@ describe('#3455 shared predicate drives private dependency isolation', () => {
     }
   });
 
-  it('source checkout with NODE_ENV=development keeps the shared workspace bind', () => {
+  it('source checkout with NODE_ENV=development overlays host dependencies with private engine storage', () => {
     seedSourceCheckout(workdir);
-    fs.mkdirSync(path.join(workdir, 'node_modules'), { recursive: true });
+    fs.mkdirSync(path.join(workdir, 'node_modules', '.bin'), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(workdir, 'node_modules', 'host-marker.txt'),
+      'macOS host dependency\n',
+    );
+    fs.symlinkSync(
+      '../host-marker.txt',
+      path.join(workdir, 'node_modules', '.bin', 'host-tool'),
+    );
+    const hostMarker = fs.readFileSync(
+      path.join(workdir, 'node_modules', 'host-marker.txt'),
+      'utf8',
+    );
+    const hostLink = fs.readlinkSync(
+      path.join(workdir, 'node_modules', '.bin', 'host-tool'),
+    );
+
     const planned = planWithEngine(engine.config, 'development');
     try {
-      expect(planned.args).toStrictEqual(['--volume', `${workdir}:${workdir}`]);
-      expect(engine.snapshot().invocations).toStrictEqual([]);
-      expect(engine.volumeNames()).toStrictEqual([]);
+      expect(mountValues(planned.args)).toHaveLength(1);
+      expect(mountValues(planned.args)[0]).toMatch(/^type=volume,/);
+      expect(engine.volumeNames()).toHaveLength(1);
+      expect(
+        fs.readFileSync(
+          path.join(workdir, 'node_modules', 'host-marker.txt'),
+          'utf8',
+        ),
+      ).toBe(hostMarker);
+      expect(
+        fs.readlinkSync(
+          path.join(workdir, 'node_modules', '.bin', 'host-tool'),
+        ),
+      ).toBe(hostLink);
     } finally {
       planned.release();
     }

--- a/packages/cli/src/utils/sandbox-ssh.test-helper.ts
+++ b/packages/cli/src/utils/sandbox-ssh.test-helper.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi, type Mock } from 'bun:test';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+
+export interface MockTunnelProcess extends EventEmitter {
+  pid: number;
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  stdout: PassThrough;
+  stderr: PassThrough;
+  kill: Mock<(signal?: NodeJS.Signals | number) => boolean>;
+}
+
+export function createMockTunnelProcess(
+  exitCode: number | null = null,
+): MockTunnelProcess {
+  const fakeProcess = new EventEmitter() as MockTunnelProcess;
+  let closed = false;
+  const close = (code: number | null, signal: NodeJS.Signals | null): void => {
+    if (closed) return;
+    closed = true;
+    fakeProcess.exitCode = code;
+    fakeProcess.signalCode = signal;
+    fakeProcess.stdout.end();
+    fakeProcess.stderr.end();
+    fakeProcess.emit('exit', code, signal);
+    fakeProcess.emit('close', code, signal);
+  };
+
+  fakeProcess.pid = 99999;
+  fakeProcess.exitCode = exitCode;
+  fakeProcess.signalCode = null;
+  fakeProcess.stdout = new PassThrough();
+  fakeProcess.stderr = new PassThrough();
+  fakeProcess.kill = vi.fn((signal: NodeJS.Signals | number = 'SIGTERM') => {
+    const signalCode = typeof signal === 'string' ? signal : 'SIGTERM';
+    close(null, signalCode);
+    return true;
+  });
+  if (exitCode !== null) {
+    queueMicrotask(() => close(exitCode, null));
+  }
+
+  return fakeProcess;
+}

--- a/packages/cli/src/utils/sandbox-ssh.test.ts
+++ b/packages/cli/src/utils/sandbox-ssh.test.ts
@@ -12,6 +12,10 @@ import fs from 'node:fs';
 import os from 'node:os';
 import { DebugLogger } from '@vybestack/llxprt-code-core';
 import { testRegex } from '../test-utils/regex.js';
+import {
+  createMockTunnelProcess,
+  type MockTunnelProcess,
+} from './sandbox-ssh.test-helper.js';
 
 const realNodeChildProcessModule = { ...(await import('node:child_process')) };
 
@@ -286,16 +290,8 @@ function mockValidPodmanConnection() {
   });
 }
 
-function mockTunnelProcess(exitCode: number | null = null) {
-  const fakeProcess = {
-    pid: 99999,
-    exitCode,
-    on: vi.fn().mockReturnThis(),
-    removeListener: vi.fn().mockReturnThis(),
-    kill: vi.fn(),
-    stdout: { on: vi.fn() },
-    stderr: { on: vi.fn() },
-  };
+function mockTunnelProcess(exitCode: number | null = null): MockTunnelProcess {
+  const fakeProcess = createMockTunnelProcess(exitCode);
   (
     child_process.spawn as unknown as Mock<typeof child_process.spawn>
   ).mockReturnValue(fakeProcess as unknown as child_process.ChildProcess);

--- a/packages/cli/src/utils/sandbox-venv.test.ts
+++ b/packages/cli/src/utils/sandbox-venv.test.ts
@@ -225,10 +225,7 @@ describe('#3462 venv destination in the engine-owned dependency plan', () => {
     expect(venvEntries).toStrictEqual(['host-venv-marker.txt']);
   });
 
-  it('excludes the venv volume for a positive source-checkout development launch like the rest of the plan', () => {
-    // #3455: ambient NODE_ENV=development alone no longer bypasses the
-    // dependency plan; the predicate additionally requires the checked-out
-    // packages/cli/index.ts entry file.
+  it('isolates the venv and root dependencies for a source-checkout development launch', () => {
     fs.mkdirSync(path.join(workdir, 'packages', 'cli'), { recursive: true });
     fs.writeFileSync(
       path.join(workdir, 'packages', 'cli', 'index.ts'),
@@ -237,9 +234,32 @@ describe('#3462 venv destination in the engine-owned dependency plan', () => {
     process.env.NODE_ENV = 'development';
     const args: string[] = ['--volume', `${workdir}:${workdir}`];
     const lifecycle = addPrivateDependencyMounts(engine.config, args, workdir);
-    expect(args).toStrictEqual(['--volume', `${workdir}:${workdir}`]);
-    expect(engine.snapshot().invocations).toStrictEqual([]);
-    lifecycle.release();
+
+    try {
+      const mounts = flagValues(args, '--mount');
+      const destinations = mounts.map((spec) => mountField(spec, 'dst'));
+      expect(destinations).toContain(
+        getContainerPath(path.join(workdir, 'node_modules')),
+      );
+      expect(destinations).toContain(
+        getContainerPath(process.env.VIRTUAL_ENV!),
+      );
+      expect(
+        fs.readFileSync(
+          path.join(workdir, 'node_modules', 'host-root-marker.txt'),
+          'utf8',
+        ),
+      ).toBe('host-root-marker\n');
+      expect(
+        fs.readFileSync(
+          path.join(workdir, '.venv', 'host-venv-marker.txt'),
+          'utf8',
+        ),
+      ).toBe('host-venv-marker\n');
+    } finally {
+      lifecycle.release();
+    }
+    expect(engine.volumeNames()).toStrictEqual([]);
   });
 
   it('initializes the venv volume in the same bounded uid-0 init container run', () => {

--- a/packages/cli/test-utils/ephemeral-port.ts
+++ b/packages/cli/test-utils/ephemeral-port.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Per-suite loopback port ownership (#3501).
+ *
+ * Suites that must name a port before the thing that binds it exists (a
+ * child proxy process, a configured proxy endpoint) previously shared one
+ * fixed number, so two test processes on the same machine collided and
+ * failed each other with EADDRINUSE. Each suite now asks the kernel for a
+ * port of its own instead.
+ */
+
+import net from 'node:net';
+
+/**
+ * Reserves a loopback TCP port by binding port 0, reading back the kernel's
+ * assignment, and releasing it again. The caller owns the returned port for
+ * the lifetime of its fixture.
+ */
+export async function allocateEphemeralPort(): Promise<number> {
+  const probe = net.createServer();
+  const port = await new Promise<number>((resolve, reject) => {
+    probe.once('error', reject);
+    probe.once('listening', () => {
+      const address = probe.address();
+      if (address === null || typeof address === 'string') {
+        reject(new Error('ephemeral port probe did not bind a TCP port'));
+        return;
+      }
+      resolve(address.port);
+    });
+    probe.listen(0, '127.0.0.1');
+  });
+  await new Promise<void>((resolve, reject) => {
+    probe.close((error) => (error === undefined ? resolve() : reject(error)));
+  });
+  return port;
+}

--- a/packages/providers/src/composition/aliasProviderFactory.authOnly.test.ts
+++ b/packages/providers/src/composition/aliasProviderFactory.authOnly.test.ts
@@ -1,0 +1,293 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Alias providers built while authOnly is on must not authenticate from
+ * ambient environment credentials.
+ *
+ * `resolveAliasEnvApiKey` already refuses to bind the key an alias names in
+ * its own `apiKeyEnv`, but every concrete provider hardcodes its own
+ * `envKeyNames` (OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY,
+ * GOOGLE_API_KEY). AuthPrecedenceResolver skips that environment fallback only
+ * while the settings service it resolves against reports authOnly, whereas the
+ * factories decide authOnly from ephemeral config and merged user settings
+ * (resolveAuthOnlyFlag). When those two sources disagree, the alias was
+ * constructed under authOnly yet still authenticated from the environment.
+ * The factories therefore have to fail closed at construction time.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import {
+  createAnthropicAliasProvider,
+  createGeminiAliasProvider,
+  createOpenAIAliasProvider,
+  createOpenAIResponsesAliasProvider,
+  createOpenAIVercelAliasProvider,
+} from './aliasProviderFactory.js';
+import type { OAuthManager } from '../auth/index.js';
+import type { ProviderAliasEntry } from './providerAliases.js';
+
+/**
+ * The responses factory takes the concrete OAuthManager. These tests only need
+ * it to report no OAuth credential, so the precedence chain falls through to
+ * the environment fallback under test; a stub of the two methods that chain
+ * calls stands in for the full manager.
+ */
+const NULL_OAUTH_MANAGER = {
+  getToken: async () => null,
+  isAuthenticated: async () => false,
+} as unknown as OAuthManager;
+
+const ALIAS_BASE_URL = 'https://alias.invalid/v1';
+
+/**
+ * The environment variables the concrete providers read on their own. The
+ * aliases below deliberately declare no `apiKeyEnv`, so nothing but these
+ * hardcoded provider-level names can supply a credential.
+ */
+const ENV_KEYS = [
+  'OPENAI_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'GEMINI_API_KEY',
+  'GOOGLE_API_KEY',
+] as const;
+
+type AliasBaseProvider =
+  | 'openai'
+  | 'openai-responses'
+  | 'openai-vercel'
+  | 'anthropic'
+  | 'gemini';
+
+/** The authentication surface every alias provider inherits from BaseProvider. */
+interface AliasAuthProbe {
+  setRuntimeSettingsService(settingsService: SettingsService): void;
+  isAuthenticated(): Promise<boolean>;
+  getAuthMethodName(): Promise<string | null>;
+}
+
+function aliasEntry(baseProvider: AliasBaseProvider): ProviderAliasEntry {
+  return {
+    alias: `${baseProvider}-authonly-alias`,
+    config: { baseProvider, 'base-url': ALIAS_BASE_URL },
+    filePath: `/virtual/${baseProvider}-authonly-alias.config`,
+    source: 'builtin',
+  };
+}
+
+/**
+ * Builds an alias provider through the real factory the composition root uses
+ * for that base provider, with no key of its own so only the provider's
+ * hardcoded environment names can authenticate it.
+ */
+function buildAliasProvider(
+  baseProvider: AliasBaseProvider,
+  authOnlyEnabled: boolean,
+): AliasAuthProbe {
+  const entry = aliasEntry(baseProvider);
+  const provider = ((): AliasAuthProbe | null => {
+    switch (baseProvider) {
+      case 'openai':
+        return createOpenAIAliasProvider(
+          entry,
+          undefined,
+          undefined,
+          {},
+          authOnlyEnabled,
+        );
+      case 'openai-responses':
+        return createOpenAIResponsesAliasProvider(
+          entry,
+          undefined,
+          undefined,
+          {},
+          NULL_OAUTH_MANAGER,
+          authOnlyEnabled,
+        );
+      case 'openai-vercel':
+        return createOpenAIVercelAliasProvider(
+          entry,
+          undefined,
+          undefined,
+          {},
+          authOnlyEnabled,
+        );
+      case 'anthropic':
+        return createAnthropicAliasProvider(entry, undefined, authOnlyEnabled);
+      case 'gemini':
+        return createGeminiAliasProvider(entry, undefined, authOnlyEnabled);
+      default:
+        return null;
+    }
+  })();
+
+  if (!provider) {
+    throw new Error(`${baseProvider} alias provider was not created`);
+  }
+  return provider;
+}
+
+/**
+ * Resolves the alias against a settings service, which is what the runtime
+ * consults. An empty service reports no authOnly, reproducing the divergence
+ * from the ephemeral setting the factories were built with.
+ */
+async function resolveAliasAuth(
+  provider: AliasAuthProbe,
+  settings: SettingsService,
+): Promise<{ authenticated: boolean; method: string | null }> {
+  provider.setRuntimeSettingsService(settings);
+  return {
+    authenticated: await provider.isAuthenticated(),
+    method: await provider.getAuthMethodName(),
+  };
+}
+
+describe('alias provider factories under authOnly', () => {
+  let environmentSnapshot: NodeJS.ProcessEnv;
+  let runtimeSettings: SettingsService;
+
+  beforeEach(() => {
+    environmentSnapshot = { ...process.env };
+    for (const key of ENV_KEYS) {
+      delete process.env[key];
+    }
+    // The runtime settings service that does not carry the ephemeral authOnly
+    // the factories were given.
+    runtimeSettings = new SettingsService();
+  });
+
+  afterEach(() => {
+    process.env = environmentSnapshot;
+  });
+
+  describe('refuses ambient environment credentials', () => {
+    it('does not authenticate an openai alias from OPENAI_API_KEY', async () => {
+      process.env.OPENAI_API_KEY = 'sk-ambient-openai';
+
+      const auth = await resolveAliasAuth(
+        buildAliasProvider('openai', true),
+        runtimeSettings,
+      );
+
+      expect(auth).toStrictEqual({ authenticated: false, method: null });
+    });
+
+    it('does not authenticate an openai-responses alias from OPENAI_API_KEY', async () => {
+      process.env.OPENAI_API_KEY = 'sk-ambient-openai';
+
+      const auth = await resolveAliasAuth(
+        buildAliasProvider('openai-responses', true),
+        runtimeSettings,
+      );
+
+      expect(auth).toStrictEqual({ authenticated: false, method: null });
+    });
+
+    it('does not authenticate an openai-vercel alias from OPENAI_API_KEY', async () => {
+      process.env.OPENAI_API_KEY = 'sk-ambient-openai';
+
+      const auth = await resolveAliasAuth(
+        buildAliasProvider('openai-vercel', true),
+        runtimeSettings,
+      );
+
+      expect(auth).toStrictEqual({ authenticated: false, method: null });
+    });
+
+    it('does not authenticate an anthropic alias from ANTHROPIC_API_KEY', async () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-ambient-anthropic';
+
+      const auth = await resolveAliasAuth(
+        buildAliasProvider('anthropic', true),
+        runtimeSettings,
+      );
+
+      expect(auth).toStrictEqual({ authenticated: false, method: null });
+    });
+
+    it('does not authenticate a gemini alias from GEMINI_API_KEY', async () => {
+      process.env.GEMINI_API_KEY = 'sk-ambient-gemini';
+
+      const auth = await resolveAliasAuth(
+        buildAliasProvider('gemini', true),
+        runtimeSettings,
+      );
+
+      expect(auth).toStrictEqual({ authenticated: false, method: null });
+    });
+
+    it('does not authenticate a gemini alias from GOOGLE_API_KEY', async () => {
+      // The Gemini provider declares two environment names; clearing only the
+      // first would leave the second as a way in.
+      process.env.GOOGLE_API_KEY = 'sk-ambient-google';
+
+      const auth = await resolveAliasAuth(
+        buildAliasProvider('gemini', true),
+        runtimeSettings,
+      );
+
+      expect(auth).toStrictEqual({ authenticated: false, method: null });
+    });
+
+    it('still refuses OPENAI_API_KEY when the runtime settings service reports authOnly too', async () => {
+      process.env.OPENAI_API_KEY = 'sk-ambient-openai';
+      runtimeSettings.set('authOnly', true);
+
+      const auth = await resolveAliasAuth(
+        buildAliasProvider('openai', true),
+        runtimeSettings,
+      );
+
+      expect(auth).toStrictEqual({ authenticated: false, method: null });
+    });
+  });
+
+  describe('leaves environment credentials alone when authOnly is off', () => {
+    it('authenticates an openai alias from OPENAI_API_KEY', async () => {
+      process.env.OPENAI_API_KEY = 'sk-ambient-openai';
+
+      const auth = await resolveAliasAuth(
+        buildAliasProvider('openai', false),
+        runtimeSettings,
+      );
+
+      expect(auth).toStrictEqual({
+        authenticated: true,
+        method: 'env-openai_api_key',
+      });
+    });
+
+    it('authenticates an anthropic alias from ANTHROPIC_API_KEY', async () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-ambient-anthropic';
+
+      const auth = await resolveAliasAuth(
+        buildAliasProvider('anthropic', false),
+        runtimeSettings,
+      );
+
+      expect(auth).toStrictEqual({
+        authenticated: true,
+        method: 'env-anthropic_api_key',
+      });
+    });
+
+    it('authenticates a gemini alias from GEMINI_API_KEY', async () => {
+      process.env.GEMINI_API_KEY = 'sk-ambient-gemini';
+
+      const auth = await resolveAliasAuth(
+        buildAliasProvider('gemini', false),
+        runtimeSettings,
+      );
+
+      expect(auth).toStrictEqual({
+        authenticated: true,
+        method: 'env-gemini_api_key',
+      });
+    });
+  });
+});

--- a/packages/providers/src/composition/aliasProviderFactory.ts
+++ b/packages/providers/src/composition/aliasProviderFactory.ts
@@ -73,12 +73,49 @@ function resolveAliasEnvApiKey(
 
 export type AliasAwareBaseProvider = {
   authResolver?: {
-    updateConfig?: (config: { providerId?: string }) => void;
+    updateConfig?: (config: {
+      providerId?: string;
+      envKeyNames?: string[];
+    }) => void;
   };
   baseProviderConfig?: {
     name?: string;
+    envKeyNames?: string[];
   };
 };
+
+/**
+ * Strips the environment credential names an alias provider would otherwise
+ * authenticate with, when the alias is built under authOnly.
+ *
+ * `resolveAliasEnvApiKey` only withholds the key an alias declares in its own
+ * `apiKeyEnv`; each concrete provider additionally hardcodes its own
+ * `envKeyNames` (OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY,
+ * GOOGLE_API_KEY) in its BaseProviderConfig. AuthPrecedenceResolver skips that
+ * environment fallback only while the settings service it resolves against
+ * reports authOnly, but the composition root derives authOnly from ephemeral
+ * config and merged user settings as well (resolveAuthOnlyFlag), which the
+ * runtime settings service need not carry. An ambient key then authenticated
+ * an alias that authOnly had already disqualified.
+ *
+ * The decision is therefore taken once, here, at construction: an alias built
+ * under authOnly holds no environment names to resolve, so no later settings
+ * lookup can disagree with the policy it was created with.
+ */
+function enforceAliasAuthOnly(
+  provider: unknown,
+  authOnlyEnabled: boolean,
+): void {
+  if (!authOnlyEnabled) {
+    return;
+  }
+
+  const aliasAwareProvider = provider as AliasAwareBaseProvider;
+  if (aliasAwareProvider.baseProviderConfig) {
+    aliasAwareProvider.baseProviderConfig.envKeyNames = [];
+  }
+  aliasAwareProvider.authResolver?.updateConfig?.({ envKeyNames: [] });
+}
 
 type AliasDefaultModelProvider = {
   getDefaultModel: () => string;
@@ -264,6 +301,8 @@ export function createOpenAIAliasProvider(
     withMediaSupport(aliasProviderConfig, entry),
   );
 
+  enforceAliasAuthOnly(provider, authOnlyEnabled);
+
   overrideAliasDefaultModel(provider, entry);
   overrideStaticModels(provider, entry);
 
@@ -310,6 +349,8 @@ export function createOpenAIResponsesAliasProvider(
     aliasProviderConfig,
     oauthManager,
   );
+
+  enforceAliasAuthOnly(provider, authOnlyEnabled);
 
   // Override the provider name to match the alias
   Object.defineProperty(provider, 'name', {
@@ -362,6 +403,8 @@ export function createOpenAIVercelAliasProvider(
     aliasProviderConfig,
   );
 
+  enforceAliasAuthOnly(provider, authOnlyEnabled);
+
   overrideAliasDefaultModel(provider, entry);
   overrideStaticModels(provider, entry);
 
@@ -384,6 +427,8 @@ export function createGeminiAliasProvider(
     resolvedBaseUrl,
     config,
   );
+
+  enforceAliasAuthOnly(provider, authOnlyEnabled);
 
   if (config && typeof provider.setConfig === 'function') {
     provider.setConfig(config);
@@ -416,6 +461,8 @@ export function createAnthropicAliasProvider(
     providerConfig,
     oauthManager,
   );
+
+  enforceAliasAuthOnly(provider, authOnlyEnabled);
 
   overrideAliasDefaultModel(provider, entry);
   overrideStaticModels(provider, entry);

--- a/packages/providers/src/composition/aliasProviderFactory.ts
+++ b/packages/providers/src/composition/aliasProviderFactory.ts
@@ -46,6 +46,31 @@ export function sanitizeApiKey(key: string): string {
   return sanitized;
 }
 
+/**
+ * Resolves the API key an alias declares through `apiKeyEnv`.
+ *
+ * Returns undefined when authOnly is enabled: authOnly forces OAuth-only
+ * authentication, so ambient environment credentials must not be bound to any
+ * alias provider. This mirrors the rule the composition root already applies
+ * to the shared OpenAI key in `resolveOpenaiApiKey`.
+ */
+function resolveAliasEnvApiKey(
+  entry: ProviderAliasEntry,
+  authOnlyEnabled: boolean,
+): string | undefined {
+  if (authOnlyEnabled || !entry.config.apiKeyEnv) {
+    return undefined;
+  }
+
+  const envValue = process.env[entry.config.apiKeyEnv];
+  if (!envValue || envValue.trim() === '') {
+    return undefined;
+  }
+
+  const sanitized = sanitizeApiKey(envValue);
+  return sanitized === '' ? undefined : sanitized;
+}
+
 export type AliasAwareBaseProvider = {
   authResolver?: {
     updateConfig?: (config: { providerId?: string }) => void;
@@ -207,6 +232,7 @@ export function createOpenAIAliasProvider(
   openaiApiKey: string | undefined,
   openaiBaseUrl: string | undefined,
   openaiProviderConfig: IProviderConfig,
+  authOnlyEnabled: boolean,
 ): OpenAIProvider | null {
   const resolvedBaseUrl = entry.config['base-url'] ?? openaiBaseUrl;
   if (!resolvedBaseUrl) {
@@ -229,16 +255,8 @@ export function createOpenAIAliasProvider(
     aliasProviderConfig.defaultModel = entry.config.defaultModel;
   }
 
-  let aliasApiKey: string | undefined;
-  if (entry.config.apiKeyEnv) {
-    const envValue = process.env[entry.config.apiKeyEnv];
-    if (envValue && envValue.trim() !== '') {
-      aliasApiKey = sanitizeApiKey(envValue);
-    }
-  }
-  if (!aliasApiKey && openaiApiKey) {
-    aliasApiKey = openaiApiKey;
-  }
+  const aliasApiKey =
+    resolveAliasEnvApiKey(entry, authOnlyEnabled) ?? openaiApiKey;
 
   const provider = new OpenAIProvider(
     aliasApiKey ?? undefined,
@@ -260,6 +278,7 @@ export function createOpenAIResponsesAliasProvider(
   openaiBaseUrl: string | undefined,
   openaiProviderConfig: IProviderConfig,
   oauthManager: OAuthManager,
+  authOnlyEnabled: boolean,
 ): OpenAIResponsesProvider | null {
   const resolvedBaseUrl = entry.config['base-url'] ?? openaiBaseUrl;
   if (!resolvedBaseUrl) {
@@ -282,16 +301,8 @@ export function createOpenAIResponsesAliasProvider(
     aliasProviderConfig.defaultModel = entry.config.defaultModel;
   }
 
-  let aliasApiKey: string | undefined;
-  if (entry.config.apiKeyEnv) {
-    const envValue = process.env[entry.config.apiKeyEnv];
-    if (envValue && envValue.trim() !== '') {
-      aliasApiKey = sanitizeApiKey(envValue);
-    }
-  }
-  if (!aliasApiKey && openaiApiKey) {
-    aliasApiKey = openaiApiKey;
-  }
+  const aliasApiKey =
+    resolveAliasEnvApiKey(entry, authOnlyEnabled) ?? openaiApiKey;
 
   const provider = new OpenAIResponsesProvider(
     aliasApiKey ?? undefined,
@@ -319,6 +330,7 @@ export function createOpenAIVercelAliasProvider(
   openaiApiKey: string | undefined,
   openaiBaseUrl: string | undefined,
   openaiProviderConfig: IProviderConfig,
+  authOnlyEnabled: boolean,
 ): OpenAIVercelProvider | null {
   const resolvedBaseUrl = entry.config['base-url'] ?? openaiBaseUrl;
   if (!resolvedBaseUrl) {
@@ -341,16 +353,8 @@ export function createOpenAIVercelAliasProvider(
     aliasProviderConfig.defaultModel = entry.config.defaultModel;
   }
 
-  let aliasApiKey: string | undefined;
-  if (entry.config.apiKeyEnv) {
-    const envValue = process.env[entry.config.apiKeyEnv];
-    if (envValue && envValue.trim() !== '') {
-      aliasApiKey = sanitizeApiKey(envValue);
-    }
-  }
-  if (!aliasApiKey && openaiApiKey) {
-    aliasApiKey = openaiApiKey;
-  }
+  const aliasApiKey =
+    resolveAliasEnvApiKey(entry, authOnlyEnabled) ?? openaiApiKey;
 
   const provider = new OpenAIVercelProvider(
     aliasApiKey ?? undefined,
@@ -368,15 +372,10 @@ export function createOpenAIVercelAliasProvider(
 
 export function createGeminiAliasProvider(
   entry: ProviderAliasEntry,
-  config?: Config,
+  config: Config | undefined,
+  authOnlyEnabled: boolean,
 ): GeminiProvider | null {
-  let aliasApiKey: string | undefined;
-  if (entry.config.apiKeyEnv) {
-    const envValue = process.env[entry.config.apiKeyEnv];
-    if (envValue && envValue.trim() !== '') {
-      aliasApiKey = sanitizeApiKey(envValue);
-    }
-  }
+  const aliasApiKey = resolveAliasEnvApiKey(entry, authOnlyEnabled);
 
   const resolvedBaseUrl = entry.config['base-url'];
 
@@ -400,16 +399,9 @@ export function createGeminiAliasProvider(
 export function createAnthropicAliasProvider(
   entry: ProviderAliasEntry,
   oauthManager: OAuthManager | undefined,
-  authOnlyEnabled = false,
+  authOnlyEnabled: boolean,
 ): AnthropicProvider | null {
-  let aliasApiKey: string | undefined;
-  // Only use environment variable API key if authOnly is not enabled
-  if (!authOnlyEnabled && entry.config.apiKeyEnv) {
-    const envValue = process.env[entry.config.apiKeyEnv];
-    if (envValue && envValue.trim() !== '') {
-      aliasApiKey = sanitizeApiKey(envValue);
-    }
-  }
+  const aliasApiKey = resolveAliasEnvApiKey(entry, authOnlyEnabled);
 
   const resolvedBaseUrl = entry.config['base-url'];
 
@@ -433,6 +425,82 @@ export function createAnthropicAliasProvider(
   return provider;
 }
 
+/** Inputs shared by every alias factory in one registration pass. */
+interface AliasProviderContext {
+  openaiApiKey: string | undefined;
+  openaiBaseUrl: string | undefined;
+  openaiProviderConfig: IProviderConfig;
+  oauthManager: OAuthManager;
+  config: Config | undefined;
+  authOnlyEnabled: boolean;
+}
+
+type AliasProvider =
+  | OpenAIProvider
+  | OpenAIResponsesProvider
+  | OpenAIVercelProvider
+  | GeminiProvider
+  | AnthropicProvider;
+
+function createAliasProvider(
+  entry: ProviderAliasEntry,
+  context: AliasProviderContext,
+): AliasProvider | null {
+  const {
+    openaiApiKey,
+    openaiBaseUrl,
+    openaiProviderConfig,
+    oauthManager,
+    config,
+    authOnlyEnabled,
+  } = context;
+
+  switch (entry.config.baseProvider.toLowerCase()) {
+    case 'openai':
+      return createOpenAIAliasProvider(
+        entry,
+        openaiApiKey,
+        openaiBaseUrl,
+        openaiProviderConfig,
+        authOnlyEnabled,
+      );
+    case 'openai-responses':
+      return createOpenAIResponsesAliasProvider(
+        entry,
+        openaiApiKey,
+        openaiBaseUrl,
+        openaiProviderConfig,
+        oauthManager,
+        authOnlyEnabled,
+      );
+    case 'openaivercel':
+    case 'openai-vercel':
+      return createOpenAIVercelAliasProvider(
+        entry,
+        openaiApiKey,
+        openaiBaseUrl,
+        openaiProviderConfig,
+        authOnlyEnabled,
+      );
+    case 'gemini':
+      return createGeminiAliasProvider(entry, config, authOnlyEnabled);
+    case 'anthropic':
+      // Binding is by identity, not host: only the `claudecode` alias
+      // receives the Claude subscription OAuth manager/identity; the
+      // `anthropic` alias is API-key-only and must not bind OAuth.
+      return createAnthropicAliasProvider(
+        entry,
+        entry.alias === 'claudecode' ? oauthManager : undefined,
+        authOnlyEnabled,
+      );
+    default:
+      debugLogger.warn(
+        `[ProviderManager] Unsupported base provider '${entry.config.baseProvider}' for alias '${entry.alias}', skipping.`,
+      );
+      return null;
+  }
+}
+
 export function registerAliasProviders(
   providerManagerInstance: ProviderManager,
   aliasEntries: ProviderAliasEntry[],
@@ -440,77 +508,20 @@ export function registerAliasProviders(
   openaiBaseUrl: string | undefined,
   openaiProviderConfig: IProviderConfig,
   oauthManager: OAuthManager,
-  config?: Config,
-  authOnlyEnabled = false,
+  config: Config | undefined,
+  authOnlyEnabled: boolean,
 ): void {
   for (const entry of aliasEntries) {
-    switch (entry.config.baseProvider.toLowerCase()) {
-      case 'openai': {
-        const provider = createOpenAIAliasProvider(
-          entry,
-          openaiApiKey,
-          openaiBaseUrl,
-          openaiProviderConfig,
-        );
-        if (provider) {
-          providerManagerInstance.registerProvider(provider as never);
-        }
-        break;
-      }
-      case 'openai-responses': {
-        const provider = createOpenAIResponsesAliasProvider(
-          entry,
-          openaiApiKey,
-          openaiBaseUrl,
-          openaiProviderConfig,
-          oauthManager,
-        );
-        if (provider) {
-          providerManagerInstance.registerProvider(provider as never);
-        }
-        break;
-      }
-      case 'openaivercel':
-      case 'openai-vercel': {
-        const provider = createOpenAIVercelAliasProvider(
-          entry,
-          openaiApiKey,
-          openaiBaseUrl,
-          openaiProviderConfig,
-        );
-        if (provider) {
-          providerManagerInstance.registerProvider(provider as never);
-        }
-        break;
-      }
-      case 'gemini': {
-        const provider = createGeminiAliasProvider(entry, config);
-        if (provider) {
-          providerManagerInstance.registerProvider(provider as never);
-        }
-        break;
-      }
-      case 'anthropic': {
-        // Binding is by identity, not host: only the `claudecode` alias
-        // receives the Claude subscription OAuth manager/identity; the
-        // `anthropic` alias is API-key-only and must not bind OAuth.
-        const oauthManagerForAlias =
-          entry.alias === 'claudecode' ? oauthManager : undefined;
-        const provider = createAnthropicAliasProvider(
-          entry,
-          oauthManagerForAlias,
-          authOnlyEnabled,
-        );
-        if (provider) {
-          providerManagerInstance.registerProvider(provider as never);
-        }
-        break;
-      }
-      default: {
-        debugLogger.warn(
-          `[ProviderManager] Unsupported base provider '${entry.config.baseProvider}' for alias '${entry.alias}', skipping.`,
-        );
-      }
+    const provider = createAliasProvider(entry, {
+      openaiApiKey,
+      openaiBaseUrl,
+      openaiProviderConfig,
+      oauthManager,
+      config,
+      authOnlyEnabled,
+    });
+    if (provider) {
+      providerManagerInstance.registerProvider(provider as never);
     }
   }
 }

--- a/packages/providers/src/composition/providerAliases.codex.factory.test.ts
+++ b/packages/providers/src/composition/providerAliases.codex.factory.test.ts
@@ -43,6 +43,7 @@ function buildCodexProvider() {
     undefined,
     {},
     NULL_OAUTH_MANAGER,
+    false,
   );
   if (!provider) {
     throw new Error('codex alias provider not created');

--- a/packages/providers/src/composition/providerManagerInstance.oauthRegistration.test.ts
+++ b/packages/providers/src/composition/providerManagerInstance.oauthRegistration.test.ts
@@ -23,6 +23,9 @@ let openaiCtorState: new (...args: unknown[]) => unknown = class {};
 let openaiResponsesCtorState: new (...args: unknown[]) => unknown = class {};
 let openaiVercelCtorState: new (...args: unknown[]) => unknown = class {};
 let anthropicCtorState: new (...args: unknown[]) => unknown = class {};
+let geminiCtorState: new (...args: unknown[]) => unknown = class {
+  setConfig(): void {}
+};
 
 // Wrapper constructors so each test can swap the target without needing
 // vi.resetModules (unsupported in Bun).
@@ -42,12 +45,9 @@ void mock.module('../ProviderManager.js', () => {
   }
   return { ProviderManager: MockProviderManager };
 });
-void mock.module('../gemini/GeminiProvider.js', () => {
-  class MockGeminiProvider {
-    setConfig(): void {}
-  }
-  return { GeminiProvider: MockGeminiProvider };
-});
+void mock.module('../gemini/GeminiProvider.js', () => ({
+  GeminiProvider: makeWrapper(() => geminiCtorState),
+}));
 void mock.module('../openai/OpenAIProvider.js', () => ({
   OpenAIProvider: makeWrapper(() => openaiCtorState),
 }));
@@ -95,10 +95,23 @@ function createRegisterStandardOAuthProvidersMock(
   };
 }
 
+/**
+ * Collects the API keys a provider constructor received across EVERY alias it
+ * was used for. Asserting on a single call would only cover whichever alias
+ * happened to be registered first, and alias registration order follows
+ * `fs.readdirSync` of the alias directory, which differs per filesystem.
+ */
+function apiKeysPassedTo(ctor: ReturnType<typeof vi.fn>): unknown[] {
+  return ctor.mock.calls
+    .map((call) => (call as unknown[])[0])
+    .filter((apiKey) => apiKey !== undefined);
+}
+
 describe('claudecode OAuth registration with environment key', () => {
   afterEach(() => {
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.OPENAI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
     vi.clearAllMocks();
   });
 
@@ -161,12 +174,14 @@ describe('claudecode OAuth registration with environment key', () => {
   it('ignores API keys when authOnly is enabled', async () => {
     process.env.ANTHROPIC_API_KEY = 'sk-test-key';
     process.env.OPENAI_API_KEY = 'sk-test-openai';
+    process.env.GEMINI_API_KEY = 'sk-test-gemini';
 
     const ensureOAuthProviderRegisteredMock = vi.fn();
     const openaiCtor = vi.fn(() => ({}));
     const openaiResponsesCtor = vi.fn(() => ({}));
     const openaivercelCtor = vi.fn(() => ({}));
     const anthropicCtor = vi.fn(() => ({}));
+    const geminiCtor = vi.fn(() => ({}));
 
     // Wire mutable state for this test
     ensureOAuthProviderRegisteredState = ensureOAuthProviderRegisteredMock;
@@ -186,6 +201,9 @@ describe('claudecode OAuth registration with environment key', () => {
       ...args: unknown[]
     ) => unknown;
     anthropicCtorState = anthropicCtor as unknown as new (
+      ...args: unknown[]
+    ) => unknown;
+    geminiCtorState = geminiCtor as unknown as new (
       ...args: unknown[]
     ) => unknown;
 
@@ -218,19 +236,86 @@ describe('claudecode OAuth registration with environment key', () => {
     });
     registerProviderManagerSingleton(manager, oauthManager);
 
+    // No alias may receive an API key while authOnly is on — not the alias
+    // that happens to be registered first, and not the ones that declare
+    // their own `apiKeyEnv` (openai, openai-responses, openai-vercel, gemini).
     expect(openaiCtor).toHaveBeenCalled();
-    const firstOpenaiCall = openaiCtor.mock.calls[0] as unknown[] | undefined;
-    expect(firstOpenaiCall?.[0]).toBeUndefined();
+    expect(apiKeysPassedTo(openaiCtor)).toEqual([]);
 
     expect(openaiResponsesCtor).toHaveBeenCalled();
-    const firstResponsesCall = openaiResponsesCtor.mock.calls[0] as
-      | unknown[]
-      | undefined;
-    expect(firstResponsesCall?.[0]).toBeUndefined();
+    expect(apiKeysPassedTo(openaiResponsesCtor)).toEqual([]);
+
+    expect(openaivercelCtor).toHaveBeenCalled();
+    expect(apiKeysPassedTo(openaivercelCtor)).toEqual([]);
 
     expect(anthropicCtor).toHaveBeenCalled();
-    const anthropicArgs = anthropicCtor.mock.calls[0] as unknown[] | undefined;
-    expect(anthropicArgs?.[0]).toBeUndefined();
+    expect(apiKeysPassedTo(anthropicCtor)).toEqual([]);
+
+    expect(geminiCtor).toHaveBeenCalled();
+    expect(apiKeysPassedTo(geminiCtor)).toEqual([]);
+  });
+
+  it('still binds alias environment keys when authOnly is disabled', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-test-key';
+    process.env.GEMINI_API_KEY = 'sk-test-gemini';
+
+    const ensureOAuthProviderRegisteredMock = vi.fn();
+    const anthropicCtor = vi.fn(() => ({}));
+    const geminiCtor = vi.fn(() => ({}));
+
+    // Wire mutable state for this test
+    ensureOAuthProviderRegisteredState = ensureOAuthProviderRegisteredMock;
+    registerStandardOAuthProvidersState =
+      createRegisterStandardOAuthProvidersMock(
+        ensureOAuthProviderRegisteredMock,
+      );
+    isOAuthProviderRegisteredState = vi.fn();
+    resetRegisteredProvidersState = vi.fn();
+    openaiCtorState = class {} as new (...args: unknown[]) => unknown;
+    openaiResponsesCtorState = class {} as new (...args: unknown[]) => unknown;
+    openaiVercelCtorState = class {} as new (...args: unknown[]) => unknown;
+    anthropicCtorState = anthropicCtor as unknown as new (
+      ...args: unknown[]
+    ) => unknown;
+    geminiCtorState = geminiCtor as unknown as new (
+      ...args: unknown[]
+    ) => unknown;
+
+    const mockSettingsService = new SettingsService();
+    const activeContext = {
+      settingsService: mockSettingsService,
+      metadata: { scope: 'test' },
+    };
+
+    const {
+      createProviderManager,
+      resetProviderManager,
+      registerProviderManagerSingleton,
+    } = await import('./providerManagerInstance.js');
+
+    resetProviderManager();
+    const mockConfig = {
+      setProviderManager(): void {},
+      getEphemeralSettings() {
+        return {};
+      },
+      getSettingsService() {
+        return mockSettingsService;
+      },
+    } as unknown as Config;
+
+    const { manager, oauthManager } = createProviderManager(activeContext, {
+      config: mockConfig,
+      allowBrowserEnvironment: false,
+    });
+    registerProviderManagerSingleton(manager, oauthManager);
+
+    // Without authOnly, an alias still receives the key its own `apiKeyEnv`
+    // names. Both families below resolve their key ONLY from that alias-level
+    // environment read — neither falls back to the shared OpenAI key — so this
+    // fails if the authOnly gate is applied unconditionally.
+    expect(apiKeysPassedTo(geminiCtor)).toContain('sk-test-gemini');
+    expect(apiKeysPassedTo(anthropicCtor)).toContain('sk-test-key');
   });
 
   it('threads OAuth manager only into OAuth-capable alias providers', async () => {

--- a/packages/providers/src/composition/providerManagerInstance.ts
+++ b/packages/providers/src/composition/providerManagerInstance.ts
@@ -78,7 +78,7 @@ interface OpenAIRegistrationContext {
   providerConfig: IProviderConfig;
   oauthManager: OAuthManager;
   config?: Config;
-  authOnlyEnabled?: boolean;
+  authOnlyEnabled: boolean;
 }
 
 function createRuntimeContentGeneratorFactory(

--- a/project-plans/issue-3534-sandbox-macos-source-isolation.md
+++ b/project-plans/issue-3534-sandbox-macos-source-isolation.md
@@ -1,0 +1,191 @@
+# Plan: macOS Podman socket paths and source dependency isolation
+
+Plan ID: PLAN-20260903-ISSUE3534
+Generated: 2026-09-03
+Issue: #3534
+
+## Purpose
+
+Fix two independent sandbox startup failures on macOS Podman. The host credential proxy must use a Unix socket path that fits Darwin's encoded `sun_path` limit even when the user's normal temporary directory is long. A source-development launch must execute checked-out TypeScript in Linux while all Linux dependencies live in private engine-owned volumes rather than the host checkout's macOS `node_modules` trees.
+
+## Requirements
+
+### REQ-3534-1: Short private credential socket runtime
+
+**Full text:** A macOS Podman launch must create its host credential proxy socket in a private mode-0700 runtime directory whose resulting socket path is shorter than Darwin's 104-byte `sun_path` field. Startup must fail before OpenSSH if that invariant cannot be guaranteed.
+
+**Behavior:**
+
+- GIVEN the normal macOS temporary root is longer than the socket limit permits
+- WHEN the Podman credential bridge starts
+- THEN the credential proxy receives a short runtime directory independent of that normal temporary root
+- AND the runtime directory has mode 0700
+- AND the concrete socket path is at most 103 encoded bytes, leaving one byte for the terminator
+- AND both the normal session directory and short socket directory are removed on success and failure
+
+### REQ-3534-2: Actionable bounded OpenSSH diagnostics
+
+**Full text:** If OpenSSH exits while a tunnel is stabilizing, the launch error must contain bounded stderr from that process and cleanup must not leave the process alive.
+
+**Behavior:**
+
+- GIVEN OpenSSH writes a concrete startup error and exits
+- WHEN the tunnel startup wait observes the exit
+- THEN the resulting `FatalSandboxError` includes the normalized stderr
+- AND no more than the configured diagnostic bound is retained
+- AND the failed child is terminated if still alive
+
+### REQ-3534-3: Source-development dependency isolation
+
+**Full text:** A checked-out LLxprt TypeScript source launch must continue to run inside Linux but may neither read nor mutate host-platform `node_modules`. Linux dependencies must be prepared deterministically from repository package metadata and the committed Bun lockfile in private engine-owned storage.
+
+**Behavior:**
+
+- GIVEN `NODE_ENV=development` and a positively identified LLxprt source checkout
+- WHEN a Docker or Podman sandbox is prepared
+- THEN every declared `node_modules` destination is overlaid by a fresh engine-owned volume
+- AND the installed-mode host wrong-platform preflight is not applied to source mode
+- AND the trusted entrypoint verifies `package.json` and `bun.lock`, runs `bun install --no-save` inside the isolated mounts, and only then executes `bun ./packages/cli/index.ts`
+- AND installer failure stops before checked-out CLI execution with a source-specific message
+- AND arbitrary projects and installed mode retain their existing command selection and preflight behavior
+
+### REQ-3534-4: Real Podman proof and lifecycle cleanup
+
+**Full text:** Real non-interactive Podman coverage must prove the branch launcher works with the default macOS temporary directory, Linux source dependencies do not affect host dependency files or `.bin` links, and success plus induced failure leave no issue-owned container, volume, temporary directory, or reverse SSH process.
+
+## Preflight findings
+
+- Branch `issue3534` starts clean at `7561710acc800d1c8cb4368ea07dff8fcbbd267b`.
+- `prepareContainerImageAndArgs` creates the general session directory beneath `os.tmpdir()` and passes it to `setupCredentialProxy`.
+- `CredentialProxyServer` generates `<pid>-<22 byte base64url nonce>.sock`, so a five-digit PID needs a 33-byte basename. Darwin permits 103 pathname bytes plus a terminator in `sun_path[104]`.
+- `spawnAndWaitForTunnel` currently pipes stderr but discards it when the child exits during startup.
+- `isSourceDevelopmentWorkdir` currently disables `planPrivateDependencyMounts`, while the same predicate chooses `bun ./packages/cli/index.ts`. This exposes host dependencies to Linux.
+- The existing engine-owned volume lifecycle already handles creation, permissions, labels, attachment order, signal cleanup, and failure cleanup. Source mode should use that mechanism rather than introduce a second storage system.
+- The root repository declares Bun metadata in `package.json` and commits `bun.lock`. Focused and real Podman RED evidence showed that plain `bun install` rewrites the host-mounted lockfile even when dependencies are isolated. Source preparation therefore uses `bun install --no-save`. `--frozen-lockfile` remains unusable for this monorepo because Bun attempts to normalize the committed lockfile and then rejects the change.
+- Installed-mode wrong-platform preflight is implemented by `preflightProtectedTree` and must remain unchanged.
+- Existing co-located Bun suites cover SSH tunnels, credential proxy lifecycle, source command selection, dependency mounts, and real engine isolation.
+
+## Integration contracts
+
+1. `prepareContainerSandbox` plans workspaces and dependency destinations before engine side effects.
+2. `planPrivateDependencyMounts` identifies source mode with the shared source-development predicate, returns enabled private destinations, and skips host dependency preflight only when those host trees will be hidden.
+3. `addPrivateDependencyMounts` creates and mounts fresh engine-owned volumes for both source and installed mode. Existing lifecycle ownership remains unchanged.
+4. `entrypoint` uses the same source-development predicate. For source mode it inserts a trusted dependency preparation stanza before the final source CLI exec. Installed mode gets no preparation stanza.
+5. `setupCredentialProxy` selects a short socket runtime only for Darwin Podman. Docker and non-Darwin paths remain unchanged.
+6. The composed credential cleanup owns the bridge, capability file, normal session directory, and short socket directory.
+7. `setupCredentialProxyPodmanMacOS` validates the concrete path before constructing `ssh -R`. Tunnel startup errors surface bounded child stderr.
+
+## Numbered pseudocode
+
+### Short socket runtime
+
+1. IF platform is Darwin AND engine is Podman
+2. SELECT the fixed short lexical runtime root `/tmp`, independent of `os.tmpdir()`
+3. CREATE a unique `lx-` directory beneath that root
+4. CHMOD the directory to 0700
+5. CALCULATE the longest concrete credential socket pathname using the current PID and fixed nonce suffix width
+6. IF encoded byte length exceeds 103, REMOVE the directory and THROW `FatalSandboxError`
+7. RETURN socket runtime path plus idempotent removal callback
+8. OTHERWISE use the existing session directory and no additional callback
+9. START credential proxy with the selected runtime path
+10. READ the concrete socket path
+11. VALIDATE its encoded length before bridge setup
+12. ON every failure, stop the proxy and run all directory cleanups
+13. ON success, compose short runtime cleanup with existing cleanup ownership
+
+### Bounded tunnel diagnostics
+
+14. SPAWN OpenSSH with stdout and stderr pipes
+15. DRAIN both streams for the full child lifetime while retaining at most 4096 encoded bytes from each
+16. RACE the stabilization interval and readiness polling against process error, exit, and close
+17. IF readiness or the child fails, abort polling, terminate the child, and await reaping with bounded SIGTERM and SIGKILL stages
+18. BUILD failure detail from nonempty stderr, then stdout
+19. THROW `FatalSandboxError` containing the existing guidance, exit state, and bounded detail
+20. REMOVE data listeners only when the child closes
+
+### Source dependency isolation
+
+21. IDENTIFY source mode with `isSourceDevelopmentWorkdir`
+22. RESOLVE the same protected dependency destinations used by installed mode
+23. FOR installed mode, run the existing host wrong-platform preflight
+24. FOR source mode, do not inspect host dependency contents because those trees will be hidden
+25. RETURN an enabled private dependency plan for both modes
+26. CREATE, initialize, label, mount, and lifecycle-own fresh volumes through the existing engine adapter
+27. FOR source-development entrypoint, verify root `package.json`, root `bun.lock`, and Bun are present
+28. RUN `bun install --no-save` in the mounted checkout before the source CLI
+29. IF install fails, print a source-specific isolation error and exit without invoking the CLI
+30. EXECUTE checked-out TypeScript only after preparation succeeds
+31. FOR installed mode, retain the image-global `llxprt` command and no source installer
+
+## Strict TDD phases
+
+### Phase 1: Credential runtime RED
+
+Extend `packages/cli/src/utils/sandbox-credential.test.ts` with behavioral cases that use a long simulated normal temporary root and the real filesystem. Assert the proxy receives a distinct short directory, that it is mode 0700, that the modeled concrete socket path fits 103 bytes, and that success and bridge failure remove both runtime directories. Run the file and save output to `tmp/issue3534/red-credential-runtime.log`. The new tests must fail before production edits.
+
+### Phase 2: Credential runtime GREEN
+
+Implement only the runtime selection, invariant validation, and cleanup ownership needed by Phase 1. Run the same file and save output to `tmp/issue3534/green-credential-runtime.log`.
+
+### Phase 3: SSH diagnostics RED
+
+Extend `packages/cli/src/utils/sandbox-ssh.test.ts` with a real child-process-style event stream that exits after writing OpenSSH stderr. Assert the error includes the concrete message, excludes data beyond the 4096-byte bound, and does not leave the child active. Add a direct over-limit socket path case that fails before `ssh -R`. Save failing output to `tmp/issue3534/red-ssh-diagnostics.log`.
+
+### Phase 4: SSH diagnostics GREEN
+
+Implement concrete socket path validation and bounded process output collection in `sandbox-podman.ts`. Preserve the existing successful tunnel and polling behavior. Save passing output to `tmp/issue3534/green-ssh-diagnostics.log`.
+
+### Phase 5: Source isolation RED
+
+Update `sandbox-source-development.test.ts`, `sandbox-node-modules.test.ts`, and `sandbox-entrypoint.test.ts`. Assert source mode receives real private engine volumes, host dependency trees remain untouched, source mode skips installed preflight, the generated shell prepares from `package.json` and `bun.lock` before invoking source, preparation failure prevents CLI invocation, and production or arbitrary repository behavior remains unchanged. Save failing output to `tmp/issue3534/red-source-isolation.log`.
+
+### Phase 6: Source isolation GREEN
+
+Remove the source bypass in dependency planning and add source preparation to the trusted entrypoint selected by the shared source predicate. Use `bun install --no-save` because focused RED evidence showed that plain install mutates the host-mounted lockfile and this repository's Bun lock cannot support frozen mode. Do not copy or bind host dependencies. Save passing output to `tmp/issue3534/green-source-isolation.log`.
+
+### Phase 7: Real Podman integration
+
+Extend `integration-tests/sandboxNodeModulesIsolation.real.test.ts` or the closest existing real sandbox suite. Use the production planner and branch launcher. Prove Linux/arm64, `/run/.containerenv`, source path selection, isolated native dependency loading, a dependency mutation in root and `.bin`, byte-identical host snapshots, and cleanup of named volumes and containers. Add induced preparation failure cleanup. Run with the exact available nightly image and save output under `tmp/issue3534/`.
+
+### Phase 8: Audit and verification
+
+Run the test-audit scanner against the clean main commit in an isolated worktree and against `issue3534`, write both outputs under `tmp/issue3534/`, diff findings, and inspect all new findings. Then run focused Bun tests and real Podman checks. Finally run, in order, `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`, and the `stepfun-37` smoke prompt. Store logs under `tmp/issue3534/verification/`. If formatting changes files, rerun affected checks.
+
+## Verification checklist
+
+- [x] Every production edit has an observed failing behavioral test first.
+- [x] No test verifies mock calls as its behavioral claim.
+- [x] Long macOS temporary roots no longer determine the Podman credential socket path.
+- [x] Socket directory is private and every OpenSSH Unix path fits Darwin's encoded limit.
+- [x] Bounded SSH stderr appears in startup failures.
+- [x] Source TypeScript runs in Linux using private Linux dependencies.
+- [x] Host `node_modules` files and `.bin` links remain byte-identical.
+- [x] Installed-mode contamination preflight still rejects a controlled wrong-platform fixture.
+- [x] Success and induced failure leave no issue-owned process, container, volume, or temp directory.
+- [x] Main-to-branch test-audit diff has no unexplained new finding.
+- [x] All six required verification commands pass in order.
+- [x] Working tree remains uncommitted.
+
+## Review finding completion
+
+1. Late OpenSSH exits are monitored through bridge readiness. Both output streams remain drained, diagnostics retain exactly 4096 encoded bytes without splitting UTF-8, and failed children are terminated and reaped. The real-process proof is `tmp/issue3534/remediation/green/32-podman-diagnostics-exact-bound.log`.
+2. The three collateral suites now describe source-mode private dependency mounts and use tunnel doubles with piped output. Final passing evidence is in `tmp/issue3534/remediation/green/27-launch-release-final.log`, `28-proxy-integration-final.log`, and `29-venv-final.log`.
+3. The real Podman source-preparation failure test waits until the container, dependency volumes, session runtime, short socket runtime, and reverse tunnel exist. It then proves the induced installer failure prevents source execution and releases each acquired resource. Final evidence is `tmp/issue3534/remediation/real-source-preparation-failure-final.log`.
+4. Credential cleanup attempts the short socket runtime and normal session removal independently, preserving cleanup errors after all attempts. RED and GREEN evidence is in `tmp/issue3534/remediation/red/02-independent-session-cleanup.log` and `tmp/issue3534/remediation/green/03-independent-session-cleanup.log`.
+5. Boundary coverage accepts an exact 103-byte Darwin socket path, rejects an exact 104-byte path before Podman or OpenSSH starts, and retains exactly 4096 diagnostic bytes. RED evidence is `tmp/issue3534/remediation/red/01-late-ssh-and-path-boundaries.log`; final GREEN evidence is `tmp/issue3534/remediation/green/32-podman-diagnostics-exact-bound.log`.
+
+## Evidence summary
+
+- Initial source-isolation RED and GREEN logs: `tmp/issue3534/red-source-isolation.log`, `tmp/issue3534/red-source-lock-preservation.log`, `tmp/issue3534/green-source-isolation.log`, and `tmp/issue3534/green-source-lock-preservation.log`.
+- Final focused source and entrypoint suites: `tmp/issue3534/remediation/green/30-entrypoint-final.log` and `tmp/issue3534/remediation/green/31-source-isolation-final.log`.
+- Final inherited-default-`TMPDIR` source success: `tmp/issue3534/remediation/source-success-final.log`. Its before/after comparison is `source-success-final-cleanup-summary.json`; every host and engine restoration field is true.
+- Final post-acquisition source preparation failure and cleanup: `tmp/issue3534/remediation/real-source-preparation-failure-final.log`, with 21 passing real-engine tests and no failures.
+- Final installed-mode identity: `tmp/issue3534/remediation/installed-mode-identity-final.log`. It reports the image-global `/usr/local/share/npm-global/bin/llxprt`, version `0.11.0-nightly.260902.1975fbab6`, Linux arm64, and `/run/.containerenv`. Its before/after comparison is `installed-mode-identity-final-cleanup-summary.json`; every restoration field is true.
+- Final scanner output: `tmp/issue3534/remediation/test-audit-final-tree.log`. The normalized main-to-branch findings diff, `test-audit-final-tree-normalized.diff`, is empty.
+- Ordered verification logs: `tmp/issue3534/remediation/verification/01-npm-test-final.log`, `02-npm-lint-final.log`, `03-npm-typecheck-final.log`, `04-npm-format-final.log`, `05-npm-build-final.log`, and `06-stepfun-smoke-final.log`. Every corresponding exit marker is `0`.
+- The post-audit, post-Podman-proof build is `tmp/issue3534/remediation/verification/08-npm-build-after-proofs.log`. The repository-standard bundle smoke is `09-bundle-version.log` and reports exactly `0.11.0`. Both exit markers are `0`.
+- Formatting changed three issue test files. Their reruns and the required lint and typecheck reruns are recorded under `tmp/issue3534/remediation/verification/04-format-*.log`, all with exit `0`.
+
+## Failure recovery
+
+Do not revert unrelated work. If a phase fails, retain its log, correct only the phase's tests or implementation, and rerun that phase before continuing. Engine resources created by interrupted real checks must be identified by issue-specific names or dependency labels and removed through their normal lifecycle. Record any cleanup failure in the proof log rather than hiding it.


### PR DESCRIPTION
## TLDR

Fixes two macOS Podman sandbox failures in release `0.11.0-nightly.260902.1975fbab6`:

1. Credential proxy sockets could exceed Darwin's 103-byte Unix pathname limit when created below the normal macOS `TMPDIR`. OpenSSH rejected the reverse-forward specification, while LLxprt hid the concrete SSH error.
2. Source-development mode exposed host macOS `node_modules` to Linux. Linux could fail on macOS native modules or write Linux artifacts into the host dependency tree.

The change gives Darwin Podman credential sockets a short private runtime, surfaces bounded SSH startup diagnostics, and places source-development dependencies in private engine-owned volumes.

## Dive Deeper

### Credential tunnel

- Creates Darwin Podman credential sockets in a unique mode-`0700` `/tmp/lx-*` directory.
- Accepts the 103-byte Darwin pathname boundary and rejects 104 bytes before invoking Podman or OpenSSH.
- Continuously drains SSH stdout and stderr while retaining at most 4096 bytes from each stream.
- Races tunnel readiness against child exit and error events, including exits after the initial stabilization period.
- Terminates and reaps failed SSH children.
- Attempts short-runtime and normal session cleanup independently so one filesystem error does not prevent the other cleanup.

### Source-development dependencies

- Keeps checked-out source available inside the Linux sandbox.
- Overlays root and workspace `node_modules` destinations with fresh engine-owned volumes.
- Verifies repository metadata and Bun before dependency preparation.
- Runs `bun install --no-save` inside the private Linux dependency storage before executing `bun ./packages/cli/index.ts`.
- Preserves host `node_modules`, `.bin` links, `bun.lock`, and `package-lock.json`.
- Keeps installed-mode wrong-platform preflight and image-global CLI selection unchanged.

### Diagnostics and lifecycle coverage

Behavioral tests use real child processes, filesystem paths, executable Podman and SSH shims, and an opt-in real Podman lane. The real failure case waits until the reverse tunnel, container, dependency volumes, and both temporary runtimes exist, then induces source dependency preparation failure and verifies that every acquired resource is removed.

## Reviewer Test Plan

1. Run the focused tests:

   ```bash
   bun test packages/cli/src/utils/sandbox-podman-diagnostics.test.ts
   bun test packages/cli/src/utils/sandbox-credential.test.ts
   bun test packages/cli/src/utils/sandbox-source-development.test.ts
   bun test packages/cli/src/utils/sandbox-node-modules.test.ts
   ```

2. Run the real post-acquisition failure test with Podman available:

   ```bash
   LLXPRT_SANDBOX_TEST_RUNTIME=podman \
   LLXPRT_RUN_REAL_PODMAN_SOURCE_FAILURE=true \
   bun test integration-tests/sandboxNodeModulesIsolation.real.test.ts
   ```

3. On macOS, keep the normal inherited `TMPDIR` and launch checked-out source non-interactively with Podman. Confirm:
   - outer runtime is Darwin/arm64
   - inner runtime is Linux/arm64 and `/run/.containerenv` exists
   - the checked-out `packages/cli/index.ts` runs
   - Linux native modules load from private storage
   - host dependencies and lockfiles have identical before-and-after digests
   - no new Podman container, dependency volume, `/tmp/lx-*` directory, session directory, or reverse-SSH process remains

4. Run the complete repository checks:

   ```bash
   npm run test
   npm run lint
   npm run typecheck
   npm run format:check
   npm run build
   bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"
   ```

Local verification completed with 406/406 test files passing. The focused issue suites passed 174 tests, installed preflight passed 32 tests, and the opt-in real Podman source-failure lane passed.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ✅  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3534

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Source-development launches now prepare dependencies in isolated private storage, protecting host `node_modules` and lockfiles.
  - Sandbox proxy endpoints and ports can be configured through standard proxy environment variables.
  - macOS Podman credential sockets use a private short runtime path for improved compatibility.
  - Podman startup failures now provide clearer, size-limited diagnostics.

- **Bug Fixes**
  - Sandbox resources and temporary credential runtimes are cleaned up reliably when setup fails.
  - Source entrypoints no longer run when dependency preparation fails.
  - OAuth-only configurations no longer pass API keys to providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->