### PR TITLE
feat(providers): add gpt-6-astra to the codex alias and shared OpenAI surfaces (Fixes #3576)

### DIFF
--- a/docs/cli/providers.md
+++ b/docs/cli/providers.md
@@ -6,27 +6,31 @@ LLxprt Code works with multiple AI providers. You can switch between them mid-se
 
 LLxprt Code ships with aliases for these providers — just use `/provider <name>` to switch:
 
-| Provider                      | Alias           | Default Model              | Auth                 |
-| ----------------------------- | --------------- | -------------------------- | -------------------- |
-| Anthropic                     | `anthropic`     | claude-opus-5              | OAuth or API key     |
-| Google Gemini                 | `gemini`        | gemini-2.5-pro             | API key or Vertex AI |
-| OpenAI (API)                  | `openai`        | gpt-5.5                    | API key              |
-| OpenAI (ChatGPT subscription) | `codex`         | gpt-5.6-sol                | OAuth                |
-| Qwen                          | `qwen`          | qwen3-coder-plus           | API key              |
-| xAI                           | `xai`           | grok-4                     | API key              |
-| Kimi                          | `kimi`          | kimi-for-coding            | API key              |
-| DeepSeek                      | `deepseek`      | deepseek-v4-flash          | API key              |
-| Z.AI                          | `zai`           | glm-5                      | API key              |
-| Synthetic                     | `Synthetic`     | hf:zai-org/GLM-4.7         | API key              |
-| Chutes.ai                     | `chutes-ai`     | zai-org/GLM-5-TEE          | API key              |
-| Mistral                       | `mistral`       | mistral-large-latest       | API key              |
-| Cerebras Code                 | `cerebras-code` | qwen-3-coder-480b          | API key              |
-| OpenRouter                    | `openrouter`    | nvidia/nemotron-nano-9b-v2 | API key              |
-| Fireworks                     | `fireworks`     | fireworks/minimax-m3       | API key              |
-| Makora                        | `makora`        | nvidia/Kimi-K2.6-NVFP4     | API key              |
-| Ollama Cloud                  | `ollama-cloud`  | kimi-k2.6                  | API key              |
-| LM Studio                     | `lm-studio`     | gemma-3b-it                | None (local)         |
-| llama.cpp                     | `llama-cpp`     | local-model                | None (local)         |
+| Provider                      | Alias           | Default / Notable Models           | Auth                 |
+| ----------------------------- | --------------- | ---------------------------------- | -------------------- |
+| Anthropic                     | `anthropic`     | claude-opus-5                      | OAuth or API key     |
+| Google Gemini                 | `gemini`        | gemini-2.5-pro                     | API key or Vertex AI |
+| OpenAI (API)                  | `openai`        | gpt-5.5                            | API key              |
+| OpenAI (ChatGPT subscription) | `codex`         | gpt-5.6-sol (default); gpt-6-astra | OAuth                |
+| Qwen                          | `qwen`          | qwen3-coder-plus                   | API key              |
+| xAI                           | `xai`           | grok-4                             | API key              |
+| Kimi                          | `kimi`          | kimi-for-coding                    | API key              |
+| DeepSeek                      | `deepseek`      | deepseek-v4-flash                  | API key              |
+| Z.AI                          | `zai`           | glm-5                              | API key              |
+| Synthetic                     | `Synthetic`     | hf:zai-org/GLM-4.7                 | API key              |
+| Chutes.ai                     | `chutes-ai`     | zai-org/GLM-5-TEE                  | API key              |
+| Mistral                       | `mistral`       | mistral-large-latest               | API key              |
+| Cerebras Code                 | `cerebras-code` | qwen-3-coder-480b                  | API key              |
+| OpenRouter                    | `openrouter`    | nvidia/nemotron-nano-9b-v2         | API key              |
+| Fireworks                     | `fireworks`     | fireworks/minimax-m3               | API key              |
+| Makora                        | `makora`        | nvidia/Kimi-K2.6-NVFP4             | API key              |
+| Ollama Cloud                  | `ollama-cloud`  | kimi-k2.6                          | API key              |
+| LM Studio                     | `lm-studio`     | gemma-3b-it                        | None (local)         |
+| llama.cpp                     | `llama-cpp`     | local-model                        | None (local)         |
+
+For Codex OAuth, `gpt-6-astra` has an 872,000-token context limit and supports
+`low`, `medium`, `high`, `xhigh`, and `max` reasoning effort. The Codex default
+remains `gpt-5.6-sol`.
 
 ## Switching Providers
 

--- a/docs/providers/models-and-limits.md
+++ b/docs/providers/models-and-limits.md
@@ -1,6 +1,6 @@
 # Provider Models and Limits
 
-**As of:** 2026-08-01
+**As of:** 2026-09-05
 **Owner:** the LLxprt Code maintainers
 **Companion page:** [Provider Setup Quick Reference](./quick-reference.md)
 
@@ -225,11 +225,19 @@ Recommended settings:
 
 ### OpenAI Codex OAuth (`codex` alias)
 
-The `codex` alias uses the ChatGPT subscription backend and has a configured
-context-limit of **262,144 tokens** — lower than the OpenAI API key path.
+The `codex` alias uses the ChatGPT subscription backend. Its provider-level
+context-limit is **262,144 tokens**, while `gpt-6-astra` has a per-model OAuth
+context-limit of **872,000 tokens**.
 
-Common Codex models: `gpt-5.6-sol` (default), `gpt-5.6-terra`, `gpt-5.6-luna`,
-`gpt-5.5`, `gpt-5.3-codex-spark` (131,072 context).
+| Model                           | OAuth context limit | Reasoning effort values                            |
+| ------------------------------- | ------------------- | -------------------------------------------------- |
+| `gpt-6-astra`                   | 872,000             | `low`, `medium`, `high`, `xhigh`, `max`            |
+| `gpt-5.6-sol` (default)         | 262,144             | `minimal`, `low`, `medium`, `high`, `xhigh`, `max` |
+| `gpt-5.6-terra`, `gpt-5.6-luna` | 262,144             | `minimal`, `low`, `medium`, `high`, `xhigh`, `max` |
+| `gpt-5.3-codex-spark`           | 131,072             | Provider-dependent                                 |
+
+Common Codex models: `gpt-6-astra`, `gpt-5.6-sol` (default), `gpt-5.6-terra`,
+`gpt-5.6-luna`, `gpt-5.5`, `gpt-5.3-codex-spark`.
 
 See [Provider Setup Quick Reference](./quick-reference.md#subscription-and-oauth-providers)
 for OAuth setup instructions.

--- a/docs/providers/quick-reference.md
+++ b/docs/providers/quick-reference.md
@@ -90,8 +90,9 @@ Two providers support OAuth for authentication:
 ```
 
 `gpt-6-astra` uses an 872,000-token OAuth context limit and supports `low`,
-`medium`, `high`, `xhigh`, and `max` reasoning effort. The alias default remains
-`gpt-5.6-sol` for accounts where Astra access has not rolled out.
+`medium`, `high`, `xhigh`, and `max` reasoning effort. `gpt-5.6-sol` remains
+the unconditional alias default; `gpt-6-astra` is an explicit model selection
+for accounts with Astra access (staged Trusted Access rollout).
 
 OAuth is lazy — authentication happens when you first use the provider, not when
 you enable it. Check OAuth status with `/auth`, and log out with

--- a/docs/providers/quick-reference.md
+++ b/docs/providers/quick-reference.md
@@ -86,8 +86,12 @@ Two providers support OAuth for authentication:
 # Or for Codex
 /auth codex enable
 /provider codex
-/model gpt-5.6-sol
+/model gpt-6-astra
 ```
+
+`gpt-6-astra` uses an 872,000-token OAuth context limit and supports `low`,
+`medium`, `high`, `xhigh`, and `max` reasoning effort. The alias default remains
+`gpt-5.6-sol` for accounts where Astra access has not rolled out.
 
 OAuth is lazy — authentication happens when you first use the provider, not when
 you enable it. Check OAuth status with `/auth`, and log out with
@@ -199,10 +203,11 @@ Or Claude Code OAuth (Claude.ai subscription):
 OpenAI models can use the newer **Responses API** or the classic **Chat
 Completions API**. LLxprt Code picks one automatically:
 
-- **GPT-5.6 and later** (bare model IDs like `gpt-5.6` and durable-tier IDs
-  like `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) use the **Responses
-  transport** when pointed at the official `api.openai.com` endpoint. Chat
-  Completions is not available for these on that endpoint.
+- **GPT-5.6 and later** (including `gpt-6-astra`, bare model IDs like
+  `gpt-5.6`, and durable-tier IDs like `gpt-5.6-sol`, `gpt-5.6-terra`, and
+  `gpt-5.6-luna`) use the **Responses transport** when pointed at the official
+  `api.openai.com` endpoint. Chat Completions is not available for these on
+  that endpoint.
 - **Custom OpenAI-compatible endpoints** (proxies, gateways, self-hosted
   servers, or any non-`api.openai.com` base URL) **default to Chat
   Completions**, even for GPT-5.6+.

--- a/packages/providers/src/composition/aliasProviderFactory.ts
+++ b/packages/providers/src/composition/aliasProviderFactory.ts
@@ -299,6 +299,7 @@ export function createOpenAIAliasProvider(
     aliasApiKey ?? undefined,
     resolvedBaseUrl,
     withMediaSupport(aliasProviderConfig, entry),
+    entry.config.modelDefaults ?? [],
   );
 
   enforceAliasAuthOnly(provider, authOnlyEnabled);
@@ -348,6 +349,7 @@ export function createOpenAIResponsesAliasProvider(
     resolvedBaseUrl,
     aliasProviderConfig,
     oauthManager,
+    entry.config.modelDefaults ?? [],
   );
 
   enforceAliasAuthOnly(provider, authOnlyEnabled);

--- a/packages/providers/src/composition/aliases/codex.config
+++ b/packages/providers/src/composition/aliases/codex.config
@@ -15,6 +15,23 @@
   },
   "modelDefaults": [
     {
+      "pattern": "^gpt-6-astra",
+      "ephemeralSettings": {
+        "context-limit": 872000
+      }
+    },
+    {
+      "pattern": "^gpt-6",
+      "ephemeralSettings": {},
+      "unallowedParameters": [
+        "temperature",
+        "top_p",
+        "top_k",
+        "frequency_penalty",
+        "presence_penalty"
+      ]
+    },
+    {
       "pattern": "gpt-5",
       "ephemeralSettings": {},
       "unallowedParameters": [
@@ -35,6 +52,11 @@
     }
   ],
   "staticModels": [
+    {
+      "id": "gpt-6-astra",
+      "name": "GPT-6 Astra",
+      "contextWindow": 872000
+    },
     {
       "id": "gpt-5.6-sol",
       "name": "GPT-5.6 Sol",

--- a/packages/providers/src/composition/aliases/codex.config
+++ b/packages/providers/src/composition/aliases/codex.config
@@ -15,7 +15,7 @@
   },
   "modelDefaults": [
     {
-      "pattern": "^gpt-6-astra",
+      "pattern": "^gpt-6-astra(?:-(?:latest|[0-9]{8}|[0-9]{4}-[0-9]{2}-[0-9]{2}))?$",
       "ephemeralSettings": {
         "context-limit": 872000
       }
@@ -27,7 +27,7 @@
       }
     },
     {
-      "pattern": "^gpt-6",
+      "pattern": "^gpt-6-astra(?:-(?:latest|[0-9]{8}|[0-9]{4}-[0-9]{2}-[0-9]{2}))?$",
       "ephemeralSettings": {},
       "unallowedParameters": [
         "temperature",

--- a/packages/providers/src/composition/aliases/codex.config
+++ b/packages/providers/src/composition/aliases/codex.config
@@ -21,6 +21,12 @@
       }
     },
     {
+      "pattern": "^gpt-5\\.3-codex-spark$",
+      "ephemeralSettings": {
+        "context-limit": 131072
+      }
+    },
+    {
       "pattern": "^gpt-6",
       "ephemeralSettings": {},
       "unallowedParameters": [

--- a/packages/providers/src/composition/providerAliases.codex.factory.test.ts
+++ b/packages/providers/src/composition/providerAliases.codex.factory.test.ts
@@ -79,6 +79,18 @@ describe('codex alias factory getModels (@issue:2272)', () => {
     );
   });
 
+  it('returns GPT-6 Astra first with its OAuth context window', async () => {
+    const provider = buildCodexProvider();
+
+    const models = await provider.getModels();
+
+    expect(models[0]).toMatchObject({
+      id: 'gpt-6-astra',
+      name: 'GPT-6 Astra',
+      contextWindow: 872000,
+    });
+  });
+
   it('returns the GPT-5.6 tiers and defaults to Sol', async () => {
     const provider = buildCodexProvider();
 

--- a/packages/providers/src/composition/providerAliases.codex.test.ts
+++ b/packages/providers/src/composition/providerAliases.codex.test.ts
@@ -6,13 +6,25 @@
 
 import { describe, it, expect } from 'bun:test';
 
-import { loadProviderAliasEntries } from './providerAliases.js';
+import {
+  computeUnallowedParameters,
+  loadProviderAliasEntries,
+} from './providerAliases.js';
+import { computeModelDefaults } from '../runtime/providerMutations.js';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+const SAMPLING_PARAMETERS = [
+  'frequency_penalty',
+  'presence_penalty',
+  'temperature',
+  'top_k',
+  'top_p',
+] as const;
 
 describe('Codex provider alias', () => {
   it('should have a codex.config file (not .json extension)', () => {
@@ -71,6 +83,7 @@ describe('Codex provider alias', () => {
     const modelIds = (codexAlias?.config.staticModels ?? []).map((m) => m.id);
 
     expect(modelIds).toStrictEqual([
+      'gpt-6-astra',
       'gpt-5.6-sol',
       'gpt-5.6-terra',
       'gpt-5.6-luna',
@@ -79,6 +92,63 @@ describe('Codex provider alias', () => {
       'gpt-5.4-mini',
       'gpt-5.3-codex-spark',
     ]);
+  });
+
+  it('exposes GPT-6 Astra with its OAuth context window while preserving provider defaults', () => {
+    const aliases = loadProviderAliasEntries();
+    const codexAlias = aliases.find((a) => a.alias === 'codex');
+    const astra = codexAlias?.config.staticModels?.find(
+      (model) => model.id === 'gpt-6-astra',
+    );
+
+    expect(astra).toStrictEqual({
+      id: 'gpt-6-astra',
+      name: 'GPT-6 Astra',
+      contextWindow: 872000,
+    });
+    expect(codexAlias?.config.ephemeralSettings['context-limit']).toBe(262144);
+    expect(codexAlias?.config.defaultModel).toBe('gpt-5.6-sol');
+  });
+
+  it('applies Astra model defaults without changing GPT-5.6 defaults', () => {
+    const aliases = loadProviderAliasEntries();
+    const codexAlias = aliases.find((a) => a.alias === 'codex');
+    const rules = codexAlias?.config.modelDefaults ?? [];
+
+    expect(computeModelDefaults('gpt-6-astra', rules)).toMatchObject({
+      'context-limit': 872000,
+    });
+    for (const model of [
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+      'gpt-5.3-codex-spark',
+    ]) {
+      expect(computeModelDefaults(model, rules)).not.toHaveProperty(
+        'context-limit',
+      );
+    }
+    expect(
+      [...computeUnallowedParameters('gpt-6-astra', rules)].sort(),
+    ).toStrictEqual([...SAMPLING_PARAMETERS]);
+    expect(
+      [...computeUnallowedParameters('gpt-5.6-sol', rules)].sort(),
+    ).toStrictEqual([...SAMPLING_PARAMETERS]);
+  });
+
+  it('resolves Astra to 872000 while retaining the 262144 GPT-5.6 effective limit', () => {
+    const aliases = loadProviderAliasEntries();
+    const codexAlias = aliases.find((a) => a.alias === 'codex');
+    if (!codexAlias) {
+      throw new Error('codex alias entry not found');
+    }
+    const effectiveDefaults = (model: string): Record<string, unknown> => ({
+      ...codexAlias.config.ephemeralSettings,
+      ...computeModelDefaults(model, codexAlias.config.modelDefaults ?? []),
+    });
+
+    expect(effectiveDefaults('gpt-6-astra')['context-limit']).toBe(872000);
+    expect(effectiveDefaults('gpt-5.6-sol')['context-limit']).toBe(262144);
   });
 
   it('should preserve the gpt-5.3-codex-spark 131072 context window', () => {

--- a/packages/providers/src/composition/providerAliases.codex.test.ts
+++ b/packages/providers/src/composition/providerAliases.codex.test.ts
@@ -149,6 +149,58 @@ describe('Codex provider alias', () => {
     expect(effectiveDefaults('gpt-5.6-sol')['context-limit']).toBe(262144);
   });
 
+  it('sanctions only documented gpt-6-astra ids for the 872000 limit and sampling stripping @issue:3576', () => {
+    const aliases = loadProviderAliasEntries();
+    const codexAlias = aliases.find((a) => a.alias === 'codex');
+    if (!codexAlias) {
+      throw new Error('codex alias entry not found');
+    }
+    const rules = codexAlias.config.modelDefaults ?? [];
+    const effectiveContextLimit = (model: string): unknown =>
+      ({
+        ...codexAlias.config.ephemeralSettings,
+        ...computeModelDefaults(model, rules),
+      })['context-limit'];
+
+    const sanctionedModels = [
+      'gpt-6-astra',
+      'gpt-6-astra-latest',
+      'gpt-6-astra-20260903',
+      'gpt-6-astra-2026-09-03',
+    ];
+    for (const model of sanctionedModels) {
+      expect(computeModelDefaults(model, rules)).toMatchObject({
+        'context-limit': 872000,
+      });
+      expect(
+        [...computeUnallowedParameters(model, rules)].sort(),
+      ).toStrictEqual([...SAMPLING_PARAMETERS]);
+      expect(effectiveContextLimit(model)).toBe(872000);
+    }
+
+    const lookalikeModels = [
+      'gpt-6-astral',
+      'gpt-6-astra-mini',
+      'gpt-6-astra-solar',
+      'gpt-6',
+      'gpt-6-turbo',
+    ];
+    for (const model of lookalikeModels) {
+      expect(computeModelDefaults(model, rules)).not.toHaveProperty(
+        'context-limit',
+      );
+      expect(computeUnallowedParameters(model, rules).size).toBe(0);
+      expect(effectiveContextLimit(model)).toBe(262144);
+    }
+
+    // Regression guards: GPT-5 behavior survives the anchored gpt-6 rules.
+    expect(
+      [...computeUnallowedParameters('gpt-5.6-sol', rules)].sort(),
+    ).toStrictEqual([...SAMPLING_PARAMETERS]);
+    expect(effectiveContextLimit('gpt-5.6-sol')).toBe(262144);
+    expect(effectiveContextLimit('gpt-5.3-codex-spark')).toBe(131072);
+  });
+
   it('should preserve the gpt-5.3-codex-spark 131072 context window', () => {
     const aliases = loadProviderAliasEntries();
     const codexAlias = aliases.find((a) => a.alias === 'codex');

--- a/packages/providers/src/composition/providerAliases.codex.test.ts
+++ b/packages/providers/src/composition/providerAliases.codex.test.ts
@@ -110,7 +110,7 @@ describe('Codex provider alias', () => {
     expect(codexAlias?.config.defaultModel).toBe('gpt-5.6-sol');
   });
 
-  it('applies Astra model defaults without changing GPT-5.6 defaults', () => {
+  it('applies Astra and Spark context defaults without changing GPT-5.6 defaults', () => {
     const aliases = loadProviderAliasEntries();
     const codexAlias = aliases.find((a) => a.alias === 'codex');
     const rules = codexAlias?.config.modelDefaults ?? [];
@@ -118,16 +118,14 @@ describe('Codex provider alias', () => {
     expect(computeModelDefaults('gpt-6-astra', rules)).toMatchObject({
       'context-limit': 872000,
     });
-    for (const model of [
-      'gpt-5.6-sol',
-      'gpt-5.6-terra',
-      'gpt-5.6-luna',
-      'gpt-5.3-codex-spark',
-    ]) {
+    for (const model of ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']) {
       expect(computeModelDefaults(model, rules)).not.toHaveProperty(
         'context-limit',
       );
     }
+    expect(computeModelDefaults('gpt-5.3-codex-spark', rules)).toMatchObject({
+      'context-limit': 131072,
+    });
     expect(
       [...computeUnallowedParameters('gpt-6-astra', rules)].sort(),
     ).toStrictEqual([...SAMPLING_PARAMETERS]);

--- a/packages/providers/src/composition/providerManagerInstance.oauthRegistration.test.ts
+++ b/packages/providers/src/composition/providerManagerInstance.oauthRegistration.test.ts
@@ -378,8 +378,9 @@ describe('claudecode OAuth registration with environment key', () => {
       | unknown[]
       | undefined;
 
-    expect(openaiArgs).toHaveLength(3);
+    expect(openaiArgs).toHaveLength(4);
     expect(openaivercelArgs).toHaveLength(3);
     expect(openaiResponsesArgs?.[3]).toBe(oauthManager);
+    expect(Array.isArray(openaiResponsesArgs?.[4])).toBe(true);
   });
 });

--- a/packages/providers/src/composition/runtimeTokenizerFactory.ts
+++ b/packages/providers/src/composition/runtimeTokenizerFactory.ts
@@ -8,7 +8,7 @@ import type {
   RuntimeTokenizer,
   RuntimeTokenizerFactory,
 } from '@vybestack/llxprt-code-core';
-import { isSanctionedGpt56Model } from '../openai/openaiModelPolicy.js';
+import { isSanctionedOpenAIO200kModel } from '../openai/openaiModelPolicy.js';
 import { AnthropicTokenizer } from '../tokenizers/AnthropicTokenizer.js';
 import {
   createGpt56RuntimeTokenizer,
@@ -77,8 +77,8 @@ function matchesTokenizer(
  *   bootstrap or composition consumer (CLI start-up, `fromConfig`, headless
  *   runtime assembly) MUST `await` it for each active provider/model BEFORE
  *   exposing `getTokenizer` or `estimatePrompt` to downstream callers. For
- *   sanctioned GPT-5.6 models it eagerly loads and smoke-tests the o200k_base
- *   encoder so that the first real counting call is never the first
+ *   sanctioned GPT-5.6 and GPT-6 models it eagerly loads and smoke-tests the
+ *   o200k_base encoder so that the first real counting call is never the first
  *   initialization attempt. Preparation failures surface with full estimator
  *   context and causal detail and are fatal to the bootstrap.
  * - `getTokenizer` is **synchronous** and deliberately free of readiness
@@ -114,7 +114,7 @@ export function createRuntimeTokenizerFactory(
   return {
     async prepareTokenizer(providerName, model): Promise<void> {
       const resolvedModel = model ?? providerName;
-      if (isSanctionedGpt56Model(resolvedModel)) {
+      if (isSanctionedOpenAIO200kModel(resolvedModel)) {
         await prepareGpt56RuntimeTokenizer(
           providerName,
           resolvedModel,
@@ -132,7 +132,7 @@ export function createRuntimeTokenizerFactory(
       model?: string,
     ): RuntimeTokenizer | undefined {
       const resolvedModel = model ?? providerName;
-      if (isSanctionedGpt56Model(resolvedModel)) {
+      if (isSanctionedOpenAIO200kModel(resolvedModel)) {
         return createGpt56RuntimeTokenizer(
           providerName,
           resolvedModel,

--- a/packages/providers/src/openai-responses/OpenAIResponsesProvider.emptyModelFallback.test.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesProvider.emptyModelFallback.test.ts
@@ -87,6 +87,7 @@ function buildDeps(
     shouldRetryOnError: () => false,
     getDefaultModel: () => 'o3-mini',
     getGlobalConfig: () => undefined,
+    getUnallowedModelParameters: () => new Set<string>(),
     ...overrides,
   };
 }

--- a/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.ts
@@ -15,6 +15,7 @@
  */
 
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { OAuthManager } from '@vybestack/llxprt-code-auth';
 import type { NormalizedGenerateChatOptions } from '../BaseProvider.js';
 import type { PromptEnvelopeProjection } from '@vybestack/llxprt-code-core/runtime/contracts/PromptEstimation.js';
 import { projectOpenAIResponsesPromptEnvelope } from '../runtime/promptEnvelopeProjections.js';
@@ -31,10 +32,17 @@ import {
   createCodexResponsesWebSocketTransport,
   type WebSocketTransport,
 } from './openAIResponsesWebSocketTransport.js';
+import type { IProviderConfig } from '../types/IProviderConfig.js';
+import type { ModelDefaultRule } from '../composition/providerAliases.js';
+import {
+  createUnallowedModelParametersResolver,
+  type UnallowedModelParametersResolver,
+} from './unallowedModelParameters.js';
 
 export { toOpenAIResponsesWireEffort } from '../openai/openaiModelPolicy.js';
 
 export class OpenAIResponsesProvider extends OpenAIResponsesProviderBase {
+  private readonly getUnallowedModelParameters: UnallowedModelParametersResolver;
   // Codex (codex-rs/core/src/responses_retry.rs) only switches to a sticky HTTP
   // fallback after exhausting its WebSocket stream-retry budget (default
   // `stream_max_retries` = 5). We rely on the outer RetryOrchestrator to retry
@@ -57,6 +65,19 @@ export class OpenAIResponsesProvider extends OpenAIResponsesProviderBase {
     Awaited<ReturnType<typeof buildResponsesRequestContextForProjection>>
   >();
 
+  constructor(
+    apiKey: string | undefined,
+    baseURL?: string,
+    config?: IProviderConfig,
+    oauthManager?: OAuthManager,
+    modelDefaultRules: readonly ModelDefaultRule[] = [],
+  ) {
+    super(apiKey, baseURL, config, oauthManager);
+
+    this.getUnallowedModelParameters =
+      createUnallowedModelParametersResolver(modelDefaultRules);
+  }
+
   private buildExecutorDeps(): ResponsesExecutorDeps {
     return {
       providerName: this.name,
@@ -69,6 +90,7 @@ export class OpenAIResponsesProvider extends OpenAIResponsesProviderBase {
       shouldRetryOnError: (error) => this.shouldRetryOnError(error),
       getDefaultModel: () => this.getDefaultModel(),
       getGlobalConfig: () => this.globalConfig,
+      getUnallowedModelParameters: this.getUnallowedModelParameters,
       getWebSocketTransport: () => this.resolveWebSocketTransport(),
       // Codex statefulness is only valid over the WebSocket transport, so the
       // request builder needs to know the transport BEFORE it decides whether

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.hooksConfigLeak.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.hooksConfigLeak.test.ts
@@ -160,12 +160,12 @@ describe('OpenAIResponsesProvider hooksConfig leak @issue:3218', () => {
 
     const requestBody = await generateAndCaptureBody(provider, settings, {
       hooksConfig: { enabled: true, notifications: false },
-      temperature: 0.7,
+      service_tier: 'priority',
     });
 
     expect(requestBody.hooksConfig).toBeUndefined();
     // Legitimate model params still pass through
-    expect(requestBody.temperature).toBe(0.7);
+    expect(requestBody.service_tier).toBe('priority');
   });
 
   it('does not send hooks (event definitions) in the Codex request body', async () => {

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.issue3255.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.issue3255.test.ts
@@ -125,6 +125,7 @@ function createDeps(
     shouldRetryOnError: () => false,
     getDefaultModel: () => 'gpt-5.6-sol',
     getGlobalConfig: () => undefined,
+    getUnallowedModelParameters: () => new Set<string>(),
   } satisfies ResponsesExecutorDeps;
 }
 

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.reasoningEffort.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.reasoningEffort.test.ts
@@ -296,6 +296,12 @@ describe('OpenAIResponsesProvider reasoning.effort', () => {
 });
 
 describe('toOpenAIResponsesWireEffort @issue:2483', () => {
+  it('maps GPT-6 Astra minimal effort to its low wire floor @issue:3576', () => {
+    expect(toOpenAIResponsesWireEffort('minimal', 'gpt-6-astra')).toBe('low');
+    expect(toOpenAIResponsesWireEffort('max', 'gpt-6-astra')).toBe('max');
+    expect(toOpenAIResponsesWireEffort('minimal', 'gpt-5.6-sol')).toBe('none');
+  });
+
   it.each([
     ['gpt-5.6', 'none'],
     ['gpt-5.6-sol', 'none'],

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.retryClassification.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.retryClassification.test.ts
@@ -165,6 +165,7 @@ function buildDeps(provider: TestableResponsesProvider): ResponsesExecutorDeps {
     shouldRetryOnError: (error) => provider.retryDecision(error),
     getDefaultModel: () => 'gpt-5',
     getGlobalConfig: () => undefined,
+    getUnallowedModelParameters: () => new Set<string>(),
   };
 }
 

--- a/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.unallowedParameters.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.unallowedParameters.test.ts
@@ -1,0 +1,182 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'bun:test';
+import type { OAuthManager } from '../../auth/index.js';
+import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { createOpenAIResponsesAliasProvider } from '../../composition/aliasProviderFactory.js';
+import {
+  loadProviderAliasEntries,
+  type ProviderAliasEntry,
+} from '../../composition/providerAliases.js';
+import { OpenAIResponsesProvider } from '../OpenAIResponsesProvider.js';
+
+const SAMPLING_PARAMETERS = {
+  temperature: 0.4,
+  top_p: 0.8,
+  top_k: 32,
+  frequency_penalty: 0.2,
+  presence_penalty: 0.3,
+} as const;
+const ALLOWED_PARAMETER = { service_tier: 'priority' } as const;
+
+const CODEX_OAUTH_MANAGER = {
+  getToken: async () => 'codex-access-token',
+  isAuthenticated: async () => true,
+  getOAuthToken: async () => ({
+    access_token: 'codex-access-token',
+    token_type: 'Bearer',
+    expiry: Math.floor(Date.now() / 1000) + 3600,
+    account_id: 'test-account-id',
+  }),
+} as unknown as OAuthManager;
+
+function findCodexAlias(): ProviderAliasEntry {
+  const entry = loadProviderAliasEntries().find(
+    ({ alias }) => alias === 'codex',
+  );
+  if (entry === undefined) {
+    throw new Error('codex alias entry not found');
+  }
+  return entry;
+}
+
+function createCodexProvider(
+  entry: ProviderAliasEntry = findCodexAlias(),
+): OpenAIResponsesProvider {
+  const provider = createOpenAIResponsesAliasProvider(
+    entry,
+    'unused-api-key',
+    undefined,
+    {},
+    CODEX_OAUTH_MANAGER,
+    false,
+  );
+  if (provider === null) {
+    throw new Error('codex alias provider was not created');
+  }
+  return provider;
+}
+
+function streamingResponse(): Response {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            'data: {"type":"response.completed","response":{"id":"response-1","status":"completed"}}\n\n',
+          ),
+        );
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+        controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    },
+  );
+}
+
+async function captureSerializedRequest(
+  provider: OpenAIResponsesProvider,
+  model: string,
+): Promise<Record<string, unknown>> {
+  let requestBody: string | undefined;
+  vi.spyOn(globalThis, 'fetch').mockImplementation(
+    async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      if (init?.body !== undefined && init.body !== null) {
+        requestBody =
+          typeof init.body === 'string'
+            ? init.body
+            : await new Response(init.body).text();
+      }
+      return streamingResponse();
+    },
+  );
+
+  const settings = new SettingsService();
+  settings.setProviderSetting(provider.name, 'model', model);
+  for (const [key, value] of Object.entries({
+    ...SAMPLING_PARAMETERS,
+    ...ALLOWED_PARAMETER,
+  })) {
+    settings.setProviderSetting(provider.name, key, value);
+  }
+  const options = createProviderCallOptions({
+    providerName: provider.name,
+    settings,
+    contents: [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'Return one word.' }],
+      },
+    ],
+  });
+
+  for await (const _content of provider.generateChatCompletion(options)) {
+    // Drain the response so the production request path completes.
+  }
+
+  if (requestBody === undefined) {
+    throw new Error('request body was not captured');
+  }
+  const parsed: unknown = JSON.parse(requestBody);
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('serialized request body was not a JSON object');
+  }
+  return Object.fromEntries(Object.entries(parsed));
+}
+
+describe('OpenAI Responses unallowed model parameters', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each(['gpt-6-astra', 'gpt-5.6-sol'])(
+    'strips sampling parameters declared by the real Codex alias for %s',
+    async (model) => {
+      const body = await captureSerializedRequest(createCodexProvider(), model);
+
+      for (const parameter of Object.keys(SAMPLING_PARAMETERS)) {
+        expect(body).not.toHaveProperty(parameter);
+      }
+      expect(body).toHaveProperty('service_tier', 'priority');
+    },
+  );
+
+  it('uses the model-default rules captured from the alias entry at construction', async () => {
+    const codexEntry = findCodexAlias();
+    const provider = createCodexProvider({
+      ...codexEntry,
+      alias: 'construction-rules-codex',
+    });
+
+    const body = await captureSerializedRequest(provider, 'gpt-5.6-sol');
+
+    for (const parameter of Object.keys(SAMPLING_PARAMETERS)) {
+      expect(body).not.toHaveProperty(parameter);
+    }
+    expect(body).toHaveProperty('service_tier', 'priority');
+  });
+
+  it('preserves sampling parameters for a plain OpenAI Responses model without an alias rule', async () => {
+    const body = await captureSerializedRequest(
+      new OpenAIResponsesProvider('test-api-key', 'https://api.openai.com/v1'),
+      'gpt-4.1',
+    );
+
+    expect(body).toMatchObject({
+      ...SAMPLING_PARAMETERS,
+      ...ALLOWED_PARAMETER,
+    });
+  });
+});

--- a/packages/providers/src/openai-responses/codexStateful.test-helpers.ts
+++ b/packages/providers/src/openai-responses/codexStateful.test-helpers.ts
@@ -157,6 +157,7 @@ export function buildDeps(
     shouldRetryOnError: () => false,
     getDefaultModel: () => 'gpt-5.6-sol',
     getGlobalConfig: () => undefined,
+    getUnallowedModelParameters: () => new Set<string>(),
     // Codex statefulness is WS-bound; these harnesses exercise the WS path.
     isWebSocketTransportActive: () => true,
     ...overrides,

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.abort.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.abort.test.ts
@@ -105,6 +105,7 @@ function buildDeps(
     shouldRetryOnError: () => true,
     getDefaultModel: () => 'gpt-5',
     getGlobalConfig: () => undefined,
+    getUnallowedModelParameters: () => new Set<string>(),
     ...overrides,
   };
 }

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.errorDump.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.errorDump.test.ts
@@ -147,6 +147,7 @@ function buildDeps(): ResponsesExecutorDeps {
     shouldRetryOnError: () => false,
     getDefaultModel: () => 'gpt-5',
     getGlobalConfig: () => undefined,
+    getUnallowedModelParameters: () => new Set<string>(),
   };
 }
 

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.liveness.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.liveness.test.ts
@@ -97,6 +97,7 @@ function buildDeps(
     shouldRetryOnError: () => false,
     getDefaultModel: () => 'gpt-5',
     getGlobalConfig: () => undefined,
+    getUnallowedModelParameters: () => new Set<string>(),
     ...overrides,
   };
 }

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.streamIntegrity.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.streamIntegrity.test.ts
@@ -152,6 +152,7 @@ function buildDeps(
     shouldRetryOnError: () => true,
     getDefaultModel: () => 'gpt-5',
     getGlobalConfig: () => undefined,
+    getUnallowedModelParameters: () => new Set<string>(),
     ...overrides,
   };
 }

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.ts
@@ -110,6 +110,8 @@ export interface ResponsesExecutorDeps {
   readonly getDefaultModel: () => string;
   /** Return the provider instance's global config for tool-output-limiter fallback. */
   readonly getGlobalConfig: () => ToolOutputSettingsProvider | undefined;
+  /** Return model parameters disallowed by the provider's captured alias rules. */
+  readonly getUnallowedModelParameters: (model: string) => Set<string>;
   /**
    * Returns the package-internal Codex WebSocket transport when the provider
    * should use WebSockets for this request (Codex mode and not sticky-fallen
@@ -863,6 +865,9 @@ function applyCodexRequestSettings(
   // See the design rationale doc comment on applyStatefulConversation in
   // openAIResponsesStateful.ts for the full trade-off discussion (#3134).
   request.store = false;
+  for (const parameter of deps.getUnallowedModelParameters(request.model)) {
+    delete request[parameter];
+  }
   if ('max_output_tokens' in request) {
     delete request.max_output_tokens;
     deps.logger.debug(

--- a/packages/providers/src/openai-responses/openAIResponsesExecutor.websocket.test.ts
+++ b/packages/providers/src/openai-responses/openAIResponsesExecutor.websocket.test.ts
@@ -89,6 +89,7 @@ function buildDeps(
     shouldRetryOnError: () => false,
     getDefaultModel: () => 'gpt-5.6-sol',
     getGlobalConfig: () => undefined,
+    getUnallowedModelParameters: () => new Set<string>(),
     // Codex statefulness is WS-bound; these harnesses exercise the WS path.
     isWebSocketTransportActive: () => true,
     ...overrides,

--- a/packages/providers/src/openai-responses/unallowedModelParameters.ts
+++ b/packages/providers/src/openai-responses/unallowedModelParameters.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  computeUnallowedParameters,
+  type ModelDefaultRule,
+} from '../composition/providerAliases.js';
+
+export type UnallowedModelParametersResolver = (model: string) => Set<string>;
+
+export function createUnallowedModelParametersResolver(
+  modelDefaultRules: readonly ModelDefaultRule[],
+): UnallowedModelParametersResolver {
+  const capturedModelDefaultRules = [...modelDefaultRules];
+  return (model) =>
+    computeUnallowedParameters(model, capturedModelDefaultRules);
+}

--- a/packages/providers/src/openai/OpenAIProvider.models.test.ts
+++ b/packages/providers/src/openai/OpenAIProvider.models.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'bun:test';
 import { OpenAIProvider } from './OpenAIProvider.js';
+import { RESPONSES_API_MODELS } from './RESPONSES_API_MODELS.js';
 
 // Use vi.hoisted so the mock is created in the hoisted scope the vi.mock
 // factory runs in. This avoids referencing a module-scoped binding from
@@ -21,6 +22,7 @@ void vi.mock('openai', () => ({
 // discovery fails. Asserting the exact list (order included) makes the
 // regression tests fail on ANY unintended addition, removal, or reorder.
 const EXPECTED_FALLBACK_MODEL_IDS = [
+  'gpt-6-astra',
   'gpt-5.6',
   'gpt-5.6-sol',
   'gpt-5.6-terra',
@@ -34,6 +36,10 @@ const EXPECTED_FALLBACK_MODEL_IDS = [
 describe('OpenAIProvider fallback models', () => {
   beforeEach(() => {
     mockModelsList.mockReset();
+  });
+
+  it('lists GPT-6 Astra first on the Responses API surface', () => {
+    expect(RESPONSES_API_MODELS[0]).toBe('gpt-6-astra');
   });
 
   it('includes the GPT-5.6 alias and named tiers when model discovery fails', async () => {

--- a/packages/providers/src/openai/OpenAIProvider.ts
+++ b/packages/providers/src/openai/OpenAIProvider.ts
@@ -74,6 +74,8 @@ import type { PromptEnvelopeProjection } from '@vybestack/llxprt-code-core/runti
 import { collectUnsupportedMedia } from '../utils/mediaUtils.js';
 import { requireAssembledSystemInstruction } from '../utils/systemPromptPlacement.js';
 import { resolveRawTokenDeltaNotifier } from '../logging/attemptLifecycle.js';
+import type { ModelDefaultRule } from '../composition/providerAliases.js';
+import { createUnallowedModelParametersResolver as makeResolver } from '../openai-responses/unallowedModelParameters.js';
 
 import { buildContinuationMessages } from './OpenAIRequestBuilder.js';
 import { extractSanitizedChunkText } from './OpenAIStreamChunkText.js';
@@ -117,6 +119,7 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
   private readonly textToolParser = new GemmaToolCallParser();
   private readonly toolCallPipeline = new ToolCallPipeline();
   private readonly preparedPromptEnvelopes = new OpenAIPromptEnvelopeStore();
+  private readonly getUnallowedModelParameters: ReturnType<typeof makeResolver>;
 
   protected getLogger(): DebugLogger {
     return new DebugLogger('llxprt:provider:openai');
@@ -125,12 +128,13 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
   /**
    * @plan:PLAN-20251023-STATELESS-HARDENING.P08
    * @requirement:REQ-SP4-003
-   * Constructor reduced to minimal initialization - no state captured
+   * Captures static alias rules while keeping request state per call.
    */
   constructor(
     apiKey: string | undefined,
     baseURL?: string,
     config?: IProviderConfig,
+    modelDefaultRules: readonly ModelDefaultRule[] = [],
   ) {
     const normalizedApiKey =
       apiKey && apiKey.trim() !== '' ? apiKey : undefined;
@@ -146,9 +150,11 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
       config,
     );
 
+    this.getUnallowedModelParameters = makeResolver(modelDefaultRules);
+
     // @plan:PLAN-20251023-STATELESS-HARDENING.P08
     // @requirement:REQ-SP4-002
-    // No constructor-captured state - all values sourced from normalized options per call
+    // Request-specific values remain sourced from normalized options per call.
   }
 
   /**
@@ -176,6 +182,7 @@ export class OpenAIProvider extends BaseProvider implements IProvider {
       shouldRetryOnError: (error) => this.shouldRetryResponse(error),
       getDefaultModel: () => this.getDefaultModel(),
       getGlobalConfig: () => undefined,
+      getUnallowedModelParameters: this.getUnallowedModelParameters,
     };
   }
 

--- a/packages/providers/src/openai/RESPONSES_API_MODELS.ts
+++ b/packages/providers/src/openai/RESPONSES_API_MODELS.ts
@@ -6,6 +6,7 @@
  * the API is unreachable.
  */
 export const RESPONSES_API_MODELS = [
+  'gpt-6-astra',
   'gpt-5.6',
   'gpt-5.6-sol',
   'gpt-5.6-terra',

--- a/packages/providers/src/openai/openAIFallbackModels.ts
+++ b/packages/providers/src/openai/openAIFallbackModels.ts
@@ -15,6 +15,7 @@ const FALLBACK_MODEL_SPECS: ReadonlyArray<{
   readonly id: string;
   readonly name: string;
 }> = [
+  { id: 'gpt-6-astra', name: 'GPT-6 Astra' },
   { id: 'gpt-5.6', name: 'GPT-5.6' },
   { id: 'gpt-5.6-sol', name: 'GPT-5.6 Sol' },
   { id: 'gpt-5.6-terra', name: 'GPT-5.6 Terra' },

--- a/packages/providers/src/openai/openaiModelPolicy.test.ts
+++ b/packages/providers/src/openai/openaiModelPolicy.test.ts
@@ -79,6 +79,35 @@ describe('parseOpenAIModelTransport', () => {
     });
   });
 
+  describe('GPT-6 Astra identity', () => {
+    it.each([
+      'gpt-6-astra',
+      'gpt-6-astra-latest',
+      'gpt-6-astra-20260903',
+      'gpt-6-astra-2026-09-03',
+    ])('requires Responses for sanctioned model %s', (model) => {
+      expect(parseOpenAIModelTransport(model)).toStrictEqual({
+        supportsResponses: true,
+        requiresResponses: true,
+      });
+    });
+
+    it.each([
+      'gpt-6',
+      'gpt-6-astral',
+      'gpt-6-astra-mini',
+      'gpt-6-astra-solar',
+      'gpt-6-astra-2026093',
+      'gpt-6-astra-20261345',
+      'gpt-6-astra-2026-02-30',
+    ])('rejects unsanctioned lookalike %s', (model) => {
+      expect(parseOpenAIModelTransport(model)).toStrictEqual({
+        supportsResponses: false,
+        requiresResponses: false,
+      });
+    });
+  });
+
   describe('durable tier IDs (sol/terra/luna) with qualifiers', () => {
     it.each(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])(
       'requires Responses for current tier %s',
@@ -238,6 +267,14 @@ describe('isOpenAICanonicalBaseURL', () => {
 });
 
 describe('toOpenAIResponsesWireEffort', () => {
+  it('maps minimal to low for GPT-6 Astra without changing other efforts', () => {
+    expect(toOpenAIResponsesWireEffort('minimal', 'gpt-6-astra')).toBe('low');
+    for (const effort of ['low', 'medium', 'high', 'xhigh', 'max']) {
+      expect(toOpenAIResponsesWireEffort(effort, 'gpt-6-astra')).toBe(effort);
+    }
+    expect(toOpenAIResponsesWireEffort('minimal', 'gpt-5.6-sol')).toBe('none');
+  });
+
   it.each([
     ['gpt-5.6', 'none'],
     ['gpt-5.6-sol', 'none'],

--- a/packages/providers/src/openai/openaiModelPolicy.ts
+++ b/packages/providers/src/openai/openaiModelPolicy.ts
@@ -8,11 +8,11 @@
  * Pure, providers-owned model/transport policy for OpenAI.
  *
  * This module is the single authority for:
- * - Which model IDs **require** the Responses API (GPT-5.6+ bare and
- *   durable tier aliases on canonical OpenAI).
+ * - Which model IDs **require** the Responses API (GPT-5.6+ dotted IDs,
+ *   durable tier aliases, and sanctioned GPT-6 IDs on canonical OpenAI).
  * - Which model IDs **support** (but do not require) Responses.
- * - Mapping the project-canonical `reasoning.effort=minimal` to the
- *   OpenAI wire value `none` for GPT-5.6+.
+ * - Mapping the project-canonical `reasoning.effort=minimal` to each
+ *   Responses model family's supported wire value.
  *
  * It is used by both the OpenAI Chat-Completions provider (for per-call
  * routing) and the UI info function (getOpenAIProviderInfo) so that UI
@@ -189,6 +189,15 @@ export function isSanctionedGpt56Model(model: string): boolean {
   );
 }
 
+const GPT_6_ASTRA = 'gpt-6-astra';
+
+export function isSanctionedGpt6Model(model: string): boolean {
+  if (!model.startsWith(GPT_6_ASTRA)) {
+    return false;
+  }
+  return isValidQualifier(model.slice(GPT_6_ASTRA.length));
+}
+
 /**
  * Validate that the suffix qualifier (the part after a bare alias or
  * after a tier) is empty, `-latest`, a compact 8-digit date snapshot
@@ -210,7 +219,7 @@ export interface OpenAIModelTransport {
   supportsResponses: boolean;
   /**
    * The model **must** use the Responses API — Chat Completions is not
-   * available for it. GPT-5.6+ bare and tier IDs only.
+   * available for it. GPT-5.6+ dotted IDs, tiers, and sanctioned GPT-6 IDs.
    */
   requiresResponses: boolean;
 }
@@ -219,6 +228,7 @@ export interface OpenAIModelTransport {
  * Parse a model ID to determine its transport policy.
  *
  * Rules:
+ * - Sanctioned `gpt-6-astra` IDs → **require** Responses.
  * - Bare `gpt-X.Y` where X.Y >= 5.6 → **requires** Responses.
  * - `gpt-X.Y-{sol|terra|luna}` where X.Y >= 5.6 → **requires** Responses.
  *   Qualifiers: bare, `-latest`, compact date (`-YYYYMMDD`), or
@@ -227,6 +237,10 @@ export interface OpenAIModelTransport {
  * - Everything else → neither.
  */
 export function parseOpenAIModelTransport(model: string): OpenAIModelTransport {
+  if (isSanctionedGpt6Model(model)) {
+    return { supportsResponses: true, requiresResponses: true };
+  }
+
   const parsed = parseGptModelId(model);
 
   // Not a parseable gpt-X.Y model — check the known pre-5.6 set
@@ -295,14 +309,15 @@ export function isOpenAICanonicalBaseURL(baseURL: string | undefined): boolean {
  * Map the project-canonical `reasoning.effort` value to the OpenAI
  * Responses API wire value for the given model.
  *
- * GPT-5.6 and later renamed the lowest effort level from "minimal" to
- * "none" on the wire. The project setting remains "minimal" for backward
- * compatibility across all providers, so we translate it here.
+ * GPT-5.6 dotted IDs renamed the lowest effort level from "minimal" to
+ * "none" on the wire. GPT-6 Astra instead has a `low` effort floor. The
+ * project setting remains "minimal" for compatibility across providers, so
+ * sanctioned GPT-6 Astra IDs map to `low` while GPT-5.6+ dotted IDs retain
+ * the existing `none` mapping.
  *
- * The mapping applies ONLY to models that require the Responses API
- * — i.e. valid GPT-5.6+ bare/tier IDs with documented qualifiers.
- * Malformed lookalikes (gpt-5.6-mini, gpt-5.6-solar, etc.) are NOT
- * mapped so they cannot accidentally receive the wire value `none`.
+ * The mapping applies only to sanctioned identities with documented
+ * qualifiers. Malformed lookalikes are not mapped to a model-specific wire
+ * value.
  *
  * Pre-5.6 Responses API models (o3, o1, gpt-5.5, etc.) still use
  * "minimal".
@@ -313,6 +328,9 @@ export function toOpenAIResponsesWireEffort(
 ): string {
   if (effort !== 'minimal' || model === undefined) {
     return effort;
+  }
+  if (isSanctionedGpt6Model(model)) {
+    return 'low';
   }
   // Only map for GPT-5.6+ models that require the Responses API.
   const transport = parseOpenAIModelTransport(model);

--- a/packages/providers/src/openai/openaiModelPolicy.ts
+++ b/packages/providers/src/openai/openaiModelPolicy.ts
@@ -198,6 +198,10 @@ export function isSanctionedGpt6Model(model: string): boolean {
   return isValidQualifier(model.slice(GPT_6_ASTRA.length));
 }
 
+export function isSanctionedOpenAIO200kModel(model: string): boolean {
+  return isSanctionedGpt56Model(model) || isSanctionedGpt6Model(model);
+}
+
 /**
  * Validate that the suffix qualifier (the part after a bare alias or
  * after a tier) is empty, `-latest`, a compact 8-digit date snapshot

--- a/packages/providers/src/runtime/providerAliases.codex.contextLimit.integration.test.ts
+++ b/packages/providers/src/runtime/providerAliases.codex.contextLimit.integration.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test';
+import { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { createAgentRuntimeContext } from '@vybestack/llxprt-code-core/runtime/createAgentRuntimeContext.js';
+import type {
+  AgentRuntimeProviderAdapter,
+  ReadonlySettingsSnapshot,
+} from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
+import type { AgentRuntimeState } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeState.js';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { resetProviderManager } from '../composition/providerManagerInstance.js';
+import { assembleCliProviderRuntime } from './assembleCliProviderRuntime.js';
+import { setActiveModel } from './providerMutations.js';
+import { switchActiveProvider } from './providerSwitch.js';
+import { disposeCliRuntime } from './runtimeRegistry.js';
+
+const RUNTIME_ID = 'issue3576-codex-context-limit';
+
+function requireProviderName(config: Config): string {
+  const provider = config.getProvider();
+  if (provider === undefined) {
+    throw new Error('runtime config has no active provider');
+  }
+  return provider;
+}
+
+function liveContextLimitSettings(config: Config): ReadonlySettingsSnapshot {
+  return {
+    get contextLimit(): number | undefined {
+      const value = config.getEphemeralSetting('context-limit');
+      return typeof value === 'number' ? value : undefined;
+    },
+  };
+}
+
+describe('Codex effective context limit runtime integration', () => {
+  afterEach(() => {
+    disposeCliRuntime(RUNTIME_ID);
+    resetProviderManager();
+  });
+
+  it('updates the live effective limit across Astra, Sol, and Spark model selection', async () => {
+    const settingsService = new SettingsService();
+    const config = new Config({
+      sessionId: 'issue3576-session',
+      targetDir: process.cwd(),
+      debugMode: false,
+      cwd: process.cwd(),
+      model: 'gpt-5.6-sol',
+      settingsService,
+    });
+    const assembled = assembleCliProviderRuntime({
+      settingsService,
+      config,
+      runtimeId: RUNTIME_ID,
+      oauthSettings: null,
+    });
+
+    await switchActiveProvider('codex');
+
+    const state: AgentRuntimeState = {
+      runtimeId: RUNTIME_ID,
+      sessionId: 'issue3576-session',
+      updatedAt: Date.now(),
+      get provider(): string {
+        return requireProviderName(config);
+      },
+      get model(): string {
+        return config.getModel();
+      },
+    };
+    const provider: AgentRuntimeProviderAdapter = {
+      getActiveProvider: () => {
+        const activeProvider = assembled.providerManager.getActiveProvider();
+        if (activeProvider === undefined) {
+          throw new Error('provider manager has no active provider');
+        }
+        return activeProvider;
+      },
+      setActiveProvider: () => undefined,
+    };
+    const context = createAgentRuntimeContext({
+      state,
+      settings: liveContextLimitSettings(config),
+      provider,
+      telemetry: {
+        logApiRequest: () => undefined,
+        logApiResponse: () => undefined,
+        logApiError: () => undefined,
+      },
+      tools: {
+        listToolNames: () => [],
+        getToolMetadata: () => undefined,
+      },
+      providerRuntime: assembled.runtime,
+    });
+
+    await setActiveModel('gpt-6-astra');
+    expect(context.ephemerals.contextLimit()).toBe(872000);
+
+    await setActiveModel('gpt-5.6-sol');
+    expect(context.ephemerals.contextLimit()).toBe(262144);
+
+    await setActiveModel('gpt-5.3-codex-spark');
+    expect(context.ephemerals.contextLimit()).toBe(131072);
+  });
+});

--- a/packages/providers/src/runtime/providerManagerRuntimeFactories.test.ts
+++ b/packages/providers/src/runtime/providerManagerRuntimeFactories.test.ts
@@ -207,6 +207,150 @@ describe('configureProviderRuntimeFactories', () => {
     ).toBe(10);
   });
 
+  it('prepares GPT-6 Astra for exact o200k runtime counting and prompt estimation', async () => {
+    const factory = createRuntimeTokenizerFactory();
+    const prepareTokenizer = factory.prepareTokenizer;
+    if (prepareTokenizer === undefined) {
+      throw new Error('runtime tokenizer factory has no readiness operation');
+    }
+
+    await prepareTokenizer('codex', 'gpt-6-astra');
+    const tokenizer = factory.getTokenizer('codex', 'gpt-6-astra');
+    const estimate = await factory.estimatePrompt({
+      activeProvider: 'codex',
+      canonicalModel: 'gpt-6-astra',
+      protocol: 'openai-responses',
+      wireMethod: 'responses/v1',
+      finalizedProjection: {
+        kind: 'llxprt-provider-prompt-v3',
+        protocol: 'openai-responses',
+        promptText: 'The quick brown fox jumps over the lazy dog.',
+      },
+      projectionRevision: 3,
+      legacyEstimate: () => Promise.resolve(999),
+    });
+
+    expect(tokenizer?.fallbackPolicy).toBe('deny');
+    expect(
+      await tokenizer?.countTokens(
+        'The quick brown fox jumps over the lazy dog.',
+      ),
+    ).toBe(10);
+    expect(estimate).toMatchObject({
+      count: 10,
+      method: 'exact',
+      family: 'openai-gpt-5.6',
+    });
+  });
+
+  it('shares the injected o200k resolver across Astra readiness, runtime counting, and final estimation', async () => {
+    const injectedCount = 29;
+    let loadCount = 0;
+    const loadModule: TiktokenModuleLoader = async () => {
+      loadCount += 1;
+      const tiktoken = await import('@dqbd/tiktoken');
+      return {
+        ...tiktoken,
+        get_encoding: (...args: Parameters<typeof tiktoken.get_encoding>) =>
+          new Proxy(tiktoken.get_encoding(...args), {
+            get(target, property, receiver) {
+              if (property === 'encode') {
+                return (): Uint32Array =>
+                  Uint32Array.from(
+                    { length: injectedCount },
+                    (_unused, index) => index,
+                  );
+              }
+              return Reflect.get(target, property, receiver);
+            },
+          }),
+      };
+    };
+    const factory = createRuntimeTokenizerFactory(loadModule);
+    const prepareTokenizer = factory.prepareTokenizer;
+    if (prepareTokenizer === undefined) {
+      throw new Error('runtime tokenizer factory has no readiness operation');
+    }
+
+    await prepareTokenizer('codex', 'gpt-6-astra');
+    const runtimeCount = await factory
+      .getTokenizer('codex', 'gpt-6-astra')
+      ?.countTokens('The quick brown fox jumps over the lazy dog.');
+    const estimate = await factory.estimatePrompt({
+      activeProvider: 'codex',
+      canonicalModel: 'gpt-6-astra',
+      protocol: 'openai-responses',
+      wireMethod: 'responses/v1',
+      finalizedProjection: {
+        kind: 'llxprt-provider-prompt-v3',
+        protocol: 'openai-responses',
+        promptText: 'The quick brown fox jumps over the lazy dog.',
+      },
+      projectionRevision: 3,
+      legacyEstimate: () => Promise.resolve(999),
+    });
+
+    expect(runtimeCount).toBe(injectedCount);
+    expect(estimate).toMatchObject({
+      count: injectedCount,
+      method: 'exact',
+      family: 'openai-gpt-5.6',
+    });
+    expect(loadCount).toBe(1);
+  });
+
+  it('fails Astra preparation when the shared o200k codec cannot initialize', async () => {
+    const loaderFailure = new Error('Astra codec initialization exploded');
+    const factory = createRuntimeTokenizerFactory(() =>
+      Promise.reject(loaderFailure),
+    );
+    const prepareTokenizer = factory.prepareTokenizer;
+    if (prepareTokenizer === undefined) {
+      throw new Error('runtime tokenizer factory has no readiness operation');
+    }
+
+    const error = await captureRejection(
+      prepareTokenizer('codex', 'gpt-6-astra'),
+    );
+
+    expect(error).toBeInstanceOf(ModelPromptEstimatorError);
+    expect(error).toMatchObject({
+      code: 'asset-unavailable',
+      context: {
+        activeProvider: 'codex',
+        canonicalModel: 'gpt-6-astra',
+        protocol: 'openai-responses',
+        family: 'openai-gpt-5.6',
+      },
+      cause: loaderFailure,
+    });
+  });
+
+  it('prepares sanctioned Astra identities without preparing or claiming lookalikes', async () => {
+    let loadCount = 0;
+    const loadModule: TiktokenModuleLoader = async () => {
+      loadCount += 1;
+      return import('@dqbd/tiktoken');
+    };
+    const factory = createRuntimeTokenizerFactory(loadModule);
+    const prepareTokenizer = factory.prepareTokenizer;
+    if (prepareTokenizer === undefined) {
+      throw new Error('runtime tokenizer factory has no readiness operation');
+    }
+
+    await prepareTokenizer('codex', 'gpt-6-astral');
+    await prepareTokenizer('codex', 'gpt-6-astra-mini');
+
+    expect(loadCount).toBe(0);
+    expect(factory.claimsModel?.('gpt-6-astral')).toBe(false);
+    expect(factory.claimsModel?.('gpt-6-astra-mini')).toBe(false);
+
+    await prepareTokenizer('codex', 'gpt-6-astra-latest');
+
+    expect(loadCount).toBe(1);
+    expect(factory.claimsModel?.('gpt-6-astra-latest')).toBe(true);
+  });
+
   it('does not load the GPT-5.6 encoder while preparing another model', async () => {
     const loaderFailure = new Error('GPT codec loader must remain unused');
     const factory = createRuntimeTokenizerFactory(() =>

--- a/packages/providers/src/tokenizers/Gpt56O200kPromptEstimator.test.ts
+++ b/packages/providers/src/tokenizers/Gpt56O200kPromptEstimator.test.ts
@@ -200,13 +200,28 @@ describe('ModelPromptEstimatorRegistry', () => {
     'gpt-5.6-sol',
     'gpt-5.6-terra-latest',
     'gpt-5.6-luna-2026-01-15',
+    'gpt-6-astra',
+    'gpt-6-astra-latest',
+    'gpt-6-astra-20260903',
+    'gpt-6-astra-2026-09-03',
   ])(
     'registers sanctioned identity %s independently of provider name',
     async (model) => {
       const result = await registry.estimatePrompt(request(model));
       expect(result.method).toBe('exact');
+      expect(registry.claimsModel(model)).toBe(true);
     },
   );
+
+  it.each([
+    'gpt-6',
+    'gpt-6-astral',
+    'gpt-6-astra-mini',
+    'gpt-6-astra-solar',
+    'gpt-6-astra-2026-02-30',
+  ])('leaves GPT-6 Astra lookalike %s unclaimed', (model) => {
+    expect(registry.claimsModel(model)).toBe(false);
+  });
 
   it('uses the explicit legacy path for unregistered families', async () => {
     const input = request('gpt-4.1');

--- a/packages/providers/src/tokenizers/ModelPromptEstimatorRegistry.ts
+++ b/packages/providers/src/tokenizers/ModelPromptEstimatorRegistry.ts
@@ -10,7 +10,10 @@ import type {
 } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeTokenizerFactory.js';
 import type { PromptEnvelopeProtocol } from '@vybestack/llxprt-code-core/runtime/contracts/PromptEstimation.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
-import { isSanctionedGpt56Model } from '../openai/openaiModelPolicy.js';
+import {
+  isSanctionedGpt56Model,
+  isSanctionedGpt6Model,
+} from '../openai/openaiModelPolicy.js';
 import {
   createGpt56PromptEstimator,
   estimateGpt56Prompt,
@@ -47,11 +50,16 @@ export interface ModelPromptEstimatorRegistration {
   ) => Promise<RuntimePromptEstimateResult>;
 }
 
+function isSanctionedO200kModel(model: string): boolean {
+  return isSanctionedGpt56Model(model) || isSanctionedGpt6Model(model);
+}
+
 export const GPT_56_PROMPT_ESTIMATOR_REGISTRATION: ModelPromptEstimatorRegistration =
   Object.freeze({
     family: GPT_56_ESTIMATOR_FAMILY,
-    claim: /^gpt-(?:0*5\.0*6)(?:$|-)/,
-    matches: isSanctionedGpt56Model,
+    claim:
+      /^gpt-(?:0*5\.0*6(?:$|-)|6-astra(?:$|-(?:latest|\d{8}|\d{4}-\d{2}-\d{2})$))/,
+    matches: isSanctionedO200kModel,
     protocols: new Set<PromptEnvelopeProtocol>([
       'openai-chat',
       'openai-responses',
@@ -211,7 +219,15 @@ export class ModelPromptEstimatorRegistry {
   }
 
   getEstimatorFamily(canonicalModel: string): string | undefined {
-    return findClaim(canonicalModel, this.registrations)?.family;
+    const registration = findClaim(canonicalModel, this.registrations);
+    if (
+      registration === undefined ||
+      (!registration.matches(canonicalModel) &&
+        registration.matchesPointRelease?.(canonicalModel) !== true)
+    ) {
+      return undefined;
+    }
+    return registration.family;
   }
 
   async estimatePrompt(

--- a/packages/providers/src/tokenizers/ModelPromptEstimatorRegistry.ts
+++ b/packages/providers/src/tokenizers/ModelPromptEstimatorRegistry.ts
@@ -10,10 +10,7 @@ import type {
 } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeTokenizerFactory.js';
 import type { PromptEnvelopeProtocol } from '@vybestack/llxprt-code-core/runtime/contracts/PromptEstimation.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/index.js';
-import {
-  isSanctionedGpt56Model,
-  isSanctionedGpt6Model,
-} from '../openai/openaiModelPolicy.js';
+import { isSanctionedOpenAIO200kModel } from '../openai/openaiModelPolicy.js';
 import {
   createGpt56PromptEstimator,
   estimateGpt56Prompt,
@@ -50,16 +47,12 @@ export interface ModelPromptEstimatorRegistration {
   ) => Promise<RuntimePromptEstimateResult>;
 }
 
-function isSanctionedO200kModel(model: string): boolean {
-  return isSanctionedGpt56Model(model) || isSanctionedGpt6Model(model);
-}
-
 export const GPT_56_PROMPT_ESTIMATOR_REGISTRATION: ModelPromptEstimatorRegistration =
   Object.freeze({
     family: GPT_56_ESTIMATOR_FAMILY,
     claim:
       /^gpt-(?:0*5\.0*6(?:$|-)|6-astra(?:$|-(?:latest|\d{8}|\d{4}-\d{2}-\d{2})$))/,
-    matches: isSanctionedO200kModel,
+    matches: isSanctionedOpenAIO200kModel,
     protocols: new Set<PromptEnvelopeProtocol>([
       'openai-chat',
       'openai-responses',

--- a/project-plans/issue3576.md
+++ b/project-plans/issue3576.md
@@ -140,6 +140,24 @@ for each new behavior before its implementation.
   `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
   `npm run build`, then
   `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.
+- 2026-09-06 post-crash cycle results: test/lint/typecheck/format/build all
+  ran; see the environment-failure record below for the test exceptions.
+  The smoke test is currently BLOCKED by sandbox host infrastructure, not
+  code: the host-side credential proxy died with the crash
+  (`/tmp/llxprt-credential.sock` is a stale socket — connect fails with
+  "No such device or address"), so `auth-key-name 'stepfun'` cannot resolve.
+  The identical failure occurs on the `main` worktree, and
+  `bun scripts/start.ts --version` boots cleanly (0.11.0) on this branch, so
+  startup, config validation, and profile load all work; only the
+  credential-dependent API round-trip is impossible until the host proxy is
+  restored. Additionally, the first smoke attempt failed on
+  `Unrecognized key(s) in object: 'logConversations'` because a full-suite
+  CLI test had written `{"telemetry":{"logConversations":true}}` into the
+  real user-global settings.json (written 15:50 during the test phase),
+  and the settings-package startup validation rejects a key that core's
+  TelemetrySettings defines — both trees fail identically on that too; the
+  local settings file was reset to `{}` to unblock. Follow-up issues filed
+  for the schema drift and the test pollution.
 - `bun scripts/test-audit/scan.ts` self-check on touched test files: no new
   MOCK_MIRROR / ALWAYS_TRUE / SELF_CONFIRMING / NO_ASSERT findings versus a
   main-baseline scan diff.
@@ -148,6 +166,76 @@ for each new behavior before its implementation.
   in-process interference between `providerAliases.mediaSupport.test.ts` and
   `providerAliases.unallowedParameters.test.ts` (run per-file). Anything else
   red must be reproduced and fixed, never assumed unrelated.
+
+### Local sandbox environment failures (2026-09-06 full-cycle, proven pre-existing on main)
+
+The post-crash full `npm run test` run had failures beyond the known flakes.
+Each was reproduced on a clean `main` worktree (`tmp/main3576`, own `bun
+install`) in this same sandbox and failed identically there, so none are
+caused by this branch:
+
+- `packages/storage/src/secure-store/secure-store.native-keyring.test.ts` —
+  requires a real OS keyring; this sandbox has none
+  (`SecureStoreError: Platform failure: Unknown(38)`). CI runs it only on
+  Ubuntu with a keyring backend installed
+  (`packages/storage` `test:secure-store:keyring` + nightly.yml).
+- `packages/providers/src/auth/` 8 files (4 behavioral specs,
+  `oauthManager.proactive-renewal`, 2 proactive-renewal specs,
+  `proxy/factory-detection-wiring`) — pass per-file in isolation on both
+  trees; fail inside the full providers suite run on BOTH branch and main
+  with identical signatures (proactive-renewal timer spies never called).
+  Main's full providers run failed exactly the same 8 files.
+- `packages/cli`: `docsCommand.test.ts` (sandbox detection changes the
+  info message; test asserts the non-sandbox text), `Footer.responsive`
+  (2), `sandbox-node-modules-preflight` (1), `cli-args.integration` (2) —
+  each fails identically on main in isolation in this sandbox.
+- `packages/vscode-ide-companion` — Bun 1.3.14 internal error ("directory
+  mismatch for tsconfig.bun-test.json ... indicates a bug"); 0 test
+  failures. Tooling, not code.
+
+All branch-owned test files (codex alias, factory, policy, estimator,
+unallowedParameters, contextLimit integration, oauthRegistration,
+runtimeFactories, executor suites) passed in the full run. Evidence logs:
+`tmp/verify3576/` (test.log, main-providers-suite.log, per-file
+branch-/main-*.log).
+
+## Review record and remediation (2026-09-06)
+
+Deepthinker review round 1 found one HIGH and two MEDIUM issues; all three
+were remediated and verified with targeted per-file test runs:
+
+1. HIGH — the `unallowedParameters` alias rule was enforced only in the UI
+   layer (`runtimeAccessors.ts` model-config dialog path); the codex
+   Responses executor forwarded `temperature` and the other sampling keys on
+   the wire. Fix: `applyCodexRequestSettings` in
+   `openAIResponsesExecutor.ts` strips request keys via an injected
+   `getUnallowedModelParameters(model)` resolver; the alias factory passes
+   the entry's `modelDefaults` rules into `OpenAIProvider` and
+   `OpenAIResponsesProvider` constructors, which capture the rules once at
+   construction (no per-request alias-file reload; the initial draft called
+   `loadProviderAliasEntries()` per request and was corrected before
+   commit). Plain (non-alias) providers get an empty rule set, so canonical
+   OpenAI behavior is unchanged; a mirror test asserts sampling parameters
+   survive on plain OpenAI.
+2. MEDIUM — the runtime tokenizer factory restricted o200k prepare/select to
+   `isSanctionedGpt56Model`, so `gpt-6-astra` fell through to the
+   OpenAITokenizer adapter with a silent char-based fallback. Fix: shared
+   `isSanctionedOpenAIO200kModel` (= GPT-5.6 or GPT-6 sanctioned identity)
+   used by both the factory and the estimator registry; the registry keeps a
+   single widened o200k registration (no duplicate GPT-5.6 entry).
+3. MEDIUM — effective-context coverage was config-level only. Fix:
+   `providerAliases.codex.contextLimit.integration.test.ts` drives the live
+   provider-switch path and asserts 872000 (astra) vs 262144 (sol) vs 131072
+   (spark, now pinned by an explicit `^gpt-5\.3-codex-spark$` context-limit
+   rule); `providerManagerRuntimeFactories.test.ts` gained factory-level
+   coverage.
+
+Post-remediation machine cycle found and fixed three mechanical issues:
+constructor-arity assertions in `providerManagerInstance.oauthRegistration.test.ts`
+(4th/5th constructor args), two TS2345 type errors in the new test files
+(bun test does not typecheck), and two `max-lines` violations resolved by
+extracting the duplicated resolver closure into
+`openai-responses/unallowedModelParameters.ts`.
 
 ## Out of scope / follow-ups
 

--- a/project-plans/issue3576.md
+++ b/project-plans/issue3576.md
@@ -237,8 +237,60 @@ constructor-arity assertions in `providerManagerInstance.oauthRegistration.test.
 extracting the duplicated resolver closure into
 `openai-responses/unallowedModelParameters.ts`.
 
+## CodeRabbit round and crash recovery (2026-09-06 evening)
+
+CodeRabbit reviewed f4765f865b and opened three threads (one Major, two
+Minor). The system crashed mid-remediation; the branch survived with the
+fixes written but uncommitted, and the sandbox lost its root `node_modules`
+(restored with plain `bun install`, exit 0). The recovered remediation was
+re-verified end-to-end and pushed:
+
+1. **Major** — the `gpt-6` `unallowedParameters` rule used a loose `^gpt-6`
+   prefix, so any resolved codex model beginning with `gpt-6` (custom or
+   lookalike ids included) would get sampling parameters deleted on the wire.
+   Fixed: the rule now uses the anchored sanctioned pattern.
+2. **Minor** — the `^gpt-6-astra` context-limit prefix also matched
+   lookalikes (`computeModelDefaults` applies patterns case-insensitively,
+   so `gpt-6-astral` / `gpt-6-astra-mini` matched). Fixed: both gpt-6 rules
+   use `^gpt-6-astra(?:-(?:latest|[0-9]{8}|[0-9]{4}-[0-9]{2}-[0-9]{2}))?$`.
+3. **Minor** — quick-reference wording could imply Astra changes the alias
+   default. Fixed: `gpt-5.6-sol` stated as the unconditional default; Astra
+   is an explicit selection for accounts with access.
+
+New behavioral test in `providerAliases.codex.test.ts` covers the sanctioned
+matrix (bare / `-latest` / compact date / hyphenated date → context-limit
+872000 + full sampling strip) and lookalikes (`gpt-6-astral`, `-mini`,
+`-solar`, bare `gpt-6`, `gpt-6-turbo` → no rule effects, provider default
+262144), with `gpt-5.6-sol` and `gpt-5.3-codex-spark` regression guards.
+
+Post-crash verification cycle: targeted per-file runs green for all six
+touched-area suites (codex 16, factory 8, contextLimit integration 1,
+unallowedParameters 4, openaiModelPolicy 150, estimator 42). Full cycle:
+test exit 1 with only environment-classified failures (see below); lint,
+typecheck, format, build all exit 0. Cycle-generated `bun.lock`
+re-normalization and `NOTICES.txt` CRLF churn were reverted as artifacts.
+Evidence: `tmp/verify3576/post-crash-*`.
+
+Two environment failures appeared that were NOT in the earlier documented
+set; both reproduced identically per-file on the clean main worktree
+(`tmp/main3576` @ 72ea679a5f) in the same sandbox, so they are
+crash-environment fallout, not branch regressions — filed as #3586
+(gitService: checkpoint tests don't provision the persistent checkpoint-store
+marker their fake HOME needs) and #3585 (editor "not in sandbox mode" cases
+don't control the sandbox-detection signal).
+
+Smoke test: still blocked by host credential infrastructure, new variant —
+the proxy socket is back (recreated 2026-09-06 20:50) but auth fails with
+`Invalid or missing capability token`, and no capability dir exists in this
+sandbox; identical on main. `bun scripts/start.ts --version` boots 0.11.0.
+CI startup coverage remains green on GitHub runners.
+
 ## Out of scope / follow-ups
 
+- Sandbox-environment test failures documented above, filed during this
+  effort: #3581 (integration test writes fixture settings into the real
+  global config dir), #3582 (`telemetry.logConversations` schema drift),
+  #3585, #3586.
 - Flipping `defaultModel` to `gpt-6-astra` once rollout is generally
   available.
 - Long-context surcharge/pricing metadata beyond context length.

--- a/project-plans/issue3576.md
+++ b/project-plans/issue3576.md
@@ -1,0 +1,160 @@
+# Issue 3576 Plan — Add gpt-6-astra (codex OAuth alias + shared OpenAI surfaces)
+
+Generated: 2026-09-05
+Branch: `issue3576`
+Issue: https://github.com/vybestack/llxprt-code/issues/3576
+
+## Accepted behavior
+
+1. The `codex` provider alias lists `gpt-6-astra` as a static model with
+   `contextWindow: 872000` and display name `GPT-6 Astra`.
+2. The effective context limit for `codex:gpt-6-astra` resolves to `872000`
+   through a per-model `modelDefaults` rule (pattern `^gpt-6-astra`, ephemeral
+   `context-limit: 872000`), following the per-model context-limit precedent
+   already shipped in the kimi and anthropic alias configs. The provider-level
+   `context-limit: 262144` in `codex.config` ephemeralSettings is unchanged, so
+   every existing model keeps its current budget (gpt-5.6 tiers stay 262144,
+   gpt-5.3-codex-spark stays 131072).
+3. Sampling parameters (`temperature`, `top_p`, `top_k`,
+   `frequency_penalty`, `presence_penalty`) are stripped for `gpt-6-astra`
+   under the codex alias via a `gpt-6` `modelDefaults` rule carrying the same
+   `unallowedParameters` list as the existing `gpt-5` rule (Astra is a
+   reasoning model; those parameters are not accepted).
+4. `defaultModel` stays `gpt-5.6-sol`. Astra's rollout is staged via Trusted
+   Access; flipping the default would break sessions on accounts without
+   access.
+5. On the plain `openai` (API-key) provider, `gpt-6-astra` is classified as
+   **Responses-required** on the canonical OpenAI base URL. Sanctioned GPT-6
+   identity accepts `gpt-6-astra` plus documented qualifiers (`-latest`,
+   compact `YYYYMMDD`, hyphenated `YYYY-MM-DD` snapshots) and rejects
+   lookalikes (`gpt-6-astral`, `gpt-6-astra-mini`, `gpt-6-astra-solar`, bare
+   `gpt-6`, malformed dates), mirroring the GPT-5.6 identity tests.
+6. The project-canonical `reasoning.effort=minimal` maps to wire value `low`
+   for sanctioned GPT-6 models — never `none` (Astra's effort floor is `low`;
+   it has no `minimal`/`none` level). All other effort values (`low`, `medium`,
+   `high`, `xhigh`, `max`) pass through unchanged. The existing
+   minimal→`none` mapping for GPT-5.6+ dotted IDs is untouched.
+7. The o200k prompt-estimator family claims `gpt-6-astra` (and its sanctioned
+   qualifiers) so prompt token estimation works instead of failing with
+   `asset-unavailable` (issue #3217 precedent); lookalikes remain unclaimed.
+8. OpenAI fallback model lists include `gpt-6-astra`
+   (`RESPONSES_API_MODELS.ts`, `openAIFallbackModels.ts`).
+9. Docs mention `gpt-6-astra` with the 872000 OAuth context and its effort
+   levels: `docs/providers/models-and-limits.md`,
+   `docs/providers/quick-reference.md`, `docs/cli/providers.md`.
+
+## Model facts and the OAuth context decision
+
+- Model string: `gpt-6-astra` (identical on the OpenAI API, Amazon Bedrock,
+  and the Codex backend). Released 2026-09-03, staged GA (Trusted Access
+  first, then Plus/Pro/Business/Enterprise and API).
+- API (key auth) window: 1,050,000 total / 922,000 max input / 128,000 max
+  output. Efforts: low, medium, high, xhigh, max (API default low). Text +
+  image input, text output.
+- OAuth (chatgpt.com/backend-api/codex) window: the ChatGPT backend is
+  catalog-driven and enforces product caps below the API window. Verified by
+  testing in Codex (anomalyco/opencode#46527): 1,000,000-token total context
+  on OAuth, leaving an 872,000-token input budget with 128,000 reserved for
+  output. openai/codex#39102 raised the GPT-5.6 `max_context_window`
+  override ceiling to 872,000 and openai/codex#41325 proved the remote
+  catalog clamps larger client-side values server-side. Shipping third-party
+  Codex configurations for Astra use `model_context_window = 872000`.
+- Decision: `872000` is the default context for `gpt-6-astra` under the codex
+  alias. `1,050,000` must NOT be used — that is the API-key window, not the
+  OAuth one.
+
+## Changes
+
+### `packages/providers/src/composition/aliases/codex.config`
+
+- `staticModels`: prepend `{ "id": "gpt-6-astra", "name": "GPT-6 Astra",
+  "contextWindow": 872000 }`.
+- `modelDefaults`: add a `^gpt-6-astra` rule with
+  `ephemeralSettings: { "context-limit": 872000 }` and a `gpt-6` rule
+  (anchored like the existing `^gpt-` rule for consistency; must match
+  `gpt-6-astra` and sanctioned GPT-6 ids but not `gpt-5.6-sol`) with the same
+  `unallowedParameters` array as the `gpt-5` rule. Keep existing rules and
+  the provider-level `context-limit: 262144` untouched.
+
+### `packages/providers/src/openai/openaiModelPolicy.ts`
+
+- Add a sanctioned GPT-6 identity (e.g. `isSanctionedGpt6Model`): anchored
+  `gpt-6-astra` prefix with qualifier validation reusing
+  `isValidQualifier`/snapshot-date helpers (bare, `-latest`, compact or
+  hyphenated date). `gpt-6-astra` does not parse as `gpt-MAJOR.MINOR`, so
+  `parseOpenAIModelTransport` must return
+  `{ supportsResponses: true, requiresResponses: true }` for it.
+- `toOpenAIResponsesWireEffort`: for sanctioned GPT-6 models, map `minimal` →
+  `low`. Keep the GPT-5.6 dotted-family `minimal` → `none` mapping unchanged.
+- Do not sanction bare `gpt-6` or any non-astra GPT-6 id.
+
+### `packages/providers/src/tokenizers/ModelPromptEstimatorRegistry.ts` (+ `Gpt56O200kPromptEstimator.ts` if the claim/identity helpers live there)
+
+- The GPT-5.6 o200k registration claims via `isSanctionedGpt56Model`; extend
+  the claim and `matches` to also accept sanctioned GPT-6 ids so the same
+  o200k estimator family covers `gpt-6-astra`. Preserve the "exactly one
+  GPT-5.6 entry, never duplicated" invariant the registry tests assert —
+  widen the existing registration rather than adding a second one that would
+  double-claim.
+
+### Fallback lists
+
+- `packages/providers/src/openai/RESPONSES_API_MODELS.ts`: add `'gpt-6-astra'`
+  at the top of the list.
+- `packages/providers/src/openai/openAIFallbackModels.ts`: add
+  `{ id: 'gpt-6-astra', name: 'GPT-6 Astra' }` at the top of
+  `FALLBACK_MODEL_SPECS`.
+
+### Docs
+
+- `docs/providers/models-and-limits.md`: codex table row/common-models note
+  for `gpt-6-astra` (872000 OAuth context).
+- `docs/providers/quick-reference.md`: mention `gpt-6-astra` where the codex
+  Responses models are listed.
+- `docs/cli/providers.md`: quick-reference table mentions the newest codex
+  model.
+
+## Test-first sequence and behavioral mapping
+
+All tests are TS/Bun (`bun:test`), co-located, behavioral (no mock theater;
+assert real transformations through real code paths). RED must be confirmed
+for each new behavior before its implementation.
+
+| # | Failing behavioral test (RED) | Implementation response (GREEN) |
+| --- | --- | --- |
+| A | `providerAliases.codex.test.ts`: codex config has staticModel `gpt-6-astra` with `contextWindow: 872000`; provider-level ephemeral `context-limit` is still 262144; `defaultModel` is still `gpt-5.6-sol`. | codex.config staticModels entry. |
+| B | `providerAliases.codex.test.ts` (or `.factory` sibling): `computeModelDefaults('gpt-6-astra', rules)` yields `context-limit: 872000` and no other model (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.3-codex-spark`) gains a `context-limit` override; sampling params are in the unallowed union for `gpt-6-astra` but rules leave `gpt-5.6-sol` behavior identical. | modelDefaults `^gpt-6-astra` context-limit rule + `gpt-6` unallowedParameters rule. |
+| C | `providerAliases.codex.factory.test.ts`: alias factory `getModels()` returns the new static model id in order; effective context resolution for the alias produces 872000 for astra while the existing 262144 spark/tier assertions still pass. | staticModels flows through the alias factory unchanged. |
+| D | `openaiModelPolicy.test.ts`: `parseOpenAIModelTransport('gpt-6-astra')` → requires Responses; sanctioned qualifiers (`-latest`, both date shapes) accepted; lookalikes (`gpt-6-astral`, `gpt-6-astra-mini`, `gpt-6-astra-solar`, `gpt-6`, bad dates) rejected. | Sanctioned GPT-6 identity in `openaiModelPolicy.ts`. |
+| E | `openaiModelPolicy.test.ts` (+ `OpenAIResponsesProvider.reasoningEffort.test.ts` where the wire mapping is exercised): `toOpenAIResponsesWireEffort('minimal', 'gpt-6-astra')` → `'low'`; `'medium'/'high'/'xhigh'/'max'` pass through; `('minimal', 'gpt-5.6-sol')` still → `'none'`. | GPT-6 branch in `toOpenAIResponsesWireEffort`. |
+| F | Estimator registry test (extend `Gpt56O200kPromptEstimator.test.ts`): registry claims `gpt-6-astra` (+ qualifiers) with the o200k family and `estimatePrompt` counts through the real estimator for `gpt-6-astra`; lookalikes stay unclaimed. | Widened o200k registration claim/matches. |
+| G | Fallback-list tests: `RESPONSES_API_MODELS` contains `gpt-6-astra`; `getOpenAIFallbackModels('x')` includes it (extend the existing model-list tests rather than adding new files where neighbors exist). | Fallback list additions. |
+| H | Effective-limit integration: extend the context-limit/effective-limit tests to prove `codex:gpt-6-astra` resolves to 872000 with the modelDefaults rule applied, while `codex:gpt-5.6-sol` still resolves to 262144. | No new production code — proves the config wiring end-to-end. |
+
+## Verification
+
+- Per-file targeted runs for every touched test file (each in its own Bun
+  process, matching the repo runner design), repeated runs for the alias
+  config tests.
+- Full cycle on the final tree:
+  `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+  `npm run build`, then
+  `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.
+- `bun scripts/test-audit/scan.ts` self-check on touched test files: no new
+  MOCK_MIRROR / ALWAYS_TRUE / SELF_CONFIRMING / NO_ASSERT findings versus a
+  main-baseline scan diff.
+- Pre-existing known flakes are not ours: darwin-only
+  `sandbox-seatbelt.test.ts` port-contention flake (#3548) and the
+  in-process interference between `providerAliases.mediaSupport.test.ts` and
+  `providerAliases.unallowedParameters.test.ts` (run per-file). Anything else
+  red must be reproduced and fixed, never assumed unrelated.
+
+## Out of scope / follow-ups
+
+- Flipping `defaultModel` to `gpt-6-astra` once rollout is generally
+  available.
+- Long-context surcharge/pricing metadata beyond context length.
+- Astra Pro variants (`gpt-6-astra-pro`) — no sanctioned id yet; deliberately
+  rejected as lookalikes for now.
+- Experimental cross-window context management (Codex `context_management`
+  feature) — client-side opt-in, server-driven; nothing to configure here.

--- a/project-plans/issue3576.md
+++ b/project-plans/issue3576.md
@@ -157,7 +157,7 @@ for each new behavior before its implementation.
   and the settings-package startup validation rejects a key that core's
   TelemetrySettings defines — both trees fail identically on that too; the
   local settings file was reset to `{}` to unblock. Follow-up issues filed
-  for the schema drift and the test pollution.
+  for the schema drift (#3582) and the test pollution (#3581).
 - `bun scripts/test-audit/scan.ts` self-check on touched test files: no new
   MOCK_MIRROR / ALWAYS_TRUE / SELF_CONFIRMING / NO_ASSERT findings versus a
   main-baseline scan diff.


### PR DESCRIPTION
## TLDR

Adds first-class `gpt-6-astra` support (OpenAI GPT-6 Astra, released 2026-09-03) to the `codex` provider alias (ChatGPT OAuth backend) and every shared OpenAI surface that classifies, routes, or estimates models, so users can select it today. The OAuth backend enforces a 1,000,000-token total window with 128,000 reserved for output, so the codex alias defaults `gpt-6-astra` to an **872000** context (the API-key window of 1,050,000 is deliberately NOT used — see Dive Deeper).

Fixes #3576.

## Dive Deeper

### Model surfaces

- `codex.config`: static model `gpt-6-astra` (`GPT-6 Astra`, contextWindow 872000), a per-model `context-limit: 872000` rule anchored to the sanctioned id set, and an `unallowedParameters` rule (same sanctioned anchor) carrying the same list as `gpt-5` (Astra is a reasoning model: `temperature`, `top_p`, `top_k`, `frequency_penalty`, `presence_penalty` must never be sent). `defaultModel` stays `gpt-5.6-sol` because Astra's rollout is staged via Trusted Access; `gpt-5.3-codex-spark` is now pinned by an explicit 131072 context-limit rule.
- `openaiModelPolicy.ts`: new sanctioned GPT-6 identity (`isSanctionedGpt6Model` + shared `isSanctionedOpenAIO200kModel`). `gpt-6-astra` does not parse as `gpt-MAJOR.MINOR`, so without this it fell through to Chat Completions on the plain `openai` provider; it is now classified Responses-required, with documented `-latest`/date-snapshot qualifiers accepted and lookalikes (`gpt-6-astral`, `gpt-6-astra-mini`, bare `gpt-6`, bad dates) rejected. `toOpenAIResponsesWireEffort` maps canonical `minimal` → `low` for GPT-6 (Astra's floor is `low`; it has no `none`), leaving the GPT-5.6 `minimal` → `none` mapping untouched.
- Tokenizers: the o200k runtime tokenizer factory and the prompt-estimator registry both claim via the shared `isSanctionedOpenAIO200kModel`, so `gpt-6-astra` gets real o200k prompt estimation (issue #3217 precedent) instead of an `asset-unavailable` failure. The registry keeps a single widened registration (no duplicate GPT-5.6 entry).
- Fallback lists: `RESPONSES_API_MODELS.ts` and `openAIFallbackModels.ts` include `gpt-6-astra`.
- Docs: `docs/providers/models-and-limits.md`, `docs/providers/quick-reference.md`, `docs/cli/providers.md`.

### Enforcement moved onto the wire (review remediation)

The initial implementation enforced the alias `unallowedParameters` rules only in the UI layer (model-config dialog path), so the codex Responses executor still forwarded sampling keys on the wire. Now `applyCodexRequestSettings` strips them via an injected `getUnallowedModelParameters(model)` resolver; the alias factory passes the entry's `modelDefaults` rules into the `OpenAIProvider` / `OpenAIResponsesProvider` constructors, which capture them once at construction (no per-request alias-file reload). Plain (non-alias) providers get an empty rule set, so canonical OpenAI behavior is unchanged (a mirror test asserts sampling parameters survive on plain OpenAI).

### CodeRabbit remediation (second round)

Both `gpt-6-astra` `modelDefaults` rules now use the anchored sanctioned pattern `^gpt-6-astra(?:-(?:latest|[0-9]{8}|[0-9]{4}-[0-9]{2}-[0-9]{2}))?$` instead of loose prefixes (`^gpt-6-astra`, `^gpt-6`), so lookalike and custom `gpt-6*` codex models keep the 262144 provider default and their configured sampling parameters; `gpt-5.6-sol` remains the unconditional alias default in the docs. New sanctioned/lookalike behavioral matrix in `providerAliases.codex.test.ts`.

### Why 872000 under OAuth

The ChatGPT-backed Codex service is catalog-driven: it enforces a product context window below the API window. Verified by testing in Codex (anomalyco/opencode issue 46527): 1,000,000-token total context on OAuth, leaving 872,000 input with 128,000 reserved for output; openai/codex issue 39102 raised the GPT-5.6 `max_context_window` ceiling to 872,000 and openai/codex issue 41325 proved the remote catalog clamps larger client-side values server-side. Shipping third-party Codex configurations for Astra use `model_context_window = 872000`.

### Verification

Full cycle run on the final tree: `npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build` — all green for this branch's code. Test-run failures observed locally were each reproduced identically on a clean `main` worktree in the same sandbox (no OS keyring backend; proactive-renewal suite interference; sandbox-detection CLI tests; a Bun 1.3.14 internal error in the vscode workspace; plus gitService/editor sandbox-coupled tests filed as #3586 / #3585) — evidence recorded in `project-plans/issue3576.md` and `tmp/verify3576/`. Two genuine pre-existing bugs uncovered while verifying were filed as #3581 (integration test writes fixture settings.json into the real global config dir) and #3582 (`telemetry.logConversations` rejected by startup validation though core defines it). The stepfun-37 smoke test is currently blocked in this sandbox by a host-side credential-proxy issue (identical failure on `main`; `--version` boots cleanly) — CI exercises startup on its own runners.

## Reviewer Test Plan

1. `bun test packages/providers/src/composition/providerAliases.codex.test.ts` — static model, 872000 window, sanctioned/lookalike matrix, provider-level 262144 untouched, `defaultModel` unchanged.
2. `bun test packages/providers/src/runtime/providerAliases.codex.contextLimit.integration.test.ts` — live provider-switch path: `codex:gpt-6-astra` → 872000, `codex:gpt-5.6-sol` → 262144, spark → 131072.
3. `bun test packages/providers/src/openai/openaiModelPolicy.test.ts` — Responses-required classification, qualifier/lookalike matrix, `minimal` → `low` for GPT-6 vs `none` for GPT-5.6.
4. `bun test packages/providers/src/openai-responses/__tests__/OpenAIResponsesProvider.unallowedParameters.test.ts` — sampling keys stripped on the wire for the alias, preserved for plain OpenAI.
5. Estimator registry test — o200k claim for `gpt-6-astra` (+qualifiers), lookalikes unclaimed.
6. Manual: `llxprt` with the codex alias, `/model codex gpt-6-astra`, confirm model lists with a 872000 context and a session round-trips (requires an account with Astra access).

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅ (test/lint/typecheck/format/build in Linux sandbox; smoke blocked by host credential-proxy outage, see above) |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | ❓  | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3576
Related to #3217 (estimator `asset-unavailable` precedent)
Filed during verification: #3581, #3582, #3585, #3586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the GPT-6 Astra model through OpenAI and Codex providers.
  - Added an 872,000-token context window and supported reasoning levels from low through max.
  - Added model-aware request handling that removes unsupported sampling parameters.
  - Added accurate token counting and prompt estimation for sanctioned GPT-6 Astra model variants.

- **Documentation**
  - Updated provider guides, model limits, setup examples, transport details, and Astra availability notes.

- **Bug Fixes**
  - Improved model-specific context-limit resolution when switching between Astra, Sol, and Spark models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->