### PR TITLE
fix(scripts): raise bind-release-deps lockfile timeout with ETIMEDOUT retry (refs #3550)

### DIFF
--- a/scripts/bind-release-deps.ts
+++ b/scripts/bind-release-deps.ts
@@ -18,7 +18,7 @@ import { isErrnoException, messageOf } from './utils/error-guards.ts';
 import { NON_NPM_RELEASE_PACKAGES } from './utils/release-packages.ts';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const DEFAULT_LOCKFILE_TIMEOUT_MS = 300_000;
+const DEFAULT_LOCKFILE_TIMEOUT_MS = 600_000;
 const MIN_LOCKFILE_TIMEOUT_MS = 10_000;
 const MAX_LOCKFILE_TIMEOUT_MS = 1_800_000;
 const BACKUP_SUFFIX = '.bind-backup';
@@ -480,41 +480,57 @@ function updateLockfileAfterBinding(
       Number.isInteger(rawTimeout) && rawTimeout >= MIN_LOCKFILE_TIMEOUT_MS
         ? Math.min(rawTimeout, MAX_LOCKFILE_TIMEOUT_MS)
         : DEFAULT_LOCKFILE_TIMEOUT_MS;
-    const result = spawnSync(
-      npmBin,
-      ['install', '--package-lock-only', '--ignore-scripts'],
-      {
-        cwd: ROOT,
-        encoding: 'utf8',
-        stdio: 'pipe',
-        timeout: lockfileTimeout,
-        maxBuffer: 16 * 1024 * 1024,
-      },
-    );
-    if (result.error !== undefined) {
-      if (isErrnoException(result.error, 'ETIMEDOUT')) {
+    let attempt = 0;
+    while (true) {
+      attempt += 1;
+      const result = spawnSync(
+        npmBin,
+        ['install', '--package-lock-only', '--ignore-scripts'],
+        {
+          cwd: ROOT,
+          encoding: 'utf8',
+          stdio: 'pipe',
+          timeout: lockfileTimeout,
+          maxBuffer: 16 * 1024 * 1024,
+        },
+      );
+      const timedOut =
+        result.error !== undefined &&
+        isErrnoException(result.error, 'ETIMEDOUT');
+      if (timedOut && attempt >= 2) {
         throw new Error(
           `npm install timed out after ${lockfileTimeout}ms. Increase BIND_LOCKFILE_TIMEOUT_MS if needed.`,
         );
       }
-      throw new Error(
-        `Failed to execute ${npmBin}: ${messageOf(result.error)}. Ensure npm is installed and available on PATH.`,
-      );
-    }
-    if (result.signal !== null) {
-      throw new Error(`npm install was terminated by signal ${result.signal}`);
-    }
-    if (result.status === null) {
-      throw new Error('npm install exited without a status code.');
-    }
-    if (result.status !== 0) {
-      const stdout = (result.stdout ?? '').trim();
-      const stderr = (result.stderr ?? '').trim();
-      const details = [stdout, stderr].filter((text) => text.length > 0);
-      const suffix = details.length > 0 ? `: ${details.join('\n')}` : '';
-      throw new Error(
-        `npm install exited with status ${result.status}${suffix}`,
-      );
+      if (timedOut) {
+        console.warn(
+          `npm lockfile update timed out after ${lockfileTimeout}ms (attempt ${attempt}); retrying.`,
+        );
+        continue;
+      }
+      if (result.error !== undefined) {
+        throw new Error(
+          `Failed to execute ${npmBin}: ${messageOf(result.error)}. Ensure npm is installed and available on PATH.`,
+        );
+      }
+      if (result.signal !== null) {
+        throw new Error(
+          `npm install was terminated by signal ${result.signal}`,
+        );
+      }
+      if (result.status === null) {
+        throw new Error('npm install exited without a status code.');
+      }
+      if (result.status !== 0) {
+        const stdout = (result.stdout ?? '').trim();
+        const stderr = (result.stderr ?? '').trim();
+        const details = [stdout, stderr].filter((text) => text.length > 0);
+        const suffix = details.length > 0 ? `: ${details.join('\n')}` : '';
+        throw new Error(
+          `npm install exited with status ${result.status}${suffix}`,
+        );
+      }
+      return;
     }
   } catch (error) {
     console.error('Failed to update package-lock.json after binding deps.');


### PR DESCRIPTION
## TLDR

Occurrence #5 of the #3550 registry-degradation window: the docker E2E job (100997065950, run 33864748091) failed in `build_sandbox.ts` → `bind-release-deps.ts` with `npm install timed out after 300000ms` during the lockfile-only update. Same failure class #3556 already fixed for `scripts/version.ts`. This PR applies the identical precedent to `bind-release-deps.ts`.

## Dive Deeper

- `DEFAULT_LOCKFILE_TIMEOUT_MS` 300s → **600s**.
- The `npm install --package-lock-only --ignore-scripts` spawn now retries **once on ETIMEDOUT** (with a warning line), then fails with the existing message. Non-timeout errors, signals, and non-zero exits flow through the original handling untouched.
- `BIND_LOCKFILE_TIMEOUT_MS` env override and the 10s/1800s clamps are unchanged.

## Reviewer Test Plan

1. `cd scripts && bun test tests/release-process.test.ts tests/release-process-b.test.ts` — 40/40 pass (includes the bind-release-deps describe block).
2. `npx prettier --check scripts/bind-release-deps.ts` and `npx eslint scripts/bind-release-deps.ts` — clean.
3. CI scripts shard + docker E2E (which exercises `build_sandbox` → this path from main) — the docker E2E check on this PR runs against main's tree with this PR merged? No — it checks out main; the arbiter is the nightly/CI on main after merge.

## Testing Matrix

- 🍏 macOS: 40/40 static tests; prettier/eslint clean.
- ✅ Linux CI: pending on this PR's shard.

Refs #3550 (occurrence #5). Follows #3556 precedent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release dependency preparation now allows more time for lockfile operations.
  * A single automatic retry is performed when lockfile generation encounters a timeout.
  * Other process failures continue to be reported explicitly, preserving existing error handling and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->