### PR TITLE
feat(cli): persist startup-fatal errors to fatal.log, print path, pause before exit (Fixes #3566)

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -12,6 +12,12 @@ import {
   applyProcessMemoryHardening,
   HARDENING_FAILURE_EXIT_CODE,
 } from './src/launcher/process-memory-hardening.js';
+import {
+  appendStartupFatalLog,
+  buildStartupFatalRecord,
+  formatStartupFatalMessage,
+  pauseBeforeExitIfNeeded,
+} from './src/utils/startup-fatal-log.js';
 
 // --- Global Entry Point ---
 
@@ -39,11 +45,24 @@ process.on('uncaughtException', (error) => {
 });
 
 function writeFatalError(error: FatalError): void {
+  // Persist first (#3566): if the pane dies, the record survives in
+  // <logHome>/fatal.log. A persistence failure must not change the output.
+  const record = buildStartupFatalRecord(error, {
+    cwd: process.cwd(),
+    argv: process.argv,
+  });
+  const persistResult = appendStartupFatalLog(record);
   let errorMessage = error.message;
   if (!process.env['NO_COLOR']) {
     errorMessage = `\x1b[31m${errorMessage}\x1b[0m`;
   }
-  writeToStderr(`${errorMessage}\n`);
+  if (persistResult.ok) {
+    writeToStderr(
+      `${formatStartupFatalMessage(errorMessage, persistResult.path)}\n`,
+    );
+  } else {
+    writeToStderr(`${errorMessage}\n`);
+  }
 }
 
 function writeUnexpectedCriticalError(error: unknown): void {
@@ -68,17 +87,34 @@ async function safeRunExitCleanup(): Promise<void> {
   }
 }
 
-function writeCriticalErrorAndGetExitCode(error: unknown): number {
+function writeCriticalErrorAndGetExitCode(error: unknown): {
+  exitCode: number;
+  fatal: boolean;
+} {
   try {
     if (error instanceof FatalError) {
       writeFatalError(error);
-      return error.exitCode;
+      return { exitCode: error.exitCode, fatal: true };
     }
     writeUnexpectedCriticalError(error);
   } catch {
-    return 1;
+    return { exitCode: 1, fatal: false };
   }
-  return 1;
+  return { exitCode: 1, fatal: false };
+}
+
+/**
+ * Shared terminal path for critical errors: report, run best-effort cleanup,
+ * pause (fatals only, when stderr is a TTY and --no-pause is absent) so the
+ * message stays readable in closing panes, then exit with the original code.
+ */
+async function exitAfterCriticalError(error: unknown): Promise<never> {
+  const { exitCode, fatal } = writeCriticalErrorAndGetExitCode(error);
+  await safeRunExitCleanup();
+  if (fatal) {
+    await pauseBeforeExitIfNeeded(process.argv, process.stderr.isTTY === true);
+  }
+  process.exit(exitCode);
 }
 
 // Use writeToStderr instead of console.error so that fatal errors are always
@@ -112,19 +148,17 @@ runBunLauncherIfNeeded()
     try {
       await main();
     } catch (error) {
-      const exitCode = writeCriticalErrorAndGetExitCode(error);
-      await safeRunExitCleanup();
-      process.exit(exitCode);
+      await exitAfterCriticalError(error);
     }
   })
   .catch(async (error: unknown) => {
     // This covers launcher failures and bootstrap import failures before main()
     // starts. Cleanup is best-effort and harmless if nothing was registered.
-    let exitCode = 1;
+    // The finally guarantees process.exit always happens even if the shared
+    // helper itself throws unexpectedly.
     try {
-      exitCode = writeCriticalErrorAndGetExitCode(error);
-      await safeRunExitCleanup();
+      await exitAfterCriticalError(error);
     } finally {
-      process.exit(exitCode);
+      process.exit(1);
     }
   });

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -46,12 +46,22 @@ process.on('uncaughtException', (error) => {
 
 function writeFatalError(error: FatalError): void {
   // Persist first (#3566): if the pane dies, the record survives in
-  // <logHome>/fatal.log. A persistence failure must not change the output.
-  const record = buildStartupFatalRecord(error, {
-    cwd: process.cwd(),
-    argv: process.argv,
-  });
-  const persistResult = appendStartupFatalLog(record);
+  // <logHome>/fatal.log. Persistence must never mask the original fatal:
+  // appendStartupFatalLog reports fs failures via its result, and the attempt
+  // itself (process.cwd() throws on a deleted cwd, or record construction
+  // fails) is guarded here because an escaping throw would land in
+  // writeCriticalErrorAndGetExitCode's catch, suppressing the message and
+  // flipping the exit code (e.g. 44 -> 1).
+  let persistResult: { ok: true; path: string } | { ok: false };
+  try {
+    const record = buildStartupFatalRecord(error, {
+      cwd: process.cwd(),
+      argv: process.argv,
+    });
+    persistResult = appendStartupFatalLog(record);
+  } catch {
+    persistResult = { ok: false };
+  }
   let errorMessage = error.message;
   if (!process.env['NO_COLOR']) {
     errorMessage = `\x1b[31m${errorMessage}\x1b[0m`;

--- a/packages/cli/src/config/cliArgParser.noPause.test.ts
+++ b/packages/cli/src/config/cliArgParser.noPause.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3566 AC4 — `--no-pause` must parse without an unknown-argument
+ * failure in both the root scope and the launch-command scope (yargs strict
+ * mode exits on unrecognized options). Drives the REAL `parseArguments` by
+ * mutating `process.argv`, so the assertions exercise the real yargs wiring
+ * and both option tables. `process.exit` is mocked to throw for the duration
+ * of each parse so a validation exit fails the test loudly instead of killing
+ * the runner.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'bun:test';
+import { parseArguments } from './cliArgParser.js';
+import { innerCommandOptions, rootOptions } from './yargsOptions.js';
+import type { Settings } from './settings.js';
+
+const ORIGINAL_ARGV = [...process.argv];
+const ORIGINAL_ENV = { ...process.env };
+
+function emptySettings(): Settings {
+  return {};
+}
+
+async function parseArgv(
+  args: readonly string[],
+): ReturnType<typeof parseArguments> {
+  process.argv = ['node', 'llxprt-code', ...args];
+  return parseArguments(emptySettings());
+}
+
+let mockExit: ReturnType<typeof vi.spyOn> | undefined;
+let mockConsoleError: ReturnType<typeof vi.spyOn> | undefined;
+
+function mockProcessExitForYargsValidation(): void {
+  mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+    throw new Error('process.exit called');
+  });
+  mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+}
+
+describe('parseArguments --no-pause acceptance (AC4)', () => {
+  afterEach(() => {
+    process.argv = [...ORIGINAL_ARGV];
+    process.env = { ...ORIGINAL_ENV };
+    mockConsoleError?.mockRestore();
+    mockExit?.mockRestore();
+    mockExit = undefined;
+    mockConsoleError = undefined;
+  });
+
+  it('accepts --no-pause at root scope without a yargs validation exit', async () => {
+    mockProcessExitForYargsValidation();
+    const argv = await parseArgv(['--no-pause']);
+    expect(argv.promptWords ?? []).toStrictEqual([]);
+  });
+
+  it('accepts --no-pause alongside the launch-command --sandbox flag', async () => {
+    mockProcessExitForYargsValidation();
+    const argv = await parseArgv(['--sandbox', '--no-pause']);
+    expect(argv.sandbox).toBe(true);
+  });
+});
+
+describe('pause option registration (AC4)', () => {
+  afterEach(() => {
+    process.argv = [...ORIGINAL_ARGV];
+    process.env = { ...ORIGINAL_ENV };
+    mockConsoleError?.mockRestore();
+    mockExit?.mockRestore();
+    mockExit = undefined;
+    mockConsoleError = undefined;
+  });
+
+  it('registers a boolean pause option in rootOptions (help documents it)', () => {
+    expect(Object.hasOwn(rootOptions, 'pause')).toBe(true);
+    expect(rootOptions['pause'].type).toBe('boolean');
+    expect(
+      typeof rootOptions['pause'].description === 'string' &&
+        rootOptions['pause'].description.length > 0,
+    ).toBe(true);
+  });
+
+  it('registers a boolean pause option in innerCommandOptions (help documents it)', () => {
+    expect(Object.hasOwn(innerCommandOptions, 'pause')).toBe(true);
+    expect(innerCommandOptions['pause'].type).toBe('boolean');
+    expect(
+      typeof innerCommandOptions['pause'].description === 'string' &&
+        innerCommandOptions['pause'].description.length > 0,
+    ).toBe(true);
+  });
+});

--- a/packages/cli/src/config/yargsOptions.ts
+++ b/packages/cli/src/config/yargsOptions.ts
@@ -160,6 +160,11 @@ export const rootOptions: Record<string, Options> = {
     description:
       'If true, when refreshing memory, LLXPRT.md files should be loaded from all directories that are added. If false, LLXPRT.md files should only be loaded from the primary working directory.',
   },
+  pause: {
+    type: 'boolean',
+    description:
+      'Briefly pause before exiting on a fatal error so the message stays readable in closing terminal panes (default: on; disable with --no-pause).',
+  },
   debug: {
     alias: 'd',
     type: 'string',
@@ -339,6 +344,11 @@ export const innerCommandOptions: Record<string, Options> = {
   'screen-reader': {
     type: 'boolean',
     description: 'Enable screen reader mode for accessibility.',
+  },
+  pause: {
+    type: 'boolean',
+    description:
+      'Briefly pause before exiting on a fatal error so the message stays readable in closing terminal panes (default: on; disable with --no-pause).',
   },
   'session-summary': {
     type: 'string',

--- a/packages/cli/src/utils/startup-fatal-log.test.ts
+++ b/packages/cli/src/utils/startup-fatal-log.test.ts
@@ -55,15 +55,23 @@ function setupIsolatedLogHome(): string {
 
 /**
  * Per-suite teardown: removes every temp tree and restores the original env.
+ * Env is restored first and each rmSync is individually guarded so one
+ * unremovable root cannot skip the rest of the cleanup or leak the
+ * LLXPRT_LOG_HOME override into later tests.
  */
 function cleanupTempRootsAndRestoreEnv(): void {
-  for (const root of tempRoots.splice(0)) {
-    rmSync(root, { recursive: true, force: true });
-  }
   if (ORIGINAL_LOG_HOME === undefined) {
     delete process.env.LLXPRT_LOG_HOME;
   } else {
     process.env.LLXPRT_LOG_HOME = ORIGINAL_LOG_HOME;
+  }
+  for (const root of tempRoots.splice(0)) {
+    try {
+      rmSync(root, { recursive: true, force: true });
+    } catch {
+      // Keep removing the remaining roots; leaked temp dirs beat a poisoned
+      // test environment.
+    }
   }
 }
 
@@ -212,14 +220,54 @@ describe('redactArgvForLog (AC1)', () => {
   });
 
   it('passes non-key tokens through verbatim and leaves the input unmutated', () => {
-    const argv = ['llxprt', 'prompt-words', '-p', 'value', '--sandbox'];
+    // -q (quiet alias) is not a value-taking flag, so its following token is
+    // a positional, not a credential; -p/-i are covered by their own tests.
+    const argv = ['llxprt', 'prompt-words', '-q', 'value', '--sandbox'];
     const redacted = redactArgvForLog(argv);
     expect(redacted).toStrictEqual(argv);
     expect(argv).toStrictEqual([
       'llxprt',
       'prompt-words',
-      '-p',
+      '-q',
       'value',
+      '--sandbox',
+    ]);
+  });
+
+  it('redacts the value after the -p prompt alias', () => {
+    expect(redactArgvForLog(['llxprt', '-p', 'SECRET'])).toStrictEqual([
+      'llxprt',
+      '-p',
+      '[REDACTED]',
+    ]);
+  });
+
+  it('redacts the value after the -i prompt-interactive alias', () => {
+    expect(redactArgvForLog(['llxprt', '-i', 'SECRET'])).toStrictEqual([
+      'llxprt',
+      '-i',
+      '[REDACTED]',
+    ]);
+  });
+
+  it('redacts the value inside -p=<value>', () => {
+    expect(redactArgvForLog(['llxprt', '-p=SECRET'])).toStrictEqual([
+      'llxprt',
+      '-p=[REDACTED]',
+    ]);
+  });
+
+  it('redacts the value inside -i=<value>', () => {
+    expect(redactArgvForLog(['llxprt', '-i=SECRET'])).toStrictEqual([
+      'llxprt',
+      '-i=[REDACTED]',
+    ]);
+  });
+
+  it('does not eat a following flag after the -p alias', () => {
+    expect(redactArgvForLog(['llxprt', '-p', '--sandbox'])).toStrictEqual([
+      'llxprt',
+      '-p',
       '--sandbox',
     ]);
   });

--- a/packages/cli/src/utils/startup-fatal-log.test.ts
+++ b/packages/cli/src/utils/startup-fatal-log.test.ts
@@ -1,0 +1,496 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3566 behavioral coverage for the startup fatal log: durable JSONL
+ * persistence of FatalError reports under <logHome>/fatal.log, argv credential
+ * redaction, the saved-to path line, and the pre-exit pause. Filesystem
+ * assertions use the real fs against isolated temp log homes; pause timing is
+ * injected so no test sleeps for real. The end-to-end case spawns the real CLI
+ * entry with LLXPRT_SANDBOX=bogus, which deterministically throws
+ * FatalSandboxError ("Invalid sandbox command") from loadSandboxConfig during
+ * bootstrap, before provider activation or network access.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { FatalError, FatalSandboxError } from '@vybestack/llxprt-code-core';
+import {
+  appendStartupFatalLog,
+  buildStartupFatalRecord,
+  formatStartupFatalMessage,
+  pauseBeforeExitIfNeeded,
+  redactArgvForLog,
+  resolveStartupFatalLogPath,
+  shouldPauseBeforeExit,
+  STARTUP_FATAL_PAUSE_MS,
+  type StartupFatalRecord,
+} from './startup-fatal-log.js';
+
+const ORIGINAL_LOG_HOME = process.env.LLXPRT_LOG_HOME;
+const tempRoots: string[] = [];
+
+/**
+ * Per-suite setup: points LLXPRT_LOG_HOME at a per-test temp dir that does
+ * not exist yet (so appendStartupFatalLog must create it).
+ */
+function setupIsolatedLogHome(): string {
+  const root = mkdtempSync(path.join(tmpdir(), 'startup-fatal-'));
+  tempRoots.push(root);
+  const logHome = path.join(root, 'log-home');
+  process.env.LLXPRT_LOG_HOME = logHome;
+  return logHome;
+}
+
+/**
+ * Per-suite teardown: removes every temp tree and restores the original env.
+ */
+function cleanupTempRootsAndRestoreEnv(): void {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+  if (ORIGINAL_LOG_HOME === undefined) {
+    delete process.env.LLXPRT_LOG_HOME;
+  } else {
+    process.env.LLXPRT_LOG_HOME = ORIGINAL_LOG_HOME;
+  }
+}
+
+function sampleRecord(message: string, exitCode: number): StartupFatalRecord {
+  return {
+    timestamp: '2026-09-08T12:00:00.000Z',
+    cwd: '/tmp/project',
+    argv: ['llxprt', '--sandbox'],
+    exitCode,
+    message,
+  };
+}
+
+describe('resolveStartupFatalLogPath (AC1)', () => {
+  let logHome = '';
+  beforeEach(() => {
+    logHome = setupIsolatedLogHome();
+  });
+  afterEach(cleanupTempRootsAndRestoreEnv);
+
+  it('resolves fatal.log inside the isolated log home', () => {
+    expect(resolveStartupFatalLogPath()).toBe(path.join(logHome, 'fatal.log'));
+  });
+});
+
+describe('appendStartupFatalLog (AC1)', () => {
+  let logHome = '';
+  beforeEach(() => {
+    logHome = setupIsolatedLogHome();
+  });
+  afterEach(cleanupTempRootsAndRestoreEnv);
+
+  it('creates the missing log dir and file and writes one valid JSON line with all five fields', () => {
+    expect(existsSync(logHome)).toBe(false);
+
+    const result = appendStartupFatalLog(sampleRecord('sandbox boom', 44));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(
+        'appendStartupFatalLog unexpectedly returned { ok: false }',
+      );
+    }
+    expect(result.path).toBe(path.join(logHome, 'fatal.log'));
+    const logPath = path.join(logHome, 'fatal.log');
+    expect(existsSync(logPath)).toBe(true);
+    const rawLines = readFileSync(logPath, 'utf8').split('\n');
+    expect(rawLines).toHaveLength(2);
+    expect(rawLines[1]).toBe('');
+    const parsed: unknown = JSON.parse(rawLines[0]);
+    if (!isFatalRecordShape(parsed)) {
+      throw new Error(`fatal.log record shape mismatch: ${rawLines[0]}`);
+    }
+    expect(!isNaN(Date.parse(parsed.timestamp))).toBe(true);
+    expect(parsed.cwd).toBe('/tmp/project');
+    expect(parsed.argv).toStrictEqual(['llxprt', '--sandbox']);
+    expect(parsed.exitCode).toBe(44);
+    expect(parsed.message).toBe('sandbox boom');
+  });
+
+  it('accumulates a second fatal as an additional JSONL line', () => {
+    appendStartupFatalLog(sampleRecord('first fatal', 44));
+    appendStartupFatalLog(sampleRecord('second fatal', 52));
+
+    const lines = readFileSync(path.join(logHome, 'fatal.log'), 'utf8')
+      .split('\n')
+      .filter((line) => line !== '');
+    expect(lines).toHaveLength(2);
+    const first: unknown = JSON.parse(lines[0]);
+    const second: unknown = JSON.parse(lines[1]);
+    if (!isFatalRecordShape(first) || !isFatalRecordShape(second)) {
+      throw new Error(`fatal.log record shape mismatch: ${lines.join(' | ')}`);
+    }
+    expect(first.message).toBe('first fatal');
+    expect(second.message).toBe('second fatal');
+    expect(second.exitCode).toBe(52);
+  });
+
+  // Root ignores directory mode bits, so the read-only setup cannot fail there.
+  it.skipIf(process.getuid?.() === 0)(
+    'returns { ok: false } and does not throw when the log home is unwritable',
+    () => {
+      const readOnlyParent = mkdtempSync(
+        path.join(tmpdir(), 'startup-fatal-ro-'),
+      );
+      tempRoots.push(readOnlyParent);
+      chmodSync(readOnlyParent, 0o500);
+      process.env.LLXPRT_LOG_HOME = path.join(readOnlyParent, 'log-home');
+      // A throw here fails the test; reaching the result assertion proves the
+      // crash-reporting path tolerated the unwritable log home.
+      const result = appendStartupFatalLog(sampleRecord('cannot write', 44));
+      expect(result.ok).toBe(false);
+    },
+  );
+});
+
+describe('buildStartupFatalRecord (AC1)', () => {
+  it('derives the record from the error and context with injectable clock', () => {
+    const fixedDate = new Date('2026-09-08T00:00:00.000Z');
+    const record = buildStartupFatalRecord(
+      new FatalSandboxError("Invalid sandbox command 'bogus'"),
+      {
+        cwd: '/work/project',
+        argv: ['bun', 'index.ts', '--key', 'SECRET', '--key=SECRET2'],
+        now: () => fixedDate,
+      },
+    );
+    expect(record.timestamp).toBe('2026-09-08T00:00:00.000Z');
+    expect(record.cwd).toBe('/work/project');
+    expect(record.argv).toStrictEqual([
+      'bun',
+      'index.ts',
+      '--key',
+      '[REDACTED]',
+      '--key=[REDACTED]',
+    ]);
+    expect(record.exitCode).toBe(44);
+    expect(record.message).toBe("Invalid sandbox command 'bogus'");
+  });
+
+  it('uses the real current time when now is not injected', () => {
+    const before = new Date();
+    const record = buildStartupFatalRecord(new FatalError('boom', 1), {
+      cwd: '/cwd',
+      argv: [],
+    });
+    const after = new Date();
+    const parsedTime = Date.parse(record.timestamp);
+    expect(parsedTime).toBeGreaterThanOrEqual(before.getTime());
+    expect(parsedTime).toBeLessThanOrEqual(after.getTime());
+  });
+});
+
+describe('redactArgvForLog (AC1)', () => {
+  it('redacts the value after a --key token', () => {
+    expect(
+      redactArgvForLog(['llxprt', '--key', 'SECRET', '--sandbox']),
+    ).toStrictEqual(['llxprt', '--key', '[REDACTED]', '--sandbox']);
+  });
+
+  it('redacts the value inside --key=<value>', () => {
+    expect(redactArgvForLog(['llxprt', '--key=SECRET'])).toStrictEqual([
+      'llxprt',
+      '--key=[REDACTED]',
+    ]);
+  });
+
+  it('passes non-key tokens through verbatim and leaves the input unmutated', () => {
+    const argv = ['llxprt', 'prompt-words', '-p', 'value', '--sandbox'];
+    const redacted = redactArgvForLog(argv);
+    expect(redacted).toStrictEqual(argv);
+    expect(argv).toStrictEqual([
+      'llxprt',
+      'prompt-words',
+      '-p',
+      'value',
+      '--sandbox',
+    ]);
+  });
+
+  it('keeps a trailing bare flag verbatim', () => {
+    expect(redactArgvForLog(['llxprt', '--sandbox'])).toStrictEqual([
+      'llxprt',
+      '--sandbox',
+    ]);
+  });
+
+  it('treats a bare flag followed by another flag as consecutive flags, not a value', () => {
+    expect(
+      redactArgvForLog(['bun', 'index.ts', '--sandbox', '--prompt', 'x']),
+    ).toStrictEqual(['bun', 'index.ts', '--sandbox', '--prompt', '[REDACTED]']);
+  });
+
+  it('keeps --prompt verbatim after --no-pause and redacts only its value', () => {
+    expect(
+      redactArgvForLog(['llxprt', '--no-pause', '--prompt', 'hi']),
+    ).toStrictEqual(['llxprt', '--no-pause', '--prompt', '[REDACTED]']);
+  });
+});
+
+describe('formatStartupFatalMessage (AC2)', () => {
+  it('appends the saved-to path line to the message with no trailing newline', () => {
+    expect(formatStartupFatalMessage('fatal boom', '/logs/fatal.log')).toBe(
+      'fatal boom\nFull error details saved to: /logs/fatal.log',
+    );
+  });
+});
+
+describe('shouldPauseBeforeExit (AC3)', () => {
+  it('pauses on a TTY without --no-pause', () => {
+    expect(shouldPauseBeforeExit(['llxprt'], true)).toBe(true);
+  });
+
+  it('does not pause on a TTY with --no-pause', () => {
+    expect(shouldPauseBeforeExit(['llxprt', '--no-pause'], true)).toBe(false);
+  });
+
+  it('does not pause off-TTY', () => {
+    expect(shouldPauseBeforeExit(['llxprt'], false)).toBe(false);
+  });
+
+  it('does not pause off-TTY with --no-pause', () => {
+    expect(shouldPauseBeforeExit(['llxprt', '--no-pause'], false)).toBe(false);
+  });
+});
+
+describe('pauseBeforeExitIfNeeded (AC3)', () => {
+  interface SleepSpy {
+    calls: number[];
+    sleep: (ms: number) => Promise<void>;
+  }
+
+  function makeSleepSpy(): SleepSpy {
+    const calls: number[] = [];
+    return {
+      calls,
+      sleep: (ms: number): Promise<void> => {
+        calls.push(ms);
+        return Promise.resolve();
+      },
+    };
+  }
+
+  it('awaits the injected sleep and writes a notice mentioning --no-pause on the TTY path', async () => {
+    const spy = makeSleepSpy();
+    const notices: string[] = [];
+    await pauseBeforeExitIfNeeded(['llxprt'], true, {
+      pauseMs: 25,
+      sleep: spy.sleep,
+      writeNotice: (line) => notices.push(line),
+    });
+    expect(spy.calls).toStrictEqual([25]);
+    expect(notices).toHaveLength(1);
+    expect(notices[0]).toContain('--no-pause');
+  });
+
+  it('defaults to the exported pause interval when none is injected', async () => {
+    const spy = makeSleepSpy();
+    await pauseBeforeExitIfNeeded(['llxprt'], true, {
+      sleep: spy.sleep,
+      writeNotice: () => {},
+    });
+    expect(spy.calls).toStrictEqual([STARTUP_FATAL_PAUSE_MS]);
+  });
+
+  it('never calls sleep or writeNotice off-TTY', async () => {
+    const spy = makeSleepSpy();
+    const notices: string[] = [];
+    await pauseBeforeExitIfNeeded(['llxprt'], false, {
+      pauseMs: 25,
+      sleep: spy.sleep,
+      writeNotice: (line) => notices.push(line),
+    });
+    expect(spy.calls).toStrictEqual([]);
+    expect(notices).toStrictEqual([]);
+  });
+
+  it('never calls sleep or writeNotice when --no-pause is present', async () => {
+    const spy = makeSleepSpy();
+    const notices: string[] = [];
+    await pauseBeforeExitIfNeeded(['llxprt', '--no-pause'], true, {
+      pauseMs: 25,
+      sleep: spy.sleep,
+      writeNotice: (line) => notices.push(line),
+    });
+    expect(spy.calls).toStrictEqual([]);
+    expect(notices).toStrictEqual([]);
+  });
+
+  it('swallows a rejecting sleep instead of failing the crash path', async () => {
+    const notices: string[] = [];
+    await pauseBeforeExitIfNeeded(['llxprt'], true, {
+      pauseMs: 1,
+      sleep: () => Promise.reject(new Error('sleep broke')),
+      writeNotice: (line) => notices.push(line),
+    });
+    // The notice proves the function ran its full body and resolved.
+    expect(notices).toHaveLength(1);
+  });
+
+  it('routes the default notice through core writeToStderr when no writer is injected', async () => {
+    // writeToStderr deliberately bypasses monkey-patched process.stderr.write
+    // (crash-path output must survive UI stdio redirection), so a property spy
+    // cannot observe it; the default path is asserted at the writeToStderr
+    // seam instead, and the module mock is restored on every exit path.
+    const realCore = await import('@vybestack/llxprt-code-core');
+    const notices: string[] = [];
+    void mock.module('@vybestack/llxprt-code-core', () => ({
+      ...realCore,
+      writeToStderr: (chunk: string): boolean => {
+        notices.push(chunk);
+        return true;
+      },
+    }));
+    try {
+      await pauseBeforeExitIfNeeded(['llxprt'], true, {
+        pauseMs: 1,
+        sleep: (): Promise<void> => Promise.resolve(),
+      });
+      expect(notices).toHaveLength(1);
+      expect(notices[0]).toContain('--no-pause');
+    } finally {
+      void mock.module('@vybestack/llxprt-code-core', () => realCore);
+    }
+  });
+});
+
+/**
+ * Minimal runtime shape of a `Bun.spawn` subprocess, restricted to the members
+ * this test reads. Defined locally because the CLI TypeScript config loads
+ * `bun-types/test` but NOT the global `Bun` namespace, so the bare
+ * `Bun.spawn` symbol is unavailable to the type-checker. Reached through
+ * `globalThis` — the same approach as jspBootstrapStartup.test.ts.
+ */
+interface BunSubprocessLike {
+  readonly stdout: ReadableStream<Uint8Array> | null;
+  readonly stderr: ReadableStream<Uint8Array> | null;
+  readonly exited: Promise<number>;
+}
+
+type BunSpawnFn = (
+  cmds: string[],
+  options: {
+    cwd?: string;
+    stdout?: 'ignore' | 'pipe' | 'inherit';
+    stderr?: 'ignore' | 'pipe' | 'inherit';
+    env?: Record<string, string | undefined>;
+  },
+) => BunSubprocessLike;
+
+function getBunSpawn(): BunSpawnFn {
+  const bun = (globalThis as { Bun?: { spawn?: unknown } }).Bun;
+  if (bun === undefined || typeof bun.spawn !== 'function') {
+    throw new Error(
+      'Bun.spawn is unavailable; startup-fatal-log e2e tests must run under bun:test',
+    );
+  }
+  return bun.spawn as unknown as BunSpawnFn;
+}
+
+function isFatalRecordShape(value: unknown): value is StartupFatalRecord {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const timestamp = Reflect.get(value, 'timestamp');
+  if (typeof timestamp !== 'string') {
+    return false;
+  }
+  const cwd = Reflect.get(value, 'cwd');
+  if (typeof cwd !== 'string') {
+    return false;
+  }
+  const argv = Reflect.get(value, 'argv');
+  if (!Array.isArray(argv) || !argv.every((t) => typeof t === 'string')) {
+    return false;
+  }
+  const exitCode = Reflect.get(value, 'exitCode');
+  if (typeof exitCode !== 'number') {
+    return false;
+  }
+  const message = Reflect.get(value, 'message');
+  return typeof message === 'string';
+}
+
+describe('end-to-end: CLI entry persists startup fatals (AC1/AC2/AC5)', () => {
+  let logHome = '';
+  beforeEach(() => {
+    logHome = setupIsolatedLogHome();
+  });
+  afterEach(cleanupTempRootsAndRestoreEnv);
+
+  it('writes fatal.log and prints the saved-to path when LLXPRT_SANDBOX is invalid', async () => {
+    const bunSpawn = getBunSpawn();
+    const entryPath = path.join(import.meta.dir, '..', '..', 'index.ts');
+    const childCwd = mkdtempSync(path.join(tmpdir(), 'startup-fatal-e2e-'));
+    tempRoots.push(childCwd);
+    const configHome = mkdtempSync(path.join(tmpdir(), 'startup-fatal-cfg-'));
+    tempRoots.push(configHome);
+    const dataHome = mkdtempSync(path.join(tmpdir(), 'startup-fatal-data-'));
+    tempRoots.push(dataHome);
+    const cacheHome = mkdtempSync(path.join(tmpdir(), 'startup-fatal-cache-'));
+    tempRoots.push(cacheHome);
+
+    const env: Record<string, string | undefined> = { ...process.env };
+    delete env['SANDBOX'];
+    env['LLXPRT_SANDBOX'] = 'bogus';
+    env['LLXPRT_LOG_HOME'] = logHome;
+    env['LLXPRT_CONFIG_HOME'] = configHome;
+    env['LLXPRT_DATA_HOME'] = dataHome;
+    env['LLXPRT_CACHE_HOME'] = cacheHome;
+
+    const proc = bunSpawn([process.execPath, entryPath, '--prompt', 'x'], {
+      cwd: childCwd,
+      stdout: 'ignore',
+      stderr: 'pipe',
+      env,
+    });
+    if (proc.stderr === null) {
+      throw new Error('stderr pipe unavailable for e2e child');
+    }
+    const stderrText = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+
+    const logPath = path.join(logHome, 'fatal.log');
+    const rawLog = existsSync(logPath)
+      ? readFileSync(logPath, 'utf8')
+      : '<fatal.log missing>';
+    if (exitCode !== 44) {
+      throw new Error(
+        `expected exit 44, got ${exitCode}; stderr:\n${stderrText}\nfatal.log:\n${rawLog}`,
+      );
+    }
+    expect(existsSync(logPath)).toBe(true);
+    const lines = rawLog.split('\n').filter((line) => line !== '');
+    expect(lines).toHaveLength(1);
+    const parsed: unknown = JSON.parse(lines[0]);
+    if (!isFatalRecordShape(parsed)) {
+      throw new Error(`fatal.log record shape mismatch: ${lines[0]}`);
+    }
+    expect(parsed.message).toContain('Invalid sandbox command');
+    expect(parsed.argv).toContain('--prompt');
+    // The prompt value follows a --key token, so it must be redacted.
+    expect(parsed.argv[parsed.argv.indexOf('--prompt') + 1]).toBe('[REDACTED]');
+    expect(parsed.cwd).toBe(childCwd);
+    expect(parsed.exitCode).toBe(44);
+    expect(!isNaN(Date.parse(parsed.timestamp))).toBe(true);
+    expect(stderrText).toContain('Invalid sandbox command');
+    expect(stderrText).toContain('fatal.log');
+  }, 60_000);
+});

--- a/packages/cli/src/utils/startup-fatal-log.ts
+++ b/packages/cli/src/utils/startup-fatal-log.ts
@@ -1,0 +1,152 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3566 — durable startup-fatal logging. When a FatalError aborts the
+ * launch, terminal panes in multiplexed workflows often die before the user
+ * can read the diagnosis; these helpers append a JSONL record to
+ * `<logHome>/fatal.log`, point the user at it on stderr, and briefly pause
+ * before exit when stderr is a TTY so the message stays readable.
+ */
+
+import { appendFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import type { FatalError } from '@vybestack/llxprt-code-core';
+import { writeToStderr } from '@vybestack/llxprt-code-core';
+import { Storage } from '@vybestack/llxprt-code-storage';
+
+export interface StartupFatalRecord {
+  timestamp: string;
+  cwd: string;
+  argv: string[];
+  exitCode: number;
+  message: string;
+}
+
+export const STARTUP_FATAL_PAUSE_MS = 5000;
+
+export function resolveStartupFatalLogPath(): string {
+  // Resolved at call time so LLXPRT_LOG_HOME overrides are honored (tests).
+  return path.join(Storage.getGlobalLogDir(), 'fatal.log');
+}
+
+/** A `--key` token (no `=`) that consumes the following token as its value. */
+function isBareKeyToken(token: string): boolean {
+  return (
+    token.startsWith('--') && token.length > 2 && token.indexOf('=') === -1
+  );
+}
+
+/**
+ * Replaces the value after a `--key` token and the value inside
+ * `--key=<value>` with '[REDACTED]'; all other tokens pass through verbatim.
+ * A `--`-prefixed token after a bare `--key` is the next flag, not a value,
+ * so it passes through; a genuine value token is still redacted.
+ * Returns a new array and never mutates the input.
+ */
+export function redactArgvForLog(argv: readonly string[]): string[] {
+  return argv.map((token, index) => {
+    const previous = index > 0 ? argv[index - 1] : undefined;
+    if (
+      previous !== undefined &&
+      isBareKeyToken(previous) &&
+      !token.startsWith('--')
+    ) {
+      return '[REDACTED]';
+    }
+    const equalsIndex = token.indexOf('=');
+    if (token.startsWith('--') && equalsIndex !== -1) {
+      return `${token.slice(0, equalsIndex + 1)}[REDACTED]`;
+    }
+    return token;
+  });
+}
+
+export function buildStartupFatalRecord(
+  error: FatalError,
+  context: { cwd: string; argv: readonly string[]; now?: () => Date },
+): StartupFatalRecord {
+  const now = context.now ?? ((): Date => new Date());
+  return {
+    timestamp: now().toISOString(),
+    cwd: context.cwd,
+    argv: redactArgvForLog(context.argv),
+    exitCode: error.exitCode,
+    message: error.message,
+  };
+}
+
+/**
+ * Appends the record as one JSONL line, creating the log dir/file if absent.
+ * Never throws: this runs on the crash-reporting path against external
+ * filesystem state and must not mask the original fatal error, so any fs
+ * failure is reported via `{ ok: false }` and the caller falls back to the
+ * pre-existing output.
+ */
+export function appendStartupFatalLog(
+  record: StartupFatalRecord,
+): { ok: true; path: string } | { ok: false } {
+  try {
+    const logPath = resolveStartupFatalLogPath();
+    mkdirSync(path.dirname(logPath), { recursive: true });
+    appendFileSync(logPath, `${JSON.stringify(record)}\n`);
+    return { ok: true, path: logPath };
+  } catch {
+    return { ok: false };
+  }
+}
+
+export function formatStartupFatalMessage(
+  message: string,
+  logPath: string,
+): string {
+  return `${message}\nFull error details saved to: ${logPath}`;
+}
+
+export function shouldPauseBeforeExit(
+  argv: readonly string[],
+  stderrIsTty: boolean,
+): boolean {
+  return stderrIsTty && !argv.includes('--no-pause');
+}
+
+/**
+ * Pauses briefly before exit so the fatal message stays visible in terminal
+ * panes that close on process exit. Never rejects: a crash-path helper must
+ * not replace the fatal error being reported.
+ */
+export async function pauseBeforeExitIfNeeded(
+  argv: readonly string[],
+  stderrIsTty: boolean,
+  options: {
+    pauseMs?: number;
+    sleep?: (ms: number) => Promise<void>;
+    writeNotice?: (line: string) => void;
+  } = {},
+): Promise<void> {
+  if (!shouldPauseBeforeExit(argv, stderrIsTty)) {
+    return;
+  }
+  const writeNotice =
+    options.writeNotice ??
+    ((line: string): void => {
+      writeToStderr(`${line}\n`);
+    });
+  const sleep =
+    options.sleep ??
+    ((ms: number): Promise<void> =>
+      new Promise((resolve) => {
+        setTimeout(resolve, ms);
+      }));
+  try {
+    writeNotice(
+      'Pausing briefly before exit so this message stays readable; pass --no-pause to skip.',
+    );
+    await sleep(options.pauseMs ?? STARTUP_FATAL_PAUSE_MS);
+  } catch {
+    // Swallowed deliberately: see function doc.
+  }
+}

--- a/packages/cli/src/utils/startup-fatal-log.ts
+++ b/packages/cli/src/utils/startup-fatal-log.ts
@@ -40,25 +40,44 @@ function isBareKeyToken(token: string): boolean {
   );
 }
 
+// Value-taking short flags, hardcoded to mirror the prompt/prompt-interactive
+// aliases registered in config/yargsOptions.ts; importing that table would
+// break this module's dependency-free invariant. Without them, `llxprt -p
+// SECRET` would leak the credential into fatal.log.
+const VALUE_TAKING_SHORT_FLAGS: readonly string[] = ['-p', '-i'];
+
+function isValueTakingShortFlag(token: string): boolean {
+  return VALUE_TAKING_SHORT_FLAGS.includes(token);
+}
+
 /**
  * Replaces the value after a `--key` token and the value inside
- * `--key=<value>` with '[REDACTED]'; all other tokens pass through verbatim.
- * A `--`-prefixed token after a bare `--key` is the next flag, not a value,
- * so it passes through; a genuine value token is still redacted.
+ * `--key=<value>` with '[REDACTED]'; the -p/-i prompt aliases get the same
+ * treatment in both bare and `=` forms. All other tokens pass through
+ * verbatim. A `--`-prefixed token after a bare `--key` is the next flag, not
+ * a value, so it passes through; likewise any `-`-prefixed token after a
+ * value-taking short flag. A genuine value token is still redacted.
  * Returns a new array and never mutates the input.
  */
 export function redactArgvForLog(argv: readonly string[]): string[] {
   return argv.map((token, index) => {
     const previous = index > 0 ? argv[index - 1] : undefined;
-    if (
-      previous !== undefined &&
-      isBareKeyToken(previous) &&
-      !token.startsWith('--')
-    ) {
-      return '[REDACTED]';
+    if (previous !== undefined) {
+      if (isBareKeyToken(previous) && !token.startsWith('--')) {
+        return '[REDACTED]';
+      }
+      if (isValueTakingShortFlag(previous) && !token.startsWith('-')) {
+        return '[REDACTED]';
+      }
     }
     const equalsIndex = token.indexOf('=');
-    if (token.startsWith('--') && equalsIndex !== -1) {
+    if (equalsIndex !== -1 && token.startsWith('--')) {
+      return `${token.slice(0, equalsIndex + 1)}[REDACTED]`;
+    }
+    if (
+      equalsIndex !== -1 &&
+      isValueTakingShortFlag(token.slice(0, equalsIndex))
+    ) {
       return `${token.slice(0, equalsIndex + 1)}[REDACTED]`;
     }
     return token;

--- a/project-plans/issue-3566-startup-fatal-logging/plan.md
+++ b/project-plans/issue-3566-startup-fatal-logging/plan.md
@@ -253,3 +253,25 @@ code; targeted suite independently re-run 28 pass / 0 fail.
   open/synchronize with credentials from repo variables/secrets, includes
   changed test files by rule, and self-limits to 2 auto-reviews — the PR OCR
   round(s) provide the AI-review coverage within the 2+2 budget.
+
+## PR round (#3615) review log
+
+CI round 1 (2dc4f7d21): fully green (35 pass / 0 fail / 3 expected skips).
+PR review round (CodeRabbit + automatic OCR #1): 9 threads, triaged:
+
+| Finding | Class | Action |
+| --- | --- | --- |
+| index.ts: persistence attempt outside guarded boundary (cwd() throw → 44→1 flip) | In-scope-Fix | Guarded in writeFatalError (0211e4555) |
+| startup-fatal-log.ts: `-p` prompt alias leaks prompt into fatal.log (CWE-532) | In-scope-Fix | `-p`/`-i` redaction, bare + equals forms, 5 regression tests |
+| test afterEach rmSync loop could abort before env restore | In-scope-Fix | Env restored first, per-root guarded rmSync |
+| ×4 "assert parsed pause value in parser tests" (OCR, 2 duplicate pairs) | Reject | `pause` deliberately not mapped into CliArgs; acceptance + boolean-registration + pause-matrix tests pin AC4; mapped field would be dead surface |
+| "add pause to CliArgs; opt-out unreachable" (OCR) | Reject | Factually wrong: handler reads raw process.argv; unit-tested |
+| OCR bug/high duplicate of the CodeRabbit persistence finding | In-scope-Fix | Same fix (0211e4555) |
+
+Two round-1 local deferrals stand (getBunSpawn double-cast precedent; `--no-pause=true` equals-form rejected by yargs itself).
+
+Verification on 0211e4555: targeted 33/33; lint/typecheck/format/build exit 0 (format made no rewrites); full suite exit 1 confined to the 4 environmentally-failing files proven identical on pristine main plus one flaky core recording file that passes 16/16 in isolation (core untouched by branch); smoke failure unchanged from pristine-proven baseline (sandbox credential proxy).
+
+CI round 2 (0211e4555): one failure — `useSessionBrowser.part2.spec.ts:839`, a transient-state sampling race in a file this PR does not touch (imports only bun:test/node/core; passed on round 1 and in both local full-suite runs). Retried via empty commit.
+
+CI round 3 (b477d194e): fully green (32 pass / 0 fail / 5 expected skips). All 9 review threads resolved; zero new actionable findings from CodeRabbit re-review and OCR #2 (auto-review budget: 2 of 2 used, as capped).

--- a/project-plans/issue-3566-startup-fatal-logging/plan.md
+++ b/project-plans/issue-3566-startup-fatal-logging/plan.md
@@ -1,0 +1,255 @@
+# Issue #3566: Fatal sandbox preflight errors are invisible in practice
+
+Branch: `issue3566`
+
+## Problem
+
+When a startup-path fatal error (a `FatalError` subclass, e.g.
+`FatalSandboxError` from the sandbox dependency preflight) aborts the launch,
+the only place the message goes is the TTY. The process exits immediately; in
+tmux/terminal-multiplexed workflows the pane dies (`Pane is dead`) so the user
+never sees the diagnosis. No durable artifact is written, so post-mortems find
+nothing.
+
+The fatal funnel is `packages/cli/index.ts`: `main()` (and the bun-launcher /
+bootstrap-import paths) reject into `writeCriticalErrorAndGetExitCode()`, which
+prints via `writeFatalError()` (stderr only) and then `process.exit()`. Nothing
+persists the error.
+
+Note: the github-actions draft plan on the issue proposes hooking
+`cli.tsx main()`, but `main()` does not handle fatal throws itself — it throws
+and `index.ts` owns printing and exiting. The integration point is the
+`index.ts` entry handler, which covers the sandbox hop preflight failures, the
+launcher failures, and every other startup fatal uniformly.
+
+## Acceptance criteria
+
+### AC1: Durable persistence of startup-fatal errors
+
+GIVEN a `FatalError` (any subclass, including `FatalSandboxError`) reaches the
+CLI entry critical-error handler (from `main()` rejection, launcher failure, or
+bootstrap import failure),
+WHEN the fatal message is reported,
+THEN a single-line JSON record is appended to
+`<logHome>/fatal.log` where `logHome = Storage.getGlobalLogDir()`
+(macOS: `~/Library/Logs/llxprt-code`), containing:
+
+- `timestamp`: ISO-8601 UTC string
+- `cwd`: process working directory at failure time
+- `argv`: the full `process.argv`, with `--key <value>` and `--key=<value>`
+  credential values replaced by `[REDACTED]` (no other redaction)
+- `exitCode`: the fatal error's exit code
+- `message`: the full fatal message
+
+The log directory and file are created if absent; repeated fatals accumulate as
+additional JSONL lines.
+
+### AC2: Persisted path is printed on the TTY
+
+WHEN the record was persisted successfully,
+THEN the stderr fatal output is followed by a line naming the persisted file
+path (e.g. `Full error details saved to: <logHome>/fatal.log`) so a user whose
+pane died can find the reason afterwards.
+WHEN persistence fails (e.g. unwritable log home),
+THEN the original message and exit code are reported exactly as before, with no
+path line; a persistence failure must never mask or replace the original error.
+
+### AC3: Pause before exit when stderr is a TTY
+
+WHEN a `FatalError` has been reported AND stderr is a TTY AND `--no-pause` is
+not present in `process.argv`,
+THEN the process waits a brief fixed interval (5 seconds) after printing the
+message (with a one-line notice saying it is pausing and how to skip it), then
+exits with the original code. SIGINT during the pause still terminates the
+process (no signal handler is installed).
+WHEN stderr is not a TTY, or `--no-pause` is present,
+THEN no pause occurs (the process exits immediately as it does today).
+
+### AC4: `--no-pause` is a recognized CLI flag
+
+`--no-pause` is accepted by the argument parser in both the root scope and the
+launch-command scope (so `llxprt --sandbox --no-pause` and
+`llxprt --no-pause` both parse without an unknown-argument failure), and is
+documented in `--help`. The fatal handler detects it from raw `process.argv`,
+so it works even for failures that occur before parsing (launcher/bootstrap
+errors).
+
+### AC5: Exit codes are unchanged
+
+Fatal exits keep their existing exit codes (44 sandbox, 43 launcher, 41 auth,
+52 config, etc.). This change adds observability only.
+
+## Boundary cases / explicit non-goals
+
+- Only `FatalError` instances get the new treatment. Unexpected critical errors
+  (the stack-trace branch) keep their existing behavior. The issue asks for
+  "startup-path fatal error" handling; `FatalError` is this codebase's fatal
+  vocabulary and covers the sandbox preflight case from the issue.
+- The handler hook cannot distinguish pre-TUI from post-TUI establishment
+  without adding global state for no user benefit; the single funnel treats all
+  `FatalError`s uniformly, which is a superset of the issue's requirement
+  ("any `FatalSandboxError` thrown before the TUI session is established").
+- Direct `process.exit` startup paths that are not exceptions (stdin guard
+  `No input provided`, `--list-extensions`, image-mode dispatch,
+  `guardUnconfiguredProvider`) are out of scope; they already print their own
+  final messages and are not thrown fatals.
+- The `uncaughtException` handler (crash path) is out of scope; crashes are a
+  different class from clean fatal exits.
+- No telemetry changes (the issue's suggested direction is the local durable
+  file; wiring fatal events into telemetry startup infra is a separate effort).
+- No changes to preflight recognition itself (#3565 is separate).
+
+## Design
+
+### New module: `packages/cli/src/utils/startup-fatal-log.ts`
+
+Pure, side-effect-free at module scope; imports only `node:fs`, `node:path`,
+`FatalError` from core, and `Storage` from `@vybestack/llxprt-code-storage`
+(already a CLI dependency, already imported by sibling utils).
+
+Public surface (all unit-tested):
+
+- `resolveStartupFatalLogPath(): string` — `join(Storage.getGlobalLogDir(),
+  'fatal.log')`; resolves the log dir at call time so tests can isolate via
+  `LLXPRT_LOG_HOME`.
+- `redactArgvForLog(argv: readonly string[]): string[]` — redacts `--key`
+  values (both `--key v` and `--key=v` forms).
+- `appendStartupFatalLog(record: StartupFatalRecord): { ok: true; path: string }
+  | { ok: false }` — builds the JSONL line and appends; creates the log dir if
+  missing; never throws (persistence failure is reported via the result so the
+  caller falls back to the old behavior).
+- `buildStartupFatalRecord(error: FatalError, context)` — timestamp/cwd/argv/
+  exitCode/message record (`now` injectable for tests).
+- `formatStartupFatalMessage(message: string, logPath: string): string` —
+  message plus the saved-to line.
+- `shouldPauseBeforeExit(argv: readonly string[], stderrIsTty: boolean):
+  boolean` — TTY and no `--no-pause`.
+- `pauseBeforeExitIfNeeded(argv, stderrIsTty, opts?)` — awaits the pause
+  interval; interval and sleep function injectable for tests; never rejects.
+
+### Entry wiring: `packages/cli/index.ts`
+
+- `writeFatalError` persists the record first, then prints the colored message
+  and, on success, the saved-to line.
+- `writeCriticalErrorAndGetExitCode` returns `{ exitCode, fatal }` so callers
+  know whether the pause applies.
+- Both catch paths (post-`main()` and launcher/bootstrap) run cleanup, then
+  `pauseBeforeExitIfNeeded(process.argv, process.stderr.isTTY === true)`, then
+  `process.exit(exitCode)` — extracted into one shared `exitAfterCriticalError`
+  helper.
+
+### Flag registration: `packages/cli/src/config/yargsOptions.ts`
+
+- `pause` boolean option in `rootOptions` and `innerCommandOptions`
+  (yargs provides `--no-pause` negation for boolean options). Not mapped into
+  `CliArgs`; the fatal handler reads raw argv.
+
+## Test plan (TDD; bun:test, behavioral)
+
+New `packages/cli/src/utils/startup-fatal-log.test.ts`:
+
+1. Path resolution: `resolveStartupFatalLogPath()` equals
+   `join(<isolated log home>, 'fatal.log')` with `LLXPRT_LOG_HOME` pointed at a
+   temp dir.
+2. Append creates missing dir/file and writes one valid JSON line with all five
+   fields (timestamp parses as ISO date, cwd, redacted argv, exitCode,
+   message).
+3. A second append accumulates (two lines, both parse).
+4. Redaction: `['llxprt', '--key', 'SECRET', '--sandbox']` and
+   `['llxprt', '--key=SECRET']` both record `[REDACTED]`; non-key args pass
+   through verbatim.
+5. Persistence failure: with the log home pointed inside a read-only directory,
+   `appendStartupFatalLog` returns `{ ok: false }` and does not throw.
+6. `formatStartupFatalMessage` output contains both the original message and
+   the path.
+7. Pause decision truth table: TTY+no flag → true; TTY+`--no-pause` → false;
+   non-TTY → false; non-TTY+`--no-pause` → false.
+8. Pause execution: with an injected sleep spy and small interval, the TTY path
+   awaits the sleep; skipped paths never call it.
+
+New parser cases (in a `config/` parser test): `--no-pause` parses at root
+scope and at launch scope without unknown-argument exit; help text documents
+it.
+
+End-to-end wiring test (in the same util test file, guarded on `Bun.spawn`
+availability like `jspBootstrapStartup.test.ts`): spawn the real CLI entry
+(`bun packages/cli/index.ts --prompt x`) with hermetic env
+(`LLXPRT_CONFIG_HOME`/`LLXPRT_LOG_HOME` at temp dirs, `LLXPRT_SANDBOX=bogus`
+to induce a deterministic `FatalSandboxError` ("Invalid sandbox command") from
+`loadSandboxConfig` during bootstrap, before any network or engine probing),
+cwd at a temp dir, stderr piped (non-TTY → no pause). Assert: exit code 44;
+`<tmpLogHome>/fatal.log` exists and its single record has the message, argv
+containing `--prompt`, cwd equal to the temp cwd, exitCode 44; stderr contains
+the fatal message and the saved-to path.
+
+Exit-code preservation is asserted by the e2e case (44) and by keeping the
+handler's return values derived from `error.exitCode` unchanged.
+
+## Files
+
+- Create `packages/cli/src/utils/startup-fatal-log.ts`
+- Create `packages/cli/src/utils/startup-fatal-log.test.ts`
+- Modify `packages/cli/index.ts` (persist + path line + pause wiring)
+- Modify `packages/cli/src/config/yargsOptions.ts` (register `pause` flag)
+- Create/extend a `config/` parser test for `--no-pause` acceptance
+
+## Out-of-scope guards for reviewers
+
+- No behavior change for non-fatal paths, no exit-code changes, no preflight
+  recognition changes, no telemetry wiring, no new dependencies, no settings
+  schema changes, no `.js`/vitest files.
+
+## Review log
+
+Round 1 (compliance review): 1 Blocker-Fix + 3 In-scope-Fix accepted and
+remediated; 2 findings deferred:
+
+1. Blocker-Fix (fixed): `redactArgvForLog` redacted the next flag's NAME after
+   a bare boolean flag (`--sandbox --prompt x` ate `--prompt`). Now skips
+   redaction when the following token starts with `--`; two regression tests
+   added.
+2. In-scope-Fix (fixed): default `writeNotice` call in
+   `pauseBeforeExitIfNeeded` sat outside the guarded region; a throwing notice
+   writer could reject the helper and flip exit 44 → 1. Moved inside the try.
+3. In-scope-Fix (fixed): `--help` documentation now pinned by asserting a
+   non-empty `description` on both option registrations.
+4. In-scope-Fix (fixed): default pause-notice destination (core
+   `writeToStderr`) now covered by a test at the module seam (a stderr
+   property spy cannot observe `writeToStderr` because it binds the original
+   `process.stderr.write` at module load).
+5. Defer: `getBunSpawn`'s double type assertion mirrors the existing
+   `jspBootstrapStartup.test.ts` precedent; repo-wide harmonization is out of
+   scope.
+6. Defer: `--no-pause=true` (equals form) would not skip the pause;
+   contradictory usage, yargs only negates booleans via the bare `--no-pause`
+   form. Follow-up note only.
+
+Round 2 (findings-verification review, cap reached): **APPROVE**. All four
+round-1 fixes verified with file:line evidence (redaction guard +
+regressions; writeNotice inside the try/swallow boundary with no exit-code
+flip path; registration pinned by description assertions on both option
+tables; default `writeToStderr` seam covered via `mock.module` with finally
+restore). AC1-AC5 all PASS as originally scoped; no defects found in the fix
+code; targeted suite independently re-run 28 pass / 0 fail.
+
+## Verification log
+
+- Targeted tests: 28 pass / 0 fail (`startup-fatal-log.test.ts` +
+  `cliArgParser.noPause.test.ts`), re-run after prettier.
+- Full chain: LINT=0, TYPECHECK=0, FORMAT=0, BUILD=0
+  (tmp/verify3566/step3-lint-v6.log, step3-typecheck-v3.log, step5-format.log,
+  step5-build.log).
+- Full suite: exit 1 with 4 failing files — docsCommand, sandbox-node-modules
+  -preflight, core editor.test.ts, core gitService.test.ts — each re-run on a
+  pristine `git stash`d tree and failing identically there (sandbox-session
+  env + container artifacts; logs tmp/verify3566/step4-fulltest-v2.log).
+- Smoke (`stepfun-37` haiku): fails on credential-proxy auth inside this
+  sandboxed session; identical failure on the pristine tree
+  (tmp/verify3566/smoke.log, smoke-pristine.log).
+- Local OCR review: not runnable in this sandbox. `ocr` was installed, but no
+  LLM credentials exist inside the container by design (keys are held by the
+  host-side credential proxy; `ocr llm test` fails for lack of endpoint). The
+  repo's `.github/workflows/ocr-review.yml` runs OCR automatically on PR
+  open/synchronize with credentials from repo variables/secrets, includes
+  changed test files by rule, and self-limits to 2 auto-reviews — the PR OCR
+  round(s) provide the AI-review coverage within the 2+2 budget.


### PR DESCRIPTION
## TLDR

Startup-path `FatalError`s (including `FatalSandboxError` from the sandbox dependency preflight) now leave a durable trace before the process exits: a JSONL record is appended to `<logHome>/fatal.log` (timestamp, cwd, redacted argv, exit code, message), the persisted path is printed alongside the message, and the process pauses briefly before exit when stderr is a TTY so multiplexer users (tmux panes dying with `Pane is dead`) can read the diagnosis in place. `--no-pause` opts out.

Fixes #3566

## Dive Deeper

**Problem**: the fatal funnel (`packages/cli/index.ts`: `writeFatalError` / `writeCriticalErrorAndGetExitCode` → `process.exit`) only wrote to the TTY. In tmux the pane closes on exit, so the user sees nothing, and no durable artifact existed (no session dir, no telemetry event, no crash report — clean exit). Post-mortem required re-running the same invocation under `tmux pipe-pane`.

**Design** (plan: `project-plans/issue-3566-startup-fatal-logging/plan.md`):

- New `packages/cli/src/utils/startup-fatal-log.ts`:
  - `appendStartupFatalLog` appends one JSON line to `join(Storage.getGlobalLogDir(), 'fatal.log')`, creating the directory if missing. Never throws — persistence failure returns `{ ok: false }` so the original message/exit code are reported exactly as before (crash-path justification for the swallow).
  - `redactArgvForLog` replaces `--key <value>` / `--key=<value>` values with `[REDACTED]`, skipping tokens that start with `--` so boolean flags followed by another flag are never eaten.
  - `pauseBeforeExitIfNeeded` pauses 5s only when stderr is a TTY and `--no-pause` is absent; prints a one-line notice mentioning the opt-out; never rejects and installs no signal handlers (SIGINT still terminates the pause).
- `packages/cli/index.ts`: `writeFatalError` persists before printing and, on success, prints `Full error details saved to: <path>`. A shared `exitAfterCriticalError` helper (report → cleanup → pause if fatal → `process.exit`) is used by both the post-`main()` catch and the outer `.catch`. Exit codes are unchanged (`error.exitCode`, e.g. 44 for `FatalSandboxError`).
- `--no-pause` is registered as a boolean option in both `rootOptions` and `innerCommandOptions` (yargs boolean negation), and is detected from raw `process.argv` by the fatal handler so pre-parse failures (launcher/bootstrap) are also covered. Not mapped into `CliArgs` — nothing downstream consumes the parsed value.

**Boundary cases**: non-`FatalError` critical errors keep their existing stack-trace output; direct `process.exit` startup paths (stdin guard, `--list-extensions`, image mode) are untouched; no preflight-recognition change (#3565 is separate); no telemetry wiring; no new dependencies.

## Reviewer Test Plan

1. `cd packages/cli && bun test src/utils/startup-fatal-log.test.ts src/config/cliArgParser.noPause.test.ts` — 28 tests including a real-spawn e2e: `LLXPRT_SANDBOX=bogus` + isolated `LLXPRT_LOG_HOME` produces exit 44, exactly one JSON line in `fatal.log` (message contains `Invalid sandbox command`, argv redacted, cwd, exitCode, parseable timestamp), and stderr contains the message plus the `fatal.log` path.
2. Manual repro of the issue scenario:
   ```
   LLXPRT_SANDBOX=bogus llxprt --prompt x   # observe message + "Full error details saved to: <path>"; cat <path>
   ```
   In a TTY the process pauses ~5s with a notice; `--no-pause` exits immediately; piped stderr never pauses.
3. `llxprt --help | grep -A1 no-pause` shows the flag in both scopes.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅ (this PR: full chain lint/typecheck/format/build + targeted 28/28 in Linux sandbox; full suite exit 1 with 4 files proven failing identically on pristine main — environmental) |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

## Linked issues / bugs

Fixes #3566
Related to #3565 (preflight recognition is unchanged here; this PR only adds observability of fatal results)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup failures are now saved to a durable log file, with sensitive command-line values redacted.
  * Error messages include the saved log location when available.
  * The CLI briefly pauses before fatal exits in interactive terminals to make messages easier to read.
  * Added a `--no-pause` option to disable the pre-exit pause for root and default commands.
* **Bug Fixes**
  * Improved fatal-error handling to preserve the original error message and exit code, even when log persistence fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->