### PR TITLE
fix(ocr): stop transmitting the internal severity key to GitHub (Fixes #3544)

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1451,6 +1451,7 @@ jobs:
           cat > ocr-workflow-helpers.sh <<'EOF'
           mark_infrastructure_failure() {
             echo "phase=$1; reason=$2" >> ocr-infrastructure-failure.txt
+            echo "::warning::OCR infrastructure failure recorded: phase=$1; reason=$2"
           }
           mark_policy_failure() {
             echo "$1" > ocr-policy-failure.txt
@@ -3344,6 +3345,28 @@ jobs:
               });
             }
 
+            // Issue #3544: GitHub's REST-to-GraphQL bridge rejects unknown
+            // members on a draft review thread — the internal `_severity`
+            // sort key maps onto a nonexistent `Severity` field and fails
+            // the whole batched createReview with HTTP 422. The transmitted
+            // payload is therefore rebuilt here as an allow-list of exactly
+            // the fields the review API defines. `_severity` is internal
+            // sort state and stays on the in-memory objects; only this
+            // boundary strips it.
+            function reviewCommentPayload(comment) {
+              const payload = {
+                path: comment.path,
+                line: comment.line,
+                side: comment.side,
+                body: comment.body,
+              };
+              if (comment.start_line) {
+                payload.start_line = comment.start_line;
+                payload.start_side = comment.start_side;
+              }
+              return payload;
+            }
+
             // Phase 2 (issue #2649): run-scoped finding fingerprint for
             // publication reconciliation within a single OCR run. Uses
             // Math.imul for correct 32-bit FNV-1a arithmetic. The fingerprint
@@ -3848,7 +3871,7 @@ jobs:
               try {
                 await github.rest.pulls.createReview({
                   owner, repo, pull_number: number,
-                  event: 'COMMENT', commit_id: commitSha, comments: validPairs.map((pair) => pair.comment),
+                  event: 'COMMENT', commit_id: commitSha, comments: validPairs.map((pair) => reviewCommentPayload(pair.comment)),
                 });
                 core.info(`OCR 422 fallback: posted ${validPairs.length} in-diff inline comment(s) as one grouped review; ${invalidPairs.length} comment(s) were outside the diff.`);
                 return {
@@ -4575,7 +4598,7 @@ jobs:
               try {
                 await github.rest.pulls.createReview({
                   owner, repo, pull_number: number,
-                  event: 'COMMENT', commit_id: headSha, comments: inlineToPost,
+                  event: 'COMMENT', commit_id: headSha, comments: inlineToPost.map(reviewCommentPayload),
                 });
                 postedInline = inlineToPost.length;
               } catch (batchErr) {

--- a/project-plans/issue3544-ocr-review-infrastructure-failure.md
+++ b/project-plans/issue3544-ocr-review-infrastructure-failure.md
@@ -1,0 +1,161 @@
+# Issue #3544 — OCR review infrastructure failure
+
+## Source
+
+Auto-filed tracking issue: OCR review run classified as `infrastructure-failure`
+on 2026-09-03. Run: https://github.com/vybestack/llxprt-code/actions/runs/33750459882
+(PR #3543, `issue3533`).
+
+## Diagnosis
+
+The run has two attempts and they failed differently.
+
+### Attempt 1 (11:34–11:46 UTC) — the attempt that produced the classification
+
+`Record OCR outcome` ran only its `infrastructure-failure` step; every other
+outcome step was skipped. That durable marker is what
+`ocr-infrastructure-notifier.yml` reads, and it is why this issue exists. The
+run's current (attempt 2) view records `success`, which is why the surface-level
+run status disagrees with the issue body.
+
+`Run OpenCodeReview` ran for 600.2 seconds (11:35:55.63 → 11:45:55.84) against a
+single selected file (`packages/cli/src/utils/sandbox-launch-release.test.ts`)
+and exited 1. The `Post OCR results` step then logged:
+
+```
+Skipping OCR output parsing because phase review already recorded exit code 1.
+OCR coverage: 0% (0/1 preview files covered)
+OpenCodeReview failed or produced unparsable output (exit code 1).
+```
+
+**The specific failure reason is unrecoverable.** Both sources the issue body
+directs a reader to are empty for this attempt:
+
+1. *Trusted workflow logs.* `mark_infrastructure_failure` appends
+   `phase=…; reason=…` to `ocr-infrastructure-failure.txt` and emits nothing to
+   the log. Every phase before `review` pairs its call with its own
+   `echo "::warning::…"`, but the six review-phase classifier branches
+   (`.github/workflows/ocr-review.yml` lines 2475–2487) do not. `ocr-stderr.log`
+   is likewise never surfaced. Attempt 1's `Run OpenCodeReview` step therefore
+   produced **zero** log output across its ten minutes.
+2. *The `ocr-review-output` artifact.* `Upload OCR artifacts` (line 6367) uses
+   the fixed name `ocr-review-output` with no run-attempt suffix, unlike the
+   telemetry artifact (`ocr-telemetry-<run_id>-<run_attempt>`). Attempt 2
+   replaced it. The single surviving `ocr-review-output`, created 11:59:22, has
+   an empty `ocr-infrastructure-failure.txt`.
+
+What is known: the failure occurred in the `review` phase, after roughly ten
+minutes, with a nonzero `ocr review` exit code. Which of the six classifier
+branches fired cannot be determined.
+
+### Attempt 2 (11:50–11:59 UTC) — a separate, deterministic defect
+
+Recorded `success`, but its annotations show:
+
+```
+Batch review post failed (3 comments), falling back to individual posting:
+Unprocessable Entity: "Variable $threads of type [DraftPullRequestReviewThread]
+was provided invalid value for 0.Severity (Field is not defined on
+DraftPullRequestReviewThread), 1.Severity (…), 2.Severity (…)"
+```
+
+Root cause: the inline comment object built at line 4467 carries an internal
+sort key alongside the GitHub-defined fields.
+
+```js
+const comment = {
+  path: String(f.path),
+  line: endLine,
+  side: 'RIGHT',
+  body: `${INLINE_MARKER}\n<!-- ocr-fp:${fingerprint} -->\n${labeledText}`,
+  _severity: effectiveSeverity(f),
+};
+```
+
+`_severity` exists only to drive `sortInlineComments` (line 3332). The same
+objects are then passed unchanged to `github.rest.pulls.createReview` at line
+4576 and again inside `regroupLineResolutionFailure` at line 3851. GitHub's
+REST-to-GraphQL bridge maps `_severity` onto a `Severity` member of
+`DraftPullRequestReviewThread`, which does not exist, so the request is
+rejected with HTTP 422.
+
+Consequences:
+
+- **Every** OCR batch inline post carrying at least one comment fails and drops
+  into the per-comment fallback. It has stayed invisible because the individual
+  `createReviewComment` path (line 4649) selects its fields explicitly, so the
+  comments still land.
+- The issue #2930 line-resolution regrouping is unreachable in practice:
+  `isLineResolutionFailure(batchErr)` never matches the `Severity` 422, which
+  always arrives first and masks the genuine line-resolution 422 underneath.
+  Attempt 2 demonstrates exactly this — the per-comment loop then hit
+  `Failed to post inline comment on packages/cli/src/utils/sandbox-launch-release.test.ts:554:
+  … pull_request_review_thread.line could not be resolved`.
+- Reconciliation could not confirm publication, leaving
+  `batchPublicationAmbiguous` set and `post_state=partial`.
+
+## Accepted behavior
+
+### B1 — the inline review payload contains only fields GitHub accepts
+
+`github.rest.pulls.createReview` receives comment objects restricted to
+`path`, `line`, `side`, `body`, and — only when the finding spans a line range —
+`start_line` and `start_side`. No internal key (`_severity` or any future
+addition) is transmitted, from either call site: the primary batch post
+(line 4576) and the grouped 422 retry inside `regroupLineResolutionFailure`
+(line 3851).
+
+Severity-ordered posting is unchanged: `sortInlineComments` continues to read
+`comment._severity`, so the internal field stays on the in-memory objects and is
+stripped only at the transmission boundary.
+
+Boundary cases:
+
+- single-line finding (`start_line === endLine`) — no `start_line`/`start_side`
+  in the payload;
+- multi-line finding (`start_line < endLine`) — both present;
+- finding whose severity is absent or `unknown` — payload identical, ordering
+  preserved via the fail-safe rank;
+- the regrouped retry path, which posts a filtered subset.
+
+### B2 — a review-phase infrastructure-failure reason reaches the workflow log
+
+Recording an infrastructure failure also emits the recorded `phase` and `reason`
+as a workflow warning, so the classification survives in the trusted log even
+when the artifact is later replaced by a re-run. Implemented once in the
+`mark_infrastructure_failure` helper so every call site — including the six
+review-phase branches that are silent today — is covered.
+
+## Out of scope
+
+Filed separately if wanted; not touched here.
+
+- The ~600 s review duration and any change to `OCR_REVIEW_TIMEOUT`.
+- Run-attempt-scoped artifact naming. It would additionally require changing the
+  `download-artifact` step in `ocr-infrastructure-notifier.yml`, which resolves
+  `ocr-review-output` by literal name; that is a second workflow and awaits
+  approval.
+- Any change to how `publicationState` / `post_state` feed classification.
+
+## Tests
+
+Behavioral, per `dev-docs/RULES.md`. The existing suites already execute the
+real workflow script out of `ocr-review.yml` in a `vm` sandbox against a fake
+Octokit, so the assertions inspect the payload the workflow actually sends
+rather than restating it.
+
+- **B1, grouped 422 retry** — extend
+  `scripts/tests/ocr-review-422-wiring.bun.test.ts`, whose harness already
+  captures `createReviewCalls`. Assert the transmitted comment key set exactly.
+- **B1, primary batch post** — cover the line 4576 call site with the same kind
+  of harness, extending an existing suite or adding a focused one.
+- **B1, payload shaping** — direct behavioral test of the extracted payload
+  helper for each boundary case above.
+- **B2** — assert the helper emits the phase and reason, exercised through the
+  heredoc-extracted `ocr-workflow-helpers.sh` in the style of
+  `scripts/tests/ocr-failure-classification.test.ts`.
+
+## Verification
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+`npm run build`, plus the `stepfun-37` startup smoke.

--- a/project-plans/issue3544-ocr-review-infrastructure-failure.md
+++ b/project-plans/issue3544-ocr-review-infrastructure-failure.md
@@ -34,8 +34,10 @@ directs a reader to are empty for this attempt:
 1. *Trusted workflow logs.* `mark_infrastructure_failure` appends
    `phase=…; reason=…` to `ocr-infrastructure-failure.txt` and emits nothing to
    the log. Every phase before `review` pairs its call with its own
-   `echo "::warning::…"`, but the six review-phase classifier branches
-   (`.github/workflows/ocr-review.yml` lines 2475–2487) do not. `ocr-stderr.log`
+   `echo "::warning::…"`, but seven call sites do not: the six review-phase
+   classifier branches (`.github/workflows/ocr-review.yml` lines 2477–2487) and
+   the preview extraction / cardinality branch
+   (`.github/workflows/ocr-review.yml` line 1909). `ocr-stderr.log`
    is likewise never surfaced. Attempt 1's `Run OpenCodeReview` step therefore
    produced **zero** log output across its ten minutes.
 2. *The `ocr-review-output` artifact.* `Upload OCR artifacts` (line 6367) uses

--- a/scripts/tests/ocr-failure-classification.test.ts
+++ b/scripts/tests/ocr-failure-classification.test.ts
@@ -139,6 +139,10 @@ describe.skipIf(!hasBash())(
       fs.rmSync(directory, { recursive: true, force: true });
     });
 
+    /**
+     * Run the real extracted classifier and return the reason it recorded in the
+     * artifact, throwing a diagnostic if it failed or recorded nothing.
+     */
     function classify(stderrContent: string): string {
       const artifactPath = path.join(
         directory,

--- a/scripts/tests/ocr-failure-classification.test.ts
+++ b/scripts/tests/ocr-failure-classification.test.ts
@@ -20,6 +20,7 @@ import {
   WORKFLOW_PATH,
   commandText,
   extractBashBlock,
+  extractHeredocBody,
   hasBash,
   readRootFile,
   stepNamed,
@@ -91,22 +92,27 @@ const TIMEOUT_REASON = 'OCR review failed: timeout';
 const ALL_FAILED_REASON =
   'all OCR per-file reviews failed; likely LLM provider/config/auth failure';
 
-// Mirrors the real helper the workflow writes in "Initialize OCR artifact
-// files" (ocr-workflow-helpers.sh).
-const MARK_STUB =
-  'mark_infrastructure_failure() {\n' +
-  '  echo "phase=$1; reason=$2" >> ocr-infrastructure-failure.txt\n' +
-  '}\n';
-
 describe.skipIf(!hasBash())(
   '.github/workflows/ocr-review.yml — review failure classification (issue #2929)',
   () => {
+    // The REAL mark_infrastructure_failure (and siblings the helper file defines)
+    // is extracted from the "Initialize OCR artifact files" heredoc rather than
+    // re-implemented here, so the artifact format under test cannot drift from
+    // what the workflow actually writes.
+    let markFailureHelper: string;
     let classifierBlock: string;
 
     beforeAll(() => {
       const workflow = parseWorkflowYaml(readRootFile(WORKFLOW_PATH));
       const jobs = workflow.jobs;
       if (!jobs) throw new Error('workflow should have jobs');
+      markFailureHelper = extractHeredocBody(
+        commandText(
+          stepNamed(jobs['code-review'], 'Initialize OCR artifact files'),
+        ),
+        'Initialize OCR artifact files',
+        'EOF',
+      );
       const reviewStep = stepNamed(
         asRecord(jobs['code-review']),
         'Run OpenCodeReview',
@@ -149,7 +155,12 @@ describe.skipIf(!hasBash())(
       try {
         execFileSync(
           'bash',
-          ['-c', ['set -euo pipefail', MARK_STUB, classifierBlock].join('\n')],
+          [
+            '-c',
+            ['set -euo pipefail', markFailureHelper, classifierBlock].join(
+              '\n',
+            ),
+          ],
           {
             cwd: directory,
             stdio: ['ignore', 'pipe', 'pipe'],

--- a/scripts/tests/ocr-infrastructure-failure-annotation.test.ts
+++ b/scripts/tests/ocr-infrastructure-failure-annotation.test.ts
@@ -75,6 +75,7 @@ describe.skipIf(!hasBash())(
       );
     }
 
+    /** Returns the raw artifact contents so tests can pin the byte-identical format the notifier workflow parses. */
     function readArtifact(): string {
       return fs.readFileSync(
         path.join(directory, 'ocr-infrastructure-failure.txt'),
@@ -82,7 +83,10 @@ describe.skipIf(!hasBash())(
       );
     }
 
-    /** Run the extracted helper once and return its stdout. */
+    /**
+     * Run the extracted helper once in the scratch directory and return its stdout,
+     * so tests can assert the warning annotation the real workflow would emit.
+     */
     function markFailure(phase: string, reason: string): string {
       try {
         return execFileSync(

--- a/scripts/tests/ocr-infrastructure-failure-annotation.test.ts
+++ b/scripts/tests/ocr-infrastructure-failure-annotation.test.ts
@@ -1,0 +1,192 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import {
+  asString,
+  errorField,
+  parseWorkflowYaml,
+} from './typed-test-helpers.ts';
+import {
+  WORKFLOW_PATH,
+  commandText,
+  extractHeredocBody,
+  hasBash,
+  readRootFile,
+  stepNamed,
+} from './ocr-review-workflow-helpers.ts';
+
+// Issue #3544: `mark_infrastructure_failure` recorded a failure reason only
+// in ocr-infrastructure-failure.txt. When a re-run replaces that artifact the
+// reason is gone forever, which is exactly what happened to attempt 1 of
+// production run 33750459882 (ten minutes of review phase with zero log
+// output). The helper must ALSO surface the phase and reason as a GitHub
+// Actions warning annotation, while keeping the artifact file byte-identical
+// for the notifier workflow that parses it.
+
+describe.skipIf(!hasBash())(
+  '.github/workflows/ocr-review.yml — mark_infrastructure_failure visibility (#3544)',
+  () => {
+    let helperScript: string;
+    let directory: string;
+
+    beforeAll(() => {
+      const workflow = parseWorkflowYaml(readRootFile(WORKFLOW_PATH));
+      const jobs = workflow.jobs;
+      if (!jobs) throw new Error('workflow should have jobs');
+      const initializeStep = stepNamed(
+        jobs['code-review'],
+        'Initialize OCR artifact files',
+      );
+      // Extract the REAL generated ocr-workflow-helpers.sh heredoc rather
+      // than re-implementing the helper in the test.
+      helperScript = extractHeredocBody(
+        commandText(initializeStep),
+        'Initialize OCR artifact files',
+        'EOF',
+      );
+      directory = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'ocr-infra-annotation-3544-'),
+      );
+      fs.writeFileSync(
+        path.join(directory, 'ocr-workflow-helpers.sh'),
+        helperScript,
+        'utf8',
+      );
+    });
+
+    afterAll(() => {
+      fs.rmSync(directory, { recursive: true, force: true });
+    });
+
+    /** Start from an empty artifact, mirroring the workflow's `: >` init. */
+    function resetArtifact(): void {
+      fs.writeFileSync(
+        path.join(directory, 'ocr-infrastructure-failure.txt'),
+        '',
+        'utf8',
+      );
+    }
+
+    function readArtifact(): string {
+      return fs.readFileSync(
+        path.join(directory, 'ocr-infrastructure-failure.txt'),
+        'utf8',
+      );
+    }
+
+    /** Run the extracted helper once and return its stdout. */
+    function markFailure(phase: string, reason: string): string {
+      try {
+        return execFileSync(
+          'bash',
+          [
+            '-c',
+            [
+              'set -euo pipefail',
+              '. ./ocr-workflow-helpers.sh',
+              `mark_infrastructure_failure ${JSON.stringify(phase)} ${JSON.stringify(reason)}`,
+            ].join('\n'),
+          ],
+          {
+            cwd: directory,
+            stdio: ['ignore', 'pipe', 'pipe'],
+            encoding: 'utf8',
+          },
+        );
+      } catch (error) {
+        throw new Error(
+          [
+            'The extracted mark_infrastructure_failure helper failed to run.',
+            `status: ${errorField(error, 'status')}`,
+            `stderr: ${errorField(error, 'stderr')}`,
+          ].join('\n'),
+          { cause: error },
+        );
+      }
+    }
+
+    it('appends the unchanged phase/reason line to ocr-infrastructure-failure.txt', () => {
+      resetArtifact();
+
+      markFailure('review', 'OCR review failed: timeout');
+
+      // Byte-identical to the pre-existing format: the notifier workflow and
+      // existing tests parse this file.
+      expect(readArtifact()).toBe(
+        'phase=review; reason=OCR review failed: timeout\n',
+      );
+    });
+
+    it('emits the phase and reason as a workflow warning annotation', () => {
+      resetArtifact();
+
+      const stdout = asString(
+        markFailure('review', 'OCR review command failed'),
+      );
+
+      expect(stdout).toContain('::warning::');
+      expect(stdout).toContain('phase=review');
+      expect(stdout).toContain('reason=OCR review command failed');
+    });
+
+    it('identifies the OCR subsystem in the annotation and keeps the prefix out of the artifact', () => {
+      resetArtifact();
+
+      const stdout = asString(
+        markFailure('review', 'OCR review command failed'),
+      );
+
+      // The annotation must be self-describing in the Actions UI, where it
+      // appears among unrelated annotations with no other subsystem context.
+      expect(stdout).toContain(
+        '::warning::OCR infrastructure failure recorded: phase=review; reason=OCR review command failed',
+      );
+      // The notifier workflow parses ocr-infrastructure-failure.txt by the
+      // byte-identical `phase=...; reason=...` format, so the prefix must
+      // never leak into the artifact.
+      expect(readArtifact()).not.toContain(
+        'OCR infrastructure failure recorded',
+      );
+    });
+
+    it('still emits an annotation for a phase whose call site has no echo of its own', () => {
+      // The six review-phase classifier branches pair their call with no
+      // echo at all — the helper itself must carry the log line so those
+      // branches stop being silent.
+      resetArtifact();
+
+      const stdout = asString(
+        markFailure('review', 'OCR review failed: HTTP 429 rate limit'),
+      );
+
+      expect(stdout.trim()).not.toBe('');
+      expect(stdout).toContain('::warning::');
+      expect(stdout).toContain('OCR review failed: HTTP 429 rate limit');
+    });
+
+    it('records repeated failures by appending and announcing each one', () => {
+      resetArtifact();
+
+      const first = markFailure(
+        'llm-preflight',
+        'OCR LLM connectivity check timed out (model=test)',
+      );
+      const second = markFailure('review', 'OCR review command failed');
+
+      expect(readArtifact()).toBe(
+        'phase=llm-preflight; reason=OCR LLM connectivity check timed out (model=test)\n' +
+          'phase=review; reason=OCR review command failed\n',
+      );
+      expect(first).toContain('::warning::');
+      expect(second).toContain('::warning::');
+    });
+  },
+);

--- a/scripts/tests/ocr-review-422-helpers.ts
+++ b/scripts/tests/ocr-review-422-helpers.ts
@@ -237,6 +237,10 @@ export function loadHarness(
   };
 }
 
+/**
+ * Associates a comment with its finding under the comment's path as id, the
+ * pair shape the post step feeds to the 422 regrouping logic.
+ */
 export function pair(comment: ReviewComment, id = comment.path): Pair {
   return { comment, finding: { path: comment.path, id } };
 }

--- a/scripts/tests/ocr-review-422-helpers.ts
+++ b/scripts/tests/ocr-review-422-helpers.ts
@@ -38,8 +38,15 @@ export interface ReviewComment {
   path: string;
   line?: number | null;
   start_line?: number | null;
+  start_side?: string | null;
   side?: string;
   body?: string;
+  /**
+   * Internal severity sort key the post step attaches to inline comment
+   * objects (issue #3544). Present on the in-memory objects; must never
+   * reach the transmitted createReview payload.
+   */
+  _severity?: string;
 }
 
 export interface Pair {
@@ -185,6 +192,10 @@ export function loadHarness(
   vm.createContext(sandbox);
   vm.runInContext(
     [
+      // The 422 block calls the payload allow-list helper (defined earlier in
+      // the post step, near sortInlineComments) at its createReview boundary,
+      // so the harness loads it alongside the extracted block.
+      extractFunctionSource(postScript, 'reviewCommentPayload'),
       block,
       '__EXPOSED__ = {',
       '  errorStatus,',

--- a/scripts/tests/ocr-review-422-wiring.bun.test.ts
+++ b/scripts/tests/ocr-review-422-wiring.bun.test.ts
@@ -142,6 +142,9 @@ describe('.github/workflows/ocr-review.yml — 422 grouping wired into the batch
       // Real key derivation, so dedup is exercised exactly as shipped.
       extractFunctionSource(postScript, 'unrenderFindingText'),
       extractFunctionSource(postScript, 'inlineCommentKey'),
+      // The 422 block strips internal keys at its createReview boundary via
+      // this helper (defined near sortInlineComments in the post step).
+      extractFunctionSource(postScript, 'reviewCommentPayload'),
       helperBlock,
       'async function existingInlineCommentKeys() {',
       '  return new Set(__listKeys().map(inlineCommentKey));',
@@ -266,6 +269,70 @@ describe('.github/workflows/ocr-review.yml — 422 grouping wired into the batch
     // The already-posted comment must not be re-sent by the grouped review.
     expect(result.createReviewCalls[0].comments).toEqual([good.comment]);
     expect(result.outOfDiffRouted).toEqual([bad.finding]);
+  });
+
+  it('transmits only GitHub-defined comment fields in the grouped 422 retry (#3544)', async () => {
+    // The pairs carry the full internal shape the post step builds: the
+    // GitHub-defined fields plus the `_severity` sort key that must be
+    // stripped at the transmission boundary.
+    const multi = pair(
+      {
+        path: 'a.ts',
+        line: 9,
+        start_line: 3,
+        start_side: 'RIGHT',
+        side: 'RIGHT',
+        body: 'spans a range',
+        _severity: 'high',
+      },
+      'multi',
+    );
+    const single = pair(
+      {
+        path: 'a.ts',
+        line: 4,
+        side: 'RIGHT',
+        body: 'single line',
+        _severity: 'low',
+      },
+      'single',
+    );
+    const bad = pair(
+      {
+        path: 'a.ts',
+        line: 900,
+        side: 'RIGHT',
+        body: 'outside',
+        _severity: 'high',
+      },
+      'bad',
+    );
+
+    const result = await runWiring({
+      pairsToPost: [multi, single, bad],
+      batchErr: LINE_422,
+    });
+
+    expect(result.createReviewCalls.length).toBe(1);
+    const transmitted = result.createReviewCalls[0].comments;
+    expect(transmitted.length).toBe(2);
+    const [multiPayload, singlePayload] = transmitted;
+    expect(Object.keys(multiPayload).sort()).toEqual([
+      'body',
+      'line',
+      'path',
+      'side',
+      'start_line',
+      'start_side',
+    ]);
+    expect(Object.keys(singlePayload).sort()).toEqual([
+      'body',
+      'line',
+      'path',
+      'side',
+    ]);
+    expect('_severity' in multiPayload).toBe(false);
+    expect('_severity' in singlePayload).toBe(false);
   });
 
   it('re-reads what landed when the grouped write throws', async () => {

--- a/scripts/tests/ocr-review-payload.bun.test.ts
+++ b/scripts/tests/ocr-review-payload.bun.test.ts
@@ -1,0 +1,358 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import vm from 'node:vm';
+import { beforeAll, describe, expect, it } from 'bun:test';
+import {
+  asRecord,
+  asString,
+  asVmFunction,
+  parseWorkflowYaml,
+} from './typed-test-helpers.ts';
+import {
+  WORKFLOW_PATH,
+  commandText,
+  extractFunctionSource,
+  readRootFile,
+  stepNamed,
+} from './ocr-review-workflow-helpers.ts';
+
+// Security note: the vm.runInContext calls in this suite execute JavaScript
+// extracted from the trusted, version-controlled ocr-review.yml workflow via
+// extractFunctionSource / verbatim block slicing. This is repository content
+// read from the checked-out HEAD, never user or PR input.
+
+// Issue #3544: the inline comment objects built by the post step carry an
+// internal `_severity` sort key. GitHub's REST-to-GraphQL bridge rejects
+// unknown members on draft review threads (the key surfaces as a nonexistent
+// `Severity` field), failing every batched `createReview` with HTTP 422.
+// These tests pin the transmission boundary: the payload handed to
+// github.rest.pulls.createReview contains exactly the fields the review API
+// defines, and nothing else.
+
+const VM_TIMEOUT_MS = 5000;
+
+/** Keys that must always be present on a transmitted review comment. */
+const BASE_KEYS = ['body', 'line', 'path', 'side'];
+
+/** Additional keys permitted only when the comment spans a line range. */
+const RANGE_KEYS = ['start_line', 'start_side'];
+
+interface InternalComment {
+  path: string;
+  line: number;
+  side: string;
+  body: string;
+  _severity?: string;
+  start_line?: number;
+  start_side?: string;
+}
+
+interface Pair {
+  comment: InternalComment;
+  finding: Record<string, unknown>;
+}
+
+interface CreateReviewCall {
+  commit_id: string;
+  comments: Array<Record<string, unknown>>;
+}
+
+function internalPair(comment: InternalComment): Pair {
+  return { comment, finding: { path: comment.path } };
+}
+
+function multiLineComment(severity: string): InternalComment {
+  return {
+    path: 'a.ts',
+    line: 9,
+    side: 'RIGHT',
+    body: '<!-- ocr-fp:ocr-run-1-0-abc -->\n> multi',
+    _severity: severity,
+    start_line: 3,
+    start_side: 'RIGHT',
+  };
+}
+
+function singleLineComment(severity: string): InternalComment {
+  return {
+    path: 'b.ts',
+    line: 4,
+    side: 'RIGHT',
+    body: '<!-- ocr-fp:ocr-run-1-1-def -->\n> single',
+    _severity: severity,
+  };
+}
+
+function sortedKeys(record: Record<string, unknown>): string[] {
+  return Object.keys(record).sort();
+}
+
+describe('.github/workflows/ocr-review.yml — review comment payload allow-list (#3544)', () => {
+  let postScript: string;
+
+  beforeAll(() => {
+    const workflow = parseWorkflowYaml(readRootFile(WORKFLOW_PATH));
+    const codeReviewJob = workflow.jobs?.['code-review'];
+    expect(
+      codeReviewJob,
+      'workflow should contain job: code-review',
+    ).toBeTruthy();
+    const postStep = stepNamed(codeReviewJob, 'Post OCR results');
+    postScript = commandText(postStep);
+  });
+
+  /**
+   * Slice the REAL primary batch-post block verbatim out of the post step:
+   * from `const inlineToPost = ...` through the success assignment. The
+   * harness closes the workflow's `try` so the sandbox compiles, and asserts
+   * the next workflow line is the catch so a future re-shaping of this block
+   * fails loudly instead of testing the wrong code.
+   */ function primaryPostBlock(): string {
+    const startMarker =
+      'const inlineToPost = pairsToPost.map((p) => p.comment);';
+    const endMarker = 'postedInline = inlineToPost.length;';
+    const blockStart = postScript.indexOf(startMarker);
+    if (blockStart < 0) {
+      throw new Error(
+        'post step should build inlineToPost from pairsToPost before the batch post',
+      );
+    }
+    const endMarkerIndex = postScript.indexOf(endMarker, blockStart);
+    if (endMarkerIndex < 0) {
+      throw new Error(
+        'post step should assign postedInline from inlineToPost after the batch post',
+      );
+    }
+    const blockEnd = endMarkerIndex + endMarker.length;
+    if (
+      !postScript.slice(blockEnd).trimStart().startsWith('} catch (batchErr)')
+    ) {
+      throw new Error(
+        'primary batch post block should end at the success assignment, immediately before its catch',
+      );
+    }
+    // Close the workflow's `try` with an empty finally so the sandbox
+    // compiles; it adds no behavior, and the fake createReview succeeds so
+    // the catch path never runs here.
+    return `${postScript.slice(blockStart, blockEnd)}\n} finally {}`;
+  }
+
+  /** Execute the primary batch-post block against a recording fake Octokit. */
+  async function runPrimaryPost(
+    pairsToPost: Pair[],
+  ): Promise<{ createReviewCalls: CreateReviewCall[]; postedInline: number }> {
+    const createReviewCalls: CreateReviewCall[] = [];
+    const github = {
+      rest: {
+        pulls: {
+          createReview: (params: {
+            commit_id: string;
+            comments: Array<Record<string, unknown>>;
+          }) => {
+            createReviewCalls.push({
+              commit_id: params.commit_id,
+              comments: params.comments,
+            });
+            return Promise.resolve({ data: {} });
+          },
+        },
+      },
+    };
+    const sandbox: Record<string, unknown> = {
+      String,
+      Number,
+      Math,
+      JSON,
+      Object,
+      Array,
+      Boolean,
+      Error,
+      Set,
+      Map,
+      Promise,
+      github,
+      owner: 'acme',
+      repo: 'widget',
+      number: 42,
+      headSha: 'sha-1',
+      pairsToPost,
+      core: { warning: () => {}, info: () => {} },
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(
+      [
+        // The primary-post block strips internal keys at its createReview
+        // boundary via this helper; the block slice itself does not contain
+        // the definition, so it is loaded alongside it.
+        extractFunctionSource(postScript, 'reviewCommentPayload'),
+        'let postedInline = 0;',
+        '__RESULT__ = (async () => {',
+        primaryPostBlock(),
+        '  return { postedInline };',
+        '})();',
+      ].join('\n'),
+      sandbox,
+      { timeout: VM_TIMEOUT_MS },
+    );
+    const settled = (await sandbox['__RESULT__']) as { postedInline: number };
+    return { createReviewCalls, postedInline: settled.postedInline };
+  }
+
+  // ------------------------------------------------------------------
+  // B1-c: the payload helper, directly, for each boundary case.
+  // ------------------------------------------------------------------
+  describe('reviewCommentPayload boundary cases', () => {
+    let payloadOf: (comment: InternalComment) => Record<string, unknown>;
+
+    beforeAll(() => {
+      const sandbox: Record<string, unknown> = {};
+      vm.createContext(sandbox);
+      vm.runInContext(
+        extractFunctionSource(postScript, 'reviewCommentPayload'),
+        sandbox,
+        { timeout: VM_TIMEOUT_MS },
+      );
+      const fn = asVmFunction(sandbox['reviewCommentPayload']);
+      payloadOf = (comment) => asRecord(fn(comment));
+    });
+
+    it('transmits a single-line comment with exactly the always-required fields', () => {
+      const payload = payloadOf(singleLineComment('high'));
+      expect(sortedKeys(payload)).toEqual(BASE_KEYS);
+      expect(payload).toEqual({
+        path: 'b.ts',
+        line: 4,
+        side: 'RIGHT',
+        body: '<!-- ocr-fp:ocr-run-1-1-def -->\n> single',
+      });
+      expect('_severity' in payload).toBe(false);
+    });
+
+    it('transmits a multi-line comment with the range fields added', () => {
+      const payload = payloadOf(multiLineComment('low'));
+      expect(sortedKeys(payload)).toEqual([...BASE_KEYS, ...RANGE_KEYS].sort());
+      expect(payload).toEqual({
+        path: 'a.ts',
+        line: 9,
+        side: 'RIGHT',
+        body: '<!-- ocr-fp:ocr-run-1-0-abc -->\n> multi',
+        start_line: 3,
+        start_side: 'RIGHT',
+      });
+      expect('_severity' in payload).toBe(false);
+    });
+
+    it('drops the internal severity when it is absent from the comment', () => {
+      const comment = singleLineComment('high');
+      delete comment._severity;
+      const payload = payloadOf(comment);
+      expect(sortedKeys(payload)).toEqual(BASE_KEYS);
+      expect('_severity' in payload).toBe(false);
+    });
+
+    it('drops the internal severity when it is the fail-safe value unknown', () => {
+      const payload = payloadOf(singleLineComment('unknown'));
+      expect(sortedKeys(payload)).toEqual(BASE_KEYS);
+      expect('_severity' in payload).toBe(false);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // B1-b: the primary batch post transmits the allow-listed payload.
+  // ------------------------------------------------------------------
+  describe('primary batch post', () => {
+    it('transmits comments whose key set is exactly the permitted set', async () => {
+      const result = await runPrimaryPost([
+        internalPair(multiLineComment('high')),
+        internalPair(singleLineComment('low')),
+      ]);
+
+      expect(result.createReviewCalls.length).toBe(1);
+      expect(result.postedInline).toBe(2);
+      const [multi, single] = result.createReviewCalls[0].comments;
+      expect(sortedKeys(multi)).toEqual([...BASE_KEYS, ...RANGE_KEYS].sort());
+      expect(sortedKeys(single)).toEqual(BASE_KEYS);
+    });
+
+    it('does not transmit the internal _severity sort key', async () => {
+      const result = await runPrimaryPost([
+        internalPair(singleLineComment('critical')),
+      ]);
+
+      const [comment] = result.createReviewCalls[0].comments;
+      expect('_severity' in comment).toBe(false);
+      expect(comment).not.toHaveProperty('_severity');
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // B1-d: severity ordering is unchanged by the payload allow-list.
+  // ------------------------------------------------------------------
+  describe('severity ordering through the primary batch post', () => {
+    it('posts mixed-severity findings in severity-priority order after stripping', async () => {
+      // Load the REAL sorter the workflow ships.
+      const sortSandbox: Record<string, unknown> = {
+        String,
+        Number,
+        Math,
+        Array,
+      };
+      vm.createContext(sortSandbox);
+      vm.runInContext(
+        [
+          extractFunctionSource(postScript, 'severityRank'),
+          extractFunctionSource(postScript, 'sortInlineComments'),
+        ].join('\n'),
+        sortSandbox,
+        { timeout: VM_TIMEOUT_MS },
+      );
+      const sortFn = asVmFunction(sortSandbox['sortInlineComments']);
+
+      const bySeverity: Array<[string, string | undefined]> = [
+        ['low.ts', 'low'],
+        ['crit.ts', 'critical'],
+        ['unk.ts', undefined],
+        ['med.ts', 'medium'],
+        ['high.ts', 'high'],
+      ];
+      const pairs = bySeverity.map(([path, severity]) => {
+        const comment =
+          severity === undefined
+            ? { ...singleLineComment('low'), path, body: path }
+            : { ...singleLineComment(severity), path, body: path };
+        if (severity === undefined) delete comment._severity;
+        return internalPair(comment);
+      });
+      const sorted = sortFn(pairs) as Pair[];
+      const sortedPaths = sorted.map((p) => asString(p.comment.path));
+      // The workflow's documented priority: critical, high, medium, unknown
+      // (fail-safe above low), low.
+      expect(sortedPaths).toEqual([
+        'crit.ts',
+        'high.ts',
+        'med.ts',
+        'unk.ts',
+        'low.ts',
+      ]);
+
+      // Run the REAL primary-post block on the sorted pairs — the same
+      // hand-off the workflow performs — and inspect the transmitted order.
+      const result = await runPrimaryPost(sorted);
+
+      expect(result.createReviewCalls.length).toBe(1);
+      const transmittedPaths = result.createReviewCalls[0].comments.map((c) =>
+        asString(c['path']),
+      );
+      // The transmitted order is the severity-priority order: stripping the
+      // sort key at the boundary does not reorder the batch.
+      expect(transmittedPaths).toEqual(sortedPaths);
+      for (const comment of result.createReviewCalls[0].comments) {
+        expect('_severity' in comment).toBe(false);
+      }
+    });
+  });
+});

--- a/scripts/tests/ocr-review-payload.bun.test.ts
+++ b/scripts/tests/ocr-review-payload.bun.test.ts
@@ -273,6 +273,7 @@ describe('.github/workflows/ocr-review.yml — review comment payload allow-list
 
       expect(result.createReviewCalls.length).toBe(1);
       expect(result.postedInline).toBe(2);
+      expect(result.createReviewCalls[0].commit_id).toBe('sha-1');
       const [multi, single] = result.createReviewCalls[0].comments;
       expect(sortedKeys(multi)).toEqual([...BASE_KEYS, ...RANGE_KEYS].sort());
       expect(sortedKeys(single)).toEqual(BASE_KEYS);

--- a/scripts/tests/ocr-review-payload.bun.test.ts
+++ b/scripts/tests/ocr-review-payload.bun.test.ts
@@ -61,10 +61,15 @@ interface CreateReviewCall {
   comments: Array<Record<string, unknown>>;
 }
 
+/** Pairs an internal comment with its finding under a path-derived id, matching the shape the post step builds before a batch post. */
 function internalPair(comment: InternalComment): Pair {
   return { comment, finding: { path: comment.path } };
 }
 
+/**
+ * Fixture for a finding that spans a line range, carrying the internal
+ * `_severity` sort key the payload helper must strip before transmission.
+ */
 function multiLineComment(severity: string): InternalComment {
   return {
     path: 'a.ts',
@@ -77,6 +82,10 @@ function multiLineComment(severity: string): InternalComment {
   };
 }
 
+/**
+ * Fixture for a finding anchored to a single line, carrying the internal
+ * `_severity` sort key the payload helper must strip before transmission.
+ */
 function singleLineComment(severity: string): InternalComment {
   return {
     path: 'b.ts',
@@ -87,6 +96,7 @@ function singleLineComment(severity: string): InternalComment {
   };
 }
 
+/** Returns a record's keys in sorted order so assertions compare key sets without depending on insertion order. */
 function sortedKeys(record: Record<string, unknown>): string[] {
   return Object.keys(record).sort();
 }

--- a/scripts/tests/ocr-review-workflow.bun.test.ts
+++ b/scripts/tests/ocr-review-workflow.bun.test.ts
@@ -770,6 +770,29 @@ describe('.github/workflows/ocr-review.yml', () => {
       'INLINE_MARKER',
     ]);
   });
+
+  it('routes every batch createReview call through reviewCommentPayload', () => {
+    // Issue #3544: the batched inline review post must transmit only GitHub-accepted
+    // fields. `reviewCommentPayload` strips the internal `_severity` sort key at
+    // the boundary; a future createReview call site that rebuilds its comments
+    // without it would reintroduce the 422 the batch call first hit. Count every
+    // call site and pin each one to the allow-list helper so none can be added
+    // unguarded, matching the style of the mark_infrastructure_failure and
+    // mark_policy_failure occurrence assertions above.
+    const callSites = [
+      ...postScript.matchAll(/await\s+github\.rest\.pulls\.createReview\(\{/g),
+    ];
+
+    expect(callSites.length).toBeGreaterThan(0);
+    for (const match of callSites) {
+      const callText = postScript.slice(match.index, match.index + 400);
+      const commentsArgument = /comments:\s*([^,}]+)/.exec(callText)?.[1] ?? '';
+      expect(
+        commentsArgument,
+        `every github.rest.pulls.createReview call in the "Post OCR results" step must pass its comments through reviewCommentPayload so the internal _severity key is stripped at the transmission boundary; the call starting at character ${match.index} passes comments via: ${commentsArgument.trim()}`,
+      ).toContain('reviewCommentPayload');
+    }
+  });
 });
 
 describe('.github/workflows/ocr-review.yml — no-reviewable-files short-circuit (issue #2824)', () => {


### PR DESCRIPTION
## TLDR

Every batched OCR inline review post has been failing with HTTP 422 since 2026-07-26, and nobody noticed because the per-comment fallback still published the comments. The inline comment objects carry an internal `_severity` sort key, and they were handed to `github.rest.pulls.createReview` unchanged. GitHub's REST-to-GraphQL bridge maps that key onto a `Severity` member of `DraftPullRequestReviewThread`, which does not exist, and rejects the whole batch. This PR rebuilds the transmitted payload as an allow-list at both `createReview` call sites.

It also makes `mark_infrastructure_failure` emit its phase and reason as a workflow annotation. Seven call sites previously recorded a reason only to `ocr-infrastructure-failure.txt` and logged nothing, which is why the failure that filed #3544 cannot be diagnosed at all.

Reviewers should look hardest at two things: the `if (comment.start_line)` gate in `reviewCommentPayload`, and the fact that this fix activates the issue #2930 line-resolution grouping path, which has never executed in production.

## Dive Deeper

### What run 33750459882 actually shows

The run has two attempts and they failed differently.

**Attempt 1** is the one that produced the classification. Its `Record OCR outcome` job ran only the `infrastructure-failure` step; every other outcome step was skipped. That durable marker is what `ocr-infrastructure-notifier.yml` reads. The run's current view shows attempt 2, which recorded `success`, which is why the run status disagrees with the issue body.

Attempt 1's `Run OpenCodeReview` ran 600.2 seconds against one selected file and exited 1. It emitted **zero** log output. `mark_infrastructure_failure` appends `phase=...; reason=...` to a file and logs nothing, and unlike every earlier phase the review-phase classifier branches pair their call with no `::warning::` of their own. The artifact that held the reason was uploaded under the fixed name `ocr-review-output` and was replaced when attempt 2 ran. The surviving copy has an empty `ocr-infrastructure-failure.txt`. The root cause of the classified failure is not recoverable, and this PR does not claim to fix it.

**Attempt 2** recorded success but its annotations show the defect this PR fixes:

```
Batch review post failed (3 comments), falling back to individual posting:
Unprocessable Entity: "Variable $threads of type [DraftPullRequestReviewThread]
was provided invalid value for 0.Severity (Field is not defined on
DraftPullRequestReviewThread), 1.Severity (...), 2.Severity (...)"
```

### The `_severity` leak

The comment object built in `Post OCR results` is:

```js
const comment = {
  path: String(f.path),
  line: endLine,
  side: 'RIGHT',
  body: `${INLINE_MARKER}\n<!-- ocr-fp:${fingerprint} -->\n${labeledText}`,
  _severity: effectiveSeverity(f),
};
```

`_severity` exists only to drive `sortInlineComments`. The same objects went to `createReview` at two places: the primary batch post, and the grouped retry inside `regroupLineResolutionFailure`. The individual `createReviewComment` path enumerates its fields explicitly, which is why the comments still landed and the breakage stayed invisible.

The fix adds a `reviewCommentPayload` allow-list helper next to `sortInlineComments` and applies it at both transmission sites. It is an allow-list rather than a `delete _severity`, so a future internal field cannot reintroduce the bug. `_severity` stays on the in-memory objects; only the boundary strips it.

Git history sharpens the impact. `_severity` entered in 517f4636c (2026-07-26, #2649). `regroupLineResolutionFailure` landed in 111ce9e9b (2026-08-03, #2930), eight days later. Its gate is `errorStatus(batchErr) === 422 && isLineResolutionFailure(batchErr)`, and the `Severity` message matches none of the line-resolution patterns. So the batch has always failed on `Severity` first, and the #2930 grouping has never run in production.

### This activates a dormant path, deliberately

Attempt 2 demonstrates the masking directly: the `Severity` 422 on the batch, then a genuine `pull_request_review_thread.line ... could not be resolved` when that comment was retried individually. After this PR that PR would enter the grouping path instead.

Review of that path found its fail-safe posture correct. Every "cannot judge" condition degrades to the existing per-comment loop rather than discarding a comment: inventory read throws, incomplete inventory, truncated pagination, head SHA moved during the walk, clipped patch, patch totals disagreeing with the file entry, non-RIGHT side, missing line. `invalid` is only reached by positive proof, which is the right polarity given that `invalid` relegates a finding to the summary permanently. Double-posting is handled: a successful grouped retry returns only `unknownPairs` as remaining, and a throw sets `secondaryFailed` so the caller re-lists before the per-comment loop can repost. Accounting is preserved, since `invalidPairs` increment `failedInline` and route to the summary exactly as an individual failure does, which keeps the invariant `shouldAdvanceCheckpoint` relies on.

One behavioral shift is worth watching on the first production runs. While batching was broken, `batchPublicationAmbiguous` was set on every run with inline comments, so `publicationState` only reached `complete` after `reconcileWithRetry` confirmed every comment present. With batching repaired the success path sets `complete` directly and the checkpoint can advance on the strength of `createReview` succeeding. That is the originally designed success path, not something this PR invented, and `createReview` is atomic, which is why one bad comment 422s the whole batch. Recording it because it is new in practice.

### The annotation

`mark_infrastructure_failure` now also emits `::warning::OCR infrastructure failure recorded: phase=...; reason=...`. The line appended to `ocr-infrastructure-failure.txt` is byte-identical, because the notifier workflow and existing tests parse that file, and a test pins both the unchanged artifact format and the absence of the prefix from it.

This covers seven previously silent call sites: the six review-phase classifier branches and the preview extraction branch. The annotation lands in per-attempt logs, which GitHub retains, so it survives exactly the re-run overwrite that destroyed attempt 1's evidence.

### Scope

Deliberately excluded, and verified untouched: run-attempt-scoped artifact naming (it also requires changing the notifier's download step, so it spans a second workflow), the review timeout, and anything feeding `publicationState` / `post_state`. The 600 second duration was never a timeout boundary, since the configured limit is 30 minutes.

Follow-ups filed rather than absorbed here: #3551 for the attempt-scoped artifact name and for the notifier omitting the recorded reason from the issue body it writes, and #3552 for a pre-existing trust-set degradation in the inline dedup path.

## Reviewer Test Plan

The change is a CI workflow, so the tests execute the real workflow source rather than a copy of it. Each suite extracts the shipped script out of `ocr-review.yml` and runs it: the JavaScript in a `vm` sandbox against a fake Octokit that records what was transmitted, and the shell helper out of its heredoc under `bash -c 'set -euo pipefail'` in a temp directory.

Run them from inside `scripts/tests`, not the repo root. `bun test <path>` treats arguments as substring filters, so from the root it also matches stale full-repo copies under the gitignored `tmp/` directory and reports their failures as yours.

```bash
cd scripts/tests
bun test ocr-review-payload.bun.test.ts \
         ocr-infrastructure-failure-annotation.test.ts \
         ocr-review-workflow.bun.test.ts \
         ocr-failure-classification.test.ts \
         ocr-review-422-wiring.bun.test.ts \
         ocr-review-422-grouping.bun.test.ts
```

To confirm the tests actually pin the fix rather than passing vacuously, restore the old workflow in a scratch copy and re-run:

```bash
git show origin/main:.github/workflows/ocr-review.yml > .github/workflows/ocr-review.yml
```

14 of the 15 new and modified tests fail. The single survivor is `appends the unchanged phase/reason line to ocr-infrastructure-failure.txt`, which is deliberately a no-change guard on the artifact format the notifier parses. Restore with `git checkout .github/workflows/ocr-review.yml` afterwards.

Worth reviewing closely:

- `reviewCommentPayload` gates the range fields on `if (comment.start_line)`. `start_line` is only assigned when `startLine < endLine`, from values already validated as integers greater than zero, so a falsy-but-meaningful value is not reachable, and this matches the gate the individual-post path already used. Confirm you agree.
- The new invariant test in `ocr-review-workflow.bun.test.ts` asserts every `pulls.createReview` in the post step routes through the helper, so a future third call site cannot reintroduce this. It was verified to fail when one call site is edited to pass raw comments.
- `ocr-failure-classification.test.ts` previously carried a hand-written stub of the shell helper with a comment claiming it mirrored the real one. Since this PR changes the real helper, the stub was replaced with the extracted heredoc so the two cannot drift.

The real behavior only shows up when this workflow runs against a PR. On the first OCR review after merge, the `Batch review post failed` annotation should be gone and the inline comments should arrive as a single review rather than one at a time.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Verified on macOS: `npm run typecheck`, `npm run format`, `npm run build`, ESLint clean across the repo, the `stepfun-37` startup smoke, and the OCR suites above. Two failures in the local `scripts` shard were traced to this machine and not to the change: `doc-tree-invariants.test.ts` fails because a local `.worktrees/pr-2052/` and stale repo copies under `tmp/` each contain a second `KEYBINDINGS-AUTOGEN:START`, and `issue-2603-release-install.test.ts` is a pack-and-install smoke that exceeds its own budget under load. Neither reads any file this PR touches.

## Linked issues / bugs

Fixes #3544

Follow-ups filed from the same investigation: #3551 and #3552.

Related prior work: #2649 introduced the `_severity` sort key, #2930 added the line-resolution grouping this unblocks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed OCR review comment submission failures by sending only GitHub-supported fields.
  - Preserved severity-based comment ordering without transmitting internal sorting metadata.
  - Added warning annotations when OCR infrastructure failures are recorded, including phase and subsystem context.

- **Tests**
  - Added regression coverage for standard and retry-based review submissions.
  - Added validation for infrastructure-failure artifacts and workflow warning annotations.
  - Verified multiline and single-line review comments retain their supported fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->