### PR TITLE
fix(ui): reject control characters in ProviderDialog search input (Fixes #3400)

### DIFF
--- a/packages/cli/src/ui/components/ProviderDialog.selection.test.tsx
+++ b/packages/cli/src/ui/components/ProviderDialog.selection.test.tsx
@@ -190,4 +190,86 @@ describe('ProviderDialog selection semantics', () => {
     expect(onClose).not.toHaveBeenCalled();
     expect(lastFrame() ?? '').toContain('No providers match');
   });
+
+  it('keeps the search term unchanged when Enter is pressed with zero matches', async () => {
+    const { stdin, lastFrame, onSelect, onClose, providers } =
+      renderProviderDialog();
+
+    await act(async () => {
+      stdin.write('\t'); // enter search mode
+    });
+    for (const char of 'zzzz') {
+      await act(async () => {
+        stdin.write(char);
+      });
+    }
+
+    const foundCount = `(Found ${String(0)} of ${String(providers.length)} providers)`;
+    expect(lastFrame() ?? '').toContain('No providers match');
+    expect(lastFrame() ?? '').toContain(foundCount);
+
+    await act(async () => {
+      stdin.write('\r');
+    });
+
+    const frameAfterEnter = lastFrame() ?? '';
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(frameAfterEnter).toContain('zzzz');
+    expect(frameAfterEnter).toContain(foundCount);
+    expect(frameAfterEnter).toContain('Search Providers');
+
+    for (const _char of 'zzzz') {
+      await act(async () => {
+        stdin.write('\x7f');
+      });
+    }
+    expect(lastFrame() ?? '').toContain('anthropic');
+
+    for (const char of 'openai') {
+      await act(async () => {
+        stdin.write(char);
+      });
+    }
+    const filteredFrame = lastFrame() ?? '';
+    expect(filteredFrame).toContain('(Found 1 of 6 providers)');
+    expect(filteredFrame).toContain('openai');
+    expect(filteredFrame).not.toContain('anthropic');
+  });
+
+  it('keeps the search term unchanged when Enter is pressed with zero matches in the narrow layout', async () => {
+    mockUseTerminalSize.mockReturnValue({ columns: 60, rows: 24 });
+    const { stdin, lastFrame, onSelect, onClose } = renderProviderDialog();
+
+    for (const char of 'zzzz') {
+      await act(async () => {
+        stdin.write(char);
+      });
+    }
+    expect(lastFrame() ?? '').toContain('No providers match');
+
+    await act(async () => {
+      stdin.write('\r');
+    });
+
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+
+    for (const _char of 'zzzz') {
+      await act(async () => {
+        stdin.write('\x7f');
+      });
+    }
+    expect(lastFrame() ?? '').toContain('anthropic');
+
+    for (const char of 'openai') {
+      await act(async () => {
+        stdin.write(char);
+      });
+    }
+    const filteredFrame = lastFrame() ?? '';
+    expect(filteredFrame).toContain('1 providers found');
+    expect(filteredFrame).toContain('openai');
+    expect(filteredFrame).not.toContain('anthropic');
+  });
 });

--- a/packages/cli/src/ui/components/ProviderDialog.tsx
+++ b/packages/cli/src/ui/components/ProviderDialog.tsx
@@ -12,6 +12,8 @@ import { truncateEnd } from '../utils/responsive.js';
 import { useKeypress } from '../hooks/useKeypress.js';
 import { getBorderStyle } from '../contexts/UnicodeRenderingContext.js';
 
+const PRINTABLE_ASCII = /[\x20-\x7E]/;
+
 interface ProviderDialogProps {
   providers: string[];
   currentProvider?: string;
@@ -423,5 +425,5 @@ function isPrintableKeypress(key: {
   if (key.sequence === undefined) return false;
   if (typeof key.sequence !== 'string') return false;
   if (key.ctrl === true || key.meta === true) return false;
-  return key.sequence.length === 1;
+  return key.sequence.length === 1 && PRINTABLE_ASCII.test(key.sequence);
 }

--- a/project-plans/issue3400.md
+++ b/project-plans/issue3400.md
@@ -1,0 +1,108 @@
+# Issue 3400 Plan — ProviderDialog: zero-match Enter must not insert a carriage return
+
+Generated: 2026-09-08
+Branch: `issue3400`
+Issue: https://github.com/vybestack/llxprt-code/issues/3400
+
+## Root cause
+
+`createProviderDialogKeypressHandler` in
+`packages/cli/src/ui/components/ProviderDialog.tsx` routes every key through
+the search branch when `isSearching || isNarrow`. The Enter guard requires
+`filteredProviders.length > 0`, so a zero-match Enter falls through to
+`isPrintableKeypress`. That helper accepts any single-character sequence that
+is not a ctrl/meta chord, and Enter arrives with `sequence === '\r'`, so the
+carriage return is appended to the search term. The term can then never match
+a provider name, and the extra character is invisible in the rendered frame.
+
+## Accepted behavior
+
+1. Wide layout, search mode (Tab entered): pressing Enter when the search
+   term matches zero providers is a no-op. The search term stays byte-for-byte
+   unchanged (no `\r` appended), the dialog stays in search mode, and neither
+   `onSelect` nor `onClose` fires. The frame keeps showing the typed term,
+   `No providers match`, and `(Found 0 of N providers)`.
+2. Narrow layout: same no-op behavior, because narrow mode always takes the
+   same search branch.
+3. Enter with one or more matches keeps every existing behavior: narrow mode
+   selects `filteredProviders[index]`; wide search mode exits search mode
+   without closing; wide non-search mode selects the highlighted provider.
+4. All other key semantics are unchanged: Tab toggles search mode (wide),
+   Backspace/Delete trim the term, printable ASCII input appends, Escape
+   clears the term first and closes on the second press.
+
+## Fix approach
+
+Narrow `isPrintableKeypress` in `ProviderDialog.tsx` to actual printable ASCII
+with a `PRINTABLE_ASCII = /[\x20-\x7E]/` test, mirroring the rule
+`ModelDialog.tsx` already uses (`isPrintableCharacterKey`). `\r` (0x0D) is no
+longer accepted as text input, so a zero-match Enter matches no branch and is
+consumed. This is the second fix option the issue suggests. Inherent,
+issue-authorized consequence: other single-character control sequences (for
+example Tab in the narrow layout) are no longer appended to the term either.
+
+Rejected alternative: special-casing `key.name === 'return'` before the
+printable branch. It fixes only the Enter name and leaves the helper accepting
+every other control character, so the same corruption remains reachable.
+
+## Tests
+
+All in `packages/cli/src/ui/components/ProviderDialog.selection.test.tsx`
+(wide default 180 cols), written first and confirmed failing (TDD RED), then
+the fix makes them pass (GREEN). No new test files.
+
+1. `keeps the search term unchanged when Enter is pressed with zero matches`
+   (wide): Tab into search mode, type `zzzz`, assert `No providers match` and
+   `(Found 0 of 6 providers)`. Press Enter. Assert `onSelect`/`onClose` were
+   not called, the frame still shows `zzzz`, `(Found 0 of 6 providers)`, and
+   the `Search Providers` title (still in search mode). Then the discriminating
+   probe for the invisible character: Backspace 4 times, assert the full list
+   is back (`anthropic` visible); type `openai`, assert `openai` is visible and
+   `anthropic` is not. With the bug the term after the probe is `\ropenai`,
+   which matches nothing, so the probe fails.
+2. Same scenario in the narrow layout (override the terminal-size mock to
+   60 columns inside the test): no Tab needed (narrow starts in search mode),
+   type `zzzz`, Enter, assert no select/close, Backspace 4 times, type
+   `openai`, assert `openai` visible and `anthropic` not.
+
+The existing test `does not select or close when Enter is pressed with zero
+matches` stays unmodified and keeps passing; it already avoids enshrining the
+bug.
+
+Placement note: the sizing-audit comment on the issue suggested extending
+`ProviderDialog.responsive.test.tsx`. That file holds layout tests with no
+stdin interaction. The component's keypress-behavior tests, including the
+zero-match Enter scenario the issue references, live in
+`ProviderDialog.selection.test.tsx`, so the regression tests go there.
+
+## Out of scope
+
+- No files other than `ProviderDialog.tsx` and
+  `ProviderDialog.selection.test.tsx`.
+- No lint/test config changes, no new suppression directives.
+- No keyboard handling changes in other dialogs (ModelDialog already has the
+  printable rule).
+
+## Verification
+
+- Targeted ProviderDialog suites passed (16/16).
+- Full `npm run typecheck` passed.
+- Lint checks passed on the touched files. Repo-wide `npm run lint` reports 11
+  pre-existing errors in unrelated MCP/consent files that are also present at
+  main HEAD.
+- `npm run format` passed without out-of-scope changes.
+- `npm run build` passed.
+- The test-audit scanner reported no MOCK_MIRROR, ALWAYS_TRUE,
+  SELF_CONFIRMING, or NO_ASSERT findings on the touched test file. It reported
+  one pre-existing DUP_ASSERT at line 130, outside the new tests.
+- Full `npm run test` fails in this sandbox only in environmental suites for
+  the native OS keyring, sandbox-mode editor utilities, and
+  capability-proxy/token-renewal. Those suites pass in GitHub CI on main at
+  this branch's base; LLxprt Code CI was green on 2026-09-08.
+- The smoke test failed during profile credential resolution with
+  `Credential proxy authentication failed: Invalid or missing capability token`
+  before model invocation. The sandbox credential proxy is broken; the PR's
+  On Merge Smoke Test CI workflow is the authoritative gate.
+- Compliance review: PASS with zero findings.
+- Final review: REQUEST_CHANGES with two LOW findings. Both were remediated in
+  this pass.

--- a/project-plans/issue3400.md
+++ b/project-plans/issue3400.md
@@ -95,10 +95,15 @@ zero-match Enter scenario the issue references, live in
 - The test-audit scanner reported no MOCK_MIRROR, ALWAYS_TRUE,
   SELF_CONFIRMING, or NO_ASSERT findings on the touched test file. It reported
   one pre-existing DUP_ASSERT at line 130, outside the new tests.
-- Full `npm run test` fails in this sandbox only in environmental suites for
-  the native OS keyring, sandbox-mode editor utilities, and
-  capability-proxy/token-renewal. Those suites pass in GitHub CI on main at
-  this branch's base; LLxprt Code CI was green on 2026-09-08.
+- Full `npm run test` (completed run, log at `tmp/verify3400/test-full2.log`) failed
+  in 6 environmental files, all byte-identical to main HEAD and unrelated to this
+  change: oauthManager.proactive-renewal (token-renewal timing),
+  factory-detection-wiring (capability proxy), secure-store.native-keyring (no
+  OS keyring in container), ide-client-integration (MCP sockets in sandbox),
+  docsCommand (asserts the non-sandbox code path inside a sandbox), and
+  sandbox-node-modules-preflight (image-global bun location layout). 737/743
+  CLI test files passed. Those suites pass in GitHub CI on main at this
+  branch's base; LLxprt Code CI was green on 2026-09-08.
 - The smoke test failed during profile credential resolution with
   `Credential proxy authentication failed: Invalid or missing capability token`
   before model invocation. The sandbox credential proxy is broken; the PR's


### PR DESCRIPTION
## TLDR

`ProviderDialog` appended a carriage return to the search term when Enter was pressed with zero search matches, silently corrupting the query so it could never match again. This PR narrows `isPrintableKeypress` to printable ASCII (`[\x20-\x7E]`, the rule `ModelDialog.tsx` already uses) so control characters can never enter the term; a zero-match Enter is now consumed as a no-op. Two regression tests (wide and narrow layouts) prove the term stays byte-identical.

Closes #3400

## Dive Deeper

**Root cause.** The wide/narrow search branch requires `filteredProviders.length > 0` before handling `key.name === 'return'`. With zero matches, control fell through to `isPrintableKeypress`, which accepted any single-character sequence without ctrl/meta — including Enter's `\r`. The corrupted term (e.g. `zzzz\ropenai`) matched nothing, and the extra character was invisible in the rendered frame, so the dialog appeared stuck on "No providers match" even after correcting the visible text.

**Fix choice.** The issue offered two options: special-case `return` before the printable branch, or narrow the predicate to actual printable characters. This PR takes the second: `PRINTABLE_ASCII = /[\x20-\x7E]/` at module scope, tested in `isPrintableKeypress`. Special-casing only the Enter key would leave every other single-character control sequence (Tab in narrow mode, newline, other C0 controls) able to corrupt the term the same way. Pattern parity with `ModelDialog.tsx`'s `PRINTABLE_ASCII` keeps the two dialogs consistent. Inherent, issue-authorized consequence: non-printable single-character sequences are no longer appended to the term anywhere in this dialog.

**Behavior preserved.** Enter with one or more matches keeps all existing semantics (narrow selects `filteredProviders[index]`; wide search mode exits search without closing; wide non-search mode selects the highlighted provider). Tab toggle, Backspace/Delete trimming (handled by `key.name`, not by sequence, so DEL `\x7f` being outside the printable range is irrelevant), and Escape clear-then-close are unchanged.

**Tests.** Both new tests type a zero-match term, press Enter, then probe for invisible corruption: four backspaces must fully empty the term (on unfixed code the term is `zzzz\r`, leaving `z`), the full provider list must reappear, and typing `openai` must filter to exactly one result — asserted via the rendered count strings (`(Found 1 of 6 providers)` wide, `1 providers found` narrow). The pre-existing test `does not select or close when Enter is pressed with zero matches` is untouched and keeps passing.

## Reviewer Test Plan

- `bun test packages/cli/src/ui/components/ProviderDialog.selection.test.tsx packages/cli/src/ui/components/ProviderDialog.responsive.test.tsx packages/cli/src/ui/components/DialogManager.test.tsx` (22 tests, all pass)
- Manual: open the provider dialog ≥80 cols wide, Tab into search, type `zzzz`, press Enter, then backspace four times and type `openai` — the list must filter to `openai`. Before the fix it stayed empty because the term was `zzzz\ropenai`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

🐧 npm run (test/lint/typecheck/format/build) validated in this branch's Linux sandbox. Local full-suite failures were adjudicated: 6 files, all byte-identical to main HEAD and environmental (OS keyring, sandbox-path expectations, capability proxy, token-renewal timing, MCP sockets, image layout); 737/743 CLI files pass and LLxprt Code CI is green on main at this branch's base. The `stepfun-37` smoke command fails in this sandbox at profile credential resolution (broken capability proxy, before any model invocation); the On Merge Smoke Test workflow is the authoritative gate.

## Linked issues / bugs

Closes #3400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider search input handling by accepting only printable characters.
  * Pressing Enter when no providers match now preserves the search term and search state without selecting a provider or closing the dialog.
  * Clearing the search term continues to restore provider filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->