### PR TITLE
fix(ui): make ModelConfigDialog staged-edit saves atomic (Fixes #2831)

### DIFF
--- a/packages/cli/src/ui/components/ModelConfigDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelConfigDialog.test.tsx
@@ -39,6 +39,11 @@ interface StatefulRuntimeState {
   modelParams: Record<string, unknown>;
   ephemeralSettings: Record<string, unknown>;
   unallowedParameters?: string[];
+  // Listed keys make the corresponding write method throw, so tests can
+  // exercise the dialog's rollback path against a stateful fake.
+  failSetParamKeys?: string[];
+  failClearParamKeys?: string[];
+  failSetEphemeralKeys?: string[];
 }
 
 function createStatefulRuntime(
@@ -52,6 +57,7 @@ function createStatefulRuntime(
   clearActiveModelParam: (key: string) => void;
   setEphemeralSetting: (key: string, value: unknown) => void;
   getUnallowedParametersForActiveModel: () => string[];
+  writeCounts: () => Record<string, number>;
 } {
   const state: StatefulRuntimeState = {
     providerName: 'openai',
@@ -60,6 +66,10 @@ function createStatefulRuntime(
     ephemeralSettings: { 'reasoning.enabled': true },
     ...overrides,
   };
+  // Completed-write counters keyed as `<op>:<key>` (setParam, clearParam,
+  // setEphemeral). A write that throws is not counted: the counters record
+  // mutations that actually landed.
+  const writes: Record<string, number> = {};
   return {
     ...state,
     getActiveProviderName: () => state.providerName,
@@ -67,15 +77,28 @@ function createStatefulRuntime(
     getActiveModelParams: () => ({ ...state.modelParams }),
     getEphemeralSettings: () => ({ ...state.ephemeralSettings }),
     setActiveModelParam: (key: string, value: unknown) => {
+      if (state.failSetParamKeys?.includes(key) === true) {
+        throw new Error(`write failed: ${key}`);
+      }
+      writes[`setParam:${key}`] = (writes[`setParam:${key}`] ?? 0) + 1;
       state.modelParams[key] = value;
     },
     clearActiveModelParam: (key: string) => {
+      if (state.failClearParamKeys?.includes(key) === true) {
+        throw new Error(`write failed: ${key}`);
+      }
+      writes[`clearParam:${key}`] = (writes[`clearParam:${key}`] ?? 0) + 1;
       delete state.modelParams[key];
     },
     setEphemeralSetting: (key: string, value: unknown) => {
+      if (state.failSetEphemeralKeys?.includes(key) === true) {
+        throw new Error(`write failed: ${key}`);
+      }
+      writes[`setEphemeral:${key}`] = (writes[`setEphemeral:${key}`] ?? 0) + 1;
       state.ephemeralSettings[key] = value;
     },
     getUnallowedParametersForActiveModel: () => state.unallowedParameters ?? [],
+    writeCounts: () => ({ ...writes }),
   };
 }
 
@@ -143,6 +166,75 @@ function navigateToField(
       stdin.write(DOWN);
     });
   }
+}
+
+// The issue-#2831 tests stage several fields in one dialog session. The list
+// only navigates DOWN, so each staging helper takes the current index and
+// returns the field's index for the next call.
+
+function moveDownTo(
+  stdin: { write: (data: string) => void },
+  from: number,
+  target: number,
+): number {
+  for (let i = from; i < target; i++) {
+    act(() => {
+      stdin.write(DOWN);
+    });
+  }
+  return target;
+}
+
+// Navigate to `key`, enter its text editor, clear any pre-filled value
+// (ctrl-a home + ctrl-k kill-to-end), type `value`, Enter to stage.
+async function stageTextAt(
+  stdin: { write: (data: string) => void },
+  key: string,
+  value: string,
+  from: number,
+): Promise<number> {
+  const at = moveDownTo(stdin, from, fieldIndex(key));
+  act(() => {
+    stdin.write(ENTER);
+  });
+  act(() => {
+    stdin.write('\x01');
+  });
+  act(() => {
+    stdin.write('\x0b');
+  });
+  for (const ch of value) {
+    act(() => {
+      stdin.write(ch);
+    });
+  }
+  await act(async () => {
+    stdin.write(ENTER);
+  });
+  return at;
+}
+
+// Navigate to the enum field `key`, enter its editor, press RIGHT
+// `rightSteps` times from the enum's start, Enter to stage.
+async function stageEnumAt(
+  stdin: { write: (data: string) => void },
+  key: string,
+  from: number,
+  rightSteps: number,
+): Promise<number> {
+  const at = moveDownTo(stdin, from, fieldIndex(key));
+  act(() => {
+    stdin.write(ENTER);
+  });
+  for (let i = 0; i < rightSteps; i++) {
+    act(() => {
+      stdin.write(RIGHT);
+    });
+  }
+  await act(async () => {
+    stdin.write(ENTER);
+  });
+  return at;
 }
 
 function defaultProps() {
@@ -714,5 +806,280 @@ describe('<ModelConfigDialog />', () => {
       expect(lastFrame()).toContain('4096');
     });
     expect(lastFrame()).not.toContain('131072');
+  });
+
+  // Issue #2831: [s]ave plans (validates) every staged edit first, then
+  // applies writes in field order, rolling back to snapshotted priors if
+  // one throws. Streaming/prompt-caching below are enum editors.
+
+  // Shared preamble for the tests below: tracked onClose plus the view.
+  function renderTracked() {
+    const props = defaultProps();
+    const view = renderWithProviders(<ModelConfigDialog {...props} />);
+    return { ...view, props };
+  }
+
+  // Live-state assertions against the stateful fake (issue #2831 suite);
+  // activeRuntime is re-read on every call, after setupRuntime overrides.
+  const expectParams = (obj: Record<string, unknown>) =>
+    expect(activeRuntime.getActiveModelParams()).toStrictEqual(obj);
+  const expectEphemeral = (obj: Record<string, unknown>) =>
+    expect(activeRuntime.getEphemeralSettings()).toStrictEqual(obj);
+
+  it('T1: later-field validation failure leaves the runtime untouched (issue #2831)', async () => {
+    const { lastFrame, stdin, props } = renderTracked();
+
+    const at = await stageTextAt(stdin, 'temperature', '9.9', 0);
+    await stageTextAt(stdin, 'top_k', 'abc', at);
+
+    await saveDialog(stdin);
+
+    // The first invalid field in field order is reported...
+    await waitFor(() => {
+      expect(lastFrame()).toContain('top_k: must be a number');
+    });
+    // ...and the earlier VALID edit was not half-committed.
+    expectParams({ temperature: 0.7 });
+    expectEphemeral({ 'reasoning.enabled': true });
+    expect(props.onClose).not.toHaveBeenCalled();
+    expect(lastFrame()).toContain('9.9');
+    expect(lastFrame()).toContain('abc');
+  });
+
+  it('T2: recovery after a failed save commits every staged edit exactly once (issue #2831)', async () => {
+    const { stdin, props } = renderTracked();
+
+    let at = await stageTextAt(stdin, 'temperature', '9.9', 0);
+    at = await stageTextAt(stdin, 'top_k', 'abc', at);
+    await saveDialog(stdin);
+    expect(props.onClose).not.toHaveBeenCalled();
+
+    // Correct the invalid field and re-save: both staged edits land.
+    await stageTextAt(stdin, 'top_k', '40', at);
+    await saveDialog(stdin);
+
+    expectParams({ temperature: 9.9, top_k: 40 });
+    // Each staged key was written exactly once across both saves.
+    expect(activeRuntime.writeCounts()['setParam:temperature']).toBe(1);
+    expect(activeRuntime.writeCounts()['setParam:top_k']).toBe(1);
+    await waitFor(() => {
+      expect(props.onClose).toHaveBeenCalled();
+    });
+  });
+
+  it('T3: mid-loop write throw rolls back already-applied writes (issue #2831)', async () => {
+    setupRuntime({ failSetParamKeys: ['top_p'] });
+    const { lastFrame, stdin, props } = renderTracked();
+
+    const at = await stageTextAt(stdin, 'temperature', '9.9', 0);
+    await stageTextAt(stdin, 'top_p', '0.5', at);
+
+    await saveDialog(stdin);
+
+    // temperature is restored when the top_p write throws.
+    await waitFor(() => {
+      expect(lastFrame()).toContain('top_p: write failed: top_p');
+    });
+    expectParams({ temperature: 0.7 });
+    expect(activeRuntime.getActiveModelParams()).not.toHaveProperty('top_p');
+    expect(props.onClose).not.toHaveBeenCalled();
+    expect(lastFrame()).toContain('9.9');
+    expect(lastFrame()).toContain('0.5');
+  });
+
+  it('T4: staged clear is rolled back when a later write throws (issue #2831)', async () => {
+    setupRuntime({ failSetParamKeys: ['top_p'] });
+    const { lastFrame, stdin, props } = renderTracked();
+
+    // Stage a temperature clear, then a top_p edit whose write throws.
+    const clearAt = moveDownTo(stdin, 0, fieldIndex('temperature'));
+    await act(async () => {
+      stdin.write('c');
+    });
+    await stageTextAt(stdin, 'top_p', '0.5', clearAt);
+
+    await saveDialog(stdin);
+
+    await waitFor(() => {
+      expect(lastFrame()).toContain('top_p: write failed: top_p');
+    });
+    expectParams({ temperature: 0.7 });
+    expect(activeRuntime.getActiveModelParams()).not.toHaveProperty('top_p');
+    expect(props.onClose).not.toHaveBeenCalled();
+    // Restored value visible in the row ('(not set)' would be vacuous).
+    expect(activeRuntime.getActiveModelParams().temperature).toBe(0.7);
+    expect(lastFrame()).toMatch(/temperature\s+0\.7/);
+  });
+
+  it('T5: multi-kind save lands param, clear, boolean, and enum edits together (issue #2831)', async () => {
+    setupRuntime({
+      modelParams: { temperature: 0.7 },
+      ephemeralSettings: { 'reasoning.enabled': false },
+    });
+    const { lastFrame, stdin, props } = renderTracked();
+
+    let at = await stageTextAt(stdin, 'max_tokens', '32000', 0);
+
+    at = moveDownTo(stdin, at, fieldIndex('temperature'));
+    await act(async () => {
+      stdin.write('c');
+    });
+
+    at = moveDownTo(stdin, at, fieldIndex('reasoning.enabled'));
+    await act(async () => {
+      stdin.write(' ');
+    });
+
+    // streaming starts at 'enabled' (one RIGHT: disabled); prompt-caching
+    // starts at 'off' (one RIGHT: 5m).
+    at = await stageEnumAt(stdin, 'streaming', at, 1);
+    await stageEnumAt(stdin, 'prompt-caching', at, 1);
+    await waitFor(() => {
+      expect(lastFrame()).toMatch(/streaming\s+disabled/);
+      expect(lastFrame()).toMatch(/prompt-caching\s+5m/);
+    });
+
+    await saveDialog(stdin);
+
+    expectParams({ max_tokens: 32000 });
+    expectEphemeral({
+      'reasoning.enabled': true,
+      streaming: 'disabled',
+      'prompt-caching': '5m',
+    });
+    await waitFor(() => {
+      expect(props.onClose).toHaveBeenCalled();
+    });
+  });
+
+  it('T6: ephemeral write throwing mid-loop rolls back earlier param clear and ephemeral edit (issue #2831)', async () => {
+    // failSetEphemeralKeys must be set at runtime creation (snapshotted).
+    setupRuntime({ failSetEphemeralKeys: ['streaming'] });
+    const { lastFrame, stdin, props } = renderTracked();
+
+    // Stage a temperature clear (writes first), then a streaming enum edit
+    // whose write throws mid-loop. The clear is verified via runtime state.
+    const clearAt = moveDownTo(stdin, 0, fieldIndex('temperature'));
+    await act(async () => {
+      stdin.write('c');
+    });
+
+    // streaming starts at 'enabled'; one RIGHT lands on 'disabled'.
+    await stageEnumAt(stdin, 'streaming', clearAt, 1);
+
+    await saveDialog(stdin);
+
+    // The throwing field is reported...
+    await waitFor(() => {
+      expect(lastFrame()).toContain('streaming: write failed: streaming');
+    });
+    // ...the clear rolled back and the failed write never landed.
+    expectParams({ temperature: 0.7 });
+    expectEphemeral({ 'reasoning.enabled': true });
+    // streaming threw before mutating: absent, not present-with-undefined.
+    expect('streaming' in activeRuntime.getEphemeralSettings()).toBe(false);
+    expect(props.onClose).not.toHaveBeenCalled();
+    // Staged edits survive: streaming 'disabled', temperature restored 0.7.
+    expect(lastFrame()).toMatch(/temperature\s+0\.7/);
+    expect(lastFrame()).toMatch(/streaming\s+disabled/);
+  });
+
+  it('T7: later ephemeral parse failure aborts before any write (issue #2831)', async () => {
+    const { lastFrame, stdin, props } = renderTracked();
+
+    // context-limit precedes temperature, so its 'abc' is first invalid.
+    const at = await stageTextAt(stdin, 'context-limit', 'abc', 0);
+    await stageTextAt(stdin, 'temperature', '0.9', at);
+
+    await saveDialog(stdin);
+
+    // The first invalid field in field order is reported...
+    await waitFor(() => {
+      expect(lastFrame()).toContain('context-limit:');
+      expect(lastFrame()).toContain('must be a positive integer');
+    });
+    // ...and phase 1 aborted before ANY write (ledger empty).
+    expectParams({ temperature: 0.7 });
+    expectEphemeral({ 'reasoning.enabled': true });
+    expect(activeRuntime.writeCounts()).toStrictEqual({});
+    expect(props.onClose).not.toHaveBeenCalled();
+    expect(lastFrame()).toMatch(/context-limit\s+abc/);
+    expect(lastFrame()).toContain('0.9');
+  });
+
+  it('T8: first planned write throwing rolls back nothing and names the failing field (issue #2831)', async () => {
+    setupRuntime({ failClearParamKeys: ['temperature'] });
+    const { lastFrame, stdin, props } = renderTracked();
+
+    // Stage ONLY the clear of temperature.
+    moveDownTo(stdin, 0, fieldIndex('temperature'));
+    await act(async () => {
+      stdin.write('c');
+    });
+
+    await saveDialog(stdin);
+
+    await waitFor(() => {
+      expect(lastFrame()).toMatch(/temperature: write failed: temperature/);
+    });
+    // Nothing applied; the rollback loop body never ran (ledger empty).
+    expectParams({ temperature: 0.7 });
+    expect(activeRuntime.writeCounts()).toStrictEqual({});
+    expect(props.onClose).not.toHaveBeenCalled();
+    expect(lastFrame()).toMatch(/temperature\s+0\.7/);
+  });
+
+  it('T9: rolling back an ephemeral edit on a previously-absent key restores undefined (issue #2831)', async () => {
+    setupRuntime({ failSetEphemeralKeys: ['prompt-caching'] });
+    const { lastFrame, stdin, props } = renderTracked();
+
+    // streaming starts at 'enabled'; one RIGHT lands on 'disabled'.
+    const at = await stageEnumAt(stdin, 'streaming', 0, 1);
+    // prompt-caching starts at 'off'; one RIGHT lands on '5m'.
+    await stageEnumAt(stdin, 'prompt-caching', at, 1);
+
+    await saveDialog(stdin);
+
+    await waitFor(() => {
+      expect(lastFrame()).toMatch(
+        /prompt-caching: write failed: prompt-caching/,
+      );
+    });
+    expect(activeRuntime.getEphemeralSettings()['reasoning.enabled']).toBe(
+      true,
+    );
+    // The rollback restores the prior value as present-but-undefined,
+    // mirroring the real SettingsService's set(key, undefined) semantics
+    // (the dialog's pre-existing clear idiom).
+    expect(activeRuntime.getEphemeralSettings().streaming).toBeUndefined();
+    expect('streaming' in activeRuntime.getEphemeralSettings()).toBe(true);
+    const counts = activeRuntime.writeCounts();
+    expect(counts).toStrictEqual({ 'setEphemeral:streaming': 2 });
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+
+  it('T10: restore failure is recorded, rollback continues, and the original error is surfaced (issue #2831)', async () => {
+    setupRuntime({
+      modelParams: {},
+      failSetParamKeys: ['top_p'],
+      failClearParamKeys: ['temperature'],
+    });
+    const { lastFrame, stdin, props } = renderTracked();
+
+    // temperature is initially ABSENT: its forward write is a set-param
+    // whose snapshotted prior is a clear-param.
+    const at = await stageTextAt(stdin, 'temperature', '9.9', 0);
+    await stageTextAt(stdin, 'top_p', '0.5', at);
+
+    await saveDialog(stdin);
+
+    await waitFor(() => {
+      expect(lastFrame()).toContain('top_p: write failed: top_p');
+      expect(lastFrame()).toContain('rollback incomplete: temperature');
+    });
+    // The clear-param restore ALSO threw (failClearParamKeys): temperature
+    // stays at its written value — degraded but reported.
+    expectParams({ temperature: 9.9 });
+    expect(props.onClose).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/ui/components/ModelConfigDialog.tsx
+++ b/packages/cli/src/ui/components/ModelConfigDialog.tsx
@@ -425,9 +425,10 @@ function planFieldEdit(field: ConfigField, edit: PendingEdit): FieldPlan {
     return { kind: 'write', write: { kind: 'set-param', value: result.value } };
   }
 
-  // Guarded like validateModelParam guards parseValue: a registry parse
-  // throw surfaces as the inline validation message instead of tearing
-  // down the Ink UI (the pre-refactor dialog caught these the same way).
+  // Unlike validateModelParam (which guards parseValue internally and never
+  // throws), parseEphemeralSettingValue can throw, so it is guarded here: a
+  // throw becomes the inline validation message instead of tearing down the
+  // Ink UI (the pre-refactor dialog caught these the same way).
   try {
     const result = parseEphemeralSettingValue(field.key, raw);
     if (!result.success) return { kind: 'invalid', message: result.message };

--- a/packages/cli/src/ui/components/ModelConfigDialog.tsx
+++ b/packages/cli/src/ui/components/ModelConfigDialog.tsx
@@ -16,10 +16,7 @@ import { TextInput } from './ProfileCreateWizard/TextInput.js';
 import { parseValue } from '../commands/setCommand.js';
 import { parseEphemeralSettingValue } from '@vybestack/llxprt-code-providers/runtime.js';
 import { getSettingSpec } from '@vybestack/llxprt-code-settings';
-import {
-  commitModelParam,
-  type CommitResult,
-} from './modelConfigParamCommit.js';
+import { validateModelParam } from './modelConfigParamCommit.js';
 
 // Pending values for one field, staged in the dialog until [Save] commits
 // them to the runtime. Cancel/Esc discards them wholesale.
@@ -382,95 +379,177 @@ function stageBooleanToggle(field: ConfigField, d: KeypressDispatch): void {
   d.setValidationError(null);
 }
 
-// Validates staged text edits, then writes every pending value into the
-// runtime. Returns true when the commit succeeded (dialog may close).
-function commitPendingEdits(d: KeypressDispatch): boolean {
-  for (const field of d.fields) {
-    if (!(field.key in d.pendingEdits)) continue;
-    const edit = d.pendingEdits[field.key];
-    const error = commitFieldEdit(field, edit, d);
-    if (error !== null) {
-      d.setValidationError(`${field.key}: ${error}`);
-      return false;
-    }
-  }
-  d.clearPendingEdits();
-  d.setValidationError(null);
-  return true;
-}
+// One runtime mutation the save path can perform, planned in phase 1 and
+// applied (or rolled back) in phase 2.
+type PlannedWrite =
+  | { kind: 'set-param'; value: unknown }
+  | { kind: 'clear-param' }
+  | { kind: 'set-ephemeral'; value: unknown };
 
-// Commits a single staged edit for a field. Returns an error message on
-// validation failure, or null when the write succeeded (or was a no-op).
-function commitFieldEdit(
-  field: ConfigField,
-  edit: PendingEdit,
-  d: KeypressDispatch,
-): string | null {
-  try {
-    return applyFieldEdit(field, edit, d);
-  } catch (e) {
-    // setEphemeralSetting/setActiveModelParam can throw (e.g. no active
-    // provider); surface the error instead of crashing the dialog.
-    return e instanceof Error ? e.message : String(e);
-  }
-}
+type FieldPlan =
+  | { kind: 'write'; write: PlannedWrite }
+  | { kind: 'skip' }
+  | { kind: 'invalid'; message: string };
 
-function applyFieldEdit(
-  field: ConfigField,
-  edit: PendingEdit,
-  d: KeypressDispatch,
-): string | null {
+// Pure: turns one staged edit into a typed write with zero runtime calls.
+function planFieldEdit(field: ConfigField, edit: PendingEdit): FieldPlan {
   if (field.editor === 'boolean') {
-    if (edit.boolValue !== null) {
-      d.runtime.setEphemeralSetting(field.key, edit.boolValue);
-    }
-    return null;
+    if (edit.boolValue === null) return { kind: 'skip' };
+    return {
+      kind: 'write',
+      write: { kind: 'set-ephemeral', value: edit.boolValue },
+    };
   }
 
   if (field.editor === 'enum') {
-    if (edit.enumIndex !== null) {
-      const value = field.enumValues?.[edit.enumIndex];
-      if (value !== undefined) {
-        d.runtime.setEphemeralSetting(field.key, value);
-      }
-    }
-    return null;
+    if (edit.enumIndex === null) return { kind: 'skip' };
+    const value = field.enumValues?.[edit.enumIndex];
+    if (value === undefined) return { kind: 'skip' };
+    return { kind: 'write', write: { kind: 'set-ephemeral', value } };
   }
 
   const raw = edit.text;
   if (raw === '') {
     if (field.kind === 'param') {
-      d.runtime.clearActiveModelParam(field.key);
-    } else {
-      d.runtime.setEphemeralSetting(field.key, undefined);
+      return { kind: 'write', write: { kind: 'clear-param' } };
     }
-    return null;
+    return {
+      kind: 'write',
+      write: { kind: 'set-ephemeral', value: undefined },
+    };
   }
 
   if (field.kind === 'param') {
-    const result = commitModelParam(field.key, raw, (value) =>
-      d.runtime.setActiveModelParam(field.key, value),
-    );
-    return result.success ? null : result.message;
+    const result = validateModelParam(field.key, raw);
+    if (!result.success) return { kind: 'invalid', message: result.message };
+    return { kind: 'write', write: { kind: 'set-param', value: result.value } };
   }
 
-  const result = commitEphemeral(field, raw, (value) =>
-    d.runtime.setEphemeralSetting(field.key, value),
-  );
-  return result.success ? null : result.message;
+  // Guarded like validateModelParam guards parseValue: a registry parse
+  // throw surfaces as the inline validation message instead of tearing
+  // down the Ink UI (the pre-refactor dialog caught these the same way).
+  try {
+    const result = parseEphemeralSettingValue(field.key, raw);
+    if (!result.success) return { kind: 'invalid', message: result.message };
+    return {
+      kind: 'write',
+      write: { kind: 'set-ephemeral', value: result.value },
+    };
+  } catch (e) {
+    return {
+      kind: 'invalid',
+      message: e instanceof Error ? e.message : String(e),
+    };
+  }
 }
 
-function commitEphemeral(
+function applyPlannedWrite(
+  d: KeypressDispatch,
   field: ConfigField,
-  raw: string,
-  setEphemeralSetting: (value: unknown) => void,
-): CommitResult {
-  const result = parseEphemeralSettingValue(field.key, raw);
-  if (!result.success) {
-    return { success: false, message: result.message };
+  write: PlannedWrite,
+): void {
+  if (write.kind === 'set-param') {
+    d.runtime.setActiveModelParam(field.key, write.value);
+    return;
   }
-  setEphemeralSetting(result.value);
-  return { success: true };
+  if (write.kind === 'clear-param') {
+    d.runtime.clearActiveModelParam(field.key);
+    return;
+  }
+  d.runtime.setEphemeralSetting(field.key, write.value);
+}
+
+// The inverse of a planned write, derived from the same store the forward
+// write targets (set-ephemeral ↔ the ephemeral map; set/clear-param ↔ the
+// params map) rather than from field.kind. Callers pass fresh pre-save
+// maps — see commitPendingEdits — because the render-time d.params and
+// d.ephemeral can be stale if the runtime changed externally.
+function priorWriteFor(
+  field: ConfigField,
+  write: PlannedWrite,
+  params: Record<string, unknown>,
+  ephemeral: Record<string, unknown>,
+): PlannedWrite {
+  if (write.kind === 'set-ephemeral') {
+    return { kind: 'set-ephemeral', value: ephemeral[field.key] };
+  }
+  if (field.key in params) {
+    return { kind: 'set-param', value: params[field.key] };
+  }
+  return { kind: 'clear-param' };
+}
+
+// Two-phase atomic save (issue #2831). Phase 1 validates every staged edit
+// with zero runtime writes; the first invalid field in field order is
+// reported and nothing is applied. Phase 2 snapshots each planned write's
+// prior value before the first write, then applies the writes in field
+// order. Returns true when the commit succeeded (dialog may close).
+function commitPendingEdits(d: KeypressDispatch): boolean {
+  const planned: Array<{ field: ConfigField; write: PlannedWrite }> = [];
+  for (const field of d.fields) {
+    if (!(field.key in d.pendingEdits)) continue;
+    const plan = planFieldEdit(field, d.pendingEdits[field.key]);
+    if (plan.kind === 'invalid') {
+      d.setValidationError(`${field.key}: ${plan.message}`);
+      return false;
+    }
+    if (plan.kind === 'write') planned.push({ field, write: plan.write });
+  }
+
+  // Snapshot the true pre-save state once, before any write: d.params and
+  // d.ephemeral are render-time reads that can be stale if the runtime
+  // changed externally since the last render, and the rollback must restore
+  // the values the runtime actually held when [s]ave fired.
+  const paramsNow = d.runtime.getActiveModelParams();
+  const ephemeralNow = d.runtime.getEphemeralSettings();
+  const priors = planned.map((entry) =>
+    priorWriteFor(entry.field, entry.write, paramsNow, ephemeralNow),
+  );
+  for (const [i, entry] of planned.entries()) {
+    try {
+      applyPlannedWrite(d, entry.field, entry.write);
+    } catch (e) {
+      // Rollback-on-throw: restore every already-applied write [0, i) to
+      // its snapshotted prior value in reverse so the runtime ends exactly
+      // where it started.
+      const failedRestores = restoreAppliedWrites(d, planned, priors, i);
+      const message = e instanceof Error ? e.message : String(e);
+      let errorText = `${entry.field.key}: ${message}`;
+      if (failedRestores.length > 0) {
+        errorText += ` (rollback incomplete: ${failedRestores.join(', ')})`;
+      }
+      d.setValidationError(errorText);
+      return false;
+    }
+  }
+
+  d.clearPendingEdits();
+  d.setValidationError(null);
+  return true;
+}
+
+// Failure-safe rollback for commitPendingEdits: restores the already-applied
+// writes [0, failIndex) in reverse to their snapshotted prior values and
+// returns the keys whose restore threw. Restores are guarded not to hedge
+// against upstream bugs but because the recovery path must surface the
+// ORIGINAL write error and finish restoring what it can; a throwing restore
+// is recorded and reported instead of masking the save failure that caused
+// it.
+function restoreAppliedWrites(
+  d: KeypressDispatch,
+  planned: Array<{ field: ConfigField; write: PlannedWrite }>,
+  priors: PlannedWrite[],
+  failIndex: number,
+): string[] {
+  const failedRestores: string[] = [];
+  for (let j = failIndex - 1; j >= 0; j--) {
+    try {
+      applyPlannedWrite(d, planned[j].field, priors[j]);
+    } catch {
+      failedRestores.push(planned[j].field.key);
+    }
+  }
+  return failedRestores;
 }
 
 function handleListKey(key: Key, d: KeypressDispatch): void {

--- a/packages/cli/src/ui/components/modelConfigParamCommit.spec.ts
+++ b/packages/cli/src/ui/components/modelConfigParamCommit.spec.ts
@@ -74,15 +74,24 @@ describe('validateModelParam (issues #2896, #2831)', () => {
     '1e400',
     '-1e400',
   ])('A5: rejects %j for top_p', (raw) => {
-    expect(validateModelParam('top_p', raw).success).toBe(false);
+    expect(validateModelParam('top_p', raw)).toStrictEqual({
+      success: false,
+      message: NOT_A_NUMBER_MESSAGE,
+    });
   });
 
   it('A5: rejects a JSON object for a number-typed param', () => {
-    expect(validateModelParam('top_p', '{"a":1}').success).toBe(false);
+    expect(validateModelParam('top_p', '{"a":1}')).toStrictEqual({
+      success: false,
+      message: NOT_A_NUMBER_MESSAGE,
+    });
   });
 
   it('A5: rejects a boolean literal for a number-typed param', () => {
-    expect(validateModelParam('temperature', 'true').success).toBe(false);
+    expect(validateModelParam('temperature', 'true')).toStrictEqual({
+      success: false,
+      message: NOT_A_NUMBER_MESSAGE,
+    });
   });
 
   // A6 — the remaining number-typed dialog fields, integer and fractional

--- a/packages/cli/src/ui/components/modelConfigParamCommit.spec.ts
+++ b/packages/cli/src/ui/components/modelConfigParamCommit.spec.ts
@@ -9,68 +9,59 @@
  * strings (`"top_p": ".95"`), which OpenRouter rejects with
  * `top_p: Invalid input: expected number, received string`.
  *
- * These tests drive the real commit path the dialog uses (real `parseValue`,
- * real settings registry) and assert on what the runtime actually receives.
+ * These tests drive the real validation path the dialog uses (real
+ * `parseValue`, real settings registry) and assert on the typed value the
+ * save would write. Validation is pure (issue #2831): the dialog validates
+ * every staged edit before applying any write, and the runtime-write
+ * failure path is covered by the dialog's phase-2 rollback tests.
  *
  * Acceptance rows covered: A4, A5, A6.
  */
 
 import { describe, it, expect } from 'bun:test';
 import {
-  commitModelParam,
+  validateModelParam,
   NOT_A_NUMBER_MESSAGE,
 } from './modelConfigParamCommit.js';
 
-/** Captures exactly what the dialog would write into the runtime. */
-function recorder() {
-  const writes: unknown[] = [];
-  return {
-    writes,
-    set: (value: unknown) => {
-      writes.push(value);
-    },
-  };
-}
-
-describe('commitModelParam (issue #2896)', () => {
+describe('validateModelParam (issues #2896, #2831)', () => {
   // A4 — the exact input from the bug report.
-  it('A4: commits ".95" for top_p as the number 0.95', () => {
-    const r = recorder();
-    const result = commitModelParam('top_p', '.95', r.set);
-
-    expect(result.success).toBe(true);
-    expect(r.writes).toStrictEqual([0.95]);
-    expect(typeof r.writes[0]).toBe('number');
+  it('A4: validates ".95" for top_p as the number 0.95', () => {
+    expect(validateModelParam('top_p', '.95')).toStrictEqual({
+      success: true,
+      value: 0.95,
+    });
   });
 
-  it('A4: commits "0.95" for top_p as the number 0.95', () => {
-    const r = recorder();
-    commitModelParam('top_p', '0.95', r.set);
-    expect(r.writes).toStrictEqual([0.95]);
+  it('A4: validates "0.95" for top_p as the number 0.95', () => {
+    expect(validateModelParam('top_p', '0.95')).toStrictEqual({
+      success: true,
+      value: 0.95,
+    });
   });
 
-  it('A4: commits negative and exponent forms as numbers', () => {
-    const r = recorder();
-    commitModelParam('presence_penalty', '-.5', r.set);
-    commitModelParam('temperature', '1e-5', r.set);
-    expect(r.writes).toStrictEqual([-0.5, 1e-5]);
+  it('A4: validates negative and exponent forms as numbers', () => {
+    expect(validateModelParam('presence_penalty', '-.5')).toStrictEqual({
+      success: true,
+      value: -0.5,
+    });
+    expect(validateModelParam('temperature', '1e-5')).toStrictEqual({
+      success: true,
+      value: 1e-5,
+    });
   });
 
-  // A5 — non-numeric input must be rejected, not written as a string.
-  it('A5: rejects "abc" for top_p and writes nothing', () => {
-    const r = recorder();
-    const result = commitModelParam('top_p', 'abc', r.set);
-
-    expect(result).toStrictEqual({
+  // A5 — non-numeric input must be rejected, never returned as a string.
+  it('A5: rejects "abc" for top_p', () => {
+    expect(validateModelParam('top_p', 'abc')).toStrictEqual({
       success: false,
       message: NOT_A_NUMBER_MESSAGE,
     });
-    expect(r.writes).toStrictEqual([]);
   });
 
   // '1e400' and '-1e400' are syntactically valid numbers that overflow to
   // +/-Infinity, which JSON-serializes to null — the finite guard must reject
-  // them rather than write an unusable value.
+  // them rather than hand back an unusable value.
   it.each([
     '.',
     '-',
@@ -82,65 +73,39 @@ describe('commitModelParam (issue #2896)', () => {
     '1_000',
     '1e400',
     '-1e400',
-  ])('A5: rejects %j for top_p and writes nothing', (raw) => {
-    const r = recorder();
-    const result = commitModelParam('top_p', raw, r.set);
-
-    expect(result.success).toBe(false);
-    expect(r.writes).toStrictEqual([]);
+  ])('A5: rejects %j for top_p', (raw) => {
+    expect(validateModelParam('top_p', raw).success).toBe(false);
   });
 
   it('A5: rejects a JSON object for a number-typed param', () => {
-    const r = recorder();
-    const result = commitModelParam('top_p', '{"a":1}', r.set);
-
-    expect(result.success).toBe(false);
-    expect(r.writes).toStrictEqual([]);
+    expect(validateModelParam('top_p', '{"a":1}').success).toBe(false);
   });
 
   it('A5: rejects a boolean literal for a number-typed param', () => {
-    const r = recorder();
-    const result = commitModelParam('temperature', 'true', r.set);
-
-    expect(result.success).toBe(false);
-    expect(r.writes).toStrictEqual([]);
+    expect(validateModelParam('temperature', 'true').success).toBe(false);
   });
 
   // A6 — the remaining number-typed dialog fields, integer and fractional
-  // alike, are written as numbers.
+  // alike, validate as numbers.
   it.each([
     ['max_tokens', '32000', 32000],
     ['top_k', '40', 40],
     ['frequency_penalty', '0', 0],
     ['presence_penalty', '1.25', 1.25],
     ['temperature', '0.7', 0.7],
-  ])('A6: commits %s=%s as the number %s', (key, raw, expected) => {
-    const r = recorder();
-    const result = commitModelParam(key, raw, r.set);
-
-    expect(result.success).toBe(true);
-    expect(r.writes).toStrictEqual([expected]);
-    expect(typeof r.writes[0]).toBe('number');
+  ])('A6: validates %s=%s as the number %s', (key, raw, expected) => {
+    expect(validateModelParam(key, raw)).toStrictEqual({
+      success: true,
+      value: expected,
+    });
   });
 
   // The numeric guard is registry-driven: a key with no number spec keeps the
   // previous pass-through behavior.
   it('passes an unregistered param through without numeric validation', () => {
-    const r = recorder();
-    const result = commitModelParam('parse_reasoning', 'true', r.set);
-
-    expect(result.success).toBe(true);
-    expect(r.writes).toStrictEqual([true]);
-  });
-
-  it('surfaces a runtime write failure as a validation message', () => {
-    const result = commitModelParam('top_p', '0.5', () => {
-      throw new Error('no active provider');
-    });
-
-    expect(result).toStrictEqual({
-      success: false,
-      message: 'no active provider',
+    expect(validateModelParam('parse_reasoning', 'true')).toStrictEqual({
+      success: true,
+      value: true,
     });
   });
 });

--- a/packages/cli/src/ui/components/modelConfigParamCommit.ts
+++ b/packages/cli/src/ui/components/modelConfigParamCommit.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * Model-parameter commit logic for the model config dialog.
+ * Model-parameter validation logic for the model config dialog.
  *
  * Extracted from `ModelConfigDialog.tsx` so the typing contract can be
  * exercised directly: full-render Ink component tests under
@@ -19,6 +19,10 @@
  * validation message instead of being written as a raw string — that is how
  * `"top_p": ".95"` reached a profile and produced
  * `top_p: Invalid input: expected number, received string` from OpenRouter.
+ *
+ * Validation-only (issue #2831): the dialog's save is two-phase — every
+ * staged edit is validated here with zero runtime writes before any write
+ * is applied — so this helper parses and checks but never writes.
  */
 
 import { getSettingSpec } from '@vybestack/llxprt-code-settings';
@@ -28,25 +32,23 @@ import { parseValue } from '../commands/setCommand.js';
  * Discriminated so a caller cannot read `message` without first narrowing on
  * the failure branch, and so the failure branch always carries one.
  */
-export type CommitResult =
-  | { success: true }
+export type ParamValidationResult =
+  | { success: true; value: unknown }
   | { success: false; message: string };
 
 export const NOT_A_NUMBER_MESSAGE = 'must be a number';
 
 /**
- * Parse `raw` for the model parameter `key` and hand the typed value to
- * `setActiveModelParam`.
+ * Parse `raw` for the model parameter `key` and return the typed value.
  *
  * Returns `{ success: false }` when the registry declares the parameter
- * numeric and the input does not parse to a finite number, or when the
- * runtime write throws (e.g. no active provider).
+ * numeric and the input does not parse to a finite number, or when parsing
+ * throws.
  */
-export function commitModelParam(
+export function validateModelParam(
   key: string,
   raw: string,
-  setActiveModelParam: (value: unknown) => void,
-): CommitResult {
+): ParamValidationResult {
   // Parsing stays inside the guarded region, as it was before this logic was
   // extracted from the dialog: an escaping throw would tear down the Ink UI
   // instead of surfacing as the inline validation message.
@@ -55,8 +57,7 @@ export function commitModelParam(
     if (requiresNumber(key) && !isFiniteNumber(parsed)) {
       return { success: false, message: NOT_A_NUMBER_MESSAGE };
     }
-    setActiveModelParam(parsed);
-    return { success: true };
+    return { success: true, value: parsed };
   } catch (e) {
     return {
       success: false,

--- a/project-plans/issue2831/plan.md
+++ b/project-plans/issue2831/plan.md
@@ -1,0 +1,210 @@
+# Issue #2831 — ModelConfigDialog two-phase save for staged edits
+
+Branch: `issue2831`. Milestone 0.12.0. Labels: Ink UI, model configuration.
+
+## Problem
+
+`commitPendingEdits` in `packages/cli/src/ui/components/ModelConfigDialog.tsx`
+iterates staged edits and applies each one to the runtime immediately
+(`commitFieldEdit` → `applyFieldEdit` performs parse/validate + write fused per
+field). If a LATER field fails validation or its runtime write throws, fields
+earlier in field order are already committed: the runtime ends up half-saved.
+
+Origin: PR #2753 OCR review (partial-commit comment), deferred as out of scope.
+
+## Shaped acceptance criteria
+
+### Behavior
+
+`[s]ave` in list mode becomes two-phase:
+
+1. **Phase 1 — validate all, write none.** Every staged edit is planned
+   (parsed + validated) with zero runtime mutation. If ANY staged edit is
+   invalid, the save stops before any write: first invalid field (in field
+   order) is reported as `<field.key>: <message>`, the dialog stays open, all
+   pending edits remain staged, and the runtime is unchanged.
+2. **Phase 2 — apply all, roll back on throw.** Prior values of every planned
+   write are snapshotted before the first write. Planned writes apply in field
+   order. If any runtime write throws mid-loop, every already-applied write is
+   restored from the snapshot, the throwing field is reported as
+   `<field.key>: <message>`, the dialog stays open, pending edits remain
+   staged, and the runtime ends exactly where it started.
+3. **Full success** behaves as today: all writes applied, pending edits
+   cleared, validation error cleared, dialog closes.
+
+### Inputs and boundary cases
+
+- Multi-field save where a later field fails validation (e.g. valid
+  `temperature=9.9` staged before invalid `prompt-caching=bogus`): zero
+  runtime writes, error names the later field.
+- Runtime write throwing on the second of two staged edits: first write rolled
+  back to its prior value; throwing field unwritten.
+- Staged CLEAR of a param (`clearActiveModelParam` path) rolled back when a
+  later write throws: prior param value present again.
+- Ephemeral prior value `undefined` restored via `setEphemeralSetting(key,
+  undefined)` (same call the existing clear path uses).
+- Boolean/enum staged edits: never fail validation; still planned writes that
+  participate in snapshot/rollback.
+- No-op staged edits (boolValue === null, enumIndex === null): no write, no
+  snapshot entry.
+- Staged edits survive a failed save so the user can correct and re-save;
+  re-save after correction commits everything exactly once.
+
+### Design (agreed shape, implementation detail may flex)
+
+- `modelConfigParamCommit.ts`: replace fused validate+write `commitModelParam`
+  with pure `validateModelParam(key, raw)` returning
+  `{ success: true; value: unknown } | { success: false; message: string }`
+  (parse + registry numeric guard, throw-safe). Keep `NOT_A_NUMBER_MESSAGE`.
+  The dialog is the only caller today; module filename and docstring stay
+  (docstring updated to the validation contract).
+- Dialog: `planFieldEdit(field, edit)` returns a planned write
+  (`set-param` value / `clear-param` / `set-ephemeral` value), a skip (no-op),
+  or a validation error — no runtime calls. `commitPendingEdits` runs phase 1
+  over all staged fields, snapshots prior state per planned write (the inverse
+  write: param with prior → `set-param` prior; param absent → `clear-param`;
+  ephemeral → `set-ephemeral` prior), then applies phase 2 in order inside a
+  try/catch; on throw it applies the inverse writes for everything already
+  applied and reports the throwing field. `commitFieldEdit`, `applyFieldEdit`,
+  and `commitEphemeral` are replaced by plan/apply/restore functions.
+- Rollback (inverse) writes are NOT individually guarded — a restore throwing
+  means a genuinely broken runtime and propagates (fail-fast preference; the
+  restore targets keys whose forward writes just succeeded).
+- Snapshot source is `d.params` / `d.ephemeral` (runtime reads from the last
+  render — current by construction, since writes only happen at save).
+
+### Tests (behavioral, bun:test; stateful fake runtime, no mock theater)
+
+`ModelConfigDialog.test.tsx` (extend `createStatefulRuntime` with a minimal
+fail-on-key mode for writes, e.g. `failSetParamKeys` / `failSetEphemeralKeys`):
+
+- T1 multi-field save, later field fails validation → zero runtime writes
+  (params AND ephemerals unchanged), error shows failing key, dialog open,
+  staged values still rendered.
+- T2 recovery: after T1-style failure, correct the invalid field and re-save →
+  both values land exactly once.
+- T3 runtime write throws on the second staged edit → first edit rolled back
+  to prior value, throwing field unwritten, error names throwing key, dialog
+  open, staged edits retained.
+- T4 staged clear rolled back when a later write throws → cleared param
+  present again with its prior value.
+- T5 multi-kind success (param edit + ephemeral enum + boolean + a clear in
+  one save) → all land, dialog closes.
+
+`modelConfigParamCommit.spec.ts`: migrate rows from `commitModelParam` +
+recorder to `validateModelParam` (assert returned typed value on success rows;
+`{ success: false; message }` on rejection rows; recorder no longer needed).
+The "runtime write failure" row is removed — that path now lives in dialog
+phase 2 and is covered by T3/T4.
+
+## Scope guardrails
+
+- Files: `ModelConfigDialog.tsx`, `ModelConfigDialog.test.tsx`,
+  `modelConfigParamCommit.ts`, `modelConfigParamCommit.spec.ts`. Nothing else.
+- No new public abstractions (no new exports beyond `validateModelParam`
+  replacing `commitModelParam` in the dialog-local helper module); runtime API
+  untouched; staging/key handling/rendering/field building untouched.
+- No persistence-level transactions; runtime `set*`/`clear*` remain the write
+  primitives.
+
+## Verification
+
+Full cycle per workflow: `npm run test`, `npm run lint`, `npm run typecheck`,
+`npm run format`, `npm run build`, smoke test
+`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.
+Targeted: `bun test packages/cli/src/ui/components/ModelConfigDialog.test.tsx`
+and `.../modelConfigParamCommit.spec.ts`, plus
+`bun scripts/test-audit/scan.ts` diff vs main for touched files.
+
+## Review plan
+
+- deepthinker compliance review (max 2 rounds).
+- OCR (open-code-review, `zai` profile, glm-5.3) — max 2 local + 2 PR rounds;
+  findings triaged Blocker-Fix / In-scope-Fix / Reject / Defer.
+
+## Status log
+
+### Implementation + local evidence (2026-09-08)
+
+- Implementation done via subagent (`codeanalyzer`, glm) after
+  `fallbacktypescriptcoder` (quota), `deepthinker` (quota), and `architect`
+  (rate limit) were all unavailable; its 1800s task timeout cut off the final
+  report, but the working tree contains the complete change (driver-verified
+  against this plan via `git diff`).
+- RED→GREEN evidence (regenerated by driver): with the two production files
+  stashed, the new dialog tests fail T1/T3/T4 (23 pass / 3 fail) — proving the
+  partial-commit bug and that the new tests detect it; with the new code both
+  files pass 48/48.
+- Test-audit scan vs main baseline: only NEW findings were two SELF_CONFIRMING
+  rows in T1 (pre-save maps captured from the same accessors used in the
+  assertion). Fixed by asserting literal default runtime state
+  (`{ temperature: 0.7 }` / `{ 'reasoning.enabled': true }`); re-scan clean.
+  The remaining DUP_ASSERT row pre-exists on main (line shift only).
+- packages/cli eslint: 11 errors, all in untouched files (mcp/*, consent.ts) —
+  verified identical with changes stashed (pre-existing on main).
+- Root cycle environmental notes: `node_modules/bun` postinstall had been
+  skipped (bun binary missing) — fixed via `cd node_modules/bun && node install.js`.
+  First typecheck pass shows stale-`dist` errors across workspaces (broader
+  than the 6 pre-existing TS6305 already documented); rerunning typecheck
+  AFTER `npm run build` regenerates dist.
+
+### Compliance review round 1 (2026-09-08) — rustcoder (substitute)
+
+Designated deepthinker + fallbacks (typescriptreviewer/reviewer gpt56,
+rustreviewer/architect opusthinking) all quota/rate-dead at review time;
+rustcoder (zai-glm-flash, different model from implementer) substituted.
+Verdict: **APPROVE-WITH-NOTES**, zero HIGH/MEDIUM findings. Confirmed: both
+failure modes atomic; rollback inverse-write semantics exact (presence-based
+param restore, `undefined` ephemeral restore); throw attribution correct via
+un-incremented `applied`; export surface changed 1:1; success path identical;
+48/48 tests pass.
+
+Findings triage:
+
+- LOW — no failure-mode test exercising `failSetEphemeralKeys` /
+  `failClearParamKeys` (ephemeral/clear-param throw paths) → **In-scope-Fix**
+  (add T6: staged ephemeral edit + staged clear with a later ephemeral write
+  throwing → both rolled back).
+- LOW — throwing field's own write not restored if a runtime mutated before
+  throwing → **Defer** (matches the issue letter "restores every field it
+  already wrote"; documented stance).
+- LOW — throw-attribution loop subtlety (for-loop update clause must not run
+  after a throw) uncommented → **In-scope-Fix** (one comment sentence).
+
+### OCR round 1 local (2026-09-08, glm-5.3 on zai via credential proxy) — 8 findings
+
+- **Blocker-Fix** — unguarded restore loop: restore throw would skip remaining
+  restores, mask the original error, and escape to the keypress handler
+  (Ink-teardown regression vs the deleted `commitFieldEdit` guard). FIXED:
+  per-restore guard, failed keys recorded, remaining restores continue,
+  original error always surfaced (`(rollback incomplete: <keys>)` suffix).
+- **In-scope-Fix** — rollback snapshot read render-time `d.params`/`d.ephemeral`
+  (stale on external mutation). FIXED: fresh `getActiveModelParams()` /
+  `getEphemeralSettings()` read once at phase-2 start.
+- **In-scope-Fix** — `priorWriteFor` branched on `field.kind` while
+  `planFieldEdit` branches on `field.editor`. FIXED: prior derived from the
+  planned write's own kind.
+- **In-scope-Fix** — `parseEphemeralSettingValue` lost the old inline-catch
+  contract. FIXED: guarded in `planFieldEdit`, returns invalid-plan.
+- **In-scope-Fix (tests)** — added T7 (later ephemeral parse failure, zero
+  writes, staged edits retained), T2 write counters proving exactly-once, T4
+  vacuous `(not set)` assertion replaced with targeted rollback assertions.
+- **In-scope-Fix (tests)** — T8: first planned write throwing (applied===0
+  case, `failClearParamKeys`).
+- **In-scope-Fix (tests)** — T9: prior-absent ephemeral rollback restores
+  present-but-`undefined` (matches real SettingsService + dialog clear idiom).
+
+### OCR round 2 local (2026-09-08, glm-5.3) — 2 findings, both on round-1 remediation code
+
+- **In-scope-Fix** — `(rollback incomplete: ...)` branch untested → T10 added
+  (forward set-param lands, later write throws, clear-param restore also
+  throws → suffix surfaced, degraded state asserted honestly).
+- **In-scope-Fix** — `planned[applied]` index-arithmetic coupled error
+  attribution to the for-loop throw rule → per-entry loop captures the failing
+  entry lexically; rollback extracted to `restoreAppliedWrites` (nested-
+  control-flow lint limit); behavior identical.
+
+Final state: 53/53 targeted tests (31 dialog incl. T1-T10, 22 spec);
+eslint/prettier/test-audit scan clean on all touched files; budgets 34/80
+(commitPendingEdits) and 798/800 (test file, counted). Local OCR cap (2)
+reached; proceeding to PR.


### PR DESCRIPTION
## TLDR

`ModelConfigDialog`'s `[s]ave` previously committed staged edits one field at a time, so a later field failing validation (or a runtime write throwing mid-loop) left earlier fields already written — a half-saved runtime config. The save is now two-phase and atomic: **validate all staged edits first (zero runtime writes), then apply all writes, rolling back every applied write from a pre-save snapshot if anything throws mid-loop.**

Fixes #2831 (raised as out-of-scope in the #2753 OCR review).

## Dive Deeper

**Phase 1 — plan/validate (pure):** `planFieldEdit` turns each staged edit into a typed `PlannedWrite` (`set-param` / `clear-param` / `set-ephemeral`) with zero runtime calls. The first invalid field in field order is reported as `<key>: <message>`, staged edits are retained, the dialog stays open, and **nothing** is written. To let param validation participate without a write, `commitModelParam` was refactored into a pure `validateModelParam(key, raw)` (same parse/number-guard contract from #2896, now returning the typed value); the ephemeral parse keeps the dialog's old inline-error contract by guarding `parseEphemeralSettingValue` inside `planFieldEdit`.

**Phase 2 — apply/rollback:** before the first write, the save reads a fresh pre-save snapshot from the runtime (`getActiveModelParams()` / `getEphemeralSettings()` — not the render-time copies, which can be stale if the runtime changed externally). Writes apply in field order inside a per-entry loop that captures the failing entry lexically. On a throw, every applied write `[0, i)` is restored in reverse from the snapshot. Restores are guarded: a throwing restore is recorded (`(rollback incomplete: <keys>)` suffix) and the remaining restores continue, so the original save error is always surfaced inline and nothing escapes to the keypress handler (preserving the old `commitFieldEdit` crash-prevention contract). Rollback restores derive from the planned write's own store, so forward and inverse writes can never diverge.

**Success path is unchanged:** clear pending edits, clear error, close.

No new public abstractions: the only export change is `commitModelParam` → `validateModelParam` in the dialog-private `modelConfigParamCommit.ts` module (its only consumer is `ModelConfigDialog.tsx`; spec migrated accordingly).

## Reviewer Test Plan

- `cd packages/cli && bun test src/ui/components/ModelConfigDialog.test.tsx src/ui/components/modelConfigParamCommit.spec.ts` — 53 tests (31 dialog incl. T1–T10, 22 spec), all passing.
- Interactive: open the model config dialog, stage edits on several fields, make one of them invalid (e.g. `top_k` = `abc`), press `s` — the error names the invalid field, every staged edit is still staged, and no partial write lands in the runtime.
- Behavioral tests cover: later-field validation failure (param and ephemeral), interactive recovery re-save landing both edits exactly once, mid-loop write throws (set/clear/ephemeral, first-write `applied === 0`, restore-also-throws), no partial state after failure, and multi-kind success.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅ (bun test / eslint / prettier targeted; full root cycle run with pre-existing main failures unchanged — none in touched files) |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2831
Related to #2753 (origin of the partial-commit finding), #2896 (the numeric-param commit contract preserved by `validateModelParam`)

Review evidence: two local OCR rounds (glm-5.3) — round 1: 8 findings (1 Blocker-Fix, 7 In-scope-Fix), all fixed; round 2: 2 findings on the remediation code, both fixed. Full triage log in `project-plans/issue2831/plan.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model configuration saving by validating multiple changes before applying updates.
  * Prevented partially saved configurations when an update fails by rolling back previously applied changes.
  * Enhanced parameter validation with clearer inline feedback for invalid or unparseable values.

* **Tests**
  * Added coverage for multi-field edits, validation failures, save errors, and rollback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->