### PR TITLE
fix(scripts): raise lockfile-only npm install timeout with ETIMEDOUT retry

### DIFF
--- a/scripts/tests/release-process.test.ts
+++ b/scripts/tests/release-process.test.ts
@@ -145,6 +145,21 @@ describe('scripts/version.ts', () => {
     expect(versionTs).toContain('isVersionedReleasePackage');
     expect(versionTs).toContain('--workspace');
   });
+
+  it('keeps the default lockfile install timeout for existing runNpm callers', () => {
+    expect(versionTs).toContain('timeoutMs ?? 120_000');
+  });
+
+  it('raises the timeout and allows a single ETIMEDOUT retry for the lockfile-only install', () => {
+    expect(versionTs).toContain("runNpm(['install', '--package-lock-only'], {");
+    expect(versionTs).toContain('timeoutMs: 600_000');
+    expect(versionTs).toContain('retries: 1');
+    expect(versionTs).toContain(
+      `(error as { code?: unknown }).code === 'ETIMEDOUT'`,
+    );
+    expect(versionTs).toContain('(attempt ');
+    expect(versionTs).toContain('retrying.');
+  });
 });
 
 describe('.github/workflows/release.yml', () => {

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -28,9 +28,39 @@ function npmBin(): string {
   return process.platform === 'win32' ? 'npm.cmd' : 'npm';
 }
 
-function runNpm(args: readonly string[]): void {
-  console.log(`> npm ${args.join(' ')}`);
-  execFileSync(npmBin(), args, { stdio: 'inherit', timeout: 120_000 });
+type RunNpmOptions = {
+  timeoutMs?: number;
+  retries?: number;
+};
+
+function runNpm(args: readonly string[], opts?: RunNpmOptions): void {
+  const timeoutMs = opts?.timeoutMs ?? 120_000;
+  const retries = opts?.retries ?? 0;
+  let attempt = 0;
+  while (true) {
+    attempt += 1;
+    console.log(`> npm ${args.join(' ')}`);
+    try {
+      execFileSync(npmBin(), args, { stdio: 'inherit', timeout: timeoutMs });
+      return;
+    } catch (error) {
+      if (attempt <= retries && isEtimedout(error)) {
+        console.warn(
+          `npm ${args.join(' ')} timed out (attempt ${attempt}); retrying.`,
+        );
+        continue;
+      }
+      throw error;
+    }
+  }
+}
+
+function isEtimedout(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    (error as { code?: unknown }).code === 'ETIMEDOUT'
+  );
 }
 
 function readJson(filePath: string): PackageJson {
@@ -169,7 +199,10 @@ updateSandboxImageUri(
 
 // 6. Update package-lock.json without reinstalling node_modules.
 try {
-  runNpm(['install', '--package-lock-only']);
+  runNpm(['install', '--package-lock-only'], {
+    timeoutMs: 600_000,
+    retries: 1,
+  });
 } catch (error) {
   console.error(
     'package-lock.json update failed. Revert package.json, packages/*/package.json, and package-lock.json before retrying.',


### PR DESCRIPTION
## TL;DR

The nightly release's version-bump step runs `npm install --package-lock-only` with a hardcoded 120s timeout and no retry; during npm-registry degradation windows this throws `spawnSync npm ETIMEDOUT` and kills the release after all gates have already passed. Raises the timeout for that single registry-metadata fetch to 10 minutes and retries once, only on ETIMEDOUT.

Refs #3550 (same registry-degradation window; that issue tracks the CI smoke-test manifestation)

## Dive Deeper

Release run 33843640478 passed preflight, integration tests, and all workspace version bumps, then failed at `scripts/version.ts` step 6: `execFileSync(npm, ['install', '--package-lock-only'], { timeout: 120_000 })`. The same overnight window produced 120-540s npm latencies in the CI scripts shard (#3550, 3/3 failures at different sub-steps). A lockfile-only install is a pure registry-metadata fetch; giving it 600s plus one ETIMEDOUT-only retry is network-I/O resilience, not a behavior fallback: non-timeout failures still fail fast, and the existing step-6 error message and rethrow semantics are unchanged.

## Reviewer Test Plan

1. `bun test scripts/tests/release-process.test.ts` — 21/21, including the new static assertions that existing callers keep the 120s default and step 6 uses `timeoutMs: 600_000, retries: 1` with the ETIMEDOUT-only guard.
2. `npx tsc --noEmit -p tsconfig.scripts.json` — exit 0.

## Testing Matrix

| Check | Result |
|---|---|
| bun test scripts/tests/release-process.test.ts | ✅ 21/21 |
| prettier --check (both files) | ✅ clean |
| eslint (both files) | ✅ 0 errors |
| tsc -p tsconfig.scripts.json | ✅ exit 0 |

 🍏 Verified locally on macOS; change is runner-agnostic (child_process behavior identical on linux).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of package-lock updates by allowing timed-out npm commands to retry automatically.
  - Added clearer warning messages when a retry is attempted.
  - Preserved existing timeout behavior for other npm operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->