### PR TITLE
refactor(naming): one canonical naming standard with no-alias-probes lint (Fixes #2533)

### DIFF
--- a/dev-docs/naming-standard.md
+++ b/dev-docs/naming-standard.md
@@ -1,0 +1,139 @@
+# Naming Standard
+
+Status: enforced. Issue #2533 established this standard and removed the
+historical alias matrix. The `custom/no-alias-probes` ESLint rule rejects new
+alias probes in CI.
+
+## Principle
+
+Every LLxprt-owned name has exactly one canonical spelling per boundary. Code
+must never probe for alternate spellings of the same field
+(`value.oldName || value.newName`). External spellings are adapted once, at the
+boundary that owns the external format, and mapped immediately to LLxprt types.
+
+## Conventions by boundary
+
+### TypeScript source
+
+- Values, functions, properties, variables: `camelCase`.
+- Types, classes, components, enums: `PascalCase`.
+- Constants that are themselves names (tool names, schema keys): declare once
+  next to the thing they name and import everywhere else
+  (for example `TaskTool.Name`, `SCOPE_LOCAL_EMIT_TOOL_NAME`).
+
+### Model-facing JSON and tool parameters
+
+- Tool parameter schemas exposed to the LLM use `snake_case`
+  (see `packages/agents/src/tools/taskSchema.ts`:
+  `subagent_name`, `goal_prompt`, `expected_outputs`, `tool_whitelist`).
+- Schemas set `additionalProperties: false` so alternate spellings are rejected
+  by the schema itself, with a validation message naming the canonical field.
+- TypeScript types describing the wire shape carry the same single spelling;
+  internal code normalizes once into camelCase invocation types
+  (`TaskToolInvocationParams`).
+
+### Slash commands and subcommands
+
+- One canonical lowercase literal per command and subcommand, declared once at
+  registration and reused by completion, dispatch, usage text, and docs.
+- Example: `/tools desc`. The `descriptions` spelling was removed.
+
+### Persisted settings and profile keys
+
+- The settings registry's primary key is the canonical spelling
+  (`tools.disabled`, `max_tokens`, `base-url`, `auth-key`).
+- Legacy spellings are migrated once, destructively, at load
+  (`packages/settings/src/settings/legacyKeyMigration.ts`); they are never
+  resolved at read time.
+- `/set` rejects legacy spellings with a message naming the canonical key.
+- Environment variables: `UPPER_SNAKE_CASE`.
+
+### Tool names and namespaces
+
+- One algorithm: `packages/tools/src/formatters/toolNameUtils.ts` and
+  `toolGovernanceUtils.ts` (`canonicalizeToolName`,
+  `canonicalizePolicyToolEntry`, `getToolNameCandidates`, `buildToolGovernance`,
+  `isToolBlocked`). Registry, policy, subagent governance, commands, and UI
+  import these; none re-implements normalization.
+- User-authored policy entries (which may contain legacy spellings such as
+  `ShellTool(npm test)` or wildcards) are decoded once at the policy boundary by
+  `canonicalizePolicyToolEntry` into canonical registry names.
+- The tool-name manifest is each tool's `static Name` declaration.
+  `SUBAGENT_EXCLUDED_TOOL_NAMES` is pinned to `TaskTool.Name` and
+  `ListSubagentsTool.Name` by a drift test.
+
+### Provider and protocol fields
+
+- Third-party wire spellings exist only inside the adapter that owns the
+  protocol and are mapped immediately to LLxprt types
+  (for example OpenAI `finish_reason` → internal `stopReason` in
+  `packages/providers/src/openai/finishReasonMapping.ts`).
+- LLxprt provider objects use `baseURL`; the settings key is `base-url`.
+- Provider-specific malformed-name repair stays confined to
+  `packages/providers/src/utils/toolNameNormalization.ts` and must emit the
+  canonical form.
+
+## Prohibited forms
+
+```ts
+// All of these are alias probes and fail lint (custom/no-alias-probes):
+value.oldName || value.newName;
+value.old_name ?? value.newName;
+obj['old-name'] ?? obj.oldName;
+params.foo_bar ?? params.fooBar;
+```
+
+Allowed, because they are not spelling probes:
+
+```ts
+x.flag || false; // boolean option fallback
+x.name ?? 'default'; // literal default
+a.b ?? c.d; // different objects
+x.foo ?? x.bar; // genuinely different fields
+```
+
+Renaming an LLxprt-owned name: pick the canonical spelling, change every
+declaration and use in one change, add the old spelling to
+`LEGACY_SETTING_KEY_MIGRATIONS` (settings) or a one-time migration for its
+format, update schemas/prompts/docs/tests, and never keep a read-side alias.
+
+## Enforcement
+
+- `eslint-rules/no-alias-probes.js`, wired as `custom/no-alias-probes` in
+  `eslint.config.js`, flags `||`/`??` chains whose operands are spelling
+  variants of the same property on the same object. Tests live in
+  `eslint-rules/no-alias-probes.test.ts`.
+- The table below is the full boundary-exception register: it records the
+  owner, reason, and removal condition for every permitted non-canonical
+  spelling.
+- `BOUNDARY_EXCEPTIONS` in `eslint-rules/no-alias-probes.js` is the
+  machine-enforced subset of that register: only the files whose exceptions
+  contain lint-detectable probe forms need an entry there. Register rows
+  without a lint entry are inert today (no flaggable chain exists); if such a
+  row ever gains a probe form, it must gain a matching `BOUNDARY_EXCEPTIONS`
+  entry, and inert rows must not be added to the allowlist preemptively.
+  Generic inline `eslint-disable` comments remain disallowed repo-wide.
+
+## Boundary-exception register
+
+Each entry names the only place a non-canonical spelling may appear, why, and
+the condition for removing it.
+
+| Location                                                                                            | Owner                   | Reason                                                                                                                        | Removal condition                                                                                                                                      |
+| --------------------------------------------------------------------------------------------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `packages/policy/src/config.ts` `normalizeToolName`                                                 | policy package          | Byte-equivalent twin of `canonicalizePolicyToolEntry`; policy has zero workspace dependencies                                 | Policy gains a tools dependency, or the decoder moves to a zero-dep shared module. Guarded by `packages/core/src/policy/toolEntryDecoderDrift.test.ts` |
+| `SHELL_TOOL_NAMES` `ShellTool` member (`core`/`policy` shell-utils)                                 | policy/core maintainers | Policy engine and shell checks match raw user policy input before boundary decoding                                           | Decode `coreTools`/`excludeTools` at the CLI boundary before they reach these checks                                                                   |
+| `packages/providers/src/openai/finishReasonMapping.ts`                                              | providers               | OpenAI wire field `finish_reason` decoding                                                                                    | Never (third-party wire format)                                                                                                                        |
+| `packages/providers/src/auth/proxy/proxy-oauth-adapter.ts`                                          | providers               | Third-party OAuth proxy response: decode both wire spellings once at this boundary                                            | Never (third-party wire format)                                                                                                                        |
+| `packages/providers/src/openai-vercel/errors.ts`                                                    | providers               | Third-party API error payload: decode both wire spellings once at this boundary                                               | Never (third-party wire format)                                                                                                                        |
+| `packages/providers/src/utils/mediaDiagnostics.ts`                                                  | providers               | Gemini wire format: decode both spellings once at this boundary                                                               | Never (third-party wire format)                                                                                                                        |
+| MCP transport `'streamable-http'` value alias                                                       | mcp                     | Ecosystem compatibility with existing MCP client configs                                                                      | Upstream MCP spec retires the value                                                                                                                    |
+| `packages/cli/src/config/settingsLegacy.ts`, `packages/settings/src/settings/legacyKeyMigration.ts` | settings                | One-time destructive migrations of legacy spellings at load                                                                   | Remove entries after releases with no observed legacy keys in the wild                                                                                 |
+| `packages/zed-acp/src/zed-tool-handler.ts` name mapping                                             | zed-acp                 | Zed ACP protocol names (`execute_command`, `exec`)                                                                            | Never (third-party protocol)                                                                                                                           |
+| `packages/providers/src/utils/toolNameNormalization.ts`                                             | providers               | Provider-specific malformed-name repair, emits canonical form only                                                            | Provider retires non-canonical names                                                                                                                   |
+| `packages/cli/src/utils/sandbox-containers.ts`, `packages/cli/src/utils/sandbox-seatbelt.ts`        | cli                     | `NO_PROXY`/`no_proxy`: both spellings are set and honored by the proxy ecosystem                                              | Never (third-party env convention)                                                                                                                     |
+| `packages/tools/src/tools/apply-patch-analysis.ts`                                                  | tools                   | Rule false positive: oldFileName/newFileName are distinct semantic fields (source vs target hunk path), not spelling variants | Never (heuristic limit; revisit if the rule gains semantic awareness)                                                                                  |
+
+`docs/token-usage-log.md` documents the token-usage wire log, whose
+`subagent_name` field is snake_case by the model-facing rule above; it is
+canonical, not an exception.

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -35,7 +35,7 @@ LLxprt Code uses JSON settings files for persistent configuration. There are fou
   - **Location:** `/etc/llxprt-code/settings.json` (Linux), `C:\ProgramData\llxprt-code\settings.json` (Windows) or `/Library/Application Support/LlxprtCode/settings.json` (macOS). The path can be overridden using the `LLXPRT_SYSTEM_SETTINGS_PATH` environment variable (a legacy alias `LLXPRT_CODE_SYSTEM_SETTINGS_PATH` is also honored for backward compatibility).
   - **Scope:** Applies to all LLxprt Code sessions on the system, for all users. System settings act as overrides, taking precedence over all other settings files. May be useful for system administrators at enterprises to have controls over users' LLxprt Code setups.
 
-**Note on environment variables in settings:** String values within your `settings.json` files can reference environment variables using either `$VAR_NAME` or `${VAR_NAME}` syntax. These variables will be automatically resolved when the settings are loaded. For example, if you have an environment variable `MY_API_TOKEN`, you could use it in `settings.json` like this: `"apiKey": "$MY_API_TOKEN"`.
+**Note on environment variables in settings:** String values within your `settings.json` files can reference environment variables using either `$VAR_NAME` or `${VAR_NAME}` syntax. These variables will be automatically resolved when the settings are loaded. For example, if you have an environment variable `MY_API_TOKEN`, you could use it in `settings.json` like this: `"auth-key": "$MY_API_TOKEN"`.
 
 > **Note for Enterprise Users:** For guidance on deploying and managing LLxprt Code in a corporate environment, please see the [Enterprise Configuration](./enterprise.md) documentation.
 
@@ -1072,17 +1072,17 @@ If you are experiencing performance issues with file searching (e.g., with `@` c
 3.  **Disable Recursive File Search:** As a last resort, you can disable recursive file search entirely by setting `enableRecursiveFileSearch` to `false`. This will be the fastest option as it avoids a recursive crawl of your project. However, it means you will need to type the full path to files when using `@` completions.
 
 - **`coreTools`** (array of strings):
-  - **Description:** Allows you to specify a list of core tool names that should be made available to the model. This can be used to restrict the set of built-in tools. See [Built-in Tools](../tools/index.md#built-in-tools) for a list of core tools. You can also specify command-specific restrictions for tools that support it, like the `ShellTool`. For example, `"coreTools": ["ShellTool(ls -l)"]` will only allow the `ls -l` command to be executed.
+  - **Description:** Allows you to specify a list of core tool names that should be made available to the model. This can be used to restrict the set of built-in tools. See [Built-in Tools](../tools/index.md#built-in-tools) for a list of core tools. You can also specify command-specific restrictions for tools that support it, like the `run_shell_command`. For example, `"coreTools": ["run_shell_command(ls -l)"]` will only allow the `ls -l` command to be executed.
   - **Default:** All tools available for use by the Gemini model.
-  - **Example:** `"coreTools": ["ReadFileTool", "GlobTool", "ShellTool(ls)"]`.
+  - **Example:** `"coreTools": ["read_file", "glob", "run_shell_command(ls)"]`.
 
 - **`allowedTools`** (array of strings):
   - **Default:** `undefined`
   - **Description:** A list of tool names that will bypass the confirmation dialog. This is useful for tools that you trust and use frequently. The match semantics are the same as `coreTools`.
-  - **Example:** `"allowedTools": ["ShellTool(git status)"]`.
+  - **Example:** `"allowedTools": ["run_shell_command(git status)"]`.
 
 - **`excludeTools`** (array of strings):
-  - **Description:** Allows you to specify a list of core tool names that should be excluded from the model. A tool listed in both `excludeTools` and `coreTools` is excluded. You can also specify command-specific restrictions for tools that support it, like the `ShellTool`. For example, `"excludeTools": ["ShellTool(rm -rf)"]` will block the `rm -rf` command.
+  - **Description:** Allows you to specify a list of core tool names that should be excluded from the model. A tool listed in both `excludeTools` and `coreTools` is excluded. You can also specify command-specific restrictions for tools that support it, like the `run_shell_command`. For example, `"excludeTools": ["run_shell_command(rm -rf)"]` will block the `rm -rf` command.
   - **Default**: No tools excluded.
   - **Example:** `"excludeTools": ["run_shell_command", "findFiles"]`.
   - **Security Note:** Command-specific restrictions in

--- a/docs/cli/enterprise.md
+++ b/docs/cli/enterprise.md
@@ -222,7 +222,7 @@ on the approved list.
 ```json
 {
   "tools": {
-    "core": ["ReadFileTool", "GlobTool", "ShellTool(ls)"]
+    "core": ["read_file", "glob", "run_shell_command(ls)"]
   }
 }
 ```
@@ -237,7 +237,7 @@ environment to a blocklist.
 ```json
 {
   "tools": {
-    "exclude": ["ShellTool(rm -rf)"]
+    "exclude": ["run_shell_command(rm -rf)"]
   }
 }
 ```
@@ -525,11 +525,11 @@ CLI.
   "tools": {
     "sandbox": "docker",
     "core": [
-      "ReadFileTool",
-      "GlobTool",
-      "ShellTool(ls)",
-      "ShellTool(cat)",
-      "ShellTool(grep)"
+      "read_file",
+      "glob",
+      "run_shell_command(ls)",
+      "run_shell_command(cat)",
+      "run_shell_command(grep)"
     ]
   },
   "mcp": {

--- a/docs/disabled-tools.md
+++ b/docs/disabled-tools.md
@@ -1,6 +1,6 @@
-# LLxprt Code: `disabled-tools` Setting
+# LLxprt Code: `tools.disabled` Setting
 
-The `disabled-tools` setting allows you to disable specific tools for the current session. This setting is particularly useful during debugging, exploration, or when you want to temporarily limit the capabilities available to the AI.
+The `tools.disabled` setting allows you to disable specific tools for the current session. This setting is particularly useful during debugging, exploration, or when you want to temporarily limit the capabilities available to the AI.
 
 ## Setting the Value
 
@@ -17,12 +17,12 @@ You can set this value using either the `/tools` command or the `/set` command. 
 
 ```bash
 # Disable the list_directory and write_file tools for the current session
-/set disabled-tools list_directory write_file
+/set tools.disabled list_directory write_file
 ```
 
 ## How it Works
 
-When you provide a list of tool names to `disabled-tools`, those tools are excluded from the list of available tools sent to the AI model for the current turn. This means the AI will not be able to request those tools.
+When you provide a list of tool names to `tools.disabled`, those tools are excluded from the list of available tools sent to the AI model for the current turn. This means the AI will not be able to request those tools.
 
 ## Tool Names
 
@@ -58,7 +58,7 @@ The `/tools` command provides several subcommands for managing disabled tools:
 
 ## Profile Integration
 
-The `disabled-tools` setting is an ephemeral setting that can be saved to profiles for reuse. When you save your current configuration to a profile, the disabled tools are included in the saved settings.
+The `tools.disabled` setting is an ephemeral setting that can be saved to profiles for reuse. When you save your current configuration to a profile, the disabled tools are included in the saved settings.
 
 ### Example Workflow
 

--- a/docs/disabled-tools.md
+++ b/docs/disabled-tools.md
@@ -54,8 +54,6 @@ The `/tools` command provides several subcommands for managing disabled tools:
 
 ```bash
 /tools desc
-# or
-/tools descriptions
 ```
 
 ## Profile Integration

--- a/docs/emoji-filter.md
+++ b/docs/emoji-filter.md
@@ -127,7 +127,7 @@ For streamed model responses, emoji filtering is applied at the **display layer*
   "providers": {
     "anthropic": {
       "enabled": true,
-      "apiKey": "your-key",
+      "auth-key": "your-key",
       "model": "claude-opus-5"
     }
   },

--- a/docs/shell-replacement.md
+++ b/docs/shell-replacement.md
@@ -76,9 +76,9 @@ cmd.exe execution maps to the Bash grammar because no dedicated cmd grammar exis
 
 ## Case-Insensitive Matching (PowerShell)
 
-PowerShell command resolution is case-insensitive. Blocklist and allowlist matching for PowerShell commands is therefore case-insensitive: `ShellTool(Get-Process)` matches `GET-PROCESS`, `get-process`, and `Get-Process`. Bash matching remains strictly case-sensitive. The case-insensitivity is PowerShell-scoped and does not affect Bash behavior.
+PowerShell command resolution is case-insensitive. Blocklist and allowlist matching for PowerShell commands is therefore case-insensitive: `run_shell_command(Get-Process)` matches `GET-PROCESS`, `get-process`, and `Get-Process`. Bash matching remains strictly case-sensitive. The case-insensitivity is PowerShell-scoped and does not affect Bash behavior.
 
-Literal call targets (`& 'C:/tools/tool.exe'`) and dot-source paths (`. ./script.ps1`) normalize to the basename before matching, so policy patterns do not require broad wildcards like `ShellTool(&)`.
+Literal call targets (`& 'C:/tools/tool.exe'`) and dot-source paths (`. ./script.ps1`) normalize to the basename before matching, so policy patterns do not require broad wildcards like `run_shell_command(&)`.
 
 ## Wrapper and Evaluator Bypass Prevention
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -133,7 +133,11 @@ You can restrict the shell tool to specific commands:
 
 ```json
 {
-  "coreTools": ["ShellTool(npm test)", "ShellTool(npm run lint)", "read_file"]
+  "coreTools": [
+    "run_shell_command(npm test)",
+    "run_shell_command(npm run lint)",
+    "read_file"
+  ]
 }
 ```
 

--- a/eslint-rules/no-alias-probes.js
+++ b/eslint-rules/no-alias-probes.js
@@ -13,24 +13,33 @@
  * canonical property name instead of probing for legacy spellings inline.
  */
 
-// Fold spelling variants (including British/American and the versioned
-// old/new alias pair) so e.g. behaviourPrompts/behaviorPrompts and
-// oldName/newName compare equal. Substring replaces applied to both sides.
-const ALIAS_FOLDS = [
-  [/isation/g, 'ization'],
-  [/ise/g, 'ize'],
-  [/yse/g, 'yze'],
-  [/our/g, 'or'],
-  [/logue/g, 'log'],
-  [/old/g, 'new'],
-];
+const ALIAS_WORD_FOLDS = new Map([
+  ['old', 'new'],
+  ['behaviour', 'behavior'],
+  ['behaviours', 'behaviors'],
+  ['colour', 'color'],
+  ['colours', 'colors'],
+  ['normalise', 'normalize'],
+  ['normalised', 'normalized'],
+  ['normalisation', 'normalization'],
+  ['analyse', 'analyze'],
+  ['analysed', 'analyzed'],
+  ['catalogue', 'catalog'],
+]);
+
+function propertyNameWords(name) {
+  return name
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .split(/[_$\s-]+/)
+    .filter(Boolean)
+    .map((word) => word.toLowerCase());
+}
 
 function normalizePropertyName(name) {
-  let folded = name.toLowerCase().replace(/[_$-]/g, '');
-  for (const [pattern, replacement] of ALIAS_FOLDS) {
-    folded = folded.replace(pattern, replacement);
-  }
-  return folded;
+  return propertyNameWords(name)
+    .map((word) => ALIAS_WORD_FOLDS.get(word) ?? word)
+    .join('');
 }
 
 function normalizeObjectText(text) {

--- a/eslint-rules/no-alias-probes.js
+++ b/eslint-rules/no-alias-probes.js
@@ -1,0 +1,193 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Custom ESLint rule to reject alias coalescing/property probing.
+ *
+ * Flags `a.propOne ?? a.propTwo` / `a.propOne || a.propTwo` shapes where both
+ * operands read the same object and the two property names are spelling
+ * variants of each other (equal after normalization). Code should use one
+ * canonical property name instead of probing for legacy spellings inline.
+ */
+
+// Fold spelling variants (including British/American and the versioned
+// old/new alias pair) so e.g. behaviourPrompts/behaviorPrompts and
+// oldName/newName compare equal. Substring replaces applied to both sides.
+const ALIAS_FOLDS = [
+  [/isation/g, 'ization'],
+  [/ise/g, 'ize'],
+  [/yse/g, 'yze'],
+  [/our/g, 'or'],
+  [/logue/g, 'log'],
+  [/old/g, 'new'],
+];
+
+function normalizePropertyName(name) {
+  let folded = name.toLowerCase().replace(/[_$-]/g, '');
+  for (const [pattern, replacement] of ALIAS_FOLDS) {
+    folded = folded.replace(pattern, replacement);
+  }
+  return folded;
+}
+
+function normalizeObjectText(text) {
+  // Treat `x?.cfg` and `x.cfg` (and incidental whitespace) as the same object.
+  return text.replace(/\s+/g, '').replace(/\?\./g, '.');
+}
+
+/**
+ * Structured allowlist of boundary exceptions. Each entry names one file
+ * (repo-relative, exact path, no globs) where the rule's heuristic is known
+ * to fire on legitimate decoding, plus the owning team, the reason, and the
+ * condition for removing the entry. Mirrored in dev-docs/naming-standard.md.
+ * Inline eslint-disable comments are NOT the mechanism for these; entries
+ * here are the only file-level exemptions.
+ */
+export const BOUNDARY_EXCEPTIONS = Object.freeze([
+  Object.freeze({
+    file: 'packages/providers/src/auth/proxy/proxy-oauth-adapter.ts',
+    owner: 'providers',
+    reason:
+      'Third-party OAuth proxy response: decode both wire spellings once at this boundary',
+    removalCondition: 'Never (third-party wire format)',
+  }),
+  Object.freeze({
+    file: 'packages/providers/src/openai-vercel/errors.ts',
+    owner: 'providers',
+    reason:
+      'Third-party API error payload: decode both wire spellings once at this boundary',
+    removalCondition: 'Never (third-party wire format)',
+  }),
+  Object.freeze({
+    file: 'packages/providers/src/utils/mediaDiagnostics.ts',
+    owner: 'providers',
+    reason: 'Gemini wire format: decode both spellings once at this boundary',
+    removalCondition: 'Never (third-party wire format)',
+  }),
+  Object.freeze({
+    file: 'packages/cli/src/utils/sandbox-containers.ts',
+    owner: 'cli',
+    reason:
+      'NO_PROXY/no_proxy: both spellings are set and honored by the proxy ecosystem',
+    removalCondition: 'Never (third-party env convention)',
+  }),
+  Object.freeze({
+    file: 'packages/cli/src/utils/sandbox-seatbelt.ts',
+    owner: 'cli',
+    reason:
+      'NO_PROXY/no_proxy: both spellings are set and honored by the proxy ecosystem',
+    removalCondition: 'Never (third-party env convention)',
+  }),
+  Object.freeze({
+    file: 'packages/tools/src/tools/apply-patch-analysis.ts',
+    owner: 'tools',
+    reason:
+      'Rule false positive: oldFileName/newFileName are distinct semantic fields (source vs target hunk path), not spelling variants',
+    removalCondition:
+      'Never (heuristic limit; revisit if the rule gains semantic awareness)',
+  }),
+]);
+
+/**
+ * Returns true when the linted filename matches a BOUNDARY_EXCEPTIONS entry,
+ * either exactly (repo-relative) or as a path suffix, so the same rule works
+ * regardless of the workspace root prefix in the reported filename.
+ */
+function isBoundaryException(filename) {
+  const normalized = filename.replace(/\\/g, '/');
+  return BOUNDARY_EXCEPTIONS.some(
+    (entry) =>
+      normalized === entry.file || normalized.endsWith('/' + entry.file),
+  );
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Reject alias coalescing where both operands are spelling variants of the same property on the same object',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    messages: {
+      aliasProbe:
+        'Alias probe: {{left}} and {{right}} are spelling variants of the same property; use one canonical name (see dev-docs/naming-standard.md).',
+    },
+    fixable: null,
+    schema: [],
+  },
+  create(context) {
+    const sourceCode = context.getSourceCode();
+
+    if (isBoundaryException(context.filename)) {
+      return {};
+    }
+
+    function unwrapChain(node) {
+      if (node.type === 'ChainExpression') {
+        return unwrapChain(node.expression);
+      }
+      return node.type === 'MemberExpression' ? node : null;
+    }
+
+    function getPropertyName(memberExpression) {
+      const property = memberExpression.property;
+      if (!memberExpression.computed) {
+        return property.type === 'Identifier' ? property.name : null;
+      }
+      if (
+        property.type === 'Literal' &&
+        (typeof property.value === 'string' ||
+          typeof property.value === 'number')
+      ) {
+        return String(property.value);
+      }
+      if (
+        property.type === 'TemplateLiteral' &&
+        property.expressions.length === 0 &&
+        property.quasis.length === 1
+      ) {
+        return property.quasis[0].value.cooked;
+      }
+      return null; // Dynamic access: cannot compare names statically.
+    }
+
+    function isAliasProbe(left, right) {
+      const leftProperty = getPropertyName(left);
+      const rightProperty = getPropertyName(right);
+      if (leftProperty === null || rightProperty === null) return false;
+      // Identical names are redundant code, not an alias probe.
+      if (leftProperty === rightProperty) return false;
+      const leftObject = normalizeObjectText(sourceCode.getText(left.object));
+      const rightObject = normalizeObjectText(sourceCode.getText(right.object));
+      if (leftObject !== rightObject) return false;
+      return (
+        normalizePropertyName(leftProperty) ===
+        normalizePropertyName(rightProperty)
+      );
+    }
+
+    return {
+      LogicalExpression(node) {
+        if (node.operator !== '||' && node.operator !== '??') return;
+        const left = unwrapChain(node.left);
+        const right = unwrapChain(node.right);
+        if (!left || !right) return;
+        if (isAliasProbe(left, right)) {
+          context.report({
+            node,
+            messageId: 'aliasProbe',
+            data: {
+              left: sourceCode.getText(left),
+              right: sourceCode.getText(right),
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/eslint-rules/no-alias-probes.js
+++ b/eslint-rules/no-alias-probes.js
@@ -175,8 +175,9 @@ export default {
       const rightObject = normalizeObjectText(sourceCode.getText(right.object));
       if (leftObject !== rightObject) return false;
       return (
+        leftProperty.toLowerCase() === rightProperty.toLowerCase() ||
         normalizePropertyName(leftProperty) ===
-        normalizePropertyName(rightProperty)
+          normalizePropertyName(rightProperty)
       );
     }
 

--- a/eslint-rules/no-alias-probes.test.ts
+++ b/eslint-rules/no-alias-probes.test.ts
@@ -161,6 +161,18 @@ describe('no-alias-probes', () => {
       expectClean('const v = x.foo ?? x.bar;');
     });
 
+    it('does not fold old inside a longer identifier segment', () => {
+      expectClean('const v = obj.olderSibling || obj.newerSibling;');
+    });
+
+    it('does not fold ise inside a longer identifier segment', () => {
+      expectClean('const v = obj.rise || obj.rize;');
+    });
+
+    it('does not fold our inside a longer identifier segment', () => {
+      expectClean('const v = obj.contour || obj.contor;');
+    });
+
     it('allows nested access on different objects', () => {
       expectClean('const v = params.a.foo ?? params.b.foo;');
     });

--- a/eslint-rules/no-alias-probes.test.ts
+++ b/eslint-rules/no-alias-probes.test.ts
@@ -1,0 +1,172 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import path from 'node:path';
+import { Linter } from 'eslint';
+import rule, { BOUNDARY_EXCEPTIONS } from './no-alias-probes.js';
+
+// cwd is set to the filesystem root so the absolute test filenames below
+// (e.g. '/x/packages/...') resolve inside the flat-config basePath instead of
+// being classified as external paths, which would skip linting entirely.
+const linter = new Linter({ cwd: path.sep });
+
+/**
+ * Filename used when a test does not care about location. It is a .ts file
+ * outside any allowlisted path so existing detection tests are unaffected.
+ */
+const NON_ALLOWLISTED_FILENAME = '/x/src/file.ts';
+
+function verify(code: string, filename: string = NON_ALLOWLISTED_FILENAME) {
+  return linter.verify(
+    code,
+    {
+      files: ['**/*.ts'],
+      plugins: {
+        custom: {
+          rules: {
+            'no-alias-probes': rule,
+          },
+        },
+      },
+      rules: {
+        'custom/no-alias-probes': 'error',
+      },
+    },
+    filename,
+  );
+}
+
+function expectFlagged(code: string, filename?: string) {
+  const messages = verify(code, filename);
+  expect(messages).toHaveLength(1);
+  expect(messages[0]?.ruleId).toBe('custom/no-alias-probes');
+  expect(messages[0]?.messageId).toBe('aliasProbe');
+}
+
+function expectClean(code: string, filename?: string) {
+  expect(verify(code, filename)).toHaveLength(0);
+}
+
+describe('no-alias-probes', () => {
+  describe('flags alias coalescing on the same object', () => {
+    it('flags camelCase old/new name probing with ||', () => {
+      expectFlagged('const v = value.oldName || value.newName;');
+    });
+
+    it('flags snake_case vs camelCase with ??', () => {
+      expectFlagged('const v = value.old_name ?? value.newName;');
+    });
+
+    it('flags computed-with-literal vs dot access', () => {
+      expectFlagged("const v = obj['old-name'] ?? obj.oldName;");
+    });
+
+    it('flags snake_case vs camelCase params', () => {
+      expectFlagged('const v = params.foo_bar ?? params.fooBar;');
+    });
+
+    it('flags case-only variants (baseUrl vs baseURL)', () => {
+      expectFlagged('const v = x.baseUrl ?? x.baseURL;');
+    });
+
+    it('flags British/American spelling variants', () => {
+      expectFlagged(
+        'const v = request.behaviourPrompts ?? request.behaviorPrompts;',
+      );
+    });
+
+    it('flags optional chains on the same object', () => {
+      expectFlagged('const v = cfg?.base_url ?? cfg?.baseUrl;');
+    });
+
+    it('flags nested member expressions comparing the full object source', () => {
+      expectFlagged('const v = params.cfg.oldName ?? params.cfg.newName;');
+    });
+  });
+
+  describe('boundary exception: third-party field decoding is flagged by design', () => {
+    // Provider adapters decoding third-party wire-format variants (e.g.
+    // OpenAI sending both `reasoning_details` and `reasoningDetails`) are
+    // flagged by design. Boundary exceptions live in the rule's exported
+    // BOUNDARY_EXCEPTIONS allowlist (each entry with owner, reason, and
+    // removal condition), mirrored in dev-docs/naming-standard.md; inline
+    // eslint-disable comments are not the mechanism.
+    it('flags an inline third-party field-variant probe in an adapter shape', () => {
+      expectFlagged(
+        'const details = payload.reasoning_details ?? payload.reasoningDetails;',
+      );
+    });
+  });
+
+  describe('boundary exception allowlist', () => {
+    it('every entry has non-empty file, owner, reason, and removalCondition', () => {
+      expect(BOUNDARY_EXCEPTIONS.length).toBeGreaterThan(0);
+      for (const entry of BOUNDARY_EXCEPTIONS) {
+        expect(entry.file).toBeTruthy();
+        expect(entry.owner).toBeTruthy();
+        expect(entry.reason).toBeTruthy();
+        expect(entry.removalCondition).toBeTruthy();
+      }
+    });
+
+    it('file values are unique, glob-free, and repo-relative', () => {
+      const files = BOUNDARY_EXCEPTIONS.map((entry) => entry.file);
+      expect(new Set(files).size).toBe(files.length);
+      for (const file of files) {
+        expect(file.startsWith('packages/')).toBe(true);
+        expect(file.includes('*')).toBe(false);
+        expect(file.includes('?')).toBe(false);
+        expect(file.includes('[')).toBe(false);
+      }
+    });
+
+    it('does not report the probe snippet in an allowlisted file', () => {
+      expectClean(
+        'const v = process.env.NO_PROXY ?? process.env.no_proxy;',
+        '/x/packages/cli/src/utils/sandbox-seatbelt.ts',
+      );
+    });
+
+    it('still reports the probe snippet in a non-allowlisted file', () => {
+      expectFlagged(
+        'const v = process.env.NO_PROXY ?? process.env.no_proxy;',
+        '/x/packages/cli/src/utils/some-other-file.ts',
+      );
+    });
+  });
+
+  describe('does not flag legitimate fallbacks', () => {
+    it('allows boolean option fallback', () => {
+      expectClean('const v = x.flag || false;');
+    });
+
+    it('allows string default fallback', () => {
+      expectClean("const v = x.name ?? 'default';");
+    });
+
+    it('allows numeric zero fallback', () => {
+      expectClean('const v = x.count ?? 0;');
+    });
+
+    it('allows different objects', () => {
+      expectClean('const v = a.b ?? c.d;');
+      expectClean('const v = x.a || y.a;');
+    });
+
+    it('allows different fields after normalization', () => {
+      expectClean('const v = x.foo ?? x.bar;');
+    });
+
+    it('allows nested access on different objects', () => {
+      expectClean('const v = params.a.foo ?? params.b.foo;');
+    });
+
+    it('allows dynamic computed access', () => {
+      expectClean('const v = obj[key] ?? obj.other;');
+    });
+  });
+});

--- a/eslint-rules/no-alias-probes.test.ts
+++ b/eslint-rules/no-alias-probes.test.ts
@@ -93,8 +93,8 @@ describe('no-alias-probes', () => {
     // OpenAI sending both `reasoning_details` and `reasoningDetails`) are
     // flagged by design. Boundary exceptions live in the rule's exported
     // BOUNDARY_EXCEPTIONS allowlist (each entry with owner, reason, and
-    // removal condition), mirrored in dev-docs/naming-standard.md; inline
-    // eslint-disable comments are not the mechanism.
+    // removal condition), mirrored in dev-docs/naming-standard.md;
+    // inline lint suppressions are not the mechanism.
     it('flags an inline third-party field-variant probe in an adapter shape', () => {
       expectFlagged(
         'const details = payload.reasoning_details ?? payload.reasoningDetails;',

--- a/eslint-rules/no-alias-probes.test.ts
+++ b/eslint-rules/no-alias-probes.test.ts
@@ -73,6 +73,21 @@ describe('no-alias-probes', () => {
       expectFlagged('const v = x.baseUrl ?? x.baseURL;');
     });
 
+    it.each([
+      'const v = a.oldname ?? a.oldName;',
+      "const v = obj['maxtokens'] ?? obj.maxTokens;",
+    ])('flags concatenated case-only variants: %s', (code) => {
+      expectFlagged(code);
+    });
+
+    it.each([
+      'const v = a.olderSibling ?? a.newerSibling;',
+      'const v = a.rise ?? a.rize;',
+      'const v = a.contour ?? a.contor;',
+    ])('allows distinct words: %s', (code) => {
+      expectClean(code);
+    });
+
     it('flags British/American spelling variants', () => {
       expectFlagged(
         'const v = request.behaviourPrompts ?? request.behaviorPrompts;',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,7 @@ import headers from 'eslint-plugin-headers';
 import reactRenderSafety from './eslint-rules/react-render-safety.js';
 import noInlineDeps from './eslint-rules/no-inline-deps.js';
 import inkTextColorRequired from './eslint-rules/ink-text-color-required.js';
+import noAliasProbes from './eslint-rules/no-alias-probes.js';
 import path from 'node:path';
 import url from 'node:url';
 
@@ -1482,6 +1483,7 @@ export default tseslint.config(
           'react-render-safety': reactRenderSafety,
           'no-inline-deps': noInlineDeps,
           'ink-text-color-required': inkTextColorRequired,
+          'no-alias-probes': noAliasProbes,
         },
       },
     },
@@ -1490,6 +1492,7 @@ export default tseslint.config(
       // 'custom/react-render-safety': 'error', // TODO: Fix for ESLint 9 API
       'custom/no-inline-deps': 'error',
       'custom/ink-text-color-required': 'error',
+      'custom/no-alias-probes': 'error',
     },
   },
   // License header configuration

--- a/packages/agents/src/api/__tests__/config-adapter.spec.ts
+++ b/packages/agents/src/api/__tests__/config-adapter.spec.ts
@@ -27,9 +27,9 @@ import {
 } from '@vybestack/llxprt-code-agents';
 import { applyRuntimeEphemerals } from '../agentConfig.adapter.js';
 
-const STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY = 'streamIdleTimeoutMs';
-const STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY =
-  'streamFirstResponseTimeoutMs';
+const STREAM_IDLE_TIMEOUT_SETTING_KEY = 'stream-idle-timeout-ms';
+const STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY =
+  'stream-first-response-timeout-ms';
 
 /** Reads a ConfigParameters field by name without leaking a cast into asserts. */
 function read(params: Readonly<Record<string, unknown>>, key: string): unknown {
@@ -510,7 +510,7 @@ describe('applyRuntimeEphemerals (typed stream timeouts) @issue:2607', () => {
       streamFirstResponseTimeoutMs: undefined,
     });
     expect(sink.entries).toStrictEqual([
-      [STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY, 12_000],
+      [STREAM_IDLE_TIMEOUT_SETTING_KEY, 12_000],
     ]);
   });
 
@@ -521,7 +521,7 @@ describe('applyRuntimeEphemerals (typed stream timeouts) @issue:2607', () => {
       streamFirstResponseTimeoutMs: 300_000,
     });
     expect(sink.entries).toStrictEqual([
-      [STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY, 300_000],
+      [STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY, 300_000],
     ]);
   });
 
@@ -532,8 +532,8 @@ describe('applyRuntimeEphemerals (typed stream timeouts) @issue:2607', () => {
       streamFirstResponseTimeoutMs: 300_000,
     });
     expect(sink.entries).toStrictEqual([
-      [STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY, 5_000],
-      [STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY, 300_000],
+      [STREAM_IDLE_TIMEOUT_SETTING_KEY, 5_000],
+      [STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY, 300_000],
     ]);
   });
 
@@ -553,7 +553,7 @@ describe('applyRuntimeEphemerals (typed stream timeouts) @issue:2607', () => {
       streamFirstResponseTimeoutMs: 0,
     });
     expect(sink.entries).toStrictEqual([
-      [STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY, 0],
+      [STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY, 0],
     ]);
   });
 
@@ -564,7 +564,7 @@ describe('applyRuntimeEphemerals (typed stream timeouts) @issue:2607', () => {
       streamFirstResponseTimeoutMs: -1,
     });
     expect(sink.entries).toStrictEqual([
-      [STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY, -1],
+      [STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY, -1],
     ]);
   });
 
@@ -577,7 +577,7 @@ describe('applyRuntimeEphemerals (typed stream timeouts) @issue:2607', () => {
     // A single explicit write at 300000; absent would have written nothing.
     expect(sink.entries).toHaveLength(1);
     expect(sink.entries[0]?.[0]).toBe(
-      STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
+      STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY,
     );
     expect(sink.entries[0]?.[1]).toBe(300_000);
   });

--- a/packages/agents/src/api/__tests__/fixtures/profile-load-balancer.json
+++ b/packages/agents/src/api/__tests__/fixtures/profile-load-balancer.json
@@ -4,7 +4,7 @@
   "model": "claude-3-5-sonnet",
   "isDefault": false,
   "isLoadBalancer": true,
-  "modelParams": { "temperature": 0.5, "maxTokens": 4096 },
+  "modelParams": { "temperature": 0.5, "max_tokens": 4096 },
   "targets": [
     { "provider": "anthropic", "model": "claude-3-5-sonnet", "weight": 1 },
     { "provider": "openai", "model": "gpt-4o", "weight": 1 }

--- a/packages/agents/src/api/__tests__/streamTimeouts.behavior.test.ts
+++ b/packages/agents/src/api/__tests__/streamTimeouts.behavior.test.ts
@@ -13,28 +13,29 @@
  *
  * These integration tests build a real public Agent over a FakeProvider, then
  * inspect its internal Config to verify the typed-to-runtime wiring without
- * asserting on adapter implementation calls. The camelCase typed API keys are
- * used so diagnostics report the actual source field the caller set.
+ * asserting on adapter implementation calls. The typed API fields map to registry keys at the runtime boundary.
  */
 
 import { describe, it, expect } from 'bun:test';
 import { buildAgent, internalConfig } from './helpers/agentHarness.js';
 import {
-  STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
-  STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
+  STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY,
+  STREAM_IDLE_TIMEOUT_SETTING_KEY,
 } from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
 
 describe('createAgent typed stream timeouts @issue:2607', () => {
-  it('applies a positive streamFirstResponseTimeoutMs to the runtime Config under its camelCase key', async () => {
+  it('applies a positive streamFirstResponseTimeoutMs to the runtime Config under its registry key', async () => {
     const { agent, cleanup } = await buildAgent('plain-text.jsonl', {
       streamFirstResponseTimeoutMs: 180_000,
     });
     try {
       const config = internalConfig(agent);
+      expect(config.getEphemeralSetting('streamIdleTimeoutMs')).toBeUndefined();
       expect(
-        config.getEphemeralSetting(
-          STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
-        ),
+        config.getEphemeralSetting('streamFirstResponseTimeoutMs'),
+      ).toBeUndefined();
+      expect(
+        config.getEphemeralSetting(STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY),
       ).toBe(180_000);
     } finally {
       await cleanup();
@@ -47,10 +48,12 @@ describe('createAgent typed stream timeouts @issue:2607', () => {
     });
     try {
       const config = internalConfig(agent);
+      expect(config.getEphemeralSetting('streamIdleTimeoutMs')).toBeUndefined();
       expect(
-        config.getEphemeralSetting(
-          STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
-        ),
+        config.getEphemeralSetting('streamFirstResponseTimeoutMs'),
+      ).toBeUndefined();
+      expect(
+        config.getEphemeralSetting(STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY),
       ).toBe(0);
     } finally {
       await cleanup();
@@ -63,12 +66,14 @@ describe('createAgent typed stream timeouts @issue:2607', () => {
     });
     try {
       const config = internalConfig(agent);
+      expect(config.getEphemeralSetting('streamIdleTimeoutMs')).toBeUndefined();
+      expect(
+        config.getEphemeralSetting('streamFirstResponseTimeoutMs'),
+      ).toBeUndefined();
       // Absent would have been undefined (no ephemeral materialized); an
       // explicit 300000 is written through as a concrete value.
       expect(
-        config.getEphemeralSetting(
-          STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
-        ),
+        config.getEphemeralSetting(STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY),
       ).toBe(300_000);
     } finally {
       await cleanup();
@@ -79,25 +84,31 @@ describe('createAgent typed stream timeouts @issue:2607', () => {
     const { agent, cleanup } = await buildAgent('plain-text.jsonl');
     try {
       const config = internalConfig(agent);
+      expect(config.getEphemeralSetting('streamIdleTimeoutMs')).toBeUndefined();
       expect(
-        config.getEphemeralSetting(
-          STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
-        ),
+        config.getEphemeralSetting('streamFirstResponseTimeoutMs'),
+      ).toBeUndefined();
+      expect(
+        config.getEphemeralSetting(STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY),
       ).toBeUndefined();
     } finally {
       await cleanup();
     }
   });
 
-  it('applies an existing streamIdleTimeoutMs to the runtime Config under its camelCase key', async () => {
+  it('applies an existing streamIdleTimeoutMs to the runtime Config under its registry key', async () => {
     const { agent, cleanup } = await buildAgent('plain-text.jsonl', {
       streamIdleTimeoutMs: 7_500,
     });
     try {
       const config = internalConfig(agent);
+      expect(config.getEphemeralSetting('streamIdleTimeoutMs')).toBeUndefined();
       expect(
-        config.getEphemeralSetting(STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY),
-      ).toBe(7_500);
+        config.getEphemeralSetting('streamFirstResponseTimeoutMs'),
+      ).toBeUndefined();
+      expect(config.getEphemeralSetting(STREAM_IDLE_TIMEOUT_SETTING_KEY)).toBe(
+        7_500,
+      );
     } finally {
       await cleanup();
     }
@@ -110,13 +121,15 @@ describe('createAgent typed stream timeouts @issue:2607', () => {
     });
     try {
       const config = internalConfig(agent);
+      expect(config.getEphemeralSetting('streamIdleTimeoutMs')).toBeUndefined();
       expect(
-        config.getEphemeralSetting(STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY),
-      ).toBe(5_000);
+        config.getEphemeralSetting('streamFirstResponseTimeoutMs'),
+      ).toBeUndefined();
+      expect(config.getEphemeralSetting(STREAM_IDLE_TIMEOUT_SETTING_KEY)).toBe(
+        5_000,
+      );
       expect(
-        config.getEphemeralSetting(
-          STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
-        ),
+        config.getEphemeralSetting(STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY),
       ).toBe(240_000);
     } finally {
       await cleanup();

--- a/packages/agents/src/api/__tests__/switch-context.spec.ts
+++ b/packages/agents/src/api/__tests__/switch-context.spec.ts
@@ -368,10 +368,10 @@ describe('Switch-context @plan:PLAN-20260617-COREAPI.P12 @requirement:REQ-004 @r
 
       // setModelParam reflects in getModelParams
       agent.setModelParam('temperature', 0.7);
-      agent.setModelParam('maxTokens', 1024);
+      agent.setModelParam('max_tokens', 1024);
       const params = agent.getModelParams();
       expect(params['temperature']).toBe(0.7);
-      expect(params['maxTokens']).toBe(1024);
+      expect(params['max_tokens']).toBe(1024);
 
       // params reach the provider call — observable via a successful follow-up
       // turn that uses the configured model + params.

--- a/packages/agents/src/api/agentConfig.adapter.ts
+++ b/packages/agents/src/api/agentConfig.adapter.ts
@@ -10,8 +10,8 @@
 
 import type { ConfigParameters } from '@vybestack/llxprt-code-core/config/config.js';
 import {
-  STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
-  STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
+  STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY,
+  STREAM_IDLE_TIMEOUT_SETTING_KEY,
 } from '@vybestack/llxprt-code-core/utils/streamIdleTimeout.js';
 import type { AgentConfig } from './config-types.js';
 import { CONFIG_FIELD_CLASSIFICATION } from './config-classification.js';
@@ -350,13 +350,13 @@ export function applyRuntimeEphemerals(
 ): void {
   if (agentConfig.streamIdleTimeoutMs !== undefined) {
     config.setEphemeralSetting(
-      STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
+      STREAM_IDLE_TIMEOUT_SETTING_KEY,
       agentConfig.streamIdleTimeoutMs,
     );
   }
   if (agentConfig.streamFirstResponseTimeoutMs !== undefined) {
     config.setEphemeralSetting(
-      STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
+      STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY,
       agentConfig.streamFirstResponseTimeoutMs,
     );
   }

--- a/packages/agents/src/core/clientToolGovernance.test.ts
+++ b/packages/agents/src/core/clientToolGovernance.test.ts
@@ -66,16 +66,13 @@ describe('getToolGovernanceEphemerals', () => {
     });
   });
 
-  it('returns disabled list when present via legacy disabled-tools key', () => {
+  it('ignores the legacy disabled-tools key', () => {
     const config = makeConfig({ 'disabled-tools': ['dangerous_tool'] });
     const result = getToolGovernanceEphemerals(config);
-    expect(result).toStrictEqual({
-      allowed: undefined,
-      disabled: ['dangerous_tool'],
-    });
+    expect(result).toBeUndefined();
   });
 
-  it('prefers tools.disabled over disabled-tools', () => {
+  it('reads only tools.disabled when the legacy key is also present', () => {
     const config = makeConfig({
       'tools.disabled': ['new_tool'],
       'disabled-tools': ['old_tool'],

--- a/packages/agents/src/core/clientToolGovernance.ts
+++ b/packages/agents/src/core/clientToolGovernance.ts
@@ -60,8 +60,7 @@ export function getToolGovernanceEphemerals(config: Config):
   const rawAllowed = config.getEphemeralSetting('tools.allowed');
   const allowedList = readToolList(rawAllowed);
   const disabledList = readToolList(
-    config.getEphemeralSetting('tools.disabled') ??
-      config.getEphemeralSetting('disabled-tools'),
+    config.getEphemeralSetting('tools.disabled'),
   );
 
   const allowedExplicit = Array.isArray(rawAllowed);

--- a/packages/agents/src/core/subagent.ts
+++ b/packages/agents/src/core/subagent.ts
@@ -27,6 +27,7 @@ import { iContentFromBlocks } from '@vybestack/llxprt-code-core/llm-types/index.
 
 import { type ChatSession } from './chatSession.js';
 import { isToolNameRestricted } from './hookToolRestrictions.js';
+import { SCOPE_LOCAL_EMIT_TOOL_NAME } from './toolGovernance.js';
 import type {
   AgentRuntimeContext,
   ToolRegistryView,
@@ -711,7 +712,7 @@ export class SubAgentScope {
       if (isToolNameRestricted(request.name, hookRestrictedAllowedTools)) {
         continue;
       }
-      if (request.name === 'self_emitvalue') {
+      if (request.name === SCOPE_LOCAL_EMIT_TOOL_NAME) {
         manualBlocks.push(
           ...handleEmitValueCall(request, {
             output: this.output,

--- a/packages/agents/src/core/subagentExcludedNames.test.ts
+++ b/packages/agents/src/core/subagentExcludedNames.test.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #2533 — SUBAGENT_EXCLUDED_TOOL_NAMES must stay in lockstep with the
+ * Name constants of the tools it excludes. A spelling drift between the
+ * manifest and the real tool names would silently let subagents spawn
+ * nested subagents or list their siblings.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { SUBAGENT_EXCLUDED_TOOL_NAMES } from './toolGovernance.js';
+import { TaskTool } from '../tools/task.js';
+import { ListSubagentsTool } from '@vybestack/llxprt-code-tools';
+
+describe('SUBAGENT_EXCLUDED_TOOL_NAMES', () => {
+  it('excludes exactly the task and list_subagents tool names', () => {
+    expect([...SUBAGENT_EXCLUDED_TOOL_NAMES].sort()).toStrictEqual(
+      [TaskTool.Name, ListSubagentsTool.Name].sort(),
+    );
+  });
+});

--- a/packages/agents/src/core/subagentSettingsPopulation.test.ts
+++ b/packages/agents/src/core/subagentSettingsPopulation.test.ts
@@ -247,7 +247,7 @@ describe('populatePreActivationSettings and populatePostActivationSettings', () 
         'context-limit': 12345,
         GOOGLE_CLOUD_LOCATION: 'us-central1',
         GOOGLE_CLOUD_PROJECT: 'project-a',
-        'tool-format': 'xml',
+        toolFormat: 'xml',
         'user-agent': 'subagent-test',
       }),
       modelParams: {
@@ -274,7 +274,7 @@ describe('populatePreActivationSettings and populatePostActivationSettings', () 
     expect(service.get('context-limit')).toBe(12345);
     expect(service.get('GOOGLE_CLOUD_LOCATION')).toBe('us-central1');
     expect(service.get('GOOGLE_CLOUD_PROJECT')).toBe('project-a');
-    expect(service.get('tool-format-override')).toBe('xml');
+    expect(service.get('toolFormatOverride')).toBe('xml');
     expect(service.get('user-agent')).toBe('subagent-test');
   });
 

--- a/packages/agents/src/core/subagentSettingsPopulation.ts
+++ b/packages/agents/src/core/subagentSettingsPopulation.ts
@@ -39,9 +39,7 @@ const COMPRESSION_EPHEMERAL_KEYS = [
 const TOOL_GOVERNANCE_EPHEMERAL_KEYS = [
   'tool-format',
   'tools.allowed',
-  'tools_allowed',
   'tools.disabled',
-  'disabled-tools',
 ] as const;
 const MISC_EPHEMERAL_KEYS = ['user-agent'] as const;
 
@@ -119,16 +117,10 @@ function resolveToolGovernance(
   defaultDisabledTools: ReadonlySet<string>,
 ): { allowed: string[] | undefined; disabled: string[] | undefined } {
   const allowed = normalizeToolArray(
-    getStringArraySetting(profile.ephemeralSettings, [
-      'tools.allowed',
-      'tools_allowed',
-    ]),
+    getStringArraySetting(profile.ephemeralSettings, ['tools.allowed']),
   );
   const disabled = mergeDefaultDisabledTools(
-    getStringArraySetting(profile.ephemeralSettings, [
-      'tools.disabled',
-      'disabled-tools',
-    ]),
+    getStringArraySetting(profile.ephemeralSettings, ['tools.disabled']),
     allowed,
     defaultDisabledTools,
   );

--- a/packages/agents/src/core/subagentSettingsPopulation.ts
+++ b/packages/agents/src/core/subagentSettingsPopulation.ts
@@ -37,7 +37,7 @@ const COMPRESSION_EPHEMERAL_KEYS = [
   'compression-preserve-threshold',
 ] as const;
 const TOOL_GOVERNANCE_EPHEMERAL_KEYS = [
-  'tool-format',
+  'toolFormat',
   'tools.allowed',
   'tools.disabled',
 ] as const;
@@ -148,7 +148,7 @@ export function createSettingsSnapshot(
       'compression-preserve-threshold',
     ]),
     toolFormatOverride: getStringSetting(profile.ephemeralSettings, [
-      'tool-format',
+      'toolFormat',
     ]),
     tools: {
       allowed,
@@ -281,10 +281,10 @@ function populateToolAndMiscSettings(
   defaultDisabledTools: ReadonlySet<string>,
 ): void {
   const toolFormat = getStringSetting(profile.ephemeralSettings, [
-    'tool-format',
+    'toolFormat',
   ]);
   if (toolFormat) {
-    service.set('tool-format-override', toolFormat);
+    service.set('toolFormatOverride', toolFormat);
   }
 
   const { allowed, disabled } = resolveToolGovernance(

--- a/packages/agents/src/core/toolGovernance.test.ts
+++ b/packages/agents/src/core/toolGovernance.test.ts
@@ -97,19 +97,17 @@ describe('buildToolGovernance', () => {
       );
     });
 
-    it('should fallback to disabled-tools if tools.disabled is not present', () => {
+    it('should ignore the legacy disabled-tools key', () => {
       const config = createMockConfig({
         ephemerals: { 'disabled-tools': ['shell', 'write_file'] },
       });
 
       const governance = buildToolGovernance(config);
 
-      expect(governance.disabled).toStrictEqual(
-        new Set(['shell', 'write_file']),
-      );
+      expect(governance.disabled).toStrictEqual(new Set());
     });
 
-    it('should prefer tools.disabled over disabled-tools when both present', () => {
+    it('should ignore legacy disabled-tools when tools.disabled is present', () => {
       const config = createMockConfig({
         ephemerals: {
           'tools.disabled': ['shell'],

--- a/packages/agents/src/tools/task.issues.test.ts
+++ b/packages/agents/src/tools/task.issues.test.ts
@@ -446,7 +446,7 @@ describe('TaskTool', () => {
     });
   });
 
-  describe('Issue #2069: toolConfig omission with output_spec', () => {
+  describe('Issue #2069: toolConfig omission with expected_outputs', () => {
     it('omits toolConfig (not empty) when no explicit whitelist and registry unavailable, so runtime uses profile defaults', async () => {
       const dispose = vi.fn().mockResolvedValue(undefined);
       const scope = {
@@ -482,7 +482,7 @@ describe('TaskTool', () => {
       const invocation = tool.build({
         subagent_name: 'rustcoder',
         goal_prompt: 'Write a function',
-        output_spec: { result: 'The implementation' },
+        expected_outputs: { result: 'The implementation' },
       });
 
       await invocation.execute(new AbortController().signal, undefined);
@@ -541,7 +541,7 @@ describe('TaskTool', () => {
       const invocation = tool.build({
         subagent_name: 'rustcoder',
         goal_prompt: 'Write a function',
-        output_spec: { result: 'The implementation' },
+        expected_outputs: { result: 'The implementation' },
       });
 
       await invocation.execute(new AbortController().signal, undefined);
@@ -708,7 +708,7 @@ describe('TaskTool', () => {
     }
 
     async function executeIssue2184Invocation(
-      params: Pick<TaskToolParams, 'tool_whitelist' | 'output_spec'>,
+      params: Pick<TaskToolParams, 'tool_whitelist' | 'expected_outputs'>,
       registryTools = ['run_shell_command'],
       ephemerals: Record<string, unknown> = {},
     ): Promise<LaunchRequest | undefined> {
@@ -849,26 +849,26 @@ describe('TaskTool', () => {
       ]);
     });
 
-    it('preserves resolved whitelist tools when output_spec is provided', async () => {
+    it('preserves resolved whitelist tools when expected_outputs is provided', async () => {
       const launchRequest = await executeIssue2184Invocation({
         tool_whitelist: ['functions.run_shell_command'],
-        output_spec: { result: 'The output' },
+        expected_outputs: { result: 'The output' },
       });
 
       expect(launchRequest).toBeDefined();
       expect(launchRequest?.toolConfig?.tools).toStrictEqual([
         'run_shell_command',
       ]);
-      // outputConfig must contain the outputs mapped from output_spec.
+      // outputConfig must contain the outputs mapped from expected_outputs.
       expect(launchRequest?.outputConfig).toStrictEqual({
         outputs: { result: 'The output' },
       });
     });
 
-    it('preserves output_spec when qualified whitelist resolution leaves zero tools', async () => {
+    it('preserves expected_outputs when qualified whitelist resolution leaves zero tools', async () => {
       const launchRequest = await executeIssue2184Invocation({
         tool_whitelist: ['functions.does_not_exist'],
-        output_spec: { result: 'The output' },
+        expected_outputs: { result: 'The output' },
       });
 
       expect(launchRequest).toBeDefined();

--- a/packages/agents/src/tools/task.output-naming.test.ts
+++ b/packages/agents/src/tools/task.output-naming.test.ts
@@ -140,6 +140,35 @@ describe('Issue #2533: TaskTool single parameter vocabulary', () => {
     );
   });
 
+  describe('validateToolParamValues', () => {
+    class ValueValidatingTaskTool extends TaskTool {
+      override validateToolParamValues(params: TaskToolParams): string | null {
+        return super.validateToolParamValues(params);
+      }
+    }
+
+    it.each([
+      ['subagentName', 'subagent_name'],
+      ['goalPrompt', 'goal_prompt'],
+    ] as const)(
+      'rejects legacy %s before validating values',
+      (legacyName, canonicalName) => {
+        const tool = new ValueValidatingTaskTool(config, {
+          messageBus: new MessageBus(),
+        });
+        const params = {
+          subagent_name: 'helper',
+          goal_prompt: 'Do work',
+          [legacyName]: 'legacy value',
+        };
+
+        expect(tool.validateToolParamValues(params)).toContain(
+          `use the canonical '${canonicalName}'`,
+        );
+      },
+    );
+  });
+
   describe('normalizeTaskParams', () => {
     it('resolves expected_outputs into outputSpec', () => {
       const normalized = normalizeTaskParams({
@@ -190,7 +219,10 @@ describe('Issue #2533: TaskTool single parameter vocabulary', () => {
         const params = {
           subagent_name: 'helper',
           goal_prompt: 'Do work',
-          [legacyName]: 'legacy value',
+          [legacyName]:
+            canonicalName === 'expected_outputs'
+              ? { result: 'The outcome' }
+              : 'legacy value',
         } as unknown as TaskToolParams;
 
         expect(() => normalizeTaskParams(params)).toThrow(
@@ -208,8 +240,14 @@ describe('Issue #2533: TaskTool single parameter vocabulary', () => {
         const params = {
           subagent_name: 'helper',
           goal_prompt: 'Do work',
-          [canonicalName]: 'canonical value',
-          [legacyName]: 'legacy value',
+          [canonicalName]:
+            canonicalName === 'expected_outputs'
+              ? { result: 'The canonical outcome' }
+              : 'canonical value',
+          [legacyName]:
+            canonicalName === 'expected_outputs'
+              ? { result: 'The outcome' }
+              : 'legacy value',
         } as unknown as TaskToolParams;
 
         expect(() => normalizeTaskParams(params)).toThrow(

--- a/packages/agents/src/tools/task.output-naming.test.ts
+++ b/packages/agents/src/tools/task.output-naming.test.ts
@@ -5,14 +5,16 @@
  */
 
 /**
- * TaskTool output-parameter naming tests (Issue #2255).
- * Covers the preferred `expected_outputs` parameter, the backward-compatible
- * `output_spec` alias, precedence when both are provided, and validation that
- * rejects JSON-Schema-shaped object values.
+ * TaskTool output-parameter naming tests (Issue #2533).
+ * Asserts the single canonical `expected_outputs` vocabulary: legacy
+ * `output_spec` and camelCase spellings are rejected with a validation error
+ * naming the canonical member, and `expected_outputs` values must be plain
+ * string descriptions.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'bun:test';
 import { TaskTool, type TaskToolParams } from './task.js';
+import { taskToolSchema } from './taskSchema.js';
 import {
   validateOutputSpec,
   normalizeTaskParams,
@@ -22,41 +24,43 @@ import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message
 import type { SubagentOrchestrator } from '../core/subagentOrchestrator.js';
 import { SubagentTerminateMode } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
 
-describe('Issue #2255: TaskTool output parameter naming', () => {
+const CANONICAL_TASK_PARAM_NAMES = [
+  'async',
+  'behaviour_prompts',
+  'context',
+  'expected_outputs',
+  'goal_prompt',
+  'grace_period_seconds',
+  'max_turns',
+  'subagent_name',
+  'timeout_seconds',
+  'tool_whitelist',
+];
+
+describe('Issue #2533: TaskTool single parameter vocabulary', () => {
   let config: Config;
 
   beforeEach(() => {
     config = {
-      getSessionId: () => 'session-2255',
+      getSessionId: () => 'session-2533',
     } as unknown as Config;
   });
 
-  function createMockLaunch() {
-    const dispose = vi.fn().mockResolvedValue(undefined);
-    // SubAgentScope requires runNonInteractive/onMessage even though the
-    // interactive-path tests only exercise runInteractive.
-    const scope = {
-      output: {
-        emitted_vars: {},
-        terminate_reason: SubagentTerminateMode.GOAL,
-      },
-      runInteractive: vi.fn().mockResolvedValue(undefined),
-      runNonInteractive: vi.fn(),
-      onMessage: undefined,
-    };
-    // SubagentLaunchResult requires all fields; prompt/profile/config/runtime
-    // are unused by these tests but must be present to satisfy the type.
-    const launch = vi.fn().mockResolvedValue({
-      agentId: 'agent-2255',
-      scope,
-      dispose,
-      prompt: {} as unknown,
-      profile: {} as unknown,
-      config: {} as unknown,
-      runtime: {} as unknown,
+  function createTool(
+    orchestrator: SubagentOrchestrator = {} as unknown as SubagentOrchestrator,
+  ): TaskTool {
+    return new TaskTool(config, {
+      messageBus: new MessageBus(),
+      orchestratorFactory: () => orchestrator,
     });
-    const orchestrator = { launch } as unknown as SubagentOrchestrator;
-    return { launch, orchestrator };
+  }
+
+  function buildWithExtra(extra: Record<string, unknown>): void {
+    createTool().build({
+      subagent_name: 'helper',
+      goal_prompt: 'Do work',
+      ...extra,
+    } as unknown as TaskToolParams);
   }
 
   describe('validateOutputSpec', () => {
@@ -118,66 +122,17 @@ describe('Issue #2255: TaskTool output parameter naming', () => {
     });
   });
 
-  describe('normalizeTaskParams precedence', () => {
-    it('prefers expected_outputs over output_spec when both are provided', () => {
+  describe('normalizeTaskParams', () => {
+    it('resolves expected_outputs into outputSpec', () => {
       const normalized = normalizeTaskParams({
         subagent_name: 'helper',
         goal_prompt: 'Do work',
-        expected_outputs: { result: 'from expected_outputs' },
-        output_spec: { result: 'from output_spec' },
+        expected_outputs: { result: 'The outcome' },
       });
-      expect(normalized.outputSpec).toStrictEqual({
-        result: 'from expected_outputs',
-      });
+      expect(normalized.outputSpec).toStrictEqual({ result: 'The outcome' });
     });
 
-    it('validates the output_spec alias when expected_outputs takes precedence', () => {
-      expect(() =>
-        normalizeTaskParams({
-          subagent_name: 'helper',
-          goal_prompt: 'Do work',
-          expected_outputs: { result: 'preferred' },
-          output_spec: {
-            result: { type: 'string', description: 'invalid alias' },
-          } as unknown as Record<string, string>,
-        }),
-      ).toThrow(
-        "output_spec 'result' must be a plain string description, not a JSON Schema object.",
-      );
-    });
-
-    it('falls back to output_spec alias when expected_outputs is absent', () => {
-      const normalized = normalizeTaskParams({
-        subagent_name: 'helper',
-        goal_prompt: 'Do work',
-        output_spec: { result: 'from output_spec' },
-      });
-      expect(normalized.outputSpec).toStrictEqual({
-        result: 'from output_spec',
-      });
-    });
-
-    it('resolves camelCase expectedOutputs', () => {
-      const normalized = normalizeTaskParams({
-        subagent_name: 'helper',
-        goal_prompt: 'Do work',
-        expectedOutputs: { result: 'camel' },
-      });
-      expect(normalized.outputSpec).toStrictEqual({ result: 'camel' });
-    });
-
-    it('resolves camelCase outputSpec alias', () => {
-      const normalized = normalizeTaskParams({
-        subagent_name: 'helper',
-        goal_prompt: 'Do work',
-        outputSpec: { result: 'camel legacy' },
-      });
-      expect(normalized.outputSpec).toStrictEqual({
-        result: 'camel legacy',
-      });
-    });
-
-    it('returns undefined when neither is provided', () => {
+    it('returns undefined when expected_outputs is absent', () => {
       const normalized = normalizeTaskParams({
         subagent_name: 'helper',
         goal_prompt: 'Do work',
@@ -198,106 +153,93 @@ describe('Issue #2255: TaskTool output parameter naming', () => {
         "expected_outputs 'findings' must be a plain string description, not a JSON Schema object.",
       );
     });
+  });
 
-    it('throws when output_spec alias contains JSON-Schema-shaped values', () => {
+  describe('taskToolSchema', () => {
+    it('exposes exactly the canonical property set', () => {
+      expect(Object.keys(taskToolSchema.properties).sort()).toStrictEqual(
+        CANONICAL_TASK_PARAM_NAMES,
+      );
+    });
+
+    it('rejects unknown properties', () => {
+      expect(taskToolSchema.additionalProperties).toBe(false);
+    });
+
+    it('describes expected_outputs string values', () => {
+      expect(taskToolSchema.properties.expected_outputs.description).toContain(
+        'Values must be strings, not JSON Schema objects.',
+      );
+    });
+  });
+
+  describe('TaskTool.build rejection of non-canonical spellings', () => {
+    it('rejects output_spec with an error naming expected_outputs', () => {
       expect(() =>
-        normalizeTaskParams({
+        buildWithExtra({ output_spec: { result: 'The outcome' } }),
+      ).toThrow("use the canonical 'expected_outputs'");
+    });
+
+    it.each([
+      ['subagentName', 'subagent_name'],
+      ['goalPrompt', 'goal_prompt'],
+      ['behaviourPrompts', 'behaviour_prompts'],
+      ['behavior_prompts', 'behaviour_prompts'],
+      ['behaviorPrompts', 'behaviour_prompts'],
+      ['toolWhitelist', 'tool_whitelist'],
+      ['outputSpec', 'expected_outputs'],
+      ['expectedOutputs', 'expected_outputs'],
+      ['context_vars', 'context'],
+      ['contextVars', 'context'],
+    ] as const)(
+      'rejects %s with an error naming %s',
+      (legacyName, canonicalName) => {
+        expect(() => buildWithExtra({ [legacyName]: 'value' })).toThrow(
+          `use the canonical '${canonicalName}'`,
+        );
+      },
+    );
+
+    it('rejects a completely unknown property via the schema', () => {
+      expect(() => buildWithExtra({ bogus_param: 'value' })).toThrow(
+        /must NOT have additional properties|use the canonical/,
+      );
+    });
+
+    it('requires the canonical subagent_name when only camelCase is given', () => {
+      expect(() =>
+        createTool().build({
+          subagentName: 'helper',
+          goalPrompt: 'Do work',
+        } as unknown as TaskToolParams),
+      ).toThrow("use the canonical 'subagent_name'");
+    });
+  });
+
+  describe('TaskTool.build accepts canonical input', () => {
+    it('accepts valid string-valued expected_outputs', () => {
+      const invocation = createTool().build({
+        subagent_name: 'helper',
+        goal_prompt: 'Do work',
+        expected_outputs: { findings: 'A concise summary' },
+      });
+      expect(invocation.result).toBeUndefined();
+    });
+
+    it('rejects JSON-Schema-shaped expected_outputs at schema validation time', () => {
+      expect(() =>
+        createTool().build({
           subagent_name: 'helper',
           goal_prompt: 'Do work',
-          output_spec: {
+          expected_outputs: {
             findings: { type: 'string', description: 'bad' },
           } as unknown as Record<string, string>,
         }),
-      ).toThrow(
-        "output_spec 'findings' must be a plain string description, not a JSON Schema object.",
-      );
-    });
-  });
-
-  describe('TaskTool schema', () => {
-    function getSchemaProperties(
-      tool: TaskTool,
-    ): Record<string, { description?: string }> | undefined {
-      const decl = tool.schema as unknown as {
-        parametersJsonSchema?: {
-          properties?: Record<string, { description?: string }>;
-        };
-      };
-      return decl.parametersJsonSchema?.properties;
-    }
-
-    it('exposes expected_outputs as a schema property', () => {
-      const tool = new TaskTool(config, {
-        messageBus: new MessageBus(),
-        orchestratorFactory: () => ({}) as unknown as SubagentOrchestrator,
-      });
-      const prop = getSchemaProperties(tool)?.['expected_outputs'];
-      expect(prop).toBeDefined();
-      expect(prop?.description).toContain(
-        'Values must be strings, not JSON Schema objects.',
-      );
-    });
-
-    it('retains output_spec as a deprecated alias in the schema', () => {
-      const tool = new TaskTool(config, {
-        messageBus: new MessageBus(),
-        orchestratorFactory: () => ({}) as unknown as SubagentOrchestrator,
-      });
-      const prop = getSchemaProperties(tool)?.['output_spec'];
-      expect(prop).toBeDefined();
-      expect(prop?.description).toContain('Deprecated alias');
-      expect(prop?.description).toContain(
-        'Values must be strings, not JSON Schema objects.',
-      );
-    });
-  });
-
-  describe('TaskTool validateToolParamValues', () => {
-    it('rejects JSON-Schema-shaped expected_outputs at schema validation time', () => {
-      const tool = new TaskTool(config, {
-        messageBus: new MessageBus(),
-        orchestratorFactory: () => ({}) as unknown as SubagentOrchestrator,
-      });
-      const params: TaskToolParams = {
-        subagent_name: 'helper',
-        goal_prompt: 'Do work',
-        expected_outputs: {
-          findings: { type: 'string', description: 'bad' },
-        } as unknown as Record<string, string>,
-      };
-      // The JSON Schema validator (additionalProperties: { type: "string" })
-      // rejects non-string values before our custom validateOutputSpec runs.
-      // The error message references the param path in the form
-      // "expected_outputs/findings must be string".
-      expect(() => tool.build(params)).toThrow(
-        /expected_outputs\/findings must be string/,
-      );
-    });
-
-    it('rejects JSON-Schema-shaped output_spec alias at schema validation time', () => {
-      const tool = new TaskTool(config, {
-        messageBus: new MessageBus(),
-        orchestratorFactory: () => ({}) as unknown as SubagentOrchestrator,
-      });
-      const params: TaskToolParams = {
-        subagent_name: 'helper',
-        goal_prompt: 'Do work',
-        output_spec: {
-          findings: { type: 'string', description: 'bad' },
-        } as unknown as Record<string, string>,
-      };
-      expect(() => tool.build(params)).toThrow(
-        /output_spec\/findings must be string/,
-      );
+      ).toThrow(/expected_outputs\/findings must be string/);
     });
 
     it('validateToolParamValues rejects non-string expected_outputs values that bypass schema', () => {
-      const tool = new TaskTool(config, {
-        messageBus: new MessageBus(),
-        orchestratorFactory: () => ({}) as unknown as SubagentOrchestrator,
-      });
-      // validateToolParamValues is a second line of defense for callers that
-      // construct params programmatically and bypass schema validation.
+      const tool = createTool();
       const error = (
         tool as unknown as {
           validateToolParamValues: (p: TaskToolParams) => string | null;
@@ -313,60 +255,30 @@ describe('Issue #2255: TaskTool output parameter naming', () => {
         "expected_outputs 'findings' must be a plain string description",
       );
     });
-
-    it('validateToolParamValues rejects non-string output_spec values that bypass schema', () => {
-      const tool = new TaskTool(config, {
-        messageBus: new MessageBus(),
-        orchestratorFactory: () => ({}) as unknown as SubagentOrchestrator,
-      });
-      const error = (
-        tool as unknown as {
-          validateToolParamValues: (p: TaskToolParams) => string | null;
-        }
-      ).validateToolParamValues({
-        subagent_name: 'helper',
-        goal_prompt: 'Do work',
-        output_spec: {
-          findings: { type: 'string', description: 'bad' },
-        } as unknown as Record<string, string>,
-      });
-      expect(error).toContain(
-        "output_spec 'findings' must be a plain string description",
-      );
-    });
-
-    it('accepts valid string-valued expected_outputs', () => {
-      const tool = new TaskTool(config, {
-        messageBus: new MessageBus(),
-        orchestratorFactory: () => ({}) as unknown as SubagentOrchestrator,
-      });
-      const params: TaskToolParams = {
-        subagent_name: 'helper',
-        goal_prompt: 'Do work',
-        expected_outputs: { findings: 'A concise summary' },
-      };
-      const invocation = tool.build(params);
-      expect(invocation.result).toBeUndefined();
-    });
-
-    it('accepts valid string-valued output_spec alias', () => {
-      const tool = new TaskTool(config, {
-        messageBus: new MessageBus(),
-        orchestratorFactory: () => ({}) as unknown as SubagentOrchestrator,
-      });
-      const params: TaskToolParams = {
-        subagent_name: 'helper',
-        goal_prompt: 'Do work',
-        output_spec: { findings: 'A concise summary' },
-      };
-      const invocation = tool.build(params);
-      expect(invocation.result).toBeUndefined();
-    });
   });
 
   describe('TaskTool end-to-end output config', () => {
     it('passes expected_outputs into launchRequest.outputConfig', async () => {
-      const { launch, orchestrator } = createMockLaunch();
+      const dispose = vi.fn().mockResolvedValue(undefined);
+      const scope = {
+        output: {
+          emitted_vars: {},
+          terminate_reason: SubagentTerminateMode.GOAL,
+        },
+        runInteractive: vi.fn().mockResolvedValue(undefined),
+        runNonInteractive: vi.fn(),
+        onMessage: undefined,
+      };
+      const launch = vi.fn().mockResolvedValue({
+        agentId: 'agent-2533',
+        scope,
+        dispose,
+        prompt: {} as unknown,
+        profile: {} as unknown,
+        config: {} as unknown,
+        runtime: {} as unknown,
+      });
+      const orchestrator = { launch } as unknown as SubagentOrchestrator;
       const tool = new TaskTool(config, {
         messageBus: new MessageBus(),
         orchestratorFactory: () => orchestrator,
@@ -384,55 +296,6 @@ describe('Issue #2255: TaskTool output parameter naming', () => {
       expect(launch).toHaveBeenCalledWith(
         expect.objectContaining({
           outputConfig: { outputs: { result: 'The outcome' } },
-        }),
-        expect.any(AbortSignal),
-      );
-    });
-
-    it('passes output_spec alias into launchRequest.outputConfig', async () => {
-      const { launch, orchestrator } = createMockLaunch();
-      const tool = new TaskTool(config, {
-        messageBus: new MessageBus(),
-        orchestratorFactory: () => orchestrator,
-        isInteractiveEnvironment: () => true,
-      });
-
-      const invocation = tool.build({
-        subagent_name: 'helper',
-        goal_prompt: 'Do work',
-        output_spec: { result: 'The outcome' },
-      });
-
-      await invocation.execute(new AbortController().signal, undefined);
-
-      expect(launch).toHaveBeenCalledWith(
-        expect.objectContaining({
-          outputConfig: { outputs: { result: 'The outcome' } },
-        }),
-        expect.any(AbortSignal),
-      );
-    });
-
-    it('prefers expected_outputs over output_spec when both are provided at runtime', async () => {
-      const { launch, orchestrator } = createMockLaunch();
-      const tool = new TaskTool(config, {
-        messageBus: new MessageBus(),
-        orchestratorFactory: () => orchestrator,
-        isInteractiveEnvironment: () => true,
-      });
-
-      const invocation = tool.build({
-        subagent_name: 'helper',
-        goal_prompt: 'Do work',
-        expected_outputs: { result: 'preferred' },
-        output_spec: { result: 'legacy' },
-      });
-
-      await invocation.execute(new AbortController().signal, undefined);
-
-      expect(launch).toHaveBeenCalledWith(
-        expect.objectContaining({
-          outputConfig: { outputs: { result: 'preferred' } },
         }),
         expect.any(AbortSignal),
       );

--- a/packages/agents/src/tools/task.output-naming.test.ts
+++ b/packages/agents/src/tools/task.output-naming.test.ts
@@ -14,9 +14,10 @@
 
 import { describe, it, expect, vi, beforeEach } from 'bun:test';
 import { TaskTool, type TaskToolParams } from './task.js';
-import { taskToolSchema } from './taskSchema.js';
+import { TaskTool, type TaskToolParams } from './task.js';
 import {
   validateOutputSpec,
+  validateOutputParams,
   normalizeTaskParams,
 } from './taskToolGovernance.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
@@ -122,6 +123,23 @@ describe('Issue #2533: TaskTool single parameter vocabulary', () => {
     });
   });
 
+  describe('validateOutputParams', () => {
+    it.each(['output_spec', 'outputSpec', 'expectedOutputs'] as const)(
+      'rejects legacy %s even without schema validation',
+      (legacyName) => {
+        const params = {
+          subagent_name: 'helper',
+          goal_prompt: 'Do work',
+          [legacyName]: { result: 'The outcome' },
+        } as unknown as TaskToolParams;
+
+        expect(validateOutputParams(params)).toContain(
+          "use the canonical 'expected_outputs'",
+        );
+      },
+    );
+  });
+
   describe('normalizeTaskParams', () => {
     it('resolves expected_outputs into outputSpec', () => {
       const normalized = normalizeTaskParams({
@@ -153,21 +171,89 @@ describe('Issue #2533: TaskTool single parameter vocabulary', () => {
         "expected_outputs 'findings' must be a plain string description, not a JSON Schema object.",
       );
     });
+
+    it.each([
+      ['subagentName', 'subagent_name'],
+      ['goalPrompt', 'goal_prompt'],
+      ['behaviourPrompts', 'behaviour_prompts'],
+      ['behavior_prompts', 'behaviour_prompts'],
+      ['behaviorPrompts', 'behaviour_prompts'],
+      ['toolWhitelist', 'tool_whitelist'],
+      ['output_spec', 'expected_outputs'],
+      ['outputSpec', 'expected_outputs'],
+      ['expectedOutputs', 'expected_outputs'],
+      ['context_vars', 'context'],
+      ['contextVars', 'context'],
+    ] as const)(
+      'rejects legacy %s before normalization can drop it',
+      (legacyName, canonicalName) => {
+        const params = {
+          subagent_name: 'helper',
+          goal_prompt: 'Do work',
+          [legacyName]: 'legacy value',
+        } as unknown as TaskToolParams;
+
+        expect(() => normalizeTaskParams(params)).toThrow(
+          `use the canonical '${canonicalName}'`,
+        );
+      },
+    );
+
+    it.each([
+      ['expected_outputs', 'output_spec', 'expected_outputs'],
+      ['subagent_name', 'subagentName', 'subagent_name'],
+    ] as const)(
+      'rejects canonical %s combined with legacy %s',
+      (canonicalName, legacyName, expectedCanonicalName) => {
+        const params = {
+          subagent_name: 'helper',
+          goal_prompt: 'Do work',
+          [canonicalName]: 'canonical value',
+          [legacyName]: 'legacy value',
+        } as unknown as TaskToolParams;
+
+        expect(() => normalizeTaskParams(params)).toThrow(
+          `use the canonical '${expectedCanonicalName}'`,
+        );
+      },
+    );
   });
 
   describe('taskToolSchema', () => {
-    it('exposes exactly the canonical property set', () => {
-      expect(Object.keys(taskToolSchema.properties).sort()).toStrictEqual(
+    function runtimeParameterSchema(): Record<string, unknown> {
+      const schema = createTool().schema.parametersJsonSchema;
+      if (
+        typeof schema !== 'object' ||
+        schema === null ||
+        Array.isArray(schema)
+      ) {
+        throw new Error('TaskTool runtime parameter schema must be an object.');
+      }
+      return schema;
+    }
+
+    it('exposes exactly the canonical property set at runtime', () => {
+      const properties = runtimeParameterSchema()['properties'];
+      if (
+        typeof properties !== 'object' ||
+        properties === null ||
+        Array.isArray(properties)
+      ) {
+        throw new Error(
+          'TaskTool runtime schema properties must be an object.',
+        );
+      }
+      expect(Object.keys(properties).sort()).toStrictEqual(
         CANONICAL_TASK_PARAM_NAMES,
       );
     });
 
     it('rejects unknown properties', () => {
-      expect(taskToolSchema.additionalProperties).toBe(false);
+      expect(runtimeParameterSchema()['additionalProperties']).toBe(false);
     });
 
     it('describes expected_outputs string values', () => {
-      expect(taskToolSchema.properties.expected_outputs.description).toContain(
+      expect(JSON.stringify(runtimeParameterSchema())).toContain(
         'Values must be strings, not JSON Schema objects.',
       );
     });
@@ -202,7 +288,7 @@ describe('Issue #2533: TaskTool single parameter vocabulary', () => {
 
     it('rejects a completely unknown property via the schema', () => {
       expect(() => buildWithExtra({ bogus_param: 'value' })).toThrow(
-        /must NOT have additional properties|use the canonical/,
+        'params must NOT have additional properties',
       );
     });
 
@@ -223,7 +309,7 @@ describe('Issue #2533: TaskTool single parameter vocabulary', () => {
         goal_prompt: 'Do work',
         expected_outputs: { findings: 'A concise summary' },
       });
-      expect(invocation.result).toBeUndefined();
+      expect(invocation).toBeDefined();
     });
 
     it('rejects JSON-Schema-shaped expected_outputs at schema validation time', () => {

--- a/packages/agents/src/tools/task.test.ts
+++ b/packages/agents/src/tools/task.test.ts
@@ -108,7 +108,7 @@ describe('TaskTool', () => {
       goal_prompt: 'Ship the feature',
       behaviour_prompts: ['Respect coding standards'],
       tool_whitelist: ['read_file', 'write_file'],
-      output_spec: { summary: 'Outcome summary' },
+      expected_outputs: { summary: 'Outcome summary' },
       context: { extra: 'value' },
     };
 

--- a/packages/agents/src/tools/task.ts
+++ b/packages/agents/src/tools/task.ts
@@ -44,6 +44,7 @@ import {
   buildGovernedToolWhitelist,
   filterExcludedFromWhitelist,
   normalizeTaskParams,
+  validateCanonicalTaskParamSpellings,
   validateOutputParams,
   type TaskToolInvocationParams,
 } from './taskToolGovernance.js';
@@ -80,22 +81,11 @@ function resolveOptionalConfigMethod<T>(
 
 export interface TaskToolParams {
   subagent_name?: string;
-  subagentName?: string;
   goal_prompt?: string;
-  goalPrompt?: string;
   behaviour_prompts?: string[];
-  behavior_prompts?: string[];
-  behaviourPrompts?: string[];
-  behaviorPrompts?: string[];
   tool_whitelist?: string[];
-  toolWhitelist?: string[];
-  output_spec?: Record<string, string>;
-  outputSpec?: Record<string, string>;
   expected_outputs?: Record<string, string>;
-  expectedOutputs?: Record<string, string>;
   context?: Record<string, unknown>;
-  context_vars?: Record<string, unknown>;
-  contextVars?: Record<string, unknown>;
   timeout_seconds?: number;
   grace_period_seconds?: number;
   max_turns?: number;
@@ -204,9 +194,7 @@ class TaskToolInvocation extends BaseToolInvocation<
 
     const registry = this.deps.getToolRegistry?.();
     let effectiveWhitelist = toolWhitelist;
-    const hasExplicitWhitelist =
-      Array.isArray(this.params.tool_whitelist) ||
-      Array.isArray(this.params.toolWhitelist);
+    const hasExplicitWhitelist = Array.isArray(this.params.tool_whitelist);
 
     // Issue #2069: no explicit whitelist must preserve omitted toolConfig so
     // the subagent runtime/profile default tools apply. Do NOT synthesize a
@@ -771,15 +759,23 @@ export class TaskTool extends BaseDeclarativeTool<TaskToolParams, ToolResult> {
     this.dependencies = { ...dependencies, messageBus };
   }
 
+  override validateToolParams(params: TaskToolParams): string | null {
+    const spellingError = validateCanonicalTaskParamSpellings(params);
+    if (spellingError !== null) {
+      return spellingError;
+    }
+    return super.validateToolParams(params);
+  }
+
   protected override validateToolParamValues(
     params: TaskToolParams,
   ): string | null {
-    const subagentName = params.subagent_name ?? params.subagentName;
+    const subagentName = params.subagent_name;
     if (!subagentName || subagentName.trim().length === 0) {
       return 'Task tool requires a subagent_name.';
     }
 
-    const goalPrompt = params.goal_prompt ?? params.goalPrompt;
+    const goalPrompt = params.goal_prompt;
     if (!goalPrompt || goalPrompt.trim().length === 0) {
       return 'Task tool requires a goal_prompt describing the assignment.';
     }

--- a/packages/agents/src/tools/task.ts
+++ b/packages/agents/src/tools/task.ts
@@ -770,6 +770,10 @@ export class TaskTool extends BaseDeclarativeTool<TaskToolParams, ToolResult> {
   protected override validateToolParamValues(
     params: TaskToolParams,
   ): string | null {
+    const spellingError = validateCanonicalTaskParamSpellings(params);
+    if (spellingError !== null) {
+      return spellingError;
+    }
     const subagentName = params.subagent_name;
     if (!subagentName || subagentName.trim().length === 0) {
       return 'Task tool requires a subagent_name.';

--- a/packages/agents/src/tools/taskSchema.ts
+++ b/packages/agents/src/tools/taskSchema.ts
@@ -5,9 +5,8 @@
  */
 
 // Model-facing schema: only snake_case properties are exposed to the LLM.
-// camelCase aliases (subagentName, expectedOutputs, etc.) exist in
-// TaskToolParams for programmatic callers but are intentionally excluded
-// from the schema — additionalProperties: false enforces this.
+// `TaskToolParams` mirrors this schema exactly (canonical snake_case members
+// only) and `additionalProperties: false` rejects every other spelling.
 export const taskToolSchema = {
   type: 'object',
   additionalProperties: false,
@@ -39,12 +38,6 @@ export const taskToolSchema = {
       type: 'object',
       description:
         'Map each output variable name to a plain string description. Values must be strings, not JSON Schema objects.',
-      additionalProperties: { type: 'string' },
-    },
-    output_spec: {
-      type: 'object',
-      description:
-        'Deprecated alias for expected_outputs. Map each output variable name to a plain string description. Values must be strings, not JSON Schema objects.',
       additionalProperties: { type: 'string' },
     },
     timeout_seconds: {

--- a/packages/agents/src/tools/taskToolGovernance.ts
+++ b/packages/agents/src/tools/taskToolGovernance.ts
@@ -141,6 +141,40 @@ export function filterExcludedFromWhitelist(
 }
 
 /**
+ * Removed TaskTool parameter spellings mapped to their canonical members.
+ * Used only to reject legacy input with guidance — never to read values.
+ */
+const REMOVED_TASK_PARAM_SPELLINGS: ReadonlyMap<string, string> = new Map([
+  ['subagentName', 'subagent_name'],
+  ['goalPrompt', 'goal_prompt'],
+  ['behaviourPrompts', 'behaviour_prompts'],
+  ['behavior_prompts', 'behaviour_prompts'],
+  ['behaviorPrompts', 'behaviour_prompts'],
+  ['toolWhitelist', 'tool_whitelist'],
+  ['output_spec', 'expected_outputs'],
+  ['outputSpec', 'expected_outputs'],
+  ['expectedOutputs', 'expected_outputs'],
+  ['context_vars', 'context'],
+  ['contextVars', 'context'],
+]);
+
+/**
+ * Rejects removed TaskTool parameter spellings with an error naming the
+ * canonical member. Returns `null` when every key is canonical.
+ */
+export function validateCanonicalTaskParamSpellings(
+  params: TaskToolParams,
+): string | null {
+  for (const key of Object.keys(params)) {
+    const canonical = REMOVED_TASK_PARAM_SPELLINGS.get(key);
+    if (canonical !== undefined) {
+      return `Task tool parameter '${key}' is not recognized; use the canonical '${canonical}'.`;
+    }
+  }
+  return null;
+}
+
+/**
  * Validates that every value in an output-spec map is a plain string.
  * Rejects JSON-Schema-shaped objects (e.g. `{ type: "string", description: "..." }`)
  * that LLMs sometimes send when the parameter name invites a schema mental model.
@@ -167,66 +201,45 @@ export function validateOutputSpec(
 }
 
 /**
- * Validates the output-spec parameters (preferred `expected_outputs` and
- * deprecated `output_spec` alias) from raw `TaskToolParams`. Returns the first
- * validation error, or `null` if valid.
+ * Validates the `expected_outputs` parameter from raw `TaskToolParams`.
+ * Returns the first validation error, or `null` if valid.
  *
  * This is the single source of truth for output-param validation, shared by
  * both `validateToolParamValues` (pre-build schema-adjacent check) and
  * `resolveOutputSpec` (runtime normalization).
  */
 export function validateOutputParams(params: TaskToolParams): string | null {
-  const preferred =
-    params.expected_outputs ?? params.expectedOutputs ?? undefined;
-  if (preferred !== undefined) {
-    const error = validateOutputSpec(preferred, 'expected_outputs');
-    if (error !== null) {
-      return error;
-    }
+  if (params.expected_outputs === undefined) {
+    return null;
   }
-
-  const legacy = params.output_spec ?? params.outputSpec ?? undefined;
-  if (legacy !== undefined) {
-    return validateOutputSpec(legacy, 'output_spec');
-  }
-
-  return null;
+  return validateOutputSpec(params.expected_outputs, 'expected_outputs');
 }
 
 /**
- * Normalizes the public `TaskToolParams` (which accepts multiple alias keys)
- * into the canonical `TaskToolInvocationParams`. Trims prompts/tools, dedupes
- * behaviour prompts, and resolves the async flag.
+ * Normalizes the public `TaskToolParams` (canonical snake_case members only)
+ * into the internal camelCase `TaskToolInvocationParams`. Trims
+ * prompts/tools, dedupes behaviour prompts, and resolves the async flag.
  *
- * Output-spec resolution precedence (Issue #2255):
- *   1. expected_outputs / expectedOutputs (preferred, non-schema-suggestive)
- *   2. output_spec / outputSpec (deprecated alias)
- *
- * @throws When either source contains non-string values.
+ * @throws When `expected_outputs` contains non-string values.
  */
 export function normalizeTaskParams(
   params: TaskToolParams,
 ): TaskToolInvocationParams {
-  const subagentName = (
-    params.subagent_name ??
-    params.subagentName ??
-    ''
-  ).trim();
-  const goalPrompt = (params.goal_prompt ?? params.goalPrompt ?? '').trim();
+  const subagentName = (params.subagent_name ?? '').trim();
+  const goalPrompt = (params.goal_prompt ?? '').trim();
 
-  const behaviourPrompts = [goalPrompt, ...resolveBehaviourPrompts(params)]
+  const behaviourPrompts = [goalPrompt, ...(params.behaviour_prompts ?? [])]
     .map((prompt) => prompt.trim())
     .filter((prompt): prompt is string => Boolean(prompt))
     .filter((prompt, index, array) => array.indexOf(prompt) === index);
 
-  const toolWhitelist = resolveToolWhitelist(params)
+  const toolWhitelist = (params.tool_whitelist ?? [])
     .map((tool) => tool.trim())
     .filter((tool): tool is string => Boolean(tool));
 
   const outputSpec = resolveOutputSpec(params);
 
-  const context =
-    params.context ?? params.context_vars ?? params.contextVars ?? {};
+  const context = params.context ?? {};
 
   return {
     subagentName,
@@ -240,56 +253,17 @@ export function normalizeTaskParams(
   };
 }
 
-function resolveBehaviourPrompts(params: TaskToolParams): string[] {
-  return (
-    firstDefined(
-      params.behaviour_prompts,
-      params.behavior_prompts,
-      params.behaviourPrompts,
-    ) ??
-    params.behaviorPrompts ??
-    []
-  );
-}
-
-function firstDefined<T>(...values: Array<T | undefined>): T | undefined {
-  for (const value of values) {
-    if (value !== undefined) {
-      return value;
-    }
-  }
-  return undefined;
-}
-
-function resolveToolWhitelist(params: TaskToolParams): string[] {
-  return params.tool_whitelist ?? params.toolWhitelist ?? [];
-}
-
 /**
- * Resolves the output spec from `expected_outputs` (preferred) or the
- * deprecated `output_spec` alias. Validates that every value is a plain
- * string and throws with a clear message if a JSON-Schema-shaped object is
- * encountered.
+ * Resolves the output spec from `expected_outputs`. Validates that every
+ * value is a plain string and throws with a clear message if a
+ * JSON-Schema-shaped object is encountered.
  */
 function resolveOutputSpec(
   params: TaskToolParams,
 ): Record<string, string> | undefined {
-  const preferred =
-    params.expected_outputs ?? params.expectedOutputs ?? undefined;
-  const legacy = params.output_spec ?? params.outputSpec ?? undefined;
-
   const error = validateOutputParams(params);
   if (error !== null) {
     throw new Error(error);
   }
-
-  if (preferred !== undefined) {
-    return preferred;
-  }
-
-  if (legacy !== undefined) {
-    return legacy;
-  }
-
-  return undefined;
+  return params.expected_outputs;
 }

--- a/packages/agents/src/tools/taskToolGovernance.ts
+++ b/packages/agents/src/tools/taskToolGovernance.ts
@@ -158,6 +158,13 @@ const REMOVED_TASK_PARAM_SPELLINGS: ReadonlyMap<string, string> = new Map([
   ['contextVars', 'context'],
 ]);
 
+function removedTaskParamError(
+  legacyName: string,
+  canonicalName: string,
+): string {
+  return `Task tool parameter '${legacyName}' is not recognized; use the canonical '${canonicalName}'.`;
+}
+
 /**
  * Rejects removed TaskTool parameter spellings with an error naming the
  * canonical member. Returns `null` when every key is canonical.
@@ -168,7 +175,7 @@ export function validateCanonicalTaskParamSpellings(
   for (const key of Object.keys(params)) {
     const canonical = REMOVED_TASK_PARAM_SPELLINGS.get(key);
     if (canonical !== undefined) {
-      return `Task tool parameter '${key}' is not recognized; use the canonical '${canonical}'.`;
+      return removedTaskParamError(key, canonical);
     }
   }
   return null;
@@ -209,6 +216,12 @@ export function validateOutputSpec(
  * `resolveOutputSpec` (runtime normalization).
  */
 export function validateOutputParams(params: TaskToolParams): string | null {
+  for (const key of Object.keys(params)) {
+    const canonical = REMOVED_TASK_PARAM_SPELLINGS.get(key);
+    if (canonical === 'expected_outputs') {
+      return removedTaskParamError(key, canonical);
+    }
+  }
   if (params.expected_outputs === undefined) {
     return null;
   }
@@ -225,6 +238,10 @@ export function validateOutputParams(params: TaskToolParams): string | null {
 export function normalizeTaskParams(
   params: TaskToolParams,
 ): TaskToolInvocationParams {
+  const spellingError = validateCanonicalTaskParamSpellings(params);
+  if (spellingError !== null) {
+    throw new Error(spellingError);
+  }
   const subagentName = (params.subagent_name ?? '').trim();
   const goalPrompt = (params.goal_prompt ?? '').trim();
 

--- a/packages/cli/src/config/postConfigRuntime.test.ts
+++ b/packages/cli/src/config/postConfigRuntime.test.ts
@@ -54,21 +54,22 @@ describe('applyStreamIdleTimeoutSettings', () => {
 
     applyStreamIdleTimeoutSettings(config, settings);
 
-    expect(config.getEphemeralSetting('streamIdleTimeoutMs')).toBe(120_000);
+    expect(config.getEphemeralSetting('stream-idle-timeout-ms')).toBe(120_000);
+    expect(config.getEphemeralSetting('streamIdleTimeoutMs')).toBeUndefined();
     expect(resolveStreamIdleTimeoutMs(config)).toBe(120_000);
   });
 
-  it('preserves hyphenated stream-idle-timeout-ms priority over streamIdleTimeoutMs', () => {
+  it('maps the typed idle timeout field to the registry key', () => {
     const config = createCapturingConfig();
     const settings: StreamTimeoutSettingsInput = {
       streamIdleTimeoutMs: 120_000,
-      'stream-idle-timeout-ms': 60_000,
     };
 
     applyStreamIdleTimeoutSettings(config, settings);
 
-    expect(config.getEphemeralSetting('stream-idle-timeout-ms')).toBe(60_000);
-    expect(resolveStreamIdleTimeoutMs(config)).toBe(60_000);
+    expect(config.getEphemeralSetting('stream-idle-timeout-ms')).toBe(120_000);
+    expect(config.getEphemeralSetting('streamIdleTimeoutMs')).toBeUndefined();
+    expect(resolveStreamIdleTimeoutMs(config)).toBe(120_000);
   });
 
   it('keeps the environment variable as the highest priority after settings are wired', () => {
@@ -88,8 +89,10 @@ describe('applyStreamIdleTimeoutSettings', () => {
     const negativeConfig = createCapturingConfig();
     applyStreamIdleTimeoutSettings(negativeConfig, { streamIdleTimeoutMs: -1 });
 
-    expect(zeroConfig.getEphemeralSetting('streamIdleTimeoutMs')).toBe(0);
-    expect(negativeConfig.getEphemeralSetting('streamIdleTimeoutMs')).toBe(-1);
+    expect(zeroConfig.getEphemeralSetting('stream-idle-timeout-ms')).toBe(0);
+    expect(negativeConfig.getEphemeralSetting('stream-idle-timeout-ms')).toBe(
+      -1,
+    );
     expect(resolveStreamIdleTimeoutMs(zeroConfig)).toBe(0);
     expect(resolveStreamIdleTimeoutMs(negativeConfig)).toBe(0);
   });
@@ -134,25 +137,30 @@ describe('applyStreamFirstResponseTimeoutSettings @issue:2607', () => {
 
     applyStreamFirstResponseTimeoutSettings(config, settings);
 
-    expect(config.getEphemeralSetting('streamFirstResponseTimeoutMs')).toBe(
+    expect(config.getEphemeralSetting('stream-first-response-timeout-ms')).toBe(
       200_000,
     );
+    expect(
+      config.getEphemeralSetting('streamFirstResponseTimeoutMs'),
+    ).toBeUndefined();
     expect(resolveStreamFirstResponseTimeoutMs(config)).toBe(200_000);
   });
 
-  it('preserves hyphenated stream-first-response-timeout-ms priority over camelCase', () => {
+  it('maps the typed first-response field to the registry key', () => {
     const config = createCapturingConfig();
     const settings: StreamTimeoutSettingsInput = {
       streamFirstResponseTimeoutMs: 200_000,
-      'stream-first-response-timeout-ms': 100_000,
     };
 
     applyStreamFirstResponseTimeoutSettings(config, settings);
 
     expect(config.getEphemeralSetting('stream-first-response-timeout-ms')).toBe(
-      100_000,
+      200_000,
     );
-    expect(resolveStreamFirstResponseTimeoutMs(config)).toBe(100_000);
+    expect(
+      config.getEphemeralSetting('streamFirstResponseTimeoutMs'),
+    ).toBeUndefined();
+    expect(resolveStreamFirstResponseTimeoutMs(config)).toBe(200_000);
   });
 
   it('keeps the environment variable as the highest priority after settings are wired', () => {
@@ -202,10 +210,11 @@ describe('applyGlobalAndProfileEphemeralSettings', () => {
       bootstrapArgs: { profileJson: null },
       argv: { provider: undefined },
       settings: {},
-      profileSettingsWithTools: { streamIdleTimeoutMs: 120_000 },
+      profileSettingsWithTools: { 'stream-idle-timeout-ms': 120_000 },
       profileLoadResult: { profileToLoad: 'work' },
     });
 
+    expect(config.getEphemeralSetting('streamIdleTimeoutMs')).toBeUndefined();
     expect(resolveStreamIdleTimeoutMs(config)).toBe(120_000);
   });
 
@@ -234,10 +243,11 @@ describe('applyGlobalAndProfileEphemeralSettings', () => {
       bootstrapArgs: { profileJson: '{"provider":"openai"}' },
       argv: { provider: undefined },
       settings: {},
-      profileSettingsWithTools: { streamIdleTimeoutMs: 120_000 },
+      profileSettingsWithTools: { 'stream-idle-timeout-ms': 120_000 },
       profileLoadResult: { profileToLoad: undefined },
     });
 
+    expect(config.getEphemeralSetting('streamIdleTimeoutMs')).toBeUndefined();
     expect(resolveStreamIdleTimeoutMs(config)).toBe(120_000);
   });
 
@@ -249,7 +259,7 @@ describe('applyGlobalAndProfileEphemeralSettings', () => {
       bootstrapArgs: { profileJson: null },
       argv: { provider: 'openai' },
       settings: {},
-      profileSettingsWithTools: { streamIdleTimeoutMs: 120_000 },
+      profileSettingsWithTools: { 'stream-idle-timeout-ms': 120_000 },
       profileLoadResult: { profileToLoad: 'work' },
     });
 
@@ -275,7 +285,7 @@ describe('applyGlobalAndProfileEphemeralSettings', () => {
       profileLoadResult: { profileToLoad: undefined },
     });
 
-    expect(config.getEphemeralSetting('streamIdleTimeoutMs')).toBe(90_000);
+    expect(config.getEphemeralSetting('stream-idle-timeout-ms')).toBe(90_000);
     expect(config.getEphemeralSetting('auth-key')).toBeUndefined();
     expect(resolveStreamIdleTimeoutMs(config)).toBe(90_000);
   });
@@ -295,7 +305,7 @@ describe('applyGlobalAndProfileEphemeralSettings', () => {
       profileLoadResult: { profileToLoad: '' },
     });
 
-    expect(config.getEphemeralSetting('streamIdleTimeoutMs')).toBe(90_000);
+    expect(config.getEphemeralSetting('stream-idle-timeout-ms')).toBe(90_000);
     expect(config.getEphemeralSetting('auth-key')).toBeUndefined();
     expect(resolveStreamIdleTimeoutMs(config)).toBe(90_000);
   });
@@ -329,11 +339,11 @@ describe('applyGlobalAndProfileEphemeralSettings', () => {
       bootstrapArgs: { profileJson: null },
       argv: { provider: 'openai' },
       settings: { streamIdleTimeoutMs: 90_000 },
-      profileSettingsWithTools: { streamIdleTimeoutMs: 120_000 },
+      profileSettingsWithTools: { 'stream-idle-timeout-ms': 120_000 },
       profileLoadResult: { profileToLoad: 'work' },
     });
 
-    expect(config.getEphemeralSetting('streamIdleTimeoutMs')).toBe(90_000);
+    expect(config.getEphemeralSetting('stream-idle-timeout-ms')).toBe(90_000);
     expect(resolveStreamIdleTimeoutMs(config)).toBe(90_000);
   });
 
@@ -345,10 +355,11 @@ describe('applyGlobalAndProfileEphemeralSettings', () => {
       bootstrapArgs: { profileJson: null },
       argv: { provider: undefined },
       settings: { streamIdleTimeoutMs: 90_000 },
-      profileSettingsWithTools: { streamIdleTimeoutMs: 120_000 },
+      profileSettingsWithTools: { 'stream-idle-timeout-ms': 120_000 },
       profileLoadResult: { profileToLoad: 'work' },
     });
 
+    expect(config.getEphemeralSetting('streamIdleTimeoutMs')).toBeUndefined();
     expect(resolveStreamIdleTimeoutMs(config)).toBe(120_000);
   });
 
@@ -360,10 +371,13 @@ describe('applyGlobalAndProfileEphemeralSettings', () => {
       bootstrapArgs: { profileJson: null },
       argv: { provider: undefined },
       settings: {},
-      profileSettingsWithTools: { streamFirstResponseTimeoutMs: 200_000 },
+      profileSettingsWithTools: { 'stream-first-response-timeout-ms': 200_000 },
       profileLoadResult: { profileToLoad: 'work' },
     });
 
+    expect(
+      config.getEphemeralSetting('streamFirstResponseTimeoutMs'),
+    ).toBeUndefined();
     expect(resolveStreamFirstResponseTimeoutMs(config)).toBe(200_000);
   });
 
@@ -375,7 +389,7 @@ describe('applyGlobalAndProfileEphemeralSettings', () => {
       bootstrapArgs: { profileJson: null },
       argv: { provider: 'openai' },
       settings: { streamFirstResponseTimeoutMs: 180_000 },
-      profileSettingsWithTools: { streamFirstResponseTimeoutMs: 200_000 },
+      profileSettingsWithTools: { 'stream-first-response-timeout-ms': 200_000 },
       profileLoadResult: { profileToLoad: 'work' },
     });
 
@@ -390,10 +404,13 @@ describe('applyGlobalAndProfileEphemeralSettings', () => {
       bootstrapArgs: { profileJson: null },
       argv: { provider: undefined },
       settings: { streamFirstResponseTimeoutMs: 180_000 },
-      profileSettingsWithTools: { streamFirstResponseTimeoutMs: 200_000 },
+      profileSettingsWithTools: { 'stream-first-response-timeout-ms': 200_000 },
       profileLoadResult: { profileToLoad: 'work' },
     });
 
+    expect(
+      config.getEphemeralSetting('streamFirstResponseTimeoutMs'),
+    ).toBeUndefined();
     expect(resolveStreamFirstResponseTimeoutMs(config)).toBe(200_000);
   });
 
@@ -405,7 +422,7 @@ describe('applyGlobalAndProfileEphemeralSettings', () => {
       bootstrapArgs: { profileJson: null },
       argv: { provider: undefined },
       settings: {},
-      profileSettingsWithTools: { streamFirstResponseTimeoutMs: 0 },
+      profileSettingsWithTools: { 'stream-first-response-timeout-ms': 0 },
       profileLoadResult: { profileToLoad: 'work' },
     });
 
@@ -431,7 +448,7 @@ describe('applyStreamFirstResponseTimeoutSettings — default-source provenance 
     applyStreamFirstResponseTimeoutSettings(config, {});
 
     expect(
-      config.getEphemeralSetting('streamFirstResponseTimeoutMs'),
+      config.getEphemeralSetting('stream-first-response-timeout-ms'),
     ).toBeUndefined();
     expect(resolveStreamFirstResponseTimeoutMs(config)).toBe(
       DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS,
@@ -448,11 +465,11 @@ describe('applyStreamFirstResponseTimeoutSettings — default-source provenance 
       streamFirstResponseTimeoutMs: DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS,
     });
 
-    expect(config.getEphemeralSetting('streamFirstResponseTimeoutMs')).toBe(
+    expect(config.getEphemeralSetting('stream-first-response-timeout-ms')).toBe(
       DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS,
     );
     expect(resolveStreamFirstResponseTimeoutMsSource(config).source).toBe(
-      'streamFirstResponseTimeoutMs',
+      'stream-first-response-timeout-ms',
     );
   });
 
@@ -462,12 +479,15 @@ describe('applyStreamFirstResponseTimeoutSettings — default-source provenance 
       streamFirstResponseTimeoutMs: 200_000,
     });
 
-    expect(config.getEphemeralSetting('streamFirstResponseTimeoutMs')).toBe(
+    expect(config.getEphemeralSetting('stream-first-response-timeout-ms')).toBe(
       200_000,
     );
+    expect(
+      config.getEphemeralSetting('streamFirstResponseTimeoutMs'),
+    ).toBeUndefined();
     expect(resolveStreamFirstResponseTimeoutMs(config)).toBe(200_000);
     expect(resolveStreamFirstResponseTimeoutMsSource(config).source).toBe(
-      'streamFirstResponseTimeoutMs',
+      'stream-first-response-timeout-ms',
     );
   });
 
@@ -477,17 +497,19 @@ describe('applyStreamFirstResponseTimeoutSettings — default-source provenance 
       streamFirstResponseTimeoutMs: 0,
     });
 
-    expect(config.getEphemeralSetting('streamFirstResponseTimeoutMs')).toBe(0);
+    expect(config.getEphemeralSetting('stream-first-response-timeout-ms')).toBe(
+      0,
+    );
     expect(resolveStreamFirstResponseTimeoutMs(config)).toBe(0);
     expect(resolveStreamFirstResponseTimeoutMsSource(config).source).toBe(
-      'streamFirstResponseTimeoutMs',
+      'stream-first-response-timeout-ms',
     );
   });
 
   it('writes the hyphenated canonical key when it is NOT the built-in default', () => {
     const config = createCapturingConfig();
     applyStreamFirstResponseTimeoutSettings(config, {
-      'stream-first-response-timeout-ms': 120_000,
+      streamFirstResponseTimeoutMs: 120_000,
     });
 
     expect(config.getEphemeralSetting('stream-first-response-timeout-ms')).toBe(
@@ -502,8 +524,7 @@ describe('applyStreamFirstResponseTimeoutSettings — default-source provenance 
   it('preserves an explicit canonical value equal to the built-in fallback', () => {
     const config = createCapturingConfig();
     applyStreamFirstResponseTimeoutSettings(config, {
-      'stream-first-response-timeout-ms':
-        DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS,
+      streamFirstResponseTimeoutMs: DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS,
     });
 
     expect(config.getEphemeralSetting('stream-first-response-timeout-ms')).toBe(

--- a/packages/cli/src/config/postConfigRuntime.ts
+++ b/packages/cli/src/config/postConfigRuntime.ts
@@ -601,11 +601,7 @@ function applyEphemeralSettings(input: PostConfigInput): void {
   // In non-interactive mode, tool governance is enforced from approval mode,
   // so /set must not override governance-managed keys after step 15.
   // Interactive mode retains /set control for tools.allowed/tools.disabled.
-  const GOVERNANCE_KEYS = new Set([
-    'tools.allowed',
-    'tools.disabled',
-    'disabled-tools',
-  ]);
+  const GOVERNANCE_KEYS = new Set(['tools.allowed', 'tools.disabled']);
   const rawSetArgs = argv.set ?? [];
   const enforceGovernanceSetProtection = !input.interactive;
   const setArgsForApplication = enforceGovernanceSetProtection

--- a/packages/cli/src/config/postConfigRuntime.ts
+++ b/packages/cli/src/config/postConfigRuntime.ts
@@ -7,9 +7,7 @@
 import {
   ApprovalMode,
   runImageOperation,
-  STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
   STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY,
-  STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
   STREAM_IDLE_TIMEOUT_SETTING_KEY,
   type Config,
   type ImageOperationBackend,
@@ -96,38 +94,18 @@ type ApplyToolPoliciesInput = Pick<
 
 // ─── Stream timeout settings application ───────────────────────────────────
 
-/**
- * Profile/runtime settings input that may carry either the camelCase Settings
- * key or the canonical hyphenated ephemeral key. The hyphenated keys are NOT
- * part of the public JSON Settings schema (they would falsely advertise
- * themselves as JSON properties); they are modeled locally here because
- * profiles and runtime code historically set them as ephemerals directly.
- */
-export type StreamTimeoutSettingsInput = Settings & {
-  readonly 'stream-idle-timeout-ms'?: unknown;
-  readonly 'stream-first-response-timeout-ms'?: unknown;
-};
+export type StreamTimeoutSettingsInput = Pick<
+  Settings,
+  'streamIdleTimeoutMs' | 'streamFirstResponseTimeoutMs'
+>;
 
-/**
- * Generic applicator for a camel/hyphenated timeout setting pair. Reads both
- * the camelCase Settings key and the canonical hyphenated ephemeral key from
- * the supplied settings object and pushes whichever are defined onto Config
- * ephemerals. The hyphenated key is applied second so it wins the resolver's
- * priority order (canonical before alias).
- */
-function applyStreamTimeoutSettingPair(
+function applyStreamTimeoutSetting(
   config: Pick<Config, 'setEphemeralSetting'>,
-  settings: StreamTimeoutSettingsInput,
-  camelKey: keyof Settings,
-  canonicalKey: 'stream-idle-timeout-ms' | 'stream-first-response-timeout-ms',
+  value: number | undefined,
+  key: 'stream-idle-timeout-ms' | 'stream-first-response-timeout-ms',
 ): void {
-  const camelValue = settings[camelKey];
-  if (camelValue !== undefined) {
-    config.setEphemeralSetting(camelKey, camelValue);
-  }
-  const canonicalValue = settings[canonicalKey];
-  if (canonicalValue !== undefined) {
-    config.setEphemeralSetting(canonicalKey, canonicalValue);
+  if (value !== undefined) {
+    config.setEphemeralSetting(key, value);
   }
 }
 
@@ -135,10 +113,9 @@ export function applyStreamIdleTimeoutSettings(
   config: Pick<Config, 'setEphemeralSetting'>,
   settings: StreamTimeoutSettingsInput,
 ): void {
-  applyStreamTimeoutSettingPair(
+  applyStreamTimeoutSetting(
     config,
-    settings,
-    STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
+    settings.streamIdleTimeoutMs,
     STREAM_IDLE_TIMEOUT_SETTING_KEY,
   );
 }
@@ -147,10 +124,9 @@ export function applyStreamFirstResponseTimeoutSettings(
   config: Pick<Config, 'setEphemeralSetting'>,
   settings: StreamTimeoutSettingsInput,
 ): void {
-  applyStreamTimeoutSettingPair(
+  applyStreamTimeoutSetting(
     config,
-    settings,
-    STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
+    settings.streamFirstResponseTimeoutMs,
     STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY,
   );
 }
@@ -192,16 +168,15 @@ export function applyGlobalAndProfileEphemeralSettings(
     return;
   }
 
-  applyStreamIdleTimeoutSettings(config, profileSettingsWithTools);
-  applyStreamFirstResponseTimeoutSettings(config, profileSettingsWithTools);
-
   const ephemeralKeys = [
+    'stream-idle-timeout-ms',
+    'stream-first-response-timeout-ms',
     'auth-key',
     'auth-keyfile',
     'context-limit',
     'compression-threshold',
     'base-url',
-    'tool-format',
+    'toolFormat',
     'api-version',
     'custom-headers',
     'socket-timeout',

--- a/packages/cli/src/config/settings.part2.test.ts
+++ b/packages/cli/src/config/settings.part2.test.ts
@@ -726,7 +726,7 @@ describe('Settings Loading and Merging', () => {
     it('should resolve environment variables in user settings', () => {
       process.env.TEST_API_KEY = 'user_api_key_from_env';
       const userSettingsContent = {
-        apiKey: '$TEST_API_KEY',
+        'auth-key': '$TEST_API_KEY',
         someUrl: 'https://test.com/${TEST_API_KEY}',
       };
       (
@@ -741,11 +741,11 @@ describe('Settings Loading and Merging', () => {
       );
 
       const arbitrary = dynamicSettings(loadSettings(MOCK_WORKSPACE_DIR));
-      expect(arbitrary.user.settings.apiKey).toBe('user_api_key_from_env');
+      expect(arbitrary.user.settings['auth-key']).toBe('user_api_key_from_env');
       expect(arbitrary.user.settings.someUrl).toBe(
         'https://test.com/user_api_key_from_env',
       );
-      expect(arbitrary.merged.apiKey).toBe('user_api_key_from_env');
+      expect(arbitrary.merged['auth-key']).toBe('user_api_key_from_env');
       delete process.env.TEST_API_KEY;
     });
 

--- a/packages/cli/src/config/settings.part3.test.ts
+++ b/packages/cli/src/config/settings.part3.test.ts
@@ -289,7 +289,7 @@ describe('Settings Loading and Merging', () => {
     });
 
     it('should leave unresolved environment variables as is', () => {
-      const userSettingsContent = { apiKey: '$UNDEFINED_VAR' };
+      const userSettingsContent = { 'auth-key': '$UNDEFINED_VAR' };
       (
         mockFsExistsSync as Mock<(...args: never[]) => unknown>
       ).mockImplementation((p: fs.PathLike) => p === USER_SETTINGS_PATH);
@@ -302,8 +302,8 @@ describe('Settings Loading and Merging', () => {
       );
 
       const arbitrary = dynamicSettings(loadSettings(MOCK_WORKSPACE_DIR));
-      expect(arbitrary.user.settings.apiKey).toBe('$UNDEFINED_VAR');
-      expect(arbitrary.merged.apiKey).toBe('$UNDEFINED_VAR');
+      expect(arbitrary.user.settings['auth-key']).toBe('$UNDEFINED_VAR');
+      expect(arbitrary.merged['auth-key']).toBe('$UNDEFINED_VAR');
     });
 
     it('should resolve multiple environment variables in a single string', () => {

--- a/packages/cli/src/config/settingsLoader.ts
+++ b/packages/cli/src/config/settingsLoader.ts
@@ -2,7 +2,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { homedir } from 'os';
 import { FatalConfigError, getErrorMessage } from '@vybestack/llxprt-code-core';
-import { Storage } from '@vybestack/llxprt-code-settings';
+import {
+  Storage,
+  migrateLegacySettingKeys,
+} from '@vybestack/llxprt-code-settings';
 import stripJsonComments from 'strip-json-comments';
 import { DefaultLight } from '../ui/themes/default-light.js';
 import { DefaultDark } from '../ui/themes/default.js';
@@ -16,7 +19,6 @@ import {
   migrateHooksConfig,
   migrateLegacyInteractiveShellSetting,
 } from './settingsLegacy.js';
-import { migrateLegacySettingKeys } from '@vybestack/llxprt-code-settings';
 import { migrateDeprecatedSettings } from './settingsMigrations.js';
 import {
   getSystemDefaultsPath,
@@ -225,14 +227,19 @@ function migrateLoadedSettings(settings: SettingsState): void {
     const providers = scopeRecord['providers'];
     if (isPlainRecord(providers)) {
       for (const provider of Object.values(providers)) {
-        if (isPlainRecord(provider)) {
-          const migratedProvider = migrateLegacySettingKeys(provider);
-          if (migratedProvider !== provider) {
-            applyMigratedScopeKeys(provider, migratedProvider);
-          }
-        }
+        migrateProviderBlock(provider);
       }
     }
+  }
+}
+
+function migrateProviderBlock(provider: unknown): void {
+  if (!isPlainRecord(provider)) {
+    return;
+  }
+  const migratedProvider = migrateLegacySettingKeys(provider);
+  if (migratedProvider !== provider) {
+    applyMigratedScopeKeys(provider, migratedProvider);
   }
 }
 

--- a/packages/cli/src/config/settingsLoader.ts
+++ b/packages/cli/src/config/settingsLoader.ts
@@ -16,6 +16,7 @@ import {
   migrateHooksConfig,
   migrateLegacyInteractiveShellSetting,
 } from './settingsLegacy.js';
+import { migrateLegacySettingKeys } from '@vybestack/llxprt-code-settings';
 import { migrateDeprecatedSettings } from './settingsMigrations.js';
 import {
   getSystemDefaultsPath,
@@ -211,6 +212,50 @@ function migrateLoadedSettings(settings: SettingsState): void {
   ]) {
     migrateLegacyInteractiveShellSetting(scopeSettings);
     migrateHooksConfig(scopeSettings);
+    // #2533 Phase C1: rewrite legacy setting-key spellings once at load,
+    // in memory, exactly like the migrations above (no immediate rewrite of
+    // the on-disk file). Provider blocks are permissive maps where legacy
+    // model-param spellings (e.g. 'max-tokens') actually live, so they are
+    // migrated too.
+    const scopeRecord = scopeSettings as unknown as Record<string, unknown>;
+    const migrated = migrateLegacySettingKeys(scopeRecord);
+    if (migrated !== scopeRecord) {
+      applyMigratedScopeKeys(scopeRecord, migrated);
+    }
+    const providers = scopeRecord['providers'];
+    if (isPlainRecord(providers)) {
+      for (const provider of Object.values(providers)) {
+        if (isPlainRecord(provider)) {
+          const migratedProvider = migrateLegacySettingKeys(provider);
+          if (migratedProvider !== provider) {
+            applyMigratedScopeKeys(provider, migratedProvider);
+          }
+        }
+      }
+    }
+  }
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Copies migrated key/value pairs back into the original scope object
+ * in place (the scope objects are referenced elsewhere), removing keys the
+ * migration deleted.
+ */
+function applyMigratedScopeKeys(
+  target: Record<string, unknown>,
+  migrated: Record<string, unknown>,
+): void {
+  for (const key of Object.keys(target)) {
+    if (!(key in migrated)) {
+      delete target[key];
+    }
+  }
+  for (const [key, value] of Object.entries(migrated)) {
+    target[key] = value;
   }
 }
 

--- a/packages/cli/src/config/settingsLoader.ts
+++ b/packages/cli/src/config/settingsLoader.ts
@@ -219,7 +219,10 @@ function migrateLoadedSettings(settings: SettingsState): void {
     // the on-disk file). Provider blocks are permissive maps where legacy
     // model-param spellings (e.g. 'max-tokens') actually live, so they are
     // migrated too.
-    const scopeRecord = scopeSettings as unknown as Record<string, unknown>;
+    if (!isPlainRecord(scopeSettings)) {
+      continue;
+    }
+    const scopeRecord: Record<string, unknown> = scopeSettings;
     const migrated = migrateLegacySettingKeys(scopeRecord);
     if (migrated !== scopeRecord) {
       applyMigratedScopeKeys(scopeRecord, migrated);

--- a/packages/cli/src/config/toolGovernance.ts
+++ b/packages/cli/src/config/toolGovernance.ts
@@ -13,9 +13,7 @@ import {
   ApprovalMode as ApprovalModeEnum,
   type LlxprtExtension,
 } from '@vybestack/llxprt-code-core';
-import {
-  canonicalizePolicyToolEntry,
-} from '@vybestack/llxprt-code-tools';
+import { canonicalizePolicyToolEntry } from '@vybestack/llxprt-code-tools';
 import type { Settings } from './settings.js';
 import type { CliArgs } from './cliArgParser.js';
 import type { ContextResolutionResult } from './interactiveContext.js';

--- a/packages/cli/src/config/toolGovernance.ts
+++ b/packages/cli/src/config/toolGovernance.ts
@@ -13,6 +13,9 @@ import {
   ApprovalMode as ApprovalModeEnum,
   type LlxprtExtension,
 } from '@vybestack/llxprt-code-core';
+import {
+  canonicalizePolicyToolEntry,
+} from '@vybestack/llxprt-code-tools';
 import type { Settings } from './settings.js';
 import type { CliArgs } from './cliArgParser.js';
 import type { ContextResolutionResult } from './interactiveContext.js';
@@ -36,7 +39,7 @@ export const READ_ONLY_TOOL_NAMES = [
 export const EDIT_TOOL_NAME = 'replace';
 
 export const normalizeToolNameForPolicy = (name: string): string =>
-  name.trim().toLowerCase();
+  canonicalizePolicyToolEntry(name);
 
 const toEntryList = (value: unknown): unknown[] => {
   if (Array.isArray(value) && value.length > 0) {
@@ -58,18 +61,9 @@ export const buildNormalizedToolSet = (value: unknown): Set<string> => {
 
   for (const entry of entries) {
     if (typeof entry === 'string' && entry.trim().length > 0) {
-      const trimmedEntry = entry.trim();
-      const openParenIndex = trimmedEntry.indexOf('(');
-      const baseName =
-        openParenIndex === -1
-          ? trimmedEntry
-          : trimmedEntry.substring(0, openParenIndex).trim();
-
-      const canonicalName =
-        normalizeToolNameForPolicy(baseName) === 'shelltool'
-          ? 'run_shell_command'
-          : baseName;
-      const normalizedName = normalizeToolNameForPolicy(canonicalName);
+      // Arg-list stripping, legacy aliases, and wildcard passthrough are all
+      // handled by the shared boundary decoder.
+      const normalizedName = normalizeToolNameForPolicy(entry);
       if (normalizedName) {
         normalized.add(normalizedName);
       }

--- a/packages/cli/src/integration-tests/cli-args.integration.test.ts
+++ b/packages/cli/src/integration-tests/cli-args.integration.test.ts
@@ -73,7 +73,7 @@ describe('CLI --profile-load Integration Tests', () => {
         model: 'gemini-exp-1206',
         modelParams: {
           temperature: 0.5,
-          maxTokens: 2000,
+          max_tokens: 2000,
         },
         ephemeralSettings: {},
       };
@@ -400,7 +400,7 @@ describe('CLI --profile-load Integration Tests', () => {
         model: 'gemini-exp-1206',
         modelParams: {
           temperature: 0.2,
-          maxTokens: 1500,
+          max_tokens: 1500,
           topP: 0.9,
         },
         ephemeralSettings: {},

--- a/packages/cli/src/integration-tests/profile-system.integration.test.ts
+++ b/packages/cli/src/integration-tests/profile-system.integration.test.ts
@@ -387,7 +387,7 @@ describe('Profile Save/Load Cycle Integration Tests', () => {
           'auth-key': 'azure-key-comprehensive',
           'base-url': 'https://my-deployment.openai.azure.com',
           'api-version': '2024-06-01',
-          'tool-format': 'azure',
+          toolFormat: 'azure',
           'custom-headers': {
             'X-Organization-ID': 'org-123',
             'X-Project-ID': 'proj-456',

--- a/packages/cli/src/integration-tests/provider-multi-runtime.integration.test.ts
+++ b/packages/cli/src/integration-tests/provider-multi-runtime.integration.test.ts
@@ -180,7 +180,7 @@ async function bootstrapRuntimeFixture(options: {
       const baseUrl = profile.ephemeralSettings['base-url'];
       settingsService.setProviderSetting(
         options.providerName,
-        'baseUrl',
+        'base-url',
         baseUrl,
       );
       if (baseUrl) {

--- a/packages/cli/src/integration-tests/tools-governance.integration.test.ts
+++ b/packages/cli/src/integration-tests/tools-governance.integration.test.ts
@@ -57,7 +57,6 @@ describe('tools governance integration', () => {
           ephemeralSettings: {
             'tools.allowed': [],
             'tools.disabled': ['code-editor'],
-            'disabled-tools': ['code-editor'],
           },
         },
         null,

--- a/packages/cli/src/ui/commands/__tests__/profileCommand.lb.test.ts
+++ b/packages/cli/src/ui/commands/__tests__/profileCommand.lb.test.ts
@@ -12,6 +12,7 @@ import { profileCommand } from '../profileCommand.js';
 import { createMockCommandContext } from '../../../test-utils/mockCommandContext.js';
 import type { CommandContext } from '../types.js';
 import type { LoadBalancerProfile } from '@vybestack/llxprt-code-settings';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
 import { testRegex } from '../../../test-utils/regex.js';
 
 const runtimeMocks = {
@@ -39,6 +40,20 @@ describe('profileCommand - load balancer save with protected settings', () => {
 
   const save = profileCommand.subCommands!.find((cmd) => cmd.name === 'save')!;
 
+  it.each([
+    ['apiKey', 'auth-key'],
+    ['apiKeyfile', 'auth-keyfile'],
+  ] as const)(
+    'rejects legacy %s writes before profile save with canonical guidance',
+    (legacyKey, canonicalKey) => {
+      const settings = new SettingsService();
+
+      expect(() => settings.set(legacyKey, 'secret')).toThrow(
+        `use the canonical '${canonicalKey}'`,
+      );
+    },
+  );
+
   describe('protected settings stripping', () => {
     it('strips protected settings when saving loadbalancer profile', async () => {
       // Setup: Mock ephemeral settings with both protected and non-protected settings
@@ -47,10 +62,8 @@ describe('profileCommand - load balancer save with protected settings', () => {
         'auth-key': 'secret-key-12345',
         'auth-keyfile': '/path/to/keyfile',
         'base-url': 'https://custom.api.example.com',
-        apiKey: 'api-key-67890',
-        apiKeyfile: '/path/to/api-keyfile',
         model: 'gpt-4',
-        'tool-format': 'openai',
+        toolFormat: 'openai',
         GOOGLE_CLOUD_PROJECT: 'my-project',
         GOOGLE_CLOUD_LOCATION: 'us-central1',
         // Non-protected settings (should be preserved)
@@ -75,10 +88,8 @@ describe('profileCommand - load balancer save with protected settings', () => {
       expect(savedProfile.ephemeralSettings).not.toHaveProperty('auth-key');
       expect(savedProfile.ephemeralSettings).not.toHaveProperty('auth-keyfile');
       expect(savedProfile.ephemeralSettings).not.toHaveProperty('base-url');
-      expect(savedProfile.ephemeralSettings).not.toHaveProperty('apiKey');
-      expect(savedProfile.ephemeralSettings).not.toHaveProperty('apiKeyfile');
       expect(savedProfile.ephemeralSettings).not.toHaveProperty('model');
-      expect(savedProfile.ephemeralSettings).not.toHaveProperty('tool-format');
+      expect(savedProfile.ephemeralSettings).not.toHaveProperty('toolFormat');
       expect(savedProfile.ephemeralSettings).not.toHaveProperty(
         'GOOGLE_CLOUD_PROJECT',
       );
@@ -189,7 +200,6 @@ describe('profileCommand - load balancer save with protected settings', () => {
     it('handles ephemeral settings with only protected values', async () => {
       runtimeMocks.getEphemeralSettings.mockReturnValue({
         'auth-key': 'secret',
-        apiKey: 'key',
         model: 'gpt-4',
       });
       runtimeMocks.saveLoadBalancerProfile.mockResolvedValue(undefined);
@@ -227,14 +237,11 @@ describe('profileCommand - load balancer save with protected settings', () => {
       ]);
     });
 
-    it('strips all variations of protected setting names', async () => {
+    it('strips all canonical protected setting names', async () => {
       runtimeMocks.getEphemeralSettings.mockReturnValue({
-        // All variations of protected settings
         'auth-key': 'key1',
         'auth-keyfile': 'file1',
         'base-url': 'url1',
-        apiKey: 'key2',
-        apiKeyfile: 'file2',
         model: 'model1',
         provider: 'openai', // LB profiles use load-balancer, not current provider
         GOOGLE_CLOUD_PROJECT: 'proj',

--- a/packages/cli/src/ui/commands/diagnosticsCommand.edges.spec.ts
+++ b/packages/cli/src/ui/commands/diagnosticsCommand.edges.spec.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'bun:test';
 import { diagnosticsCommand } from './diagnosticsCommand.js';
 import type { MessageActionReturn } from './types.js';
 import { MCPOAuthTokenStorage } from '@vybestack/llxprt-code-core';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
 import {
   createTestToken,
   createMockTokenStore,
@@ -417,17 +418,13 @@ describe('diagnosticsCommand OAuth token display (edges)', () => {
       expect(content).not.toContain('supersecretapikey123');
     });
 
-    it('masks apiKey values and groups them under Authentication', async () => {
-      setupRuntimeMockWithEphemeral({
-        apiKey: 'sk-secretapikeyvalue1234',
-      });
+    it('rejects legacy apiKey before diagnostics can receive it', () => {
+      const settings = new SettingsService();
 
-      const result = await diagnosticsCommand.action?.(mockContext, '');
-      const content = (result as MessageActionReturn).content;
-
-      expect(content).toContain('Authentication:');
-      expect(content).toContain('apiKey:');
-      expect(content).not.toContain('sk-secretapikeyvalue1234');
+      expect(() => settings.set('apiKey', 'sk-secretapikeyvalue1234')).toThrow(
+        "use the canonical 'auth-key'",
+      );
+      expect(settings.getAllGlobalSettings()).not.toHaveProperty('apiKey');
     });
   });
 });

--- a/packages/cli/src/ui/commands/mcpCommand.schema-edge.test.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.schema-edge.test.ts
@@ -271,18 +271,21 @@ describe('mcpCommand', () => {
       });
     });
 
-    it('should handle "descriptions" as alias for "desc"', async () => {
+    it('should not treat the removed "descriptions" spelling as "desc"', async () => {
       const result = await mcpCommand.action!(mockContext, 'descriptions');
       assertMessageAction(result);
-      expect(result.content).toContain('Test tool');
-      expect(result.content).toContain('Server description');
+      expect(result.content).not.toContain('Test tool');
+      expect(result.content).not.toContain('Server description');
+      expect(result.content).not.toContain('Parameters:');
+      expect(result.content).toContain('\u001b[36mtool1\u001b[0m');
     });
 
-    it('should handle "nodescriptions" as alias for "nodesc"', async () => {
+    it('should not treat the removed "nodescriptions" spelling as "nodesc"', async () => {
       const result = await mcpCommand.action!(mockContext, 'nodescriptions');
       assertMessageAction(result);
       expect(result.content).not.toContain('Test tool');
       expect(result.content).not.toContain('Server description');
+      expect(result.content).not.toContain('Parameters:');
       expect(result.content).toContain('\u001b[36mtool1\u001b[0m');
     });
 

--- a/packages/cli/src/ui/commands/mcpCommand.ts
+++ b/packages/cli/src/ui/commands/mcpCommand.ts
@@ -118,11 +118,8 @@ const listCommand: SlashCommand = {
   action: async (context: CommandContext, args: string) => {
     const lowerCaseArgs = args.toLowerCase().split(/\s+/).filter(Boolean);
 
-    const hasDesc =
-      lowerCaseArgs.includes('desc') || lowerCaseArgs.includes('descriptions');
-    const hasNodesc =
-      lowerCaseArgs.includes('nodesc') ||
-      lowerCaseArgs.includes('nodescriptions');
+    const hasDesc = lowerCaseArgs.includes('desc');
+    const hasNodesc = lowerCaseArgs.includes('nodesc');
     const showSchema = lowerCaseArgs.includes('schema');
 
     // Show descriptions if `desc` or `schema` is present,

--- a/packages/cli/src/ui/commands/setCommand.test.ts
+++ b/packages/cli/src/ui/commands/setCommand.test.ts
@@ -262,15 +262,19 @@ describe('setCommand runtime integration', () => {
     },
   );
 
-  it('validates through the registry alias, not just the canonical key', async () => {
+  it('rejects a legacy modelparam spelling with canonical-key guidance', async () => {
     const result = await setCommand.action!(
       context,
       'modelparam max-tokens abc',
     );
 
     expect(mockRuntime.setActiveModelParam).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      type: 'message',
+      messageType: 'error',
+    });
     expect((result as { content: string }).content).toContain(
-      'must be a number',
+      "Unknown setting 'max-tokens'. Canonical key: 'max_tokens'.",
     );
   });
 

--- a/packages/cli/src/ui/commands/setCommand.test.ts
+++ b/packages/cli/src/ui/commands/setCommand.test.ts
@@ -278,6 +278,21 @@ describe('setCommand runtime integration', () => {
     );
   });
 
+  it('rejects unsetting a legacy modelparam before changing runtime state', async () => {
+    const result = await setCommand.action!(
+      context,
+      'unset modelparam max-tokens',
+    );
+
+    expect(result).toMatchObject({
+      type: 'message',
+      messageType: 'error',
+      content: "Unknown setting 'max-tokens'. Canonical key: 'max_tokens'.",
+    });
+    expect(mockRuntime.clearActiveModelParam).not.toHaveBeenCalled();
+    expect(mockRuntime.setEphemeralSetting).not.toHaveBeenCalled();
+  });
+
   it('still accepts an unregistered provider-specific param verbatim', async () => {
     await setCommand.action!(context, 'modelparam parse_reasoning true');
 

--- a/packages/cli/src/ui/commands/setCommand.test.ts
+++ b/packages/cli/src/ui/commands/setCommand.test.ts
@@ -409,6 +409,24 @@ describe('setCommand runtime integration', () => {
     });
   });
 
+  it('surfaces ephemeral clear failures without reporting success', async () => {
+    mockRuntime.setEphemeralSetting.mockImplementationOnce(() => {
+      throw new Error('cannot clear ephemeral');
+    });
+
+    const result = await setCommand.action!(
+      context,
+      'unset modelparam max_tokens',
+    );
+
+    expect(result).toStrictEqual({
+      type: 'message',
+      messageType: 'error',
+      content:
+        'Failed to clear ephemeral model parameter: cannot clear ephemeral',
+    });
+  });
+
   it('surfaces error from clearActiveModelParam even when ephemeral also cleared', async () => {
     mockRuntime.clearActiveModelParam.mockImplementationOnce(() => {
       throw new Error('cannot clear');

--- a/packages/cli/src/ui/commands/setCommand.ts
+++ b/packages/cli/src/ui/commands/setCommand.ts
@@ -131,12 +131,21 @@ function handleUnsetModelParam(subKey: string): MessageActionReturn {
   const runtime = getRuntimeApi();
   try {
     runtime.clearActiveModelParam(subKey);
-    runtime.setEphemeralSetting(subKey, undefined);
   } catch (error) {
     return {
       type: 'message',
       messageType: 'error',
       content: `Failed to clear model parameter: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  try {
+    runtime.setEphemeralSetting(subKey, undefined);
+  } catch (error) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: `Failed to clear ephemeral model parameter: ${error instanceof Error ? error.message : String(error)}`,
     };
   }
 

--- a/packages/cli/src/ui/commands/setCommand.ts
+++ b/packages/cli/src/ui/commands/setCommand.ts
@@ -199,6 +199,10 @@ function handleSetUnset(parts: string[]): MessageActionReturn {
   const subKey = parts[2];
 
   if (targetKey === 'modelparam') {
+    const legacyParamRejection = rejectLegacySettingKey(subKey);
+    if (legacyParamRejection) {
+      return legacyParamRejection;
+    }
     return handleUnsetModelParam(subKey);
   }
 

--- a/packages/cli/src/ui/commands/setCommand.ts
+++ b/packages/cli/src/ui/commands/setCommand.ts
@@ -17,8 +17,8 @@ import {
   parseEphemeralSettingValue,
 } from '@vybestack/llxprt-code-providers/runtime.js';
 import {
-  resolveAlias,
   isStrictNumericString,
+  LEGACY_SETTING_KEY_MIGRATIONS,
   validateSetting,
 } from '@vybestack/llxprt-code-settings';
 import { buildSetSchema } from './setCommandSchema.js';
@@ -32,6 +32,22 @@ import { buildSetSchema } from './setCommandSchema.js';
  */
 
 const setSchema = buildSetSchema();
+
+/**
+ * Legacy key spellings are migrated once at settings load; /set must not
+ * silently accept them, so reject with the canonical spelling instead.
+ */
+function rejectLegacySettingKey(key: string): MessageActionReturn | null {
+  const canonicalKey = LEGACY_SETTING_KEY_MIGRATIONS.get(key);
+  if (canonicalKey === undefined) {
+    return null;
+  }
+  return {
+    type: 'message',
+    messageType: 'error',
+    content: `Unknown setting '${key}'. Canonical key: '${canonicalKey}'.`,
+  };
+}
 
 function formatParsedValue(value: unknown): string {
   if (typeof value === 'string') {
@@ -59,6 +75,10 @@ function handleSetModelParam(parts: string[]): MessageActionReturn {
 
   const runtime = getRuntimeApi();
   const paramName = parts[1];
+  const legacyParamRejection = rejectLegacySettingKey(paramName);
+  if (legacyParamRejection) {
+    return legacyParamRejection;
+  }
   const rawValue = parts.slice(2).join(' ');
   const parsed = parseValue(rawValue);
 
@@ -173,9 +193,13 @@ function handleSetUnset(parts: string[]): MessageActionReturn {
     return handleUnsetModelParam(subKey);
   }
 
-  const resolvedTargetKey = resolveAlias(targetKey);
+  const legacyUnsetRejection = rejectLegacySettingKey(targetKey);
+  if (legacyUnsetRejection) {
+    return legacyUnsetRejection;
+  }
+
   const validEphemeralKeys = Object.keys(ephemeralSettingHelp);
-  if (!validEphemeralKeys.includes(resolvedTargetKey)) {
+  if (!validEphemeralKeys.includes(targetKey)) {
     return {
       type: 'message',
       messageType: 'error',
@@ -183,7 +207,7 @@ function handleSetUnset(parts: string[]): MessageActionReturn {
     };
   }
 
-  if (resolvedTargetKey === 'custom-headers' && subKey) {
+  if (targetKey === 'custom-headers' && subKey) {
     return handleUnsetCustomHeader(targetKey, subKey);
   }
 
@@ -200,6 +224,11 @@ function handleSetEphemeral(
   key: string,
   parts: string[],
 ): MessageActionReturn {
+  const legacyRejection = rejectLegacySettingKey(key);
+  if (legacyRejection) {
+    return legacyRejection;
+  }
+
   // If only key is provided, show help for that key
   if (parts.length === 1) {
     if (ephemeralSettingHelp[key]) {

--- a/packages/cli/src/ui/commands/setCommandSchema.ts
+++ b/packages/cli/src/ui/commands/setCommandSchema.ts
@@ -13,10 +13,7 @@ import type {
 import type { CommandContext } from './types.js';
 import { getRuntimeApi } from '../contexts/RuntimeContext.js';
 import { ephemeralSettingHelp } from '@vybestack/llxprt-code-providers/runtime.js';
-import {
-  getDirectSettingSpecs,
-  resolveAlias,
-} from '@vybestack/llxprt-code-settings';
+import { getDirectSettingSpecs } from '@vybestack/llxprt-code-settings';
 import {
   filterStrings,
   filterCompletions,
@@ -177,9 +174,7 @@ function buildSettingValueCompleter(): NonNullable<ValueArgument['completer']> {
     const setting = tokens.tokens[0] || tokens.partialToken;
     const enableFuzzy = getFuzzyEnabled(ctx);
 
-    const resolvedSetting = resolveAlias(setting);
-    const registryOptions =
-      directSettingSpecByValue.get(resolvedSetting)?.options;
+    const registryOptions = directSettingSpecByValue.get(setting)?.options;
 
     if (registryOptions && registryOptions.length > 0) {
       return filterCompletions(registryOptions, partial, { enableFuzzy });

--- a/packages/cli/src/ui/commands/toolsCommand.ts
+++ b/packages/cli/src/ui/commands/toolsCommand.ts
@@ -12,6 +12,10 @@ import {
 import { MessageType } from '../types.js';
 import type { ToolInfo } from '@vybestack/llxprt-code-agents';
 import type { SettingsService } from '@vybestack/llxprt-code-settings';
+import {
+  canonicalizeToolName,
+  INVALID_TOOL_NAME,
+} from '@vybestack/llxprt-code-tools';
 import { type CommandArgumentSchema } from './schema/types.js';
 
 const toolsSchema: CommandArgumentSchema = [
@@ -29,7 +33,10 @@ const toolsSchema: CommandArgumentSchema = [
   },
 ];
 
-const normalizeToolName = (name: string): string => name.trim().toLowerCase();
+const normalizeToolName = (name: string): string => {
+  const canonical = canonicalizeToolName(name);
+  return canonical === INVALID_TOOL_NAME ? '' : canonical;
+};
 
 // Tokenizes quoted/unquoted args. The pattern is passed to RegExp via an
 // identifier so it is not a static literal flagged by sonarjs/regular-expr.

--- a/packages/cli/src/ui/commands/toolsCommand.ts
+++ b/packages/cli/src/ui/commands/toolsCommand.ts
@@ -28,7 +28,6 @@ const toolsSchema: CommandArgumentSchema = [
       { value: 'disable', description: 'Disable a tool by name' },
       { value: 'enable', description: 'Enable a tool by name' },
       { value: 'desc', description: 'List tools with descriptions' },
-      { value: 'descriptions', description: 'Alias for desc' },
     ],
   },
 ];
@@ -304,8 +303,7 @@ export const toolsCommand: SlashCommand = {
     const { disabled, allowed } = readToolLists(context);
     const tools = agent.tools.list();
 
-    const showDescriptions =
-      subcommand === 'desc' || subcommand === 'descriptions';
+    const showDescriptions = subcommand === 'desc';
 
     if (subcommand === 'list' || showDescriptions) {
       const message = formatListMessage(

--- a/packages/cli/src/ui/commands/toolsCommand.ts
+++ b/packages/cli/src/ui/commands/toolsCommand.ts
@@ -86,13 +86,6 @@ function readToolLists(context: CommandContext): {
     ? new Set((read('tools.allowed') as string[]).map(normalizeToolName))
     : new Set<string>();
 
-  const legacy = read('disabled-tools');
-  if (Array.isArray(legacy)) {
-    for (const name of legacy as string[]) {
-      disabled.add(normalizeToolName(name));
-    }
-  }
-
   return { disabled, allowed };
 }
 
@@ -108,14 +101,12 @@ function persistToolLists(
 
   if (settings) {
     settings.set('tools.disabled', disabledList);
-    settings.set('disabled-tools', disabledList);
     settings.set('tools.allowed', allowedList);
   }
 
   if (config) {
     if (typeof config.setEphemeralSetting === 'function') {
       config.setEphemeralSetting('tools.disabled', disabledList);
-      config.setEphemeralSetting('disabled-tools', disabledList);
       config.setEphemeralSetting('tools.allowed', allowedList);
     }
     if (typeof config.getEphemeralSettings === 'function') {
@@ -123,7 +114,6 @@ function persistToolLists(
       if (ephemerals !== null && typeof ephemerals === 'object') {
         const ephemeralSettings = ephemerals as Record<string, unknown>;
         ephemeralSettings['tools.disabled'] = disabledList;
-        ephemeralSettings['disabled-tools'] = disabledList;
         ephemeralSettings['tools.allowed'] = allowedList;
       }
     }

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -19,6 +19,7 @@ import {
   DEFAULT_AGENT_ID,
   formatTodoListForDisplay,
 } from '@vybestack/llxprt-code-core';
+import { canonicalizeToolName } from '@vybestack/llxprt-code-tools';
 import { SHELL_COMMAND_NAME, SHELL_NAME } from '../../constants.js';
 import { useTodoContext } from '../../contexts/TodoContext.js';
 import type { CliUiRuntime } from '../../cliUiRuntime.js';
@@ -52,14 +53,11 @@ const extractCountFromText = (text?: string): number | undefined => {
   return Number(match[1]);
 };
 
-const normalizeToolName = (name: string): string =>
-  name.replace(/[^a-z]/gi, '').toLowerCase();
-
 const isTodoReadTool = (name: string): boolean =>
-  normalizeToolName(name) === 'todoread';
+  canonicalizeToolName(name) === 'todo_read';
 
 const isTodoWriteTool = (name: string): boolean =>
-  normalizeToolName(name) === 'todowrite';
+  canonicalizeToolName(name) === 'todo_write';
 
 const formatTaskCountLabel = (count: number): string => {
   const normalized = Math.max(count, 0);

--- a/packages/cli/src/ui/hooks/useToolsDialog.ts
+++ b/packages/cli/src/ui/hooks/useToolsDialog.ts
@@ -24,7 +24,7 @@ interface UseToolsDialogParams {
 
 function getDisabledToolsFromConfig(config: CliUiRuntime): string[] {
   const ephemeralSettings = config.getEphemeralSettings();
-  const disabledToolsValue = ephemeralSettings['disabled-tools'];
+  const disabledToolsValue = ephemeralSettings['tools.disabled'];
   return Array.isArray(disabledToolsValue)
     ? (disabledToolsValue as string[])
     : [];
@@ -158,7 +158,7 @@ export const useToolsDialog = ({
       );
 
       // Update ephemeral settings
-      config.setEphemeralSetting('disabled-tools', updatedDisabledTools);
+      config.setEphemeralSetting('tools.disabled', updatedDisabledTools);
 
       addMessage({
         type: MessageType.INFO,

--- a/packages/core/src/policy/config.ts
+++ b/packages/core/src/policy/config.ts
@@ -8,6 +8,7 @@ import * as path from 'node:path';
 import fs from 'node:fs/promises';
 import toml from '@iarna/toml';
 import { Storage } from '@vybestack/llxprt-code-settings';
+import { canonicalizePolicyToolEntry } from '@vybestack/llxprt-code-tools';
 import {
   ADMIN_POLICY_TIER,
   DEFAULT_CORE_POLICIES_DIR,
@@ -280,23 +281,12 @@ function addSingleAllowedToolRule(tool: string, rules: PolicyRule[]): void {
     }
   } else {
     rules.push({
-      toolName: normalizeToolName(tool),
+      toolName: canonicalizePolicyToolEntry(tool),
       decision: PolicyDecision.ALLOW,
       priority: 2.3,
       source: 'Settings (Tools Allowed)',
     });
   }
-}
-
-function normalizeToolName(toolName: string): string {
-  if (
-    toolName === 'ShellTool' ||
-    toolName.startsWith('ShellTool(') ||
-    toolName.startsWith('run_shell_command(')
-  ) {
-    return 'run_shell_command';
-  }
-  return toolName;
 }
 
 export const MCP_TRUSTED_POLICY_SOURCE = 'Settings (MCP Trusted)';

--- a/packages/core/src/policy/toolEntryDecoderDrift.test.ts
+++ b/packages/core/src/policy/toolEntryDecoderDrift.test.ts
@@ -7,7 +7,7 @@
 /**
  * Drift test: policy's zero-dep normalizeToolName duplicate must stay
  * behavior-identical to the shared decoder in tools
- * (canonicalizePolicyToolEntry) — see issue #2533 Phase B2a.
+ * (canonicalizePolicyToolEntry), per issue #2533 Phase B2a.
  */
 
 import { describe, it, expect } from 'bun:test';
@@ -50,6 +50,8 @@ describe('policy tool-entry decoder drift', () => {
     expect(canonicalizePolicyToolEntry('user-server__*')).toBe(
       'user-server__*',
     );
-    expect(normalizeToolName('mcp__server__tool*')).toBe('mcp__server__tool*');
+    expect(canonicalizePolicyToolEntry('mcp__server__tool*')).toBe(
+      'mcp__server__tool*',
+    );
   });
 });

--- a/packages/core/src/policy/toolEntryDecoderDrift.test.ts
+++ b/packages/core/src/policy/toolEntryDecoderDrift.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Drift test: policy's zero-dep normalizeToolName duplicate must stay
+ * behavior-identical to the shared decoder in tools
+ * (canonicalizePolicyToolEntry) — see issue #2533 Phase B2a.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { normalizeToolName } from '@vybestack/llxprt-code-policy';
+import { canonicalizePolicyToolEntry } from '@vybestack/llxprt-code-tools';
+
+const CORPUS = [
+  'ShellTool',
+  'ShellTool(npm test)',
+  'run_shell_command',
+  'run_shell_command(npm test)',
+  'ReadFileTool',
+  'read_file',
+  'user-server__*',
+  'mcp__server__tool*',
+  'search_file_content',
+  '  padded  ',
+  'TodoRead',
+  '',
+] as const;
+
+describe('policy tool-entry decoder drift', () => {
+  it('policy normalizeToolName matches tools canonicalizePolicyToolEntry over the corpus', () => {
+    for (const entry of CORPUS) {
+      expect(normalizeToolName(entry)).toBe(canonicalizePolicyToolEntry(entry));
+    }
+  });
+
+  it('decodes legacy ShellTool spellings to the canonical registry name', () => {
+    expect(canonicalizePolicyToolEntry('ShellTool')).toBe('run_shell_command');
+    expect(canonicalizePolicyToolEntry('ShellTool(npm test)')).toBe(
+      'run_shell_command',
+    );
+    expect(canonicalizePolicyToolEntry('ShellTool(wc)')).toBe(
+      'run_shell_command',
+    );
+  });
+
+  it('preserves wildcard policy entries verbatim', () => {
+    expect(canonicalizePolicyToolEntry('user-server__*')).toBe(
+      'user-server__*',
+    );
+    expect(normalizeToolName('mcp__server__tool*')).toBe('mcp__server__tool*');
+  });
+});

--- a/packages/core/src/runtime/AgentRuntimeLoader.ts
+++ b/packages/core/src/runtime/AgentRuntimeLoader.ts
@@ -14,7 +14,9 @@ import {
   hasToolSchema,
   resolveToolDescription,
   type ToolRegistry,
-  normalizeToolName,
+  buildToolGovernance,
+  isToolBlocked,
+  type ToolGovernance,
 } from '@vybestack/llxprt-code-tools';
 import type { RuntimeProviderManager } from './contracts/RuntimeProviderManager.js';
 import {
@@ -114,53 +116,20 @@ function hydrateContentGeneratorConfig(
   };
 }
 
-type ToolGovernance = {
-  allowed: Set<string>;
-  allowedExplicit: boolean;
-  disabled: Set<string>;
-  excluded: Set<string>;
-};
-
-function buildToolGovernance(
+function buildToolGovernanceFromProfile(
   profile: AgentRuntimeProfileSnapshot,
 ): ToolGovernance {
-  const allowedRaw = Array.isArray(profile.settings.tools?.allowed)
-    ? profile.settings.tools.allowed
-    : undefined;
-  const disabledRaw = Array.isArray(profile.settings.tools?.disabled)
-    ? profile.settings.tools.disabled
-    : undefined;
-  const excludedRaw = profile.config.getExcludeTools() ?? [];
-
-  return {
-    allowed: new Set(
-      (allowedRaw ?? []).map((tool) => normalizeToolName(tool) ?? tool),
-    ),
-    allowedExplicit: allowedRaw !== undefined,
-    disabled: new Set(
-      (disabledRaw ?? []).map((tool) => normalizeToolName(tool) ?? tool),
-    ),
-    excluded: new Set(
-      excludedRaw.map((tool) => normalizeToolName(tool) ?? tool),
-    ),
-  };
-}
-
-function isToolPermitted(
-  toolName: string,
-  governance: ToolGovernance,
-): boolean {
-  const canonical = normalizeToolName(toolName) ?? toolName;
-  if (governance.excluded.has(canonical)) {
-    return false;
-  }
-  if (governance.disabled.has(canonical)) {
-    return false;
-  }
-  if (governance.allowedExplicit && !governance.allowed.has(canonical)) {
-    return false;
-  }
-  return true;
+  return buildToolGovernance({
+    getEphemeralSettings: () => ({
+      ...(Array.isArray(profile.settings.tools?.allowed)
+        ? { 'tools.allowed': profile.settings.tools.allowed }
+        : {}),
+      ...(Array.isArray(profile.settings.tools?.disabled)
+        ? { 'tools.disabled': profile.settings.tools.disabled }
+        : {}),
+    }),
+    getExcludeTools: () => profile.config.getExcludeTools(),
+  });
 }
 
 function createFilteredToolRegistryView(
@@ -180,10 +149,10 @@ function createFilteredToolRegistryView(
   return {
     listToolNames: () =>
       getTools()
-        .filter((tool) => isToolPermitted(tool.name, governance))
+        .filter((tool) => !isToolBlocked(tool.name, governance))
         .map((tool) => tool.name),
     getToolMetadata: (name) => {
-      if (!isToolPermitted(name, governance)) {
+      if (isToolBlocked(name, governance)) {
         return undefined;
       }
       const tool = getTools().find((candidate) => candidate.name === name);
@@ -228,7 +197,7 @@ export async function loadAgentRuntime(
     overrides.telemetryAdapter ??
     createTelemetryAdapterFromConfig(profile.config);
 
-  const governance = buildToolGovernance(profile);
+  const governance = buildToolGovernanceFromProfile(profile);
   const toolsView: ToolRegistryView =
     overrides.toolsView ??
     createFilteredToolRegistryView(

--- a/packages/core/src/runtime/__tests__/RuntimeInvocationContext.separation.test.ts
+++ b/packages/core/src/runtime/__tests__/RuntimeInvocationContext.separation.test.ts
@@ -122,17 +122,18 @@ describe('RuntimeInvocationContext Settings Separation', () => {
     expect(context.cliSettings['temperature']).toBeUndefined();
   });
 
-  it('context with apiKey in ephemerals does not contain apiKey in modelParams', () => {
+  it('context with auth-key in ephemerals does not contain auth-key in modelParams', () => {
     const context = createRuntimeInvocationContext({
       runtime: createMockRuntime(),
       settings: createMockSettings(),
       providerName: 'openai',
       ephemeralsSnapshot: {
-        apiKey: 'sk-test-key',
+        'auth-key': 'sk-test-key',
         temperature: 0.7,
       },
     });
 
+    expect(context.modelParams['auth-key']).toBeUndefined();
     expect(context.modelParams['apiKey']).toBeUndefined();
   });
 
@@ -141,17 +142,18 @@ describe('RuntimeInvocationContext Settings Separation', () => {
    * Tests verify aliases are resolved to canonical keys.
    */
 
-  it('context with max-tokens=4096 in ephemerals returns 4096 from getModelParam using max_tokens', () => {
+  it('context with max_tokens=4096 in ephemerals returns 4096 from getModelParam', () => {
     const context = createRuntimeInvocationContext({
       runtime: createMockRuntime(),
       settings: createMockSettings(),
       providerName: 'openai',
       ephemeralsSnapshot: {
-        'max-tokens': 4096,
+        max_tokens: 4096,
       },
     });
 
     expect(context.getModelParam('max_tokens')).toBe(4096);
+    expect(context.modelParams['max-tokens']).toBeUndefined();
   });
 
   /**
@@ -284,20 +286,21 @@ describe('RuntimeInvocationContext Settings Separation', () => {
     expect(context.modelParams['temperature']).toBe(0.7);
   });
 
-  it('context with multiple settings puts max-tokens in modelParams', () => {
+  it('context with multiple settings puts max_tokens in modelParams', () => {
     const context = createRuntimeInvocationContext({
       runtime: createMockRuntime(),
       settings: createMockSettings(),
       providerName: 'openai',
       ephemeralsSnapshot: {
         temperature: 0.7,
-        'max-tokens': 4096,
+        max_tokens: 4096,
         'shell-replacement': 'none',
         'reasoning.enabled': true,
       },
     });
 
     expect(context.modelParams['max_tokens']).toBe(4096);
+    expect(context.modelParams['max-tokens']).toBeUndefined();
   });
 
   it('context with multiple settings puts shell-replacement in cliSettings', () => {
@@ -354,13 +357,13 @@ describe('RuntimeInvocationContext Settings Separation', () => {
       expect(context.modelBehavior['text.verbosity']).toBe('medium');
     });
 
-    it('does not place streamIdleTimeoutMs into modelParams for any provider', () => {
+    it('does not place stream-idle-timeout-ms into modelParams for any provider', () => {
       for (const provider of ['anthropic', 'codex', 'openai']) {
         const context = createRuntimeInvocationContext({
           runtime: createMockRuntime(),
           settings: createMockSettings(),
           providerName: provider,
-          ephemeralsSnapshot: { streamIdleTimeoutMs: 60_000 },
+          ephemeralsSnapshot: { 'stream-idle-timeout-ms': 60_000 },
         });
 
         expect(context.modelParams['streamIdleTimeoutMs']).toBeUndefined();
@@ -375,7 +378,7 @@ describe('RuntimeInvocationContext Settings Separation', () => {
         settings: createMockSettings(),
         providerName: 'anthropic',
         ephemeralsSnapshot: {
-          streamIdleTimeoutMs: 60_000,
+          'stream-idle-timeout-ms': 60_000,
           text: { verbosity: 'medium' },
           reasoning: { enabled: true, effort: 'high' },
           'prompt-caching': '24h',

--- a/packages/core/src/test-utils/__tests__/providerCallOptions.test.ts
+++ b/packages/core/src/test-utils/__tests__/providerCallOptions.test.ts
@@ -13,7 +13,7 @@ describe('createProviderCallOptions', () => {
     const settings = new SettingsService();
     settings.set('global-setting', 'enabled');
     settings.setProviderSetting('openai', 'temperature', 0.42);
-    settings.setProviderSetting('openai', 'maxTokens', 256);
+    settings.setProviderSetting('openai', 'max_tokens', 256);
 
     const options = createProviderCallOptions({
       providerName: 'openai',
@@ -27,7 +27,7 @@ describe('createProviderCallOptions', () => {
     expect(options.invocation.ephemerals['global-setting']).toBe('enabled');
     expect(options.invocation.ephemerals.openai).toMatchObject({
       temperature: 0.42,
-      maxTokens: 256,
+      max_tokens: 256,
     });
   });
 

--- a/packages/core/src/tools-adapters/CoreSubagentServiceAdapter.test.ts
+++ b/packages/core/src/tools-adapters/CoreSubagentServiceAdapter.test.ts
@@ -492,3 +492,39 @@ describe('CoreSubagentServiceAdapter inferred explicit whitelist (Issue #2069 di
     expect(launchRequest?.toolConfig?.tools).toStrictEqual(['read_file']);
   });
 });
+
+describe('CoreSubagentServiceAdapter behaviourPrompts (Issue #2533 single spelling)', () => {
+  it('forwards request.behaviourPrompts to the launch request', async () => {
+    const { adapter, launch } = createAdapterWithLaunch();
+
+    await adapter.executeSubagent({
+      name: 'helper',
+      prompt: 'Do work',
+      behaviourPrompts: ['Respect coding standards', 'Emit findings only'],
+    });
+
+    const launchRequest = launch.mock.calls[0]?.[0] as
+      | { behaviourPrompts?: string[] }
+      | undefined;
+    expect(launchRequest).toBeDefined();
+    expect(launchRequest?.behaviourPrompts).toStrictEqual([
+      'Respect coding standards',
+      'Emit findings only',
+    ]);
+  });
+
+  it('omits behaviourPrompts from the launch request when not supplied', async () => {
+    const { adapter, launch } = createAdapterWithLaunch();
+
+    await adapter.executeSubagent({
+      name: 'helper',
+      prompt: 'Do work',
+    });
+
+    const launchRequest = launch.mock.calls[0]?.[0] as
+      | { behaviourPrompts?: string[] }
+      | undefined;
+    expect(launchRequest).toBeDefined();
+    expect(launchRequest).not.toHaveProperty('behaviourPrompts');
+  });
+});

--- a/packages/core/src/tools-adapters/CoreSubagentServiceAdapter.ts
+++ b/packages/core/src/tools-adapters/CoreSubagentServiceAdapter.ts
@@ -366,10 +366,11 @@ export class CoreSubagentServiceAdapter implements ISubagentService {
       launchRequest.runConfig = { max_time_minutes: timeoutMs / 60_000 };
     }
 
-    const behaviourPrompts =
-      request.behaviourPrompts ?? request.behaviorPrompts;
-    if (behaviourPrompts !== undefined && behaviourPrompts.length > 0) {
-      launchRequest.behaviourPrompts = behaviourPrompts;
+    if (
+      request.behaviourPrompts !== undefined &&
+      request.behaviourPrompts.length > 0
+    ) {
+      launchRequest.behaviourPrompts = request.behaviourPrompts;
     }
 
     const config = this.requireConfig();

--- a/packages/core/src/tools-adapters/coreSubagentServiceHelpers.ts
+++ b/packages/core/src/tools-adapters/coreSubagentServiceHelpers.ts
@@ -82,7 +82,7 @@ export function buildContextState(
 
   context.set('task_behaviour_prompts', [
     request.prompt,
-    ...(request.behaviourPrompts ?? request.behaviorPrompts ?? []),
+    ...(request.behaviourPrompts ?? []),
   ]);
   return context;
 }

--- a/packages/core/src/utils/streamIdleTimeout.liveness.test.ts
+++ b/packages/core/src/utils/streamIdleTimeout.liveness.test.ts
@@ -16,9 +16,7 @@ import {
   LLXPRT_STREAM_IDLE_TIMEOUT_MS_ENV,
   LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS_ENV,
   STREAM_IDLE_TIMEOUT_SETTING_KEY,
-  STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
   STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY,
-  STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
 } from './streamIdleTimeout.js';
 
 /**
@@ -101,14 +99,11 @@ describe('resolveStreamIdleTimeoutMsSource', () => {
     expect(source).toBe(STREAM_IDLE_TIMEOUT_SETTING_KEY);
   });
 
-  it('reports the camelCase alias when only it is set', () => {
-    const mockConfig = sourceConfigFor(
-      STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
-      90_000,
-    );
+  it('ignores legacy spelling and uses the default', () => {
+    const mockConfig = sourceConfigFor('streamIdleTimeoutMs', 90_000);
     const { ms, source } = resolveStreamIdleTimeoutMsSource(mockConfig);
-    expect(ms).toBe(90_000);
-    expect(source).toBe(STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY);
+    expect(ms).toBe(DEFAULT_STREAM_IDLE_TIMEOUT_MS);
+    expect(source).toBe('default');
   });
 
   it('env var takes precedence over both setting keys for source', () => {
@@ -167,15 +162,12 @@ describe('resolveStreamFirstResponseTimeoutMsSource', () => {
     expect(source).toBe(STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY);
   });
 
-  it('reports the camelCase alias when only it is set', () => {
-    const mockConfig = sourceConfigFor(
-      STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
-      150_000,
-    );
+  it('ignores legacy spelling and uses the default', () => {
+    const mockConfig = sourceConfigFor('streamFirstResponseTimeoutMs', 150_000);
     const { ms, source } =
       resolveStreamFirstResponseTimeoutMsSource(mockConfig);
-    expect(ms).toBe(150_000);
-    expect(source).toBe(STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY);
+    expect(ms).toBe(DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS);
+    expect(source).toBe('default');
   });
 
   it('env var takes precedence over both canonical and camelCase ephemerals for source', () => {

--- a/packages/core/src/utils/streamIdleTimeout.test.ts
+++ b/packages/core/src/utils/streamIdleTimeout.test.ts
@@ -16,9 +16,7 @@ import {
   LLXPRT_STREAM_IDLE_TIMEOUT_MS_ENV,
   LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS_ENV,
   STREAM_IDLE_TIMEOUT_SETTING_KEY,
-  STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
   STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY,
-  STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
 } from './streamIdleTimeout.js';
 
 function timeoutConfigFor(
@@ -398,7 +396,7 @@ describe('resolveStreamIdleTimeoutMs', () => {
     });
   });
 
-  describe('camelCase streamIdleTimeoutMs runtime wiring', () => {
+  describe('legacy idle timeout spellings are ignored', () => {
     const originalEnv = process.env;
 
     beforeEach(() => {
@@ -410,40 +408,31 @@ describe('resolveStreamIdleTimeoutMs', () => {
       process.env = originalEnv;
     });
 
-    it('camelCase streamIdleTimeoutMs with a very large finite value resolves to that value', () => {
+    it('ignores a legacy large finite value', () => {
       const mockConfig = timeoutConfigFor(
-        STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
+        'streamIdleTimeoutMs',
         Number.MAX_SAFE_INTEGER,
       );
       const result = resolveStreamIdleTimeoutMs(mockConfig);
-      expect(result).toBe(Number.MAX_SAFE_INTEGER);
+      expect(result).toBe(DEFAULT_STREAM_IDLE_TIMEOUT_MS);
     });
 
-    it('camelCase 0 resolves to 0 (disabled semantics preserved)', () => {
-      const mockConfig = timeoutConfigFor(
-        STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
-        0,
-      );
+    it('ignores legacy zero and uses the default', () => {
+      const mockConfig = timeoutConfigFor('streamIdleTimeoutMs', 0);
       const result = resolveStreamIdleTimeoutMs(mockConfig);
-      expect(result).toBe(0);
+      expect(result).toBe(DEFAULT_STREAM_IDLE_TIMEOUT_MS);
     });
 
-    it('camelCase negative resolves to 0 (disabled semantics preserved)', () => {
-      const mockConfig = timeoutConfigFor(
-        STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
-        -100,
-      );
+    it('ignores legacy negative values and uses the default', () => {
+      const mockConfig = timeoutConfigFor('streamIdleTimeoutMs', -100);
       const result = resolveStreamIdleTimeoutMs(mockConfig);
-      expect(result).toBe(0);
+      expect(result).toBe(DEFAULT_STREAM_IDLE_TIMEOUT_MS);
     });
 
-    it('camelCase string value is parsed correctly', () => {
-      const mockConfig = timeoutConfigFor(
-        STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
-        '45000',
-      );
+    it('ignores a legacy numeric string', () => {
+      const mockConfig = timeoutConfigFor('streamIdleTimeoutMs', '45000');
       const result = resolveStreamIdleTimeoutMs(mockConfig);
-      expect(result).toBe(45_000);
+      expect(result).toBe(DEFAULT_STREAM_IDLE_TIMEOUT_MS);
     });
 
     it('existing hyphenated stream-idle-timeout-ms behavior remains preserved', () => {
@@ -458,7 +447,7 @@ describe('resolveStreamIdleTimeoutMs', () => {
     it('hyphenated takes priority over camelCase when both are present', () => {
       const mockConfig = timeoutConfigForMany({
         [STREAM_IDLE_TIMEOUT_SETTING_KEY]: 300_000,
-        [STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY]: 150_000,
+        streamIdleTimeoutMs: 150_000,
       });
       const result = resolveStreamIdleTimeoutMs(mockConfig);
       expect(result).toBe(300_000); // hyphenated wins
@@ -467,26 +456,26 @@ describe('resolveStreamIdleTimeoutMs', () => {
     it('hyphenated 0 (disabled) wins over camelCase positive value', () => {
       const mockConfig = timeoutConfigForMany({
         [STREAM_IDLE_TIMEOUT_SETTING_KEY]: 0,
-        [STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY]: 150_000,
+        streamIdleTimeoutMs: 150_000,
       });
       const result = resolveStreamIdleTimeoutMs(mockConfig);
       expect(result).toBe(0);
     });
 
-    it('invalid hyphenated value falls through to camelCase', () => {
+    it('uses the default for an invalid registry value despite a legacy value', () => {
       const mockConfig = timeoutConfigForMany({
         [STREAM_IDLE_TIMEOUT_SETTING_KEY]: 'not-a-number',
-        [STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY]: 90_000,
+        streamIdleTimeoutMs: 90_000,
       });
       const result = resolveStreamIdleTimeoutMs(mockConfig);
-      expect(result).toBe(90_000);
+      expect(result).toBe(DEFAULT_STREAM_IDLE_TIMEOUT_MS);
     });
 
     it('env var LLXPRT_STREAM_IDLE_TIMEOUT_MS remains highest priority', () => {
       process.env[LLXPRT_STREAM_IDLE_TIMEOUT_MS_ENV] = '500000';
       const mockConfig = timeoutConfigForMany({
         [STREAM_IDLE_TIMEOUT_SETTING_KEY]: 300_000,
-        [STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY]: 150_000,
+        streamIdleTimeoutMs: 150_000,
       });
       const result = resolveStreamIdleTimeoutMs(mockConfig);
       expect(result).toBe(500_000); // env wins
@@ -494,17 +483,14 @@ describe('resolveStreamIdleTimeoutMs', () => {
 
     it('env var takes priority over camelCase when hyphenated is absent', () => {
       process.env[LLXPRT_STREAM_IDLE_TIMEOUT_MS_ENV] = '500000';
-      const mockConfig = timeoutConfigFor(
-        STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
-        60_000,
-      );
+      const mockConfig = timeoutConfigFor('streamIdleTimeoutMs', 60_000);
       const result = resolveStreamIdleTimeoutMs(mockConfig);
       expect(result).toBe(500_000);
     });
 
     it('falls through to default when camelCase is invalid', () => {
       const mockConfig = timeoutConfigFor(
-        STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
+        'streamIdleTimeoutMs',
         'not-a-number',
       );
       const result = resolveStreamIdleTimeoutMs(mockConfig);
@@ -520,10 +506,7 @@ describe('resolveStreamIdleTimeoutMs', () => {
     });
 
     it('camelCase empty string falls through to default (not parsed as 0)', () => {
-      const mockConfig = timeoutConfigFor(
-        STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
-        '',
-      );
+      const mockConfig = timeoutConfigFor('streamIdleTimeoutMs', '');
       const result = resolveStreamIdleTimeoutMs(mockConfig);
       expect(result).toBe(DEFAULT_STREAM_IDLE_TIMEOUT_MS);
     });
@@ -582,19 +565,19 @@ describe('resolveStreamFirstResponseTimeoutMs', () => {
     expect(result).toBe(180_000);
   });
 
-  it('camelCase ephemeral setting is used when no env var and no hyphenated', () => {
+  it('ignores legacy spelling and uses the default', () => {
     const mockConfig = timeoutConfigFor(
-      STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
+      'streamFirstResponseTimeoutMs',
       150_000,
     );
     const result = resolveStreamFirstResponseTimeoutMs(mockConfig);
-    expect(result).toBe(150_000);
+    expect(result).toBe(DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS);
   });
 
   it('hyphenated takes priority over camelCase when both are present', () => {
     const mockConfig = timeoutConfigForMany({
       [STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY]: 200_000,
-      [STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY]: 100_000,
+      streamFirstResponseTimeoutMs: 100_000,
     });
     const result = resolveStreamFirstResponseTimeoutMs(mockConfig);
     expect(result).toBe(200_000); // hyphenated wins
@@ -604,7 +587,7 @@ describe('resolveStreamFirstResponseTimeoutMs', () => {
     process.env[LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS_ENV] = '450000';
     const mockConfig = timeoutConfigForMany({
       [STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY]: 200_000,
-      [STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY]: 100_000,
+      streamFirstResponseTimeoutMs: 100_000,
     });
     const result = resolveStreamFirstResponseTimeoutMs(mockConfig);
     expect(result).toBe(450_000); // env wins
@@ -667,22 +650,22 @@ describe('resolveStreamFirstResponseTimeoutMs', () => {
     expect(result).toBe(300_000);
   });
 
-  it('invalid hyphenated value falls through to camelCase', () => {
+  it('uses the default for an invalid registry value despite a legacy value', () => {
     const mockConfig = timeoutConfigForMany({
       [STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY]: 'not-a-number',
-      [STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY]: 90_000,
+      streamFirstResponseTimeoutMs: 90_000,
     });
     const result = resolveStreamFirstResponseTimeoutMs(mockConfig);
-    expect(result).toBe(90_000);
+    expect(result).toBe(DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS);
   });
 
   it('falls through to default when camelCase is invalid', () => {
     const mockConfig = timeoutConfigFor(
-      STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
+      'streamFirstResponseTimeoutMs',
       'not-a-number',
     );
     const result = resolveStreamFirstResponseTimeoutMs(mockConfig);
-    expect(result).toBe(300_000);
+    expect(result).toBe(DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS);
   });
 
   it('string config value is parsed correctly', () => {

--- a/packages/core/src/utils/streamIdleTimeout.ts
+++ b/packages/core/src/utils/streamIdleTimeout.ts
@@ -61,22 +61,12 @@ export const LLXPRT_STREAM_IDLE_TIMEOUT_MS_ENV =
 /**
  * Ephemeral setting key for stream idle timeout.
  * This hyphenated key is the canonical source-of-truth key used by
- * the SettingsService / registry. It takes priority over the camelCase alias.
+ * the SettingsService / registry.
  */
 export const STREAM_IDLE_TIMEOUT_SETTING_KEY = 'stream-idle-timeout-ms';
 
-/**
- * CamelCase alias for the stream idle timeout setting key.
- * settings.json surfaces this key via the CLI schema (see schema-core.ts).
- * Without reading it here, a settings.json value would never reach the
- * watchdog because there is no automatic camelCase→hyphenated conversion
- * in the SettingsService.
- */
-export const STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY = 'streamIdleTimeoutMs';
-
 const STREAM_IDLE_TIMEOUT_CONFIG_KEYS = [
   STREAM_IDLE_TIMEOUT_SETTING_KEY,
-  STREAM_IDLE_TIMEOUT_CAMEL_CASE_KEY,
 ] as const;
 
 /**
@@ -103,22 +93,13 @@ export const LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS_ENV =
 
 /**
  * Ephemeral setting key for the first-response timeout.
- * Hyphenated canonical key (mirrors stream-idle-timeout-ms convention);
- * takes priority over the camelCase alias.
+ * Uses the registry spelling.
  */
 export const STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY =
   'stream-first-response-timeout-ms';
 
-/**
- * CamelCase alias for the first-response timeout setting key, surfaced via
- * settings.json through the CLI schema (config-schema.ts).
- */
-export const STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY =
-  'streamFirstResponseTimeoutMs';
-
 const STREAM_FIRST_RESPONSE_CONFIG_KEYS = [
   STREAM_FIRST_RESPONSE_TIMEOUT_SETTING_KEY,
-  STREAM_FIRST_RESPONSE_TIMEOUT_CAMEL_CASE_KEY,
 ] as const;
 
 function parseTimeoutConfigValue(value: unknown): number {
@@ -158,8 +139,7 @@ function normalizeTimeoutConfigValue(value: unknown): number | undefined {
 /**
  * The provenance of a resolved timeout value, for diagnostics. 'default' means
  * the fallback default was used; 'env' means the environment variable won;
- * otherwise the value is the specific ephemeral setting key (hyphenated or
- * camelCase alias) that supplied the value.
+ * otherwise the value is the registry setting key that supplied the value.
  */
 export type StreamTimeoutSource = 'default' | 'env' | (string & {});
 
@@ -202,12 +182,7 @@ function resolveTimeoutSource(
  * Priority order:
  * 1. Environment variable LLXPRT_STREAM_IDLE_TIMEOUT_MS (if set and valid)
  * 2. Config ephemeral setting 'stream-idle-timeout-ms' (hyphenated; canonical)
- * 3. Config ephemeral setting 'streamIdleTimeoutMs' (camelCase alias from settings.json)
- * 4. DEFAULT_STREAM_IDLE_TIMEOUT_MS (0 — disabled)
- *
- * The hyphenated key takes priority over the camelCase alias for backward
- * compatibility with profiles and code that set 'stream-idle-timeout-ms'
- * directly.
+ * 3. DEFAULT_STREAM_IDLE_TIMEOUT_MS (0 — disabled)
  *
  * Values <= 0 disable the watchdog (return 0).
  * Invalid string values (including empty/whitespace) fall back to the next priority level.
@@ -254,8 +229,7 @@ export function resolveStreamIdleTimeoutMsSource(config?: {
  * Priority order (same semantics as resolveStreamIdleTimeoutMs):
  * 1. Environment variable LLXPRT_STREAM_FIRST_RESPONSE_TIMEOUT_MS
  * 2. Config ephemeral setting 'stream-first-response-timeout-ms' (hyphenated)
- * 3. Config ephemeral setting 'streamFirstResponseTimeoutMs' (camelCase alias)
- * 4. DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS (300000 — enabled)
+ * 3. DEFAULT_STREAM_FIRST_RESPONSE_TIMEOUT_MS (300000 — enabled)
  *
  * Values <= 0 disable the watchdog (return 0).
  * Invalid/empty string values fall back to the next priority level.

--- a/packages/policy/src/config.ts
+++ b/packages/policy/src/config.ts
@@ -103,15 +103,77 @@ ${error.details}`;
   return message;
 }
 
-function normalizeToolName(toolName: string): string {
-  if (
-    toolName === 'ShellTool' ||
-    toolName.startsWith('ShellTool(') ||
-    toolName.startsWith('run_shell_command(')
-  ) {
-    return 'run_shell_command';
+// Legacy policy spellings mapped to canonical registry names, compared
+// lowercased. Mirrors LEGACY_TOOL_NAME_ALIASES in @vybestack/llxprt-code-tools.
+const LEGACY_TOOL_NAME_ALIASES: ReadonlyMap<string, string> = new Map([
+  ['shelltool', 'run_shell_command'],
+]);
+
+function isValidPolicyToolName(name: string): boolean {
+  return name.length > 0 && name.length <= 100 && /^[a-zA-Z0-9_.-]+$/.test(name);
+}
+
+function toSnakeCaseToolName(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[\s-]+/g, '_')
+    .toLowerCase();
+}
+
+function hasMultipleWordsInName(name: string): boolean {
+  return /[A-Z]/.test(name.slice(1)) || name.includes('_') || name.includes('-');
+}
+
+// Strip a trailing 'Tool' suffix from the last dotted segment when the
+// remainder is still multi-word ('ReadFileTool' -> 'ReadFile').
+function stripToolSuffixFromLastSegment(name: string): string {
+  const dot = name.lastIndexOf('.');
+  const last = name.slice(dot + 1);
+  if (!last.endsWith('Tool') || last.length <= 4) {
+    return name;
   }
-  return toolName;
+  const withoutTool = last.slice(0, -4);
+  if (!hasMultipleWordsInName(withoutTool)) {
+    return name;
+  }
+  return name.slice(0, dot + 1) + withoutTool;
+}
+
+// Mirror of tools' canonicalizeToolName for policy entries (zero-dep).
+function canonicalizeEntryName(base: string): string {
+  if (base.split('.').some((segment) => segment === '')) {
+    return '';
+  }
+  const stripped = stripToolSuffixFromLastSegment(base);
+  if (isValidPolicyToolName(stripped) && stripped === stripped.toLowerCase()) {
+    return stripped;
+  }
+  return toSnakeCaseToolName(stripped);
+}
+
+/**
+ * Decode one user-authored policy entry to its canonical registry name.
+ *
+ * Boundary duplicate of tools canonicalizePolicyToolEntry (policy has zero
+ * workspace deps); removal condition: policy gains a tools dependency or the
+ * decoder moves to a zero-dep shared module. Must stay behavior-identical —
+ * guarded by the tools drift test (core toolEntryDecoderDrift.test.ts).
+ */
+export function normalizeToolName(toolName: string): string {
+  const trimmed = toolName.trim();
+  if (!trimmed || trimmed.includes('*')) {
+    return trimmed;
+  }
+  const openParen = trimmed.indexOf('(');
+  const base = (openParen === -1 ? trimmed : trimmed.slice(0, openParen)).trim();
+  if (!base) {
+    return '';
+  }
+  const alias = LEGACY_TOOL_NAME_ALIASES.get(base.toLowerCase());
+  if (alias) {
+    return alias;
+  }
+  return canonicalizeEntryName(base);
 }
 
 export const AUTO_EDIT_TOOLS = [

--- a/packages/policy/src/config.ts
+++ b/packages/policy/src/config.ts
@@ -110,7 +110,9 @@ const LEGACY_TOOL_NAME_ALIASES: ReadonlyMap<string, string> = new Map([
 ]);
 
 function isValidPolicyToolName(name: string): boolean {
-  return name.length > 0 && name.length <= 100 && /^[a-zA-Z0-9_.-]+$/.test(name);
+  return (
+    name.length > 0 && name.length <= 100 && /^[a-zA-Z0-9_.-]+$/.test(name)
+  );
 }
 
 function toSnakeCaseToolName(value: string): string {
@@ -121,7 +123,9 @@ function toSnakeCaseToolName(value: string): string {
 }
 
 function hasMultipleWordsInName(name: string): boolean {
-  return /[A-Z]/.test(name.slice(1)) || name.includes('_') || name.includes('-');
+  return (
+    /[A-Z]/.test(name.slice(1)) || name.includes('_') || name.includes('-')
+  );
 }
 
 // Strip a trailing 'Tool' suffix from the last dotted segment when the
@@ -165,7 +169,9 @@ export function normalizeToolName(toolName: string): string {
     return trimmed;
   }
   const openParen = trimmed.indexOf('(');
-  const base = (openParen === -1 ? trimmed : trimmed.slice(0, openParen)).trim();
+  const base = (
+    openParen === -1 ? trimmed : trimmed.slice(0, openParen)
+  ).trim();
   if (!base) {
     return '';
   }

--- a/packages/policy/src/index.ts
+++ b/packages/policy/src/index.ts
@@ -27,6 +27,7 @@ export {
   getPolicyTier,
   formatPolicyError,
   migrateLegacyApprovalMode,
+  normalizeToolName,
   AUTO_EDIT_TOOLS,
 } from './config.js';
 export type { PolicyConfigSource, PolicyPathResolver } from './config.js';

--- a/packages/providers/src/BaseProvider.test.ts
+++ b/packages/providers/src/BaseProvider.test.ts
@@ -862,9 +862,9 @@ describe('BaseProvider', () => {
       clearActiveProviderRuntimeContext();
     });
 
-    it('strips legacy apiKey from additionalSettings', async () => {
+    it('strips canonical auth-key from additionalSettings', async () => {
       const settingsService = getSettingsService();
-      settingsService.setProviderSetting('test', 'apiKey', 'leaked-legacy-key');
+      settingsService.setProviderSetting('test', 'auth-key', 'provider-key');
       settingsService.setProviderSetting('test', 'model', 'gpt-4');
       settingsService.setProviderSetting('test', 'enabled', true);
 
@@ -879,14 +879,14 @@ describe('BaseProvider', () => {
         }
       ).getModelParamsFromSettings();
 
-      expect(params?.apiKey).toBeUndefined();
+      expect(params?.['auth-key']).toBeUndefined();
     });
 
-    it('strips legacy apiKeyfile from additionalSettings', async () => {
+    it('strips canonical auth-keyfile from additionalSettings', async () => {
       const settingsService = getSettingsService();
       settingsService.setProviderSetting(
         'test',
-        'apiKeyfile',
+        'auth-keyfile',
         '/path/to/keyfile',
       );
       settingsService.setProviderSetting('test', 'model', 'gpt-4');
@@ -903,15 +903,15 @@ describe('BaseProvider', () => {
         }
       ).getModelParamsFromSettings();
 
-      expect(params?.apiKeyfile).toBeUndefined();
+      expect(params?.['auth-keyfile']).toBeUndefined();
     });
 
-    it('strips legacy api-key and api-keyfile from additionalSettings', async () => {
+    it('strips canonical auth settings from additionalSettings', async () => {
       const settingsService = getSettingsService();
-      settingsService.setProviderSetting('test', 'api-key', 'leaked-key');
+      settingsService.setProviderSetting('test', 'auth-key', 'provider-key');
       settingsService.setProviderSetting(
         'test',
-        'api-keyfile',
+        'auth-keyfile',
         '/path/to/keyfile',
       );
       settingsService.setProviderSetting('test', 'model', 'gpt-4');
@@ -928,13 +928,13 @@ describe('BaseProvider', () => {
         }
       ).getModelParamsFromSettings();
 
-      expect(params?.['api-key']).toBeUndefined();
-      expect(params?.['api-keyfile']).toBeUndefined();
+      expect(params?.['auth-key']).toBeUndefined();
+      expect(params?.['auth-keyfile']).toBeUndefined();
     });
 
     it('preserves non-sensitive custom params alongside stripping', async () => {
       const settingsService = getSettingsService();
-      settingsService.setProviderSetting('test', 'apiKey', 'leaked');
+      settingsService.setProviderSetting('test', 'auth-key', 'provider-key');
       settingsService.setProviderSetting('test', 'model', 'gpt-4');
       settingsService.setProviderSetting('test', 'enabled', true);
       settingsService.setProviderSetting('test', 'customParam', 'keep-me');
@@ -950,7 +950,7 @@ describe('BaseProvider', () => {
         }
       ).getModelParamsFromSettings();
 
-      expect(params?.apiKey).toBeUndefined();
+      expect(params?.['auth-key']).toBeUndefined();
       expect(params?.customParam).toBe('keep-me');
     });
   });

--- a/packages/providers/src/BaseProvider.ts
+++ b/packages/providers/src/BaseProvider.ts
@@ -1058,7 +1058,7 @@ export abstract class BaseProvider implements IProvider {
         'auth-keyfile': _authKeyfile,
         'base-url': _baseUrl,
         model: _model,
-        maxTokens,
+        max_tokens,
         temperature,
         // Defensive: strip legacy sensitive aliases that should never reach
         // the model params pass-through, even if present in imported/malformed
@@ -1070,10 +1070,10 @@ export abstract class BaseProvider implements IProvider {
         ...additionalSettings
       } = settings;
 
-      // Include temperature and maxTokens as model params if they exist
+      // Include registered model parameters when present
       const params: Record<string, unknown> = {};
       if (temperature !== undefined) params.temperature = temperature;
-      if (maxTokens !== undefined) params.max_tokens = maxTokens;
+      if (max_tokens !== undefined) params.max_tokens = max_tokens;
 
       return Object.keys(params).length > 0 ||
         Object.keys(additionalSettings).length > 0
@@ -1098,40 +1098,15 @@ export abstract class BaseProvider implements IProvider {
   ): Promise<void> {
     const settingsService = this.resolveSettingsService();
 
-    try {
-      if (params === undefined) {
-        // Clear model parameters by setting them to undefined
-        await settingsService.updateSettings(this.name, {
-          temperature: undefined,
-          maxTokens: undefined,
-        });
-        return;
-      }
-
-      // Convert standard model params to settings format
-      const updates: Record<string, unknown> = {};
-      if ('temperature' in params) updates.temperature = params.temperature;
-      if ('max_tokens' in params) updates.maxTokens = params.max_tokens;
-      if ('maxTokens' in params) updates.maxTokens = params.maxTokens;
-
-      // Store other parameters as custom fields
-      for (const [key, value] of Object.entries(params)) {
-        if (!['temperature', 'max_tokens', 'maxTokens'].includes(key)) {
-          updates[key] = value;
-        }
-      }
-
-      if (Object.keys(updates).length > 0) {
-        await settingsService.updateSettings(this.name, updates);
-      }
-    } catch (error) {
-      if (process.env.DEBUG) {
-        debugLogger.error(
-          `Failed to set model params in SettingsService for ${this.name}:`,
-          error,
-        );
-      }
+    if (params === undefined) {
+      await settingsService.updateSettings(this.name, {
+        temperature: undefined,
+        max_tokens: undefined,
+      });
+      return;
     }
+
+    await settingsService.updateSettings(this.name, params);
   }
 
   /**

--- a/packages/providers/src/__tests__/LoadBalancingProvider.settings-merge.test.ts
+++ b/packages/providers/src/__tests__/LoadBalancingProvider.settings-merge.test.ts
@@ -348,7 +348,7 @@ describe('LoadBalancingProvider', () => {
     });
 
     describe('issue #2182: cross-provider ephemerals must not leak into modelParams', () => {
-      it('does not surface a nested text object or streamIdleTimeoutMs on the delegate invocation', async () => {
+      it('does not surface a nested text object or stream-idle-timeout-ms on the delegate invocation', async () => {
         const resolvedSubProfiles: ResolvedSubProfile[] = [
           {
             name: 'opusthinking',
@@ -378,13 +378,13 @@ describe('LoadBalancingProvider', () => {
             profileName: 'opusfirst',
             strategy: 'failover',
             subProfiles: resolvedSubProfiles,
-            // LB-level nested object + the global camelCase setting from
-            // settings.json that previously leaked verbatim into the body.
+            // LB-level nested objects plus the stream timeout setting that
+            // previously leaked verbatim into the request body.
             lbProfileEphemeralSettings: {
               reasoning: { enabled: true, effort: 'high' },
               text: { verbosity: 'medium' },
               'prompt-caching': '24h',
-              streamIdleTimeoutMs: 60000,
+              'stream-idle-timeout-ms': 60000,
             },
           },
           providerManager,

--- a/packages/providers/src/__tests__/ProviderManager.guard.test.ts
+++ b/packages/providers/src/__tests__/ProviderManager.guard.test.ts
@@ -782,7 +782,7 @@ describe('ProviderManager.normalizeRuntimeInputs empty/whitespace fallback seman
     settingsService.setProviderSetting('empty-model-provider', 'model', '');
     settingsService.setProviderSetting(
       'empty-model-provider',
-      'apiKey',
+      'auth-key',
       'test-key',
     );
     settingsService.setProviderSetting(

--- a/packages/providers/src/__tests__/ProviderManager.settingsSeparation.test.ts
+++ b/packages/providers/src/__tests__/ProviderManager.settingsSeparation.test.ts
@@ -53,9 +53,10 @@ describe('ProviderManager Settings Separation', () => {
     expect(getSnapshot('openai')).toHaveProperty('custom-headers');
   });
 
-  it('context with max-tokens alias accessible via normalized key', () => {
-    settingsService.set('max-tokens', 1000);
-    expect(getSnapshot('openai')).toHaveProperty('max-tokens', 1000);
+  it('snapshot includes canonical max_tokens when set', () => {
+    settingsService.set('max_tokens', 1000);
+    expect(getSnapshot('openai')).toHaveProperty('max_tokens', 1000);
+    expect(getSnapshot('openai')['max-tokens']).toBeUndefined();
   });
 
   it('snapshot includes provider-scoped temperature override', () => {
@@ -71,13 +72,14 @@ describe('ProviderManager Settings Separation', () => {
     expect(getSnapshot('openai').temperature).toBe(0.5);
   });
 
-  it('snapshot does NOT include apiKey in root level', () => {
-    settingsService.set('apiKey', 'sk-test-12345');
-    expect(getSnapshot('openai').apiKey).toBeUndefined();
+  it('snapshot does NOT include auth-key in root level', () => {
+    settingsService.set('auth-key', 'sk-test-12345');
+    expect(getSnapshot('openai')['auth-key']).toBeUndefined();
   });
 
-  it('snapshot does NOT include api-key alias in root level', () => {
-    settingsService.set('api-key', 'sk-test-12345');
+  it('snapshot does NOT include legacy apiKey spellings in root level', () => {
+    settingsService.set('auth-key', 'sk-test-12345');
+    expect(getSnapshot('openai')['apiKey']).toBeUndefined();
     expect(getSnapshot('openai')['api-key']).toBeUndefined();
   });
 

--- a/packages/providers/src/__tests__/ProviderManager.settingsSeparation.test.ts
+++ b/packages/providers/src/__tests__/ProviderManager.settingsSeparation.test.ts
@@ -77,11 +77,16 @@ describe('ProviderManager Settings Separation', () => {
     expect(getSnapshot('openai')['auth-key']).toBeUndefined();
   });
 
-  it('snapshot does NOT include legacy apiKey spellings in root level', () => {
-    settingsService.set('auth-key', 'sk-test-12345');
-    expect(getSnapshot('openai')['apiKey']).toBeUndefined();
-    expect(getSnapshot('openai')['api-key']).toBeUndefined();
-  });
+  it.each(['apiKey', 'api-key'])(
+    'rejects runtime writes of legacy %s with auth-key guidance',
+    (legacyKey) => {
+      expect(() => settingsService.set(legacyKey, 'sk-test-12345')).toThrow(
+        'auth-key',
+      );
+      expect(getSnapshot('openai')['apiKey']).toBeUndefined();
+      expect(getSnapshot('openai')['api-key']).toBeUndefined();
+    },
+  );
 
   it('snapshot does NOT include base-url in root level', () => {
     settingsService.set('base-url', 'https://api.example.com');

--- a/packages/providers/src/gemini/__tests__/gemini.stateless.test.ts
+++ b/packages/providers/src/gemini/__tests__/gemini.stateless.test.ts
@@ -257,13 +257,13 @@ describe('Gemini provider stateless contract tests', () => {
     const settingsPrimary = new SettingsService();
     settingsPrimary.set('call-id', 'runtime-config');
     settingsPrimary.set('temperature', 0.21);
-    settingsPrimary.set('max-output-tokens', 1024);
+    settingsPrimary.set('max_output_tokens', 1024);
     settingsPrimary.setProviderSetting('gemini', 'temperature', 0.21);
-    settingsPrimary.setProviderSetting('gemini', 'max-output-tokens', 1024);
+    settingsPrimary.setProviderSetting('gemini', 'max_output_tokens', 1024);
     const configPrimary = createRuntimeConfigStub(settingsPrimary, {
       getEphemeralSettings: () => ({
         temperature: 0.21,
-        'max-output-tokens': 1024,
+        max_output_tokens: 1024,
       }),
     });
     const runtimePrimary = createProviderRuntimeContext({
@@ -285,8 +285,8 @@ describe('Gemini provider stateless contract tests', () => {
 
     // @plan:PLAN-20251023-STATELESS-HARDENING.P08 @requirement:REQ-SP4-003
     // @plan PLAN-20260126-SETTINGS-SEPARATION.P09
-    // In stateless implementation, parameters are resolved from invocation.modelParams
-    // 'max-output-tokens' is normalized to 'max_output_tokens' by alias rules
+    // In stateless implementation, canonical parameters are resolved directly
+    // from invocation.modelParams.
     const firstRequest = googleGenAIState.streamCalls.at(-1)?.request as
       | { config?: Record<string, unknown> }
       | undefined;
@@ -308,13 +308,13 @@ describe('Gemini provider stateless contract tests', () => {
     const settingsOverride = new SettingsService();
     settingsOverride.set('call-id', 'runtime-config');
     settingsOverride.set('temperature', 0.78);
-    settingsOverride.set('max-output-tokens', 256);
+    settingsOverride.set('max_output_tokens', 256);
     settingsOverride.setProviderSetting('gemini', 'temperature', 0.78);
-    settingsOverride.setProviderSetting('gemini', 'max-output-tokens', 256);
+    settingsOverride.setProviderSetting('gemini', 'max_output_tokens', 256);
     const configOverride = createRuntimeConfigStub(settingsOverride, {
       getEphemeralSettings: () => ({
         temperature: 0.78,
-        'max-output-tokens': 256,
+        max_output_tokens: 256,
       }),
     });
     const runtimeOverride = createProviderRuntimeContext({
@@ -336,8 +336,8 @@ describe('Gemini provider stateless contract tests', () => {
 
     // @plan:PLAN-20251023-STATELESS-HARDENING.P08 @requirement:REQ-SP4-003
     // @plan PLAN-20260126-SETTINGS-SEPARATION.P09
-    // In stateless implementation, parameters are resolved from invocation.modelParams
-    // 'max-output-tokens' is normalized to 'max_output_tokens' by alias rules
+    // In stateless implementation, canonical parameters are resolved directly
+    // from invocation.modelParams.
     const secondRequest = googleGenAIState.streamCalls.at(-1)?.request as
       | { config?: Record<string, unknown> }
       | undefined;

--- a/packages/providers/src/openai-responses/__tests__/openaiResponses.stateless.test.ts
+++ b/packages/providers/src/openai-responses/__tests__/openaiResponses.stateless.test.ts
@@ -241,11 +241,11 @@ describe('OpenAI Responses provider stateless contract tests', () => {
 
     const settingsA = createSettings('conversation-A', 'parent-A');
     settingsA.set('temperature', 0.17);
-    settingsA.set('max-output-tokens', 2048);
+    settingsA.set('max_output_tokens', 2048);
     const configA = createRuntimeConfigStub(settingsA, {
       getEphemeralSettings: () => ({
         temperature: 0.17,
-        'max-output-tokens': 2048,
+        max_output_tokens: 2048,
       }),
     });
     const runtimeA = createProviderRuntimeContext({
@@ -269,15 +269,15 @@ describe('OpenAI Responses provider stateless contract tests', () => {
     };
     const firstRequest = Fake.requests.at(-1)?.request;
     expect(firstRequest?.temperature).toBe(0.17);
-    expect(firstRequest?.['max-output-tokens']).toBe(2048);
+    expect(firstRequest?.max_output_tokens).toBe(2048);
 
     const settingsB = createSettings('conversation-B', 'parent-B');
     settingsB.set('temperature', 0.44);
-    settingsB.set('max-output-tokens', 512);
+    settingsB.set('max_output_tokens', 512);
     const configB = createRuntimeConfigStub(settingsB, {
       getEphemeralSettings: () => ({
         temperature: 0.44,
-        'max-output-tokens': 512,
+        max_output_tokens: 512,
       }),
     });
     const runtimeB = createProviderRuntimeContext({
@@ -298,7 +298,7 @@ describe('OpenAI Responses provider stateless contract tests', () => {
 
     const secondRequest = Fake.requests.at(-1)?.request;
     expect(secondRequest?.temperature).toBe(0.44);
-    expect(secondRequest?.['max-output-tokens']).toBe(512);
+    expect(secondRequest?.max_output_tokens).toBe(512);
   });
 
   it('uses invocation ephemerals when config cannot supply overrides', async () => {
@@ -325,7 +325,7 @@ describe('OpenAI Responses provider stateless contract tests', () => {
       providerName: 'openai-responses',
       ephemeralsSnapshot: {
         temperature: 0.11,
-        'max-output-tokens': 1024,
+        max_output_tokens: 1024,
       },
       metadata: { testCase: 'openai-responses-invocation' },
     });
@@ -346,7 +346,7 @@ describe('OpenAI Responses provider stateless contract tests', () => {
     };
     const request = Fake.requests.at(-1)?.request;
     expect(request?.temperature).toBe(0.11);
-    expect(request?.['max-output-tokens']).toBe(1024);
+    expect(request?.max_output_tokens).toBe(1024);
     expect(getEphemerals).not.toHaveBeenCalled();
   });
 });

--- a/packages/providers/src/openai-vercel/OpenAIVercelProvider.ts
+++ b/packages/providers/src/openai-vercel/OpenAIVercelProvider.ts
@@ -248,7 +248,7 @@ export class OpenAIVercelProvider extends BaseProvider implements IProvider {
       logChatPayload(logger, materializedMessages, formattedTools ?? undefined);
 
       const aiTools = buildVercelTools(formattedTools);
-      const params = resolveModelCallParams(effectiveOptions, metadata, this);
+      const params = resolveModelCallParams(effectiveOptions, this);
       const rawFieldName = effectiveOptions.settings.get(
         'reasoning.fieldName',
       ) as string | undefined;

--- a/packages/providers/src/openai-vercel/streaming.test.ts
+++ b/packages/providers/src/openai-vercel/streaming.test.ts
@@ -690,7 +690,7 @@ describe('OpenAIVercelProvider - Streaming', () => {
         settings: settingsService,
         settingsOverrides: {
           provider: {
-            maxTokens: 100,
+            max_tokens: 100,
           },
         },
         streaming: true,

--- a/packages/providers/src/openai-vercel/vercelRequestParams.maxRetries.test.ts
+++ b/packages/providers/src/openai-vercel/vercelRequestParams.maxRetries.test.ts
@@ -30,14 +30,13 @@ describe('resolveModelCallParams maxRetries @issue:2532', () => {
   const provider = {} as BaseProvider;
 
   it('pins SDK maxRetries to 0 by default', () => {
-    const params = resolveModelCallParams(makeOptions({}), {}, provider);
+    const params = resolveModelCallParams(makeOptions({}), provider);
     expect(params.maxRetries).toBe(0);
   });
 
   it('keeps SDK maxRetries at 0 even when the retries ephemeral is set', () => {
     const params = resolveModelCallParams(
       makeOptions({ retries: 5 }),
-      {},
       provider,
     );
     expect(params.maxRetries).toBe(0);

--- a/packages/providers/src/openai-vercel/vercelRequestParams.ts
+++ b/packages/providers/src/openai-vercel/vercelRequestParams.ts
@@ -98,6 +98,10 @@ export function resolveStreamingEnabled(
   return streamingSetting !== 'disabled';
 }
 
+/**
+ * Validates the canonical `modelParams['max_tokens']` value. Metadata and
+ * ephemeral legacy spellings are intentionally not read (issue #2533).
+ */
 export function resolveMaxOutputTokens(
   maxTokensOverride: number | undefined,
 ): number | undefined {
@@ -119,7 +123,9 @@ export function resolveStopSequences(
 }
 
 /**
- * Resolves all model call parameters from normalized options.
+ * Resolves model call parameters from canonical modelParams keys. For maximum
+ * output tokens, only `modelParams['max_tokens']` is honored; metadata and
+ * ephemeral legacy spellings are intentionally unread (issue #2533).
  */
 export function resolveModelCallParams(
   options: NormalizedGenerateChatOptions,

--- a/packages/providers/src/openai-vercel/vercelRequestParams.ts
+++ b/packages/providers/src/openai-vercel/vercelRequestParams.ts
@@ -99,12 +99,8 @@ export function resolveStreamingEnabled(
 }
 
 export function resolveMaxOutputTokens(
-  maxTokensMeta: number | undefined,
   maxTokensOverride: number | undefined,
 ): number | undefined {
-  if (typeof maxTokensMeta === 'number' && Number.isFinite(maxTokensMeta)) {
-    return maxTokensMeta;
-  }
   if (
     typeof maxTokensOverride === 'number' &&
     Number.isFinite(maxTokensOverride)
@@ -123,23 +119,15 @@ export function resolveStopSequences(
 }
 
 /**
- * Resolves all model call parameters from options and metadata.
+ * Resolves all model call parameters from normalized options.
  */
 export function resolveModelCallParams(
   options: NormalizedGenerateChatOptions,
-  metadata: NormalizedGenerateChatOptions['metadata'],
   provider: BaseProvider,
 ): ModelCallParams {
   const modelParams = extractModelParamsFromOptions(options) ?? {};
-  const ephemerals = options.invocation.ephemerals;
-  const maxTokensMeta =
-    (metadata['maxTokens'] as number | undefined) ??
-    (ephemerals['max-tokens'] as number | undefined);
-  const maxTokensOverride =
-    (modelParams['max_tokens'] as number | undefined) ?? undefined;
   const maxOutputTokens = resolveMaxOutputTokens(
-    maxTokensMeta,
-    maxTokensOverride,
+    modelParams['max_tokens'] as number | undefined,
   );
   const temperature = modelParams['temperature'] as number | undefined;
   const topP = modelParams['top_p'] as number | undefined;

--- a/packages/providers/src/openai/OpenAIProvider.concurrentRouting.test.ts
+++ b/packages/providers/src/openai/OpenAIProvider.concurrentRouting.test.ts
@@ -82,26 +82,6 @@ interface CallRecord {
   body: string | undefined;
 }
 
-function extractHeaderRecord(
-  headers: HeadersInit | undefined,
-): Record<string, string> {
-  const headerRecord: Record<string, string> = {};
-  if (headers instanceof Headers) {
-    headers.forEach((value, key) => {
-      headerRecord[key] = value;
-    });
-  } else if (
-    headers &&
-    typeof headers === 'object' &&
-    !Array.isArray(headers)
-  ) {
-    for (const [key, value] of Object.entries(headers)) {
-      headerRecord[key] = String(value);
-    }
-  }
-  return headerRecord;
-}
-
 async function extractBody(
   init: RequestInit | undefined,
 ): Promise<string | undefined> {
@@ -116,10 +96,9 @@ async function recordRoutedFetch(
   input: RequestInfo | URL,
   init: RequestInit | undefined,
 ): Promise<Response> {
-  const headerRecord = extractHeaderRecord(init?.headers);
   records.push({
     url: String(input),
-    authHeader: headerRecord.Authorization || headerRecord.authorization,
+    authHeader: new Headers(init?.headers).get('authorization') ?? undefined,
     body: await extractBody(init),
   });
   const url = String(input);

--- a/packages/providers/src/openai/OpenAIRequestPreparation.ts
+++ b/packages/providers/src/openai/OpenAIRequestPreparation.ts
@@ -123,14 +123,14 @@ function resolveReasoningConfig(
 }
 
 /**
- * Apply reasoning, max-tokens, and stream-options to the request body.
+ * Apply model-param overrides, reasoning config, and stream-options to the
+ * request body.
  */
 function applyRequestBodyOverrides(
   requestBody: OpenAIChatRequestBody,
   options: NormalizedGenerateChatOptions,
   ephemeralSettings: Readonly<Record<string, unknown>>,
   model: string,
-  maxTokens: number | undefined,
   streamingEnabled: boolean,
   providerName: string,
   logger: DebugLogger,
@@ -163,10 +163,6 @@ function applyRequestBodyOverrides(
     providerName,
     logger,
   );
-
-  if (typeof maxTokens === 'number' && Number.isFinite(maxTokens)) {
-    requestBody.max_tokens = maxTokens;
-  }
 
   // Add stream options if streaming is enabled
   const streamOptions = (ephemeralSettings['stream-options'] as
@@ -205,16 +201,6 @@ function sanitizeOverridesCacheKey(
     );
   }
   return Object.keys(result).length > 0 ? result : undefined;
-}
-
-function resolveMaxTokens(
-  metadataValue: unknown,
-  ephemeralValue: unknown,
-): number | undefined {
-  if (typeof metadataValue === 'number') {
-    return metadataValue;
-  }
-  return typeof ephemeralValue === 'number' ? ephemeralValue : undefined;
 }
 
 interface OpenAIMessagePayload {
@@ -274,18 +260,12 @@ export async function prepareRequest(
   providerName?: string,
   mediaTransportCapabilities: ProviderMediaTransportCapabilities = conservativeMediaTransportCapabilities(),
 ): Promise<RequestContext> {
-  const { metadata } = options;
   const model = options.resolved.model || defaultModel;
   const ephemeralSettings = readInvocationRecord(options.invocation.ephemerals);
   const resolvedProviderName = providerName ?? 'openai';
   const { detectedFormat, formattedTools, messagesWithSystem } =
     prepareMessagePayload(options, model, config, logger, resolvedProviderName);
   const streamingEnabled = ephemeralSettings['streaming'] !== 'disabled';
-
-  const maxTokens = resolveMaxTokens(
-    metadata.maxTokens,
-    ephemeralSettings['max-tokens'],
-  );
 
   // Build request
   const requestBody: OpenAIChatRequestBody = {
@@ -299,13 +279,12 @@ export async function prepareRequest(
     requestBody.tool_choice = 'auto';
   }
 
-  // Apply reasoning, max-tokens, and stream-options overrides
+  // Apply model params, reasoning, and stream-options overrides
   applyRequestBodyOverrides(
     requestBody,
     options,
     ephemeralSettings,
     model,
-    maxTokens,
     streamingEnabled,
     resolvedProviderName,
     logger,

--- a/packages/providers/src/openai/__tests__/openai.stateless.test.ts
+++ b/packages/providers/src/openai/__tests__/openai.stateless.test.ts
@@ -190,11 +190,11 @@ describe('OpenAI provider stateless contract tests', () => {
     );
     const settingsPrimary = createSettings({ callId: 'runtime-config' });
     settingsPrimary.setProviderSetting('openai', 'temperature', 0.42);
-    settingsPrimary.setProviderSetting('openai', 'max-tokens', 512);
+    settingsPrimary.setProviderSetting('openai', 'max_tokens', 512);
     const configPrimary = createRuntimeConfigStub(settingsPrimary, {
       getEphemeralSettings: () => ({
         temperature: 0.42,
-        'max-tokens': 512,
+        max_tokens: 512,
       }),
     });
     const callOptions = buildCallOptions(provider, {
@@ -211,11 +211,11 @@ describe('OpenAI provider stateless contract tests', () => {
 
     const settingsOverride = createSettings({ callId: 'runtime-config' });
     settingsOverride.setProviderSetting('openai', 'temperature', 0.85);
-    settingsOverride.setProviderSetting('openai', 'max-tokens', 128);
+    settingsOverride.setProviderSetting('openai', 'max_tokens', 128);
     const configOverride = createRuntimeConfigStub(settingsOverride, {
       getEphemeralSettings: () => ({
         temperature: 0.85,
-        'max-tokens': 128,
+        max_tokens: 128,
       }),
     });
     const runtimeOverride = createProviderRuntimeContext({
@@ -237,6 +237,21 @@ describe('OpenAI provider stateless contract tests', () => {
     const secondRequest = FakeOpenAIClass.requests.at(-1)?.request;
     expect(secondRequest?.temperature).toBe(0.85);
     expect(secondRequest?.['max_tokens']).toBe(128);
+  });
+
+  it('does not translate legacy max-tokens ephemerals into max_tokens on the wire', async () => {
+    const provider = new TestOpenAIProvider('token-legacy');
+    const settings = createSettings({ callId: 'legacy-max-tokens' });
+    const callOptions = buildCallOptions(provider, {
+      settings,
+      runtimeId: 'legacy-max-tokens',
+      ephemerals: { 'max-tokens': 999 },
+    });
+
+    await provider.generateChatCompletion(callOptions).next();
+
+    const request = FakeOpenAIClass.requests.at(-1)?.request;
+    expect(request?.['max_tokens']).toBeUndefined();
   });
 
   it('relies on invocation ephemerals instead of config when provided', async () => {

--- a/packages/providers/src/openai/openaiRequestParams.test.ts
+++ b/packages/providers/src/openai/openaiRequestParams.test.ts
@@ -3,11 +3,11 @@ import { filterOpenAIRequestParams } from './openaiRequestParams.js';
 import { MAX_PROMPT_CACHE_KEY_LENGTH } from '../openai-responses/sanitizePromptCacheKey.js';
 
 describe('filterOpenAIRequestParams', () => {
-  it('keeps supported OpenAI parameters and normalizes aliases', () => {
+  it('keeps supported canonical OpenAI parameters', () => {
     const filtered = filterOpenAIRequestParams({
       temperature: 0.5,
-      'max-tokens': 2048,
-      responseFormat: { type: 'json_schema' },
+      max_tokens: 2048,
+      response_format: { type: 'json_schema' },
       stop: ['END'],
     });
 
@@ -17,6 +17,19 @@ describe('filterOpenAIRequestParams', () => {
       response_format: { type: 'json_schema' },
       stop: ['END'],
     });
+  });
+
+  it('drops removed legacy spellings instead of translating them', () => {
+    const filtered = filterOpenAIRequestParams({
+      'max-tokens': 2048,
+      maxTokens: 2048,
+      'response-format': { type: 'json_schema' },
+      responseFormat: { type: 'json_schema' },
+      'tool-choice': 'auto',
+      toolChoice: 'auto',
+    });
+
+    expect(filtered).toBeUndefined();
   });
 
   it('drops CLI-only or unrelated ephemeral settings', () => {

--- a/packages/providers/src/openai/openaiRequestParams.ts
+++ b/packages/providers/src/openai/openaiRequestParams.ts
@@ -38,22 +38,6 @@ const OPENAI_ALLOWED_PARAM_KEYS = new Set<string>([
   'prompt_cache_retention',
 ]);
 
-const OPENAI_PARAM_KEY_ALIASES: Record<string, string> = {
-  'max-tokens': 'max_tokens',
-  maxTokens: 'max_tokens',
-  'response-format': 'response_format',
-  responseFormat: 'response_format',
-  'tool-choice': 'tool_choice',
-  toolChoice: 'tool_choice',
-};
-
-function normalizeOpenAIParamKey(key: string): string {
-  if (OPENAI_PARAM_KEY_ALIASES[key]) {
-    return OPENAI_PARAM_KEY_ALIASES[key];
-  }
-  return key.replace(/-/g, '_');
-}
-
 const OPENAI_REASONING_INTERNAL_KEYS = new Set<string>([
   'enabled',
   'includeInContext',
@@ -100,18 +84,17 @@ function processParamEntry(
   if (value === undefined || value === null) {
     return undefined;
   }
-  const normalizedKey = normalizeOpenAIParamKey(rawKey);
-  if (!OPENAI_ALLOWED_PARAM_KEYS.has(normalizedKey)) {
+  if (!OPENAI_ALLOWED_PARAM_KEYS.has(rawKey)) {
     return undefined;
   }
-  if (normalizedKey === 'reasoning') {
+  if (rawKey === 'reasoning') {
     const sanitized = stripInternalReasoningKeys(value);
     if (!sanitized) {
       return undefined;
     }
-    return { key: normalizedKey, value: sanitized };
+    return { key: rawKey, value: sanitized };
   }
-  if (normalizedKey === 'prompt_cache_key') {
+  if (rawKey === 'prompt_cache_key') {
     // OpenAI rejects prompt_cache_key longer than 64 chars (issue #2135);
     // clamp at egress so overlong runtime/session-derived keys never reach
     // the API regardless of which layer injected them. Non-string or empty
@@ -119,9 +102,9 @@ function processParamEntry(
     if (typeof value !== 'string' || value.trim() === '') {
       return undefined;
     }
-    return { key: normalizedKey, value: sanitizePromptCacheKey(value) };
+    return { key: rawKey, value: sanitizePromptCacheKey(value) };
   }
-  return { key: normalizedKey, value };
+  return { key: rawKey, value };
 }
 
 export function filterOpenAIRequestParams(

--- a/packages/providers/src/providerConfigKeys.ts
+++ b/packages/providers/src/providerConfigKeys.ts
@@ -1,14 +1,15 @@
 import { SETTINGS_REGISTRY } from '@vybestack/llxprt-code-settings/settings/settingsRegistry.js';
 
 /**
- * Set of all provider-config keys (canonical + aliases) derived from the
- * central settings registry. Used to filter provider-config settings out of
- * the global ephemerals snapshot so they only appear in provider-scoped sections.
+ * Set of all provider-config canonical keys derived from the central settings
+ * registry. Used to filter provider-config settings out of the global
+ * ephemerals snapshot so they only appear in provider-scoped sections.
+ * Legacy spellings are no longer listed: they are migrated at load (#2533 C1).
  *
  * @plan PLAN-20260126-SETTINGS-SEPARATION.P09
  */
 export const PROVIDER_CONFIG_KEYS: ReadonlySet<string> = new Set(
-  SETTINGS_REGISTRY.filter((s) => s.category === 'provider-config').flatMap(
-    (s) => [s.key, ...(s.aliases ?? [])],
+  SETTINGS_REGISTRY.filter((s) => s.category === 'provider-config').map(
+    (s) => s.key,
   ),
 );

--- a/packages/providers/src/runtime/__tests__/profileApplication.workflow.test.ts
+++ b/packages/providers/src/runtime/__tests__/profileApplication.workflow.test.ts
@@ -515,7 +515,7 @@ describe('profile application workflow', () => {
     it('applies profile modelParams and clears stale params', async () => {
       getActiveModelParamsMock.mockReturnValue({
         temperature: 0.5,
-        'max-tokens': 1000,
+        max_tokens: 1000,
         'old-param': 'stale',
       });
 
@@ -539,7 +539,7 @@ describe('profile application workflow', () => {
 
       expect(setActiveModelParamMock).toHaveBeenCalledWith('temperature', 0.9);
       expect(setActiveModelParamMock).toHaveBeenCalledWith('top-p', 0.95);
-      expect(clearActiveModelParamMock).toHaveBeenCalledWith('max-tokens');
+      expect(clearActiveModelParamMock).toHaveBeenCalledWith('max_tokens');
       expect(clearActiveModelParamMock).toHaveBeenCalledWith('old-param');
     });
 

--- a/packages/providers/src/runtime/ephemeralSettings.ts
+++ b/packages/providers/src/runtime/ephemeralSettings.ts
@@ -7,7 +7,6 @@
 import {
   getSettingHelp,
   parseSetting,
-  resolveAlias,
   SETTINGS_REGISTRY,
   validateSetting,
 } from '@vybestack/llxprt-code-settings/settings/settingsRegistry.js';
@@ -36,16 +35,15 @@ export function parseEphemeralSettingValue(
   key: string,
   rawValue: string,
 ): EphemeralParseResult {
-  const resolved = resolveAlias(key);
-  if (!validEphemeralKeys.includes(resolved)) {
+  if (!validEphemeralKeys.includes(key)) {
     return {
       success: false,
       message: `Invalid setting key: ${key}. Valid keys are: ${validEphemeralKeys.join(', ')}`,
     };
   }
 
-  const parsed = parseSetting(resolved, rawValue);
-  const validation = validateSetting(resolved, parsed);
+  const parsed = parseSetting(key, rawValue);
+  const validation = validateSetting(key, parsed);
 
   if (!validation.success) {
     return {
@@ -68,11 +66,9 @@ export function parseEphemeralSettingValue(
  * @returns true if the setting is valid, false otherwise
  */
 export function isValidEphemeralSetting(key: string, value: unknown): boolean {
-  // Resolve aliases first so 'max-tokens' etc. work the same as in parseEphemeralSettingValue
-  const resolved = resolveAlias(key);
-  if (!validEphemeralKeys.includes(resolved)) {
+  if (!validEphemeralKeys.includes(key)) {
     return false;
   }
-  const result = parseEphemeralSettingValue(resolved, String(value));
+  const result = parseEphemeralSettingValue(key, String(value));
   return result.success;
 }

--- a/packages/providers/src/runtime/profileSnapshot.ts
+++ b/packages/providers/src/runtime/profileSnapshot.ts
@@ -12,7 +12,6 @@ import { isLoadBalancerProfile } from '@vybestack/llxprt-code-settings/profiles/
 import {
   getProfilePersistableKeys,
   isInternalSettingKey,
-  resolveAlias,
 } from '@vybestack/llxprt-code-settings/settings/settingsRegistry.js';
 import type {
   Profile,
@@ -151,22 +150,7 @@ function getProfileEphemeralValue(
   ephemeralRecord: Record<string, unknown>,
   key: string,
 ): unknown {
-  const directValue = getNestedValue(ephemeralRecord, key);
-  if (directValue !== undefined) {
-    return directValue;
-  }
-
-  for (const [aliasKey, aliasValue] of Object.entries(ephemeralRecord)) {
-    if (
-      aliasValue !== undefined &&
-      !isInternalSettingKey(aliasKey) &&
-      resolveAlias(aliasKey) === key
-    ) {
-      return aliasValue;
-    }
-  }
-
-  return undefined;
+  return getNestedValue(ephemeralRecord, key);
 }
 
 /**

--- a/packages/providers/src/runtime/provider-alias-defaults.switch.test.ts
+++ b/packages/providers/src/runtime/provider-alias-defaults.switch.test.ts
@@ -403,18 +403,40 @@ describe('Provider alias defaults (model + ephemerals)', () => {
     expect(stubConfig.getEphemeralSetting('max_tokens')).toBe(8192);
   });
 
-  it('does not allow alias ephemerals to set auth-like keys', async () => {
+  it('does not allow alias ephemerals to set protected canonical keys', async () => {
     const entry = aliasEntries[0] as {
       config?: { ephemeralSettings?: Record<string, unknown> };
     };
     ensureAliasConfig(entry).ephemeralSettings = {
-      'api-key': 'should-not-apply',
+      'auth-key': 'should-not-apply',
+      'auth-keyfile': '/should/not/apply',
+      'base-url': 'https://alias.example/v1',
       max_tokens: 50000,
     };
 
     await switchActiveProvider('qwenvercel');
 
-    expect(stubConfig.getEphemeralSetting('api-key')).toBeUndefined();
+    expect(stubConfig.getEphemeralSetting('auth-key')).toBeUndefined();
+    expect(stubConfig.getEphemeralSetting('auth-keyfile')).toBeUndefined();
+    expect(stubConfig.getEphemeralSetting('base-url')).toBeUndefined();
+    expect(stubConfig.getEphemeralSetting('max_tokens')).toBe(50000);
+  });
+
+  it('does not let a legacy auth spelling reach the canonical auth slot', async () => {
+    // Exact-key semantics (issue #2533): 'api-key' is not resolved to
+    // 'auth-key' anywhere in the runtime, so a legacy spelling in alias
+    // data can never populate the canonical credential slot.
+    const entry = aliasEntries[0] as {
+      config?: { ephemeralSettings?: Record<string, unknown> };
+    };
+    ensureAliasConfig(entry).ephemeralSettings = {
+      'api-key': 'legacy-value',
+      max_tokens: 50000,
+    };
+
+    await switchActiveProvider('qwenvercel');
+
+    expect(stubConfig.getEphemeralSetting('auth-key')).toBeUndefined();
     expect(stubConfig.getEphemeralSetting('max_tokens')).toBe(50000);
   });
 

--- a/packages/providers/src/runtime/providerMutations.issue1943.test.ts
+++ b/packages/providers/src/runtime/providerMutations.issue1943.test.ts
@@ -6,7 +6,7 @@
  * is captured during profile saves.
  *
  * Before the fix, only settingsService.updateSettings() was called.
- * After the fix, config.setEphemeralSetting('tool-format', value) is also called,
+ * After the fix, config.setEphemeralSetting('toolFormat', value) is also called,
  * mirroring the pattern used by updateActiveProviderBaseUrl.
  */
 
@@ -54,7 +54,7 @@ describe('setActiveToolFormatOverride ephemeral persistence (issue #1943)', () =
       toolFormat: 'openai',
     });
     expect(mockConfig.setEphemeralSetting).toHaveBeenCalledWith(
-      'tool-format',
+      'toolFormat',
       'openai',
     );
   });
@@ -66,7 +66,7 @@ describe('setActiveToolFormatOverride ephemeral persistence (issue #1943)', () =
       toolFormat: 'auto',
     });
     expect(mockConfig.setEphemeralSetting).toHaveBeenCalledWith(
-      'tool-format',
+      'toolFormat',
       'auto',
     );
   });
@@ -78,7 +78,7 @@ describe('setActiveToolFormatOverride ephemeral persistence (issue #1943)', () =
       toolFormat: 'auto',
     });
     expect(mockConfig.setEphemeralSetting).toHaveBeenCalledWith(
-      'tool-format',
+      'toolFormat',
       'auto',
     );
   });
@@ -90,7 +90,7 @@ describe('setActiveToolFormatOverride ephemeral persistence (issue #1943)', () =
       toolFormat: 'kimi',
     });
     expect(mockConfig.setEphemeralSetting).toHaveBeenCalledWith(
-      'tool-format',
+      'toolFormat',
       'kimi',
     );
   });

--- a/packages/providers/src/runtime/providerMutations.ts
+++ b/packages/providers/src/runtime/providerMutations.ts
@@ -91,48 +91,32 @@ function extractWrappedProviderBaseUrl(
 function extractDirectProviderBaseUrl(
   provider: Record<string, unknown>,
 ): string | undefined {
-  return (
-    normalizeProviderBaseUrl(
-      (provider as { baseUrl?: string | null }).baseUrl ??
-        (provider as { baseURL?: string | null }).baseURL,
-    ) ??
-    normalizeProviderBaseUrl(
-      (provider as { BaseUrl?: string | null }).BaseUrl ??
-        (provider as { BaseURL?: string | null }).BaseURL,
-    )
+  return normalizeProviderBaseUrl(
+    (provider as { baseURL?: string | null }).baseURL,
   );
 }
 
 function extractConfiguredProviderBaseUrl(
   provider: Record<string, unknown>,
 ): string | undefined {
-  const configCandidate = (
-    provider as {
-      providerConfig?: { baseUrl?: string; baseURL?: string };
-    }
-  ).providerConfig;
+  const configCandidate = (provider as { providerConfig?: { baseURL?: string } })
+    .providerConfig;
   if (!configCandidate) {
     return undefined;
   }
-  return normalizeProviderBaseUrl(
-    configCandidate.baseUrl ?? configCandidate.baseURL,
-  );
+  return normalizeProviderBaseUrl(configCandidate.baseURL);
 }
 
 function extractBaseProviderConfigUrl(
   provider: Record<string, unknown>,
 ): string | undefined {
   const baseProviderConfig = (
-    provider as {
-      baseProviderConfig?: { baseURL?: string; baseUrl?: string };
-    }
+    provider as { baseProviderConfig?: { baseURL?: string } }
   ).baseProviderConfig;
   if (!baseProviderConfig) {
     return undefined;
   }
-  return normalizeProviderBaseUrl(
-    baseProviderConfig.baseURL ?? baseProviderConfig.baseUrl,
-  );
+  return normalizeProviderBaseUrl(baseProviderConfig.baseURL);
 }
 
 function extractProviderGetBaseUrl(
@@ -151,8 +135,11 @@ function extractProviderGetBaseUrl(
 }
 
 /**
- * Extract base URL from a provider object by checking various properties.
- * Handles wrapped providers and multiple naming conventions (baseUrl/baseURL).
+ * Extract base URL from a provider object by checking the canonical baseURL
+ * field on the provider, its providerConfig/baseProviderConfig containers,
+ * and the getBaseURL() accessor, following wrapped providers. Provider
+ * objects are LLxprt-owned IProvider instances; legacy spellings are
+ * migrated at settings load and never appear here (issue #2533).
  */
 export function extractProviderBaseUrl(
   provider: unknown,

--- a/packages/providers/src/runtime/providerMutations.ts
+++ b/packages/providers/src/runtime/providerMutations.ts
@@ -99,8 +99,9 @@ function extractDirectProviderBaseUrl(
 function extractConfiguredProviderBaseUrl(
   provider: Record<string, unknown>,
 ): string | undefined {
-  const configCandidate = (provider as { providerConfig?: { baseURL?: string } })
-    .providerConfig;
+  const configCandidate = (
+    provider as { providerConfig?: { baseURL?: string } }
+  ).providerConfig;
   if (!configCandidate) {
     return undefined;
   }
@@ -394,14 +395,14 @@ export async function setActiveToolFormatOverride(
 
   if (!formatName || formatName === 'auto') {
     await settingsService.updateSettings(provider.name, { toolFormat: 'auto' });
-    config.setEphemeralSetting('tool-format', 'auto');
+    config.setEphemeralSetting('toolFormat', 'auto');
     return getActiveToolFormatState();
   }
 
   await settingsService.updateSettings(provider.name, {
     toolFormat: formatName,
   });
-  config.setEphemeralSetting('tool-format', formatName);
+  config.setEphemeralSetting('toolFormat', formatName);
   return getActiveToolFormatState();
 }
 

--- a/packages/providers/src/runtime/providerSwitch.ts
+++ b/packages/providers/src/runtime/providerSwitch.ts
@@ -678,23 +678,19 @@ function applyAliasEphemeralSettings(context: ProviderSwitchContext): void {
     typeof aliasEphemeralSettings === 'object' &&
     !Array.isArray(aliasEphemeralSettings)
   ) {
-    const protectedAliasEphemeralKeys = new Set([
-      'activeprovider',
-      'base-url',
-      'baseurl',
-      'base_url',
-      'model',
-      'auth-key',
-      'auth-keyfile',
-      'authkey',
-      'authkeyfile',
-      'api-key',
-      'api-keyfile',
-      'api_key',
-      'api_keyfile',
-      'apikey',
-      'apikeyfile',
-    ]);
+    // Canonical protected keys only (issue #2533): legacy spellings are
+    // rewritten to canonical at load, so only the registered names need
+    // protection here. Comparison is case-insensitive because the raw alias
+    // key is lowercased below, which also blocks case variants of these keys.
+    const protectedAliasEphemeralKeys = new Set(
+      [
+        'activeProvider',
+        'base-url',
+        'model',
+        'auth-key',
+        'auth-keyfile',
+      ].map((canonicalKey) => canonicalKey.toLowerCase()),
+    );
 
     Object.entries(aliasEphemeralSettings).forEach(([rawKey, rawValue]) => {
       if (

--- a/packages/providers/src/runtime/providerSwitch.ts
+++ b/packages/providers/src/runtime/providerSwitch.ts
@@ -683,13 +683,9 @@ function applyAliasEphemeralSettings(context: ProviderSwitchContext): void {
     // protection here. Comparison is case-insensitive because the raw alias
     // key is lowercased below, which also blocks case variants of these keys.
     const protectedAliasEphemeralKeys = new Set(
-      [
-        'activeProvider',
-        'base-url',
-        'model',
-        'auth-key',
-        'auth-keyfile',
-      ].map((canonicalKey) => canonicalKey.toLowerCase()),
+      ['activeProvider', 'base-url', 'model', 'auth-key', 'auth-keyfile'].map(
+        (canonicalKey) => canonicalKey.toLowerCase(),
+      ),
     );
 
     Object.entries(aliasEphemeralSettings).forEach(([rawKey, rawValue]) => {

--- a/packages/settings/src/__tests__/SettingsService.test.ts
+++ b/packages/settings/src/__tests__/SettingsService.test.ts
@@ -527,7 +527,7 @@ describe('SettingsService — change event redacts sensitive values (Issue #2472
     expect(evt?.newValue).toBe('[REDACTED]');
   });
 
-  it('redacts oldValue and newValue for apiKey alias in change events', () => {
+  it('does not redact unmigrated legacy apiKey events (#2533 C1: canonical keys only)', () => {
     const svc = new SettingsService();
     svc.set('apiKey', 'sk-original');
     let evt: { key: string; oldValue: unknown; newValue: unknown } | undefined;
@@ -536,9 +536,10 @@ describe('SettingsService — change event redacts sensitive values (Issue #2472
     });
     svc.set('apiKey', 'sk-rotated');
 
+    // 'apiKey' is no longer a sensitive registry key: the alias is gone and
+    // the spelling is rewritten at load. Only canonical 'auth-key' redacts.
     expect(evt?.key).toBe('apiKey');
-    expect(evt?.oldValue).toBe('[REDACTED]');
-    expect(evt?.newValue).toBe('[REDACTED]');
+    expect(evt?.newValue).toBe('sk-rotated');
   });
 
   it('preserves non-sensitive newValue in change events', () => {

--- a/packages/settings/src/__tests__/SettingsService.test.ts
+++ b/packages/settings/src/__tests__/SettingsService.test.ts
@@ -527,19 +527,22 @@ describe('SettingsService — change event redacts sensitive values (Issue #2472
     expect(evt?.newValue).toBe('[REDACTED]');
   });
 
-  it('does not redact unmigrated legacy apiKey events (#2533 C1: canonical keys only)', () => {
+  it('rejects legacy apiKey writes with canonical guidance', () => {
     const svc = new SettingsService();
-    svc.set('apiKey', 'sk-original');
-    let evt: { key: string; oldValue: unknown; newValue: unknown } | undefined;
-    svc.on('change', (e) => {
-      evt = e;
-    });
-    svc.set('apiKey', 'sk-rotated');
 
-    // 'apiKey' is no longer a sensitive registry key: the alias is gone and
-    // the spelling is rewritten at load. Only canonical 'auth-key' redacts.
-    expect(evt?.key).toBe('apiKey');
-    expect(evt?.newValue).toBe('sk-rotated');
+    expect(() => svc.set('apiKey', 'sk-secret')).toThrow(
+      "use the canonical 'auth-key'",
+    );
+    expect(svc.get('apiKey')).toBeUndefined();
+  });
+
+  it('rejects legacy disabled-tools clears with canonical guidance', () => {
+    const svc = new SettingsService();
+
+    expect(() => svc.set('disabled-tools', undefined)).toThrow(
+      "use the canonical 'tools.disabled'",
+    );
+    expect(svc.get('disabled-tools')).toBeUndefined();
   });
 
   it('preserves non-sensitive newValue in change events', () => {
@@ -571,19 +574,13 @@ describe('SettingsService — change event redacts sensitive values (Issue #2472
     expect(evt?.newValue).toBe('[REDACTED]');
   });
 
-  it('preserves provider and key metadata in provider-change events for sensitive keys', () => {
+  it('rejects legacy provider-setting writes with canonical guidance', () => {
     const svc = new SettingsService();
-    svc.setProviderSetting('anthropic', 'apiKey', 'sk-original');
-    let evt:
-      | { provider: string; key: string; oldValue: unknown; newValue: unknown }
-      | undefined;
-    svc.on('provider-change', (e) => {
-      evt = e;
-    });
-    svc.setProviderSetting('anthropic', 'apiKey', 'sk-rotated');
 
-    expect(evt?.provider).toBe('anthropic');
-    expect(evt?.key).toBe('apiKey');
+    expect(() =>
+      svc.setProviderSetting('anthropic', 'apiKey', 'sk-secret'),
+    ).toThrow("use the canonical 'auth-key'");
+    expect(svc.getProviderSettings('anthropic')).not.toHaveProperty('apiKey');
   });
 
   it('preserves non-sensitive newValue in provider-change events', () => {

--- a/packages/settings/src/__tests__/legacyKeyMigration.test.ts
+++ b/packages/settings/src/__tests__/legacyKeyMigration.test.ts
@@ -112,6 +112,37 @@ describe('migrateLegacySettingKeys', () => {
     expect('tools_allowed' in migrated).toBe(false);
   });
 
+  it('migrates legacy baseUrl spellings in a provider block to the canonical base-url key', () => {
+    // The settingsLoader applies this migration to each provider block in
+    // settings.json; the canonical provider-block key is the registered
+    // 'base-url' (registry-entries-1.ts), not the IProvider field 'baseURL'.
+    const providerBlock = {
+      baseUrl: 'https://a.example/v1',
+      baseurl: 'https://b.example/v1',
+      base_url: 'https://c.example/v1',
+      BaseUrl: 'https://d.example/v1',
+      BaseURL: 'https://e.example/v1',
+    };
+    const migrated = migrateLegacySettingKeys(providerBlock);
+    // The map iteration order applies the first legacy spelling; all legacy
+    // keys are deleted and only the canonical key remains.
+    expect(migrated['base-url']).toBe('https://a.example/v1');
+    expect(migrated['baseUrl']).toBeUndefined();
+    expect(migrated['baseurl']).toBeUndefined();
+    expect(migrated['base_url']).toBeUndefined();
+    expect(migrated['BaseUrl']).toBeUndefined();
+    expect(migrated['BaseURL']).toBeUndefined();
+  });
+
+  it('keeps a canonical base-url value over a legacy baseUrl value in a provider block', () => {
+    const migrated = migrateLegacySettingKeys({
+      'base-url': 'https://canonical.example/v1',
+      baseUrl: 'https://legacy.example/v1',
+    });
+    expect(migrated['base-url']).toBe('https://canonical.example/v1');
+    expect('baseUrl' in migrated).toBe(false);
+  });
+
   it('is idempotent: a second run changes nothing', () => {
     const once = migrateLegacySettingKeys({
       'max-tokens': 1024,

--- a/packages/settings/src/__tests__/legacyKeyMigration.test.ts
+++ b/packages/settings/src/__tests__/legacyKeyMigration.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @issue #2533 Phase C1
+ *
+ * Legacy setting-key spellings are rewritten once at load by
+ * migrateLegacySettingKeys. These tests pin the behavior: legacy keys are
+ * rewritten to canonical and deleted, canonical values win collisions, the
+ * nested tools shape is handled, and a second run is a no-op.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  LEGACY_SETTING_KEY_MIGRATIONS,
+  migrateLegacySettingKeys,
+} from '../settings/legacyKeyMigration.js';
+
+describe('migrateLegacySettingKeys', () => {
+  it('rewrites legacy spellings to canonical keys', () => {
+    const migrated = migrateLegacySettingKeys({
+      'max-tokens': 1024,
+      'response-format': { type: 'json_object' },
+      'tool-choice': 'auto',
+      apiKey: 'sk-legacy',
+      apiKeyfile: '/tmp/key',
+      'tool-format': 'anthropic',
+      'tool-format-override': 'openai',
+      'User-Agent': 'agent/1.0',
+      'max-output-tokens': 512,
+      'max-output': 256,
+      streamIdleTimeoutMs: 60_000,
+      streamFirstResponseTimeoutMs: 300_000,
+    });
+
+    expect(migrated['max_tokens']).toBe(1024);
+    expect(migrated['response_format']).toStrictEqual({
+      type: 'json_object',
+    });
+    expect(migrated['tool_choice']).toBe('auto');
+    expect(migrated['auth-key']).toBe('sk-legacy');
+    expect(migrated['auth-keyfile']).toBe('/tmp/key');
+    expect(migrated['toolFormat']).toBe('anthropic');
+    expect(migrated['toolFormatOverride']).toBe('openai');
+    expect(migrated['user-agent']).toBe('agent/1.0');
+    expect(migrated['max_output_tokens']).toBe(512);
+    expect(migrated['maxOutputTokens']).toBe(256);
+    expect(migrated['stream-idle-timeout-ms']).toBe(60_000);
+    expect(migrated['stream-first-response-timeout-ms']).toBe(300_000);
+
+    for (const legacyKey of LEGACY_SETTING_KEY_MIGRATIONS.keys()) {
+      expect(migrated[legacyKey]).toBeUndefined();
+    }
+  });
+
+  it('deletes the legacy key even when the canonical key wins', () => {
+    const migrated = migrateLegacySettingKeys({
+      'max-tokens': 1024,
+      max_tokens: 4096,
+    });
+    // Canonical wins; the legacy spelling is removed either way.
+    expect(migrated['max_tokens']).toBe(4096);
+    expect('max-tokens' in migrated).toBe(false);
+  });
+
+  it('applies the legacy value only when the canonical key is absent', () => {
+    const migrated = migrateLegacySettingKeys({ 'max-tokens': 1024 });
+    expect(migrated['max_tokens']).toBe(1024);
+    expect('max-tokens' in migrated).toBe(false);
+  });
+
+  it('rewrites a flat disabled-tools key into an existing nested tools container', () => {
+    const migrated = migrateLegacySettingKeys({
+      tools: { allowed: ['read_file'] },
+      'disabled-tools': ['shell'],
+    });
+    expect(migrated['tools']).toStrictEqual({
+      allowed: ['read_file'],
+      disabled: ['shell'],
+    });
+    expect('disabled-tools' in migrated).toBe(false);
+  });
+
+  it('writes a flat dotted tools.disabled key when no tools container exists', () => {
+    const migrated = migrateLegacySettingKeys({
+      'disabled-tools': ['shell'],
+    });
+    expect(migrated['tools.disabled']).toStrictEqual(['shell']);
+    expect('disabled-tools' in migrated).toBe(false);
+  });
+
+  it('keeps a nested tools.disabled value over a legacy disabled-tools value', () => {
+    const migrated = migrateLegacySettingKeys({
+      tools: { disabled: ['webproxy'] },
+      'disabled-tools': ['shell'],
+    });
+    expect(migrated['tools']).toStrictEqual({ disabled: ['webproxy'] });
+    expect('disabled-tools' in migrated).toBe(false);
+  });
+
+  it('migrates tools_allowed to tools.allowed', () => {
+    const migrated = migrateLegacySettingKeys({
+      tools_allowed: ['read_file', 'write_file'],
+    });
+    expect(migrated['tools.allowed']).toStrictEqual([
+      'read_file',
+      'write_file',
+    ]);
+    expect('tools_allowed' in migrated).toBe(false);
+  });
+
+  it('is idempotent: a second run changes nothing', () => {
+    const once = migrateLegacySettingKeys({
+      'max-tokens': 1024,
+      'disabled-tools': ['shell'],
+      tools: { allowed: ['read_file'] },
+    });
+    const twice = migrateLegacySettingKeys(once);
+    expect(twice).toStrictEqual(once);
+    expect(twice).toBe(once);
+  });
+
+  it('returns the input reference untouched when nothing needs migrating', () => {
+    const canonical = { max_tokens: 1024, 'tools.disabled': ['shell'] };
+    expect(migrateLegacySettingKeys(canonical)).toBe(canonical);
+  });
+
+  it('does not mutate nested containers owned by the caller', () => {
+    const tools = { allowed: ['read_file'] };
+    const raw = { tools, 'disabled-tools': ['shell'] };
+    const migrated = migrateLegacySettingKeys(raw);
+    expect(migrated['tools']).not.toBe(tools);
+    expect(tools).toStrictEqual({ allowed: ['read_file'] });
+    expect(raw['disabled-tools']).toStrictEqual(['shell']);
+  });
+});

--- a/packages/settings/src/__tests__/settingsRegistry.issue2182.test.ts
+++ b/packages/settings/src/__tests__/settingsRegistry.issue2182.test.ts
@@ -24,51 +24,60 @@ import {
   getSettingSpec,
   separateSettings,
 } from '../settings/settingsRegistry.js';
+import { migrateLegacySettingKeys } from '../settings/legacyKeyMigration.js';
 
-describe('issue #2182: streamIdleTimeoutMs camelCase alias', () => {
-  it('resolves streamIdleTimeoutMs to the canonical stream-idle-timeout-ms', () => {
-    expect(resolveAlias('streamIdleTimeoutMs')).toBe('stream-idle-timeout-ms');
+describe('issue #2182: stream idle timeout (canonical key + load-time migration)', () => {
+  it('canonical stream-idle-timeout-ms resolves exactly', () => {
+    expect(resolveAlias('stream-idle-timeout-ms')).toBe(
+      'stream-idle-timeout-ms',
+    );
   });
 
-  it('finds the cli-behavior spec for streamIdleTimeoutMs via the alias', () => {
-    const spec = getSettingSpec('streamIdleTimeoutMs');
+  it('legacy streamIdleTimeoutMs is migrated at load, not resolved', () => {
+    expect(resolveAlias('streamIdleTimeoutMs')).toBe('streamIdleTimeoutMs');
+    const migrated = migrateLegacySettingKeys({ streamIdleTimeoutMs: 60_000 });
+    expect(migrated['stream-idle-timeout-ms']).toBe(60_000);
+    expect('streamIdleTimeoutMs' in migrated).toBe(false);
+  });
+
+  it('finds the cli-behavior spec for the canonical key', () => {
+    const spec = getSettingSpec('stream-idle-timeout-ms');
     expect(spec?.key).toBe('stream-idle-timeout-ms');
     expect(spec?.category).toBe('cli-behavior');
   });
 
-  it('does not leak streamIdleTimeoutMs into modelParams for anthropic', () => {
+  it('does not leak the canonical key into modelParams for anthropic', () => {
     const result = separateSettings(
-      { streamIdleTimeoutMs: 60_000 },
+      { 'stream-idle-timeout-ms': 60_000 },
       'anthropic',
     );
-    expect(result.modelParams['streamIdleTimeoutMs']).toBeUndefined();
-    expect(result.modelParams['stream_idle_timeout_ms']).toBeUndefined();
     expect(result.modelParams['stream-idle-timeout-ms']).toBeUndefined();
+    expect(result.modelParams['stream_idle_timeout_ms']).toBeUndefined();
   });
 
-  it('classifies streamIdleTimeoutMs into cliSettings for every provider', () => {
+  it('classifies the canonical key into cliSettings for every provider', () => {
     for (const provider of ['anthropic', 'codex', 'openai', 'gemini']) {
       const result = separateSettings(
-        { streamIdleTimeoutMs: 60_000 },
+        { 'stream-idle-timeout-ms': 60_000 },
         provider,
       );
       expect(result.cliSettings['stream-idle-timeout-ms']).toBe(60_000);
       expect(Object.keys(result.modelParams)).not.toContain(
-        'streamIdleTimeoutMs',
+        'stream-idle-timeout-ms',
       );
     }
   });
 
-  it('treats the canonical hyphenated key identically', () => {
+  it('a migrated legacy value behaves identically to the canonical key', () => {
     const canonical = separateSettings(
       { 'stream-idle-timeout-ms': 60_000 },
       'anthropic',
     );
-    const camel = separateSettings(
-      { streamIdleTimeoutMs: 60_000 },
+    const migrated = separateSettings(
+      migrateLegacySettingKeys({ streamIdleTimeoutMs: 60_000 }),
       'anthropic',
     );
-    expect(camel.cliSettings['stream-idle-timeout-ms']).toBe(
+    expect(migrated.cliSettings['stream-idle-timeout-ms']).toBe(
       canonical.cliSettings['stream-idle-timeout-ms'],
     );
   });

--- a/packages/settings/src/__tests__/settingsRegistry.issue2607.test.ts
+++ b/packages/settings/src/__tests__/settingsRegistry.issue2607.test.ts
@@ -21,48 +21,57 @@ import {
   getSettingSpec,
   separateSettings,
 } from '../settings/settingsRegistry.js';
+import { migrateLegacySettingKeys } from '../settings/legacyKeyMigration.js';
 
-describe('issue #2607: streamFirstResponseTimeoutMs camelCase alias', () => {
-  it('resolves streamFirstResponseTimeoutMs to the canonical stream-first-response-timeout-ms', () => {
-    expect(resolveAlias('streamFirstResponseTimeoutMs')).toBe(
+describe('issue #2607: first-response watchdog (canonical key + load-time migration)', () => {
+  it('canonical stream-first-response-timeout-ms resolves exactly', () => {
+    expect(resolveAlias('stream-first-response-timeout-ms')).toBe(
       'stream-first-response-timeout-ms',
     );
   });
 
-  it('finds the cli-behavior spec for streamFirstResponseTimeoutMs via the alias', () => {
-    const spec = getSettingSpec('streamFirstResponseTimeoutMs');
+  it('legacy streamFirstResponseTimeoutMs is migrated at load, not resolved', () => {
+    expect(resolveAlias('streamFirstResponseTimeoutMs')).toBe(
+      'streamFirstResponseTimeoutMs',
+    );
+    const migrated = migrateLegacySettingKeys({
+      streamFirstResponseTimeoutMs: 300_000,
+    });
+    expect(migrated['stream-first-response-timeout-ms']).toBe(300_000);
+    expect('streamFirstResponseTimeoutMs' in migrated).toBe(false);
+  });
+
+  it('finds the cli-behavior spec for the canonical key', () => {
+    const spec = getSettingSpec('stream-first-response-timeout-ms');
     expect(spec?.key).toBe('stream-first-response-timeout-ms');
     expect(spec?.category).toBe('cli-behavior');
   });
 
-  it('classifies streamFirstResponseTimeoutMs into cliSettings (not modelParams) for every provider', () => {
+  it('classifies the canonical key into cliSettings (not modelParams) for every provider', () => {
     for (const provider of ['anthropic', 'codex', 'openai', 'gemini']) {
       const result = separateSettings(
-        { streamFirstResponseTimeoutMs: 300_000 },
+        { 'stream-first-response-timeout-ms': 300_000 },
         provider,
       );
       expect(result.cliSettings['stream-first-response-timeout-ms']).toBe(
         300_000,
       );
       expect(
-        result.modelParams['streamFirstResponseTimeoutMs'],
-      ).toBeUndefined();
-      expect(
         result.modelParams['stream-first-response-timeout-ms'],
       ).toBeUndefined();
     }
   });
 
-  it('treats the canonical hyphenated key identically', () => {
+  it('a migrated legacy value behaves identically to the canonical key', () => {
     const canonical = separateSettings(
       { 'stream-first-response-timeout-ms': 300_000 },
       'anthropic',
     );
-    const camel = separateSettings(
-      { streamFirstResponseTimeoutMs: 300_000 },
+    const migrated = separateSettings(
+      migrateLegacySettingKeys({ streamFirstResponseTimeoutMs: 300_000 }),
       'anthropic',
     );
-    expect(camel.cliSettings['stream-first-response-timeout-ms']).toBe(
+    expect(migrated.cliSettings['stream-first-response-timeout-ms']).toBe(
       canonical.cliSettings['stream-first-response-timeout-ms'],
     );
   });

--- a/packages/settings/src/__tests__/settingsRegistry.redaction.test.ts
+++ b/packages/settings/src/__tests__/settingsRegistry.redaction.test.ts
@@ -17,12 +17,15 @@ describe('redactSensitiveValues', () => {
     });
   });
 
-  it('redacts auth-key aliases', () => {
+  it('no longer redacts legacy auth-key spellings (#2533 C1: migrated at load)', () => {
+    // Legacy spellings are not registry keys anymore; they are rewritten to
+    // 'auth-key' by migrateLegacySettingKeys before values reach storage.
+    // After migration the canonical key is what gets redacted.
     expect(
       redactSensitiveValues({ apiKey: 'first', 'api-key': 'second' }),
     ).toStrictEqual({
-      apiKey: REDACTED_VALUE,
-      'api-key': REDACTED_VALUE,
+      apiKey: 'first',
+      'api-key': 'second',
     });
   });
 

--- a/packages/settings/src/__tests__/settingsRegistry.test.ts
+++ b/packages/settings/src/__tests__/settingsRegistry.test.ts
@@ -30,6 +30,7 @@ import {
   getProviderConfigKeys,
   getDirectSettingSpecs,
 } from '../settings/settingsRegistry.js';
+import { LEGACY_SETTING_KEY_MIGRATIONS } from '../settings/legacyKeyMigration.js';
 
 // ---------------------------------------------------------------------------
 // Compression strategy literal values — tested without importing core
@@ -44,50 +45,37 @@ const EXPECTED_COMPRESSION_STRATEGIES = [
   'high-density',
 ] as const;
 
-describe('resolveAlias — alias normalization', () => {
-  it('resolves max-tokens to max_tokens', () => {
-    expect(resolveAlias('max-tokens')).toBe('max_tokens');
-  });
-
-  it('resolves maxTokens to max_tokens', () => {
-    expect(resolveAlias('maxTokens')).toBe('max_tokens');
-  });
-
-  it('resolves response-format to response_format', () => {
-    expect(resolveAlias('response-format')).toBe('response_format');
-  });
-
-  it('resolves responseFormat to response_format', () => {
-    expect(resolveAlias('responseFormat')).toBe('response_format');
-  });
-
-  it('resolves tool-choice to tool_choice', () => {
-    expect(resolveAlias('tool-choice')).toBe('tool_choice');
-  });
-
-  it('resolves toolChoice to tool_choice', () => {
-    expect(resolveAlias('toolChoice')).toBe('tool_choice');
-  });
-
-  it('resolves disabled-tools to tools.disabled', () => {
-    expect(resolveAlias('disabled-tools')).toBe('tools.disabled');
-  });
-
-  it('resolves streamIdleTimeoutMs to stream-idle-timeout-ms', () => {
-    expect(resolveAlias('streamIdleTimeoutMs')).toBe('stream-idle-timeout-ms');
-  });
-
-  it('preserves user-agent without underscore conversion', () => {
+describe('resolveAlias — exact canonical-key semantics (#2533 C1)', () => {
+  it('returns canonical registry keys unchanged', () => {
+    expect(resolveAlias('max_tokens')).toBe('max_tokens');
+    expect(resolveAlias('response_format')).toBe('response_format');
+    expect(resolveAlias('tool_choice')).toBe('tool_choice');
+    expect(resolveAlias('tools.disabled')).toBe('tools.disabled');
+    expect(resolveAlias('stream-idle-timeout-ms')).toBe(
+      'stream-idle-timeout-ms',
+    );
     expect(resolveAlias('user-agent')).toBe('user-agent');
-  });
-
-  it('returns temperature unchanged (already canonical)', () => {
     expect(resolveAlias('temperature')).toBe('temperature');
+    expect(resolveAlias('auth-key')).toBe('auth-key');
   });
 
-  it('returns an unknown key unchanged', () => {
+  it('does NOT resolve legacy spellings — they are migrated at load instead', () => {
+    // Legacy spellings pass through untouched; load-time
+    // migrateLegacySettingKeys is the only thing that rewrites them.
+    expect(resolveAlias('max-tokens')).toBe('max-tokens');
+    expect(resolveAlias('maxTokens')).toBe('maxTokens');
+    expect(resolveAlias('response-format')).toBe('response-format');
+    expect(resolveAlias('responseFormat')).toBe('responseFormat');
+    expect(resolveAlias('tool-choice')).toBe('tool-choice');
+    expect(resolveAlias('toolChoice')).toBe('toolChoice');
+    expect(resolveAlias('disabled-tools')).toBe('disabled-tools');
+    expect(resolveAlias('apiKey')).toBe('apiKey');
+    expect(resolveAlias('streamIdleTimeoutMs')).toBe('streamIdleTimeoutMs');
+  });
+
+  it('returns an unknown key unchanged with NO kebab-to-snake fallback', () => {
     expect(resolveAlias('completely-unknown-key')).toBe(
-      'completely_unknown_key',
+      'completely-unknown-key',
     );
   });
 });
@@ -103,10 +91,10 @@ describe('getSettingSpec — spec lookup', () => {
     expect(spec?.category).toBe('cli-behavior');
   });
 
-  it('resolves apiKey alias to auth-key canonical spec', () => {
+  it('resolves the auth-key canonical spec directly (#2533 C1: no aliases)', () => {
     const spec = getSettingSpec('auth-key');
     expect(spec?.category).toBe('provider-config');
-    expect(spec?.aliases).toContain('apiKey');
+    expect(spec?.key).toBe('auth-key');
   });
 
   it('resolves auth-key canonical spec directly', () => {
@@ -115,18 +103,18 @@ describe('getSettingSpec — spec lookup', () => {
     expect(spec?.persistToProfile).toBe(true);
   });
 
-  it('resolves auth-keyfile canonical spec with apiKeyfile alias', () => {
+  it('resolves the auth-keyfile canonical spec without aliases', () => {
     const spec = getSettingSpec('auth-keyfile');
     expect(spec?.category).toBe('provider-config');
-    expect(spec?.aliases).toContain('apiKeyfile');
+    expect(spec?.key).toBe('auth-keyfile');
   });
 
-  it('resolves apiKey to auth-key via resolveAlias', () => {
-    expect(resolveAlias('apiKey')).toBe('auth-key');
+  it('does not resolve legacy apiKey to auth-key via resolveAlias', () => {
+    expect(resolveAlias('apiKey')).toBe('apiKey');
   });
 
-  it('resolves apiKeyfile to auth-keyfile via resolveAlias', () => {
-    expect(resolveAlias('apiKeyfile')).toBe('auth-keyfile');
+  it('does not resolve legacy apiKeyfile to auth-keyfile via resolveAlias', () => {
+    expect(resolveAlias('apiKeyfile')).toBe('apiKeyfile');
   });
 
   it('returns a spec with type enum for compression.strategy', () => {
@@ -191,42 +179,45 @@ describe('separateSettings — settings categorization', () => {
     expect(result.customHeaders['X-Foo']).toBe('bar');
   });
 
-  it('does not include apiKey in cliSettings (provider-config filtered)', () => {
-    const result = separateSettings({ apiKey: 'sk-123' });
-    expect(result.cliSettings.apiKey).toBeUndefined();
-  });
-
-  it('does not include apiKey in modelParams', () => {
-    const result = separateSettings({ apiKey: 'sk-123' });
-    expect(result.modelParams.apiKey).toBeUndefined();
-  });
-
   it('places unknown keys in modelParams as pass-through', () => {
     const result = separateSettings({ unknownKey: 'val' });
     expect(result.modelParams.unknownKey).toBe('val');
   });
 
-  it('resolves max-tokens alias to max_tokens in modelParams', () => {
-    const result = separateSettings({ 'max-tokens': 4096 });
+  it('does not special-case legacy apiKey: unknown keys pass through (provider-config filtered after migration)', () => {
+    // With exact-key semantics the registry no longer resolves 'apiKey';
+    // it must be migrated to 'auth-key' at load (legacyKeyMigration).
+    const result = separateSettings({ apiKey: 'sk-123' });
+    expect(result.cliSettings.apiKey).toBeUndefined();
+    expect(result.cliSettings['auth-key']).toBeUndefined();
+  });
+
+  it('migrated canonical max_tokens lands in modelParams', () => {
+    const result = separateSettings({ max_tokens: 4096 });
     expect(result.modelParams.max_tokens).toBe(4096);
   });
 
-  it('places streamIdleTimeoutMs (camelCase) in cliSettings, never modelParams', () => {
-    const result = separateSettings({ streamIdleTimeoutMs: 0 });
+  it('places canonical stream-idle-timeout-ms in cliSettings, never modelParams', () => {
+    const result = separateSettings({ 'stream-idle-timeout-ms': 0 });
     expect(result.cliSettings['stream-idle-timeout-ms']).toBe(0);
-    expect(result.modelParams.streamIdleTimeoutMs).toBeUndefined();
     expect(result.modelParams['stream-idle-timeout-ms']).toBeUndefined();
   });
 
-  it('does not leak streamIdleTimeoutMs into modelParams for anthropic', () => {
-    const result = separateSettings({ streamIdleTimeoutMs: 5000 }, 'anthropic');
-    expect(result.modelParams.streamIdleTimeoutMs).toBeUndefined();
+  it('does not leak canonical stream-idle-timeout-ms into modelParams for anthropic', () => {
+    const result = separateSettings(
+      { 'stream-idle-timeout-ms': 5000 },
+      'anthropic',
+    );
+    expect(result.modelParams['stream-idle-timeout-ms']).toBeUndefined();
     expect(result.cliSettings['stream-idle-timeout-ms']).toBe(5000);
   });
 
-  it('does not leak streamIdleTimeoutMs into modelParams for openai', () => {
-    const result = separateSettings({ streamIdleTimeoutMs: 5000 }, 'openai');
-    expect(result.modelParams.streamIdleTimeoutMs).toBeUndefined();
+  it('does not leak canonical stream-idle-timeout-ms into modelParams for openai', () => {
+    const result = separateSettings(
+      { 'stream-idle-timeout-ms': 5000 },
+      'openai',
+    );
+    expect(result.modelParams['stream-idle-timeout-ms']).toBeUndefined();
     expect(result.cliSettings['stream-idle-timeout-ms']).toBe(5000);
   });
 
@@ -648,32 +639,28 @@ describe('getProfilePersistableKeys — profile persistence', () => {
     expect(keys).toContain('auth-keyfile');
   });
 
-  it('apiKey alias resolves to auth-key spec via getSettingSpec', () => {
-    const spec = getSettingSpec('apiKey');
-    expect(spec).toBeDefined();
-    expect(spec?.key).toBe('auth-key');
-    expect(spec?.category).toBe('provider-config');
-    expect(spec?.aliases).toContain('apiKey');
+  it('legacy apiKey has no spec — it must be migrated at load (#2533 C1)', () => {
+    expect(getSettingSpec('apiKey')).toBeUndefined();
+    expect(LEGACY_SETTING_KEY_MIGRATIONS.get('apiKey')).toBe('auth-key');
   });
 
-  it('apiKeyfile alias resolves to auth-keyfile spec via getSettingSpec', () => {
-    const spec = getSettingSpec('apiKeyfile');
-    expect(spec).toBeDefined();
-    expect(spec?.key).toBe('auth-keyfile');
-    expect(spec?.category).toBe('provider-config');
-    expect(spec?.aliases).toContain('apiKeyfile');
+  it('legacy apiKeyfile has no spec — it must be migrated at load', () => {
+    expect(getSettingSpec('apiKeyfile')).toBeUndefined();
+    expect(LEGACY_SETTING_KEY_MIGRATIONS.get('apiKeyfile')).toBe(
+      'auth-keyfile',
+    );
   });
 
-  it('api-key alias resolves to auth-key spec via getSettingSpec', () => {
-    const spec = getSettingSpec('api-key');
-    expect(spec).toBeDefined();
-    expect(spec?.key).toBe('auth-key');
+  it('legacy api-key has no spec — it must be migrated at load', () => {
+    expect(getSettingSpec('api-key')).toBeUndefined();
+    expect(LEGACY_SETTING_KEY_MIGRATIONS.get('api-key')).toBe('auth-key');
   });
 
-  it('api-keyfile alias resolves to auth-keyfile spec via getSettingSpec', () => {
-    const spec = getSettingSpec('api-keyfile');
-    expect(spec).toBeDefined();
-    expect(spec?.key).toBe('auth-keyfile');
+  it('legacy api-keyfile has no spec — it must be migrated at load', () => {
+    expect(getSettingSpec('api-keyfile')).toBeUndefined();
+    expect(LEGACY_SETTING_KEY_MIGRATIONS.get('api-keyfile')).toBe(
+      'auth-keyfile',
+    );
   });
 });
 
@@ -734,9 +721,10 @@ describe('getProtectedSettingKeys — protected/hidden keys', () => {
     expect(keys).toContain('auth-key');
   });
 
-  it('includes apiKey alias in protected keys', () => {
+  it('no longer includes legacy apiKey alias in protected keys (#2533 C1)', () => {
     const keys = getProtectedSettingKeys();
-    expect(keys).toContain('apiKey');
+    expect(keys).not.toContain('apiKey');
+    expect(keys).toContain('auth-key');
   });
 
   it('includes auth-keyfile in protected keys', () => {
@@ -761,9 +749,9 @@ describe('getProviderConfigKeys — provider config key enumeration', () => {
     expect(keys).toContain('auth-key');
   });
 
-  it('includes apiKey alias', () => {
+  it('no longer includes legacy apiKey alias (#2533 C1)', () => {
     const keys = getProviderConfigKeys();
-    expect(keys).toContain('apiKey');
+    expect(keys).not.toContain('apiKey');
   });
 
   it('includes auth-keyfile canonical', () => {
@@ -771,9 +759,9 @@ describe('getProviderConfigKeys — provider config key enumeration', () => {
     expect(keys).toContain('auth-keyfile');
   });
 
-  it('includes apiKeyfile alias', () => {
+  it('no longer includes legacy apiKeyfile alias (#2533 C1)', () => {
     const keys = getProviderConfigKeys();
-    expect(keys).toContain('apiKeyfile');
+    expect(keys).not.toContain('apiKeyfile');
   });
 
   it('includes base-url', () => {

--- a/packages/settings/src/__tests__/settingsRegistry.test.ts
+++ b/packages/settings/src/__tests__/settingsRegistry.test.ts
@@ -184,12 +184,13 @@ describe('separateSettings — settings categorization', () => {
     expect(result.modelParams.unknownKey).toBe('val');
   });
 
-  it('does not special-case legacy apiKey: unknown keys pass through (provider-config filtered after migration)', () => {
-    // With exact-key semantics the registry no longer resolves 'apiKey';
-    // it must be migrated to 'auth-key' at load (legacyKeyMigration).
+  it('does not pass legacy apiKey into any request settings bucket', () => {
+    // The legacy spelling is never resolved here; persisted input migrates at
+    // load, while this final separation boundary drops it from request data.
     const result = separateSettings({ apiKey: 'sk-123' });
     expect(result.cliSettings.apiKey).toBeUndefined();
     expect(result.cliSettings['auth-key']).toBeUndefined();
+    expect(result.modelParams.apiKey).toBeUndefined();
   });
 
   it('migrated canonical max_tokens lands in modelParams', () => {

--- a/packages/settings/src/index.ts
+++ b/packages/settings/src/index.ts
@@ -39,6 +39,7 @@ export {
   SETTINGS_REGISTRY,
 } from './settings/settingsRegistry.js';
 export {
+  assertCanonicalSettingKey,
   LEGACY_SETTING_KEY_MIGRATIONS,
   migrateLegacySettingKeys,
 } from './settings/legacyKeyMigration.js';

--- a/packages/settings/src/index.ts
+++ b/packages/settings/src/index.ts
@@ -38,6 +38,10 @@ export {
   REDACTED_VALUE,
   SETTINGS_REGISTRY,
 } from './settings/settingsRegistry.js';
+export {
+  LEGACY_SETTING_KEY_MIGRATIONS,
+  migrateLegacySettingKeys,
+} from './settings/legacyKeyMigration.js';
 export { isStrictNumericString } from './settings/numericString.js';
 export type {
   ValidationResult,

--- a/packages/settings/src/profiles/ProfileManager.ts
+++ b/packages/settings/src/profiles/ProfileManager.ts
@@ -388,7 +388,7 @@ export class ProfileManager {
         'prompt-caching': parsePromptCaching(
           providerSettings['prompt-caching'],
         ),
-        'tool-format': optionalString(providerSettings.toolFormat),
+        toolFormat: optionalString(providerSettings.toolFormat),
       } satisfies EphemeralSettings,
     };
 
@@ -432,7 +432,7 @@ export class ProfileManager {
           'auth-key': profile.ephemeralSettings['auth-key'],
           'auth-keyfile': profile.ephemeralSettings['auth-keyfile'],
           'prompt-caching': profile.ephemeralSettings['prompt-caching'],
-          toolFormat: profile.ephemeralSettings['tool-format'],
+          toolFormat: profile.ephemeralSettings.toolFormat,
         },
       },
       tools: {

--- a/packages/settings/src/profiles/ProfileManager.ts
+++ b/packages/settings/src/profiles/ProfileManager.ts
@@ -22,6 +22,7 @@ import {
   parseProfileJson,
   parsePromptCaching,
 } from '../settings/validation.js';
+import { migrateLegacySettingKeys } from '../settings/legacyKeyMigration.js';
 
 import fs from 'fs/promises';
 import path from 'path';
@@ -224,6 +225,16 @@ export class ProfileManager {
           ? parseLoadBalancerProfile(profileName, parsed)
           : parseProfile(parsed);
 
+      if (!isLoadBalancerProfile(profile)) {
+        // The one allowed compat point (#2533 Phase C1): profiles exported
+        // before the canonical-key policy may persist legacy ephemeral key
+        // spellings (e.g. 'disabled-tools'); migrate them once at load so
+        // everything downstream reads canonical keys only.
+        profile.ephemeralSettings = migrateLegacySettingKeys(
+          profile.ephemeralSettings as unknown as Record<string, unknown>,
+        ) as unknown as EphemeralSettings;
+      }
+
       if (isLoadBalancerProfile(profile)) {
         await this.validateLoadBalancerReferences(profileName, profile);
       }
@@ -390,7 +401,6 @@ export class ProfileManager {
 
     profile.ephemeralSettings['tools.allowed'] = toolsAllowed;
     profile.ephemeralSettings['tools.disabled'] = toolsDisabled;
-    profile.ephemeralSettings['disabled-tools'] = toolsDisabled;
 
     if (typeof settingsService.setCurrentProfileName === 'function') {
       settingsService.setCurrentProfileName(profileName);
@@ -408,15 +418,7 @@ export class ProfileManager {
     const allowedTools = stringArray(allowedValue);
 
     const disabledValue = profile.ephemeralSettings['tools.disabled'];
-    const legacyDisabled = profile.ephemeralSettings['disabled-tools'];
-    let disabledTools: string[];
-    if (Array.isArray(disabledValue)) {
-      disabledTools = stringArray(disabledValue);
-    } else if (Array.isArray(legacyDisabled)) {
-      disabledTools = stringArray(legacyDisabled);
-    } else {
-      disabledTools = [];
-    }
+    const disabledTools: string[] = stringArray(disabledValue);
 
     return {
       defaultProvider: profile.provider,
@@ -449,7 +451,6 @@ export class ProfileManager {
     if (settingsService.set) {
       settingsService.set('tools.allowed', settingsData.tools.allowed);
       settingsService.set('tools.disabled', settingsData.tools.disabled);
-      settingsService.set('disabled-tools', settingsData.tools.disabled);
     }
   }
 

--- a/packages/settings/src/profiles/__tests__/ProfileManager.test.ts
+++ b/packages/settings/src/profiles/__tests__/ProfileManager.test.ts
@@ -347,7 +347,8 @@ describe('ProfileManager — save and load with SettingsService', () => {
       'false',
     ]);
     expect(appliedData['tools.disabled']).toStrictEqual(['2', 'shell']);
-    expect(appliedData['disabled-tools']).toStrictEqual(['2', 'shell']);
+    // #2533 C1: canonical keys only — no legacy 'disabled-tools' write.
+    expect(appliedData['disabled-tools']).toBeUndefined();
   });
 
   it('load normalizes legacy disabled-tools entries before applying settings', async () => {
@@ -373,14 +374,13 @@ describe('ProfileManager — save and load with SettingsService', () => {
 
     await pm.load('legacy-tool-normalization', mockSettingsService);
 
+    // The legacy spelling is migrated once at profile load (#2533 C1
+    // compat point), then applied under the canonical key only.
     expect(appliedData['tools.disabled']).toStrictEqual([
       '3',
       'read_many_files',
     ]);
-    expect(appliedData['disabled-tools']).toStrictEqual([
-      '3',
-      'read_many_files',
-    ]);
+    expect(appliedData['disabled-tools']).toBeUndefined();
   });
 
   it('save persists auth-keyfile in ephemeralSettings', async () => {

--- a/packages/settings/src/profiles/__tests__/ProfileManager.test.ts
+++ b/packages/settings/src/profiles/__tests__/ProfileManager.test.ts
@@ -317,6 +317,30 @@ describe('ProfileManager — save and load with SettingsService', () => {
     expect(appliedData['currentProfile']).toBe('load-target');
   });
 
+  it('saves and loads toolFormat through provider settings', async () => {
+    await pm.save('tool-format-profile', {
+      exportForProfile: async () => ({
+        defaultProvider: 'openai',
+        providers: { openai: { model: 'gpt-4', toolFormat: 'xml' } },
+      }),
+    });
+
+    const saved: unknown = JSON.parse(
+      await fs.readFile(path.join(tempDir, 'tool-format-profile.json'), 'utf8'),
+    );
+    expect(saved).toMatchObject({ ephemeralSettings: { toolFormat: 'xml' } });
+
+    let imported: unknown;
+    await pm.load('tool-format-profile', {
+      importFromProfile: async (data: unknown) => {
+        imported = data;
+      },
+    });
+    expect(imported).toMatchObject({
+      providers: { openai: { toolFormat: 'xml' } },
+    });
+  });
+
   it('load normalizes tool array entries before applying settings', async () => {
     const profile = {
       version: 1,

--- a/packages/settings/src/profiles/types.ts
+++ b/packages/settings/src/profiles/types.ts
@@ -103,7 +103,7 @@ export interface ProfileEphemeralSettings {
   'base-url'?: string;
   'sandbox-base-url'?: string;
   'requires-auth'?: boolean;
-  'tool-format'?: string;
+  toolFormat?: string;
   'api-version'?: string;
   'custom-headers'?: Record<string, string>;
   'tool-output-max-items'?: number;
@@ -180,9 +180,7 @@ export interface ProfileEphemeralSettings {
   'compression.density.recencyRetention'?: number;
   'compression.density.compressHeadroom'?: number;
   'stream-first-response-timeout-ms'?: number;
-  streamFirstResponseTimeoutMs?: number;
   'stream-idle-timeout-ms'?: number;
-  streamIdleTimeoutMs?: number;
   'image-payload-budget-bytes'?: number;
   'media-store-quota-bytes'?: number;
   'session-recording-queue-max-bytes'?: number;

--- a/packages/settings/src/profiles/types.ts
+++ b/packages/settings/src/profiles/types.ts
@@ -117,7 +117,6 @@ export interface ProfileEphemeralSettings {
   'max-image-dimension'?: number;
   'max-image-pixels'?: number;
   'max-prompt-tokens'?: number;
-  'disabled-tools'?: string[];
   'shell-replacement'?: 'allowlist' | 'all' | 'none' | boolean;
   'todo-continuation'?: boolean;
   'socket-timeout'?: number;

--- a/packages/settings/src/settings/SettingsService.ts
+++ b/packages/settings/src/settings/SettingsService.ts
@@ -492,18 +492,9 @@ export class SettingsService extends EventEmitter {
 
     const allowedValue = this.get('tools.allowed');
     const disabledValue = this.get('tools.disabled');
-    const legacyDisabled = this.get('disabled-tools');
 
     const allowedTools = copyStringArray(allowedValue);
-
-    let disabledTools: string[];
-    if (Array.isArray(disabledValue)) {
-      disabledTools = copyStringArray(disabledValue);
-    } else if (Array.isArray(legacyDisabled)) {
-      disabledTools = copyStringArray(legacyDisabled);
-    } else {
-      disabledTools = [];
-    }
+    const disabledTools = copyStringArray(disabledValue);
 
     const providers: Record<string, Record<string, unknown>> = {};
     for (const [provider, settings] of Object.entries(
@@ -549,7 +540,6 @@ export class SettingsService extends EventEmitter {
       allowed: toolsAllowed,
       disabled: toolsDisabled,
     };
-    this.settings.global['disabled-tools'] = toolsDisabled;
 
     return Promise.resolve();
   }

--- a/packages/settings/src/settings/SettingsService.ts
+++ b/packages/settings/src/settings/SettingsService.ts
@@ -23,6 +23,7 @@ import {
   assertSessionScopedKey,
 } from './settingsRegistry.js';
 import { SessionSettingsOverlay } from './SessionSettingsOverlay.js';
+import { assertCanonicalSettingKey } from './legacyKeyMigration.js';
 
 function redactEventValue(key: string, value: unknown): unknown {
   return isSensitiveSettingKey(key) ? REDACTED_VALUE : value;
@@ -131,6 +132,7 @@ export class SettingsService extends EventEmitter {
   }
 
   set(key: string, value: unknown): void {
+    assertCanonicalSettingKey(key);
     const oldValue = this.get(key);
 
     if (key.includes('.')) {
@@ -235,6 +237,7 @@ export class SettingsService extends EventEmitter {
   }
 
   setProviderSetting(provider: string, key: string, value: unknown): void {
+    assertCanonicalSettingKey(key);
     this.assertSafePath([provider]);
     const entry = this.getOrCreateProvider(provider);
     const oldValue = entry[key];

--- a/packages/settings/src/settings/legacyKeyMigration.ts
+++ b/packages/settings/src/settings/legacyKeyMigration.ts
@@ -1,0 +1,132 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @issue #2533 Phase C1
+ *
+ * Every settings key has exactly ONE canonical spelling. Legacy spellings
+ * (old aliases, camelCase, kebab-case variants) are NOT resolved at read
+ * time anymore; they are rewritten ONCE to the canonical key at load via
+ * {@link migrateLegacySettingKeys}. The registry performs exact-key lookups
+ * only.
+ */
+
+/**
+ * Legacy setting-key spellings → canonical registry key. Keys that were
+ * accepted by the old alias resolution (ALIAS_NORMALIZATION_RULES, spec
+ * aliases, and the tools_allowed spelling accepted by subagent ephemeral
+ * population) map to their one canonical key here.
+ */
+export const LEGACY_SETTING_KEY_MIGRATIONS: ReadonlyMap<string, string> =
+  new Map<string, string>([
+    // model params
+    ['max-tokens', 'max_tokens'],
+    ['maxTokens', 'max_tokens'],
+    ['max-output-tokens', 'max_output_tokens'],
+    ['max-output', 'maxOutputTokens'],
+    ['response-format', 'response_format'],
+    ['responseFormat', 'response_format'],
+    ['tool-choice', 'tool_choice'],
+    ['toolChoice', 'tool_choice'],
+    // provider config
+    ['apiKey', 'auth-key'],
+    ['api-key', 'auth-key'],
+    ['apiKeyfile', 'auth-keyfile'],
+    ['api-keyfile', 'auth-keyfile'],
+    ['tool-format', 'toolFormat'],
+    ['tool-format-override', 'toolFormatOverride'],
+    // headers
+    ['User-Agent', 'user-agent'],
+    // tool governance (canonical keys are dotted)
+    ['disabled-tools', 'tools.disabled'],
+    ['tools_allowed', 'tools.allowed'],
+    // stream watchdogs (settings.json historically stored camelCase)
+    ['streamIdleTimeoutMs', 'stream-idle-timeout-ms'],
+    ['streamFirstResponseTimeoutMs', 'stream-first-response-timeout-ms'],
+  ]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Reports whether `raw` already carries a value for the canonical dotted
+ * `key` ('tools.disabled'), either as a nested leaf (settings.json shape:
+ * `tools: { disabled: [...] }`) or as a flat dotted key (ephemeral-settings
+ * map shape: `'tools.disabled'`).
+ */
+function hasCanonicalValue(raw: Record<string, unknown>, key: string): boolean {
+  if (key in raw) {
+    return true;
+  }
+  const dotIndex = key.indexOf('.');
+  if (dotIndex <= 0) {
+    return false;
+  }
+  const container = raw[key.slice(0, dotIndex)];
+  const leaf = key.slice(dotIndex + 1);
+  return isPlainObject(container) && leaf in container;
+}
+
+/**
+ * Writes `value` at the canonical dotted `key`, matching the shape already
+ * used by the surrounding map: nested under the existing container when one
+ * is present, otherwise as a flat dotted key.
+ */
+function writeCanonicalValue(
+  raw: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void {
+  const dotIndex = key.indexOf('.');
+  if (dotIndex <= 0) {
+    raw[key] = value;
+    return;
+  }
+  const containerKey = key.slice(0, dotIndex);
+  const leaf = key.slice(dotIndex + 1);
+  const container = raw[containerKey];
+  if (isPlainObject(container)) {
+    // Copy before mutating so a nested container owned by the caller (e.g. a
+    // loaded settings scope) is not modified in place.
+    raw[containerKey] = { ...container, [leaf]: value };
+    return;
+  }
+  raw[key] = value;
+}
+
+/**
+ * Rewrites legacy setting-key spellings to their canonical key once, and
+ * deletes the legacy key.
+ *
+ * Collision policy: the CANONICAL value wins. A legacy value is applied only
+ * when no canonical value is present (nested leaf or flat dotted key); the
+ * legacy key is deleted either way. This keeps a file that carries both a
+ * stale legacy value and an up-to-date canonical value deterministic.
+ *
+ * Idempotent: a map that is already canonical is returned unchanged (a
+ * second run is a no-op).
+ */
+export function migrateLegacySettingKeys(
+  raw: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...raw };
+  let changed = false;
+
+  for (const [legacyKey, canonicalKey] of LEGACY_SETTING_KEY_MIGRATIONS) {
+    if (!(legacyKey in result)) {
+      continue;
+    }
+    const legacyValue = result[legacyKey];
+    delete result[legacyKey];
+    if (!hasCanonicalValue(result, canonicalKey)) {
+      writeCanonicalValue(result, canonicalKey, legacyValue);
+    }
+    changed = true;
+  }
+
+  return changed ? result : raw;
+}

--- a/packages/settings/src/settings/legacyKeyMigration.ts
+++ b/packages/settings/src/settings/legacyKeyMigration.ts
@@ -36,6 +36,11 @@ export const LEGACY_SETTING_KEY_MIGRATIONS: ReadonlyMap<string, string> =
     ['api-key', 'auth-key'],
     ['apiKeyfile', 'auth-keyfile'],
     ['api-keyfile', 'auth-keyfile'],
+    ['baseUrl', 'base-url'],
+    ['baseurl', 'base-url'],
+    ['base_url', 'base-url'],
+    ['BaseUrl', 'base-url'],
+    ['BaseURL', 'base-url'],
     ['tool-format', 'toolFormat'],
     ['tool-format-override', 'toolFormatOverride'],
     // headers

--- a/packages/settings/src/settings/legacyKeyMigration.ts
+++ b/packages/settings/src/settings/legacyKeyMigration.ts
@@ -104,6 +104,19 @@ function writeCanonicalValue(
 }
 
 /**
+ * Rejects a known legacy spelling at a mutation boundary. Migration is only
+ * permitted while loading persisted state.
+ */
+export function assertCanonicalSettingKey(key: string): void {
+  const canonicalKey = LEGACY_SETTING_KEY_MIGRATIONS.get(key);
+  if (canonicalKey !== undefined) {
+    throw new Error(
+      `Setting '${key}' is not recognized; use the canonical '${canonicalKey}'.`,
+    );
+  }
+}
+
+/**
  * Rewrites legacy setting-key spellings to their canonical key once, and
  * deletes the legacy key.
  *

--- a/packages/settings/src/settings/registry/registry-entries-1.ts
+++ b/packages/settings/src/settings/registry/registry-entries-1.ts
@@ -110,7 +110,6 @@ function validateReasoningEnabledMap(value: unknown): ValidationResult {
 export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   {
     key: 'auth-key',
-    aliases: ['apiKey', 'api-key'],
     category: 'provider-config',
     owner: 'provider-connection',
     propagation: 'service-reconfigure',
@@ -121,7 +120,6 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   },
   {
     key: 'auth-keyfile',
-    aliases: ['apiKeyfile', 'api-keyfile'],
     category: 'provider-config',
     owner: 'provider-connection',
     propagation: 'service-reconfigure',
@@ -197,7 +195,6 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   },
   {
     key: 'toolFormat',
-    aliases: ['tool-format'],
     category: 'provider-config',
     owner: 'provider-connection',
     propagation: 'service-reconfigure',
@@ -219,7 +216,6 @@ export const REGISTRY_ENTRIES_PART_1: readonly SettingSpec[] = [
   },
   {
     key: 'toolFormatOverride',
-    aliases: ['tool-format-override'],
     category: 'provider-config',
     owner: 'provider-connection',
     propagation: 'service-reconfigure',

--- a/packages/settings/src/settings/registry/registry-entries-2.ts
+++ b/packages/settings/src/settings/registry/registry-entries-2.ts
@@ -316,7 +316,6 @@ export const REGISTRY_ENTRIES_PART_2: readonly SettingSpec[] = [
   },
   {
     key: 'tools.disabled',
-    aliases: ['disabled-tools'],
     category: 'cli-behavior',
     owner: 'agent-policy',
     propagation: 'next-turn',

--- a/packages/settings/src/settings/registry/registry-entries-3.ts
+++ b/packages/settings/src/settings/registry/registry-entries-3.ts
@@ -32,7 +32,6 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   },
   {
     key: 'max_tokens',
-    aliases: ['max-tokens', 'maxTokens'],
     category: 'model-param',
     owner: 'model',
     propagation: 'next-turn',
@@ -42,7 +41,6 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   },
   {
     key: 'max_output_tokens',
-    aliases: ['max-output-tokens'],
     category: 'model-param',
     owner: 'model',
     propagation: 'next-turn',
@@ -52,7 +50,6 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   },
   {
     key: 'maxOutputTokens',
-    aliases: ['max-output'],
     category: 'cli-behavior',
     owner: 'model',
     propagation: 'next-turn',
@@ -117,7 +114,6 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   },
   {
     key: 'response_format',
-    aliases: ['response-format', 'responseFormat'],
     category: 'model-param',
     owner: 'model',
     propagation: 'next-turn',
@@ -136,7 +132,6 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   },
   {
     key: 'tool_choice',
-    aliases: ['tool-choice', 'toolChoice'],
     category: 'model-param',
     owner: 'model',
     propagation: 'next-turn',
@@ -184,7 +179,6 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   },
   {
     key: 'user-agent',
-    aliases: ['User-Agent'],
     category: 'custom-header',
     owner: 'provider-connection',
     propagation: 'service-reconfigure',
@@ -466,10 +460,6 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   },
   {
     key: 'stream-idle-timeout-ms',
-    // settings.json stores this under the camelCase key; the alias keeps it a
-    // recognized CLI setting so it is not treated as an unknown pass-through
-    // model-param and leaked into API request bodies. @issue #2182
-    aliases: ['streamIdleTimeoutMs'],
     category: 'cli-behavior',
     owner: 'model',
     propagation: 'next-turn',
@@ -490,10 +480,6 @@ export const REGISTRY_ENTRIES_PART_3: readonly SettingSpec[] = [
   },
   {
     key: 'stream-first-response-timeout-ms',
-    // Mirrors stream-idle-timeout-ms: the alias keeps the camelCase form as a
-    // recognized CLI setting so it is not leaked into API request bodies
-    // (modelParams). @issue #2607
-    aliases: ['streamFirstResponseTimeoutMs'],
     category: 'cli-behavior',
     owner: 'model',
     propagation: 'next-turn',

--- a/packages/settings/src/settings/registry/registry-types.ts
+++ b/packages/settings/src/settings/registry/registry-types.ts
@@ -49,7 +49,6 @@ export interface ValidationResult {
 
 export interface SettingSpec {
   key: string;
-  aliases?: readonly string[];
   category: SettingCategory;
   owner: SettingOwner;
   propagation: SettingPropagation;

--- a/packages/settings/src/settings/settingsRegistry.ts
+++ b/packages/settings/src/settings/settingsRegistry.ts
@@ -23,6 +23,7 @@ import { REGISTRY_ENTRIES_PART_1 } from './registry/registry-entries-1.js';
 import { REGISTRY_ENTRIES_PART_2 } from './registry/registry-entries-2.js';
 import { REGISTRY_ENTRIES_PART_3 } from './registry/registry-entries-3.js';
 import { isStrictNumericString } from './numericString.js';
+import { LEGACY_SETTING_KEY_MIGRATIONS } from './legacyKeyMigration.js';
 
 export const SETTINGS_REGISTRY: readonly SettingSpec[] = [
   ...REGISTRY_ENTRIES_PART_1,
@@ -362,6 +363,10 @@ function categorizeSettingEntry(
   },
 ): void {
   if (value === undefined || value === null) return;
+
+  if (LEGACY_SETTING_KEY_MIGRATIONS.has(rawKey)) {
+    return;
+  }
 
   if (
     typeof value === 'object' &&

--- a/packages/settings/src/settings/settingsRegistry.ts
+++ b/packages/settings/src/settings/settingsRegistry.ts
@@ -35,18 +35,13 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Exact-match key canonicalization: returns `key` unchanged unless it is
- * already a canonical registry key (in which case it is also returned
- * unchanged). Legacy spellings are NOT resolved here — they are rewritten
- * once at load time by `migrateLegacySettingKeys` (legacyKeyMigration.ts,
- * issue #2533 Phase C1). Kept as an export for external callers, which are
- * cleaned up in Phase C2.
+ * Exact-match identity seam: returns `key` unchanged. Legacy spellings are
+ * NOT resolved here — they are rewritten once at load time by
+ * `migrateLegacySettingKeys` (legacyKeyMigration.ts, issue #2533 Phase C1).
+ * Kept as an export for external callers, which are cleaned up in Phase C2.
  */
 export function resolveAlias(key: string): string {
-  // Exact semantics: every registry key resolves to itself; any other key
-  // (including legacy spellings) is returned unchanged.
-  const isRegistryKey = SETTINGS_REGISTRY.some((spec) => spec.key === key);
-  return isRegistryKey ? key : key;
+  return key;
 }
 
 export function getSettingSpec(key: string): SettingSpec | undefined {
@@ -112,13 +107,11 @@ const SESSION_SCOPED_SETTING_KEYS: ReadonlySet<string> = new Set(
 // correctly canonicalize or dispatch such keys. Fail fast rather than
 // silently accept unsupported specs.
 for (const spec of SETTINGS_REGISTRY) {
-  if (spec.sessionScope === true) {
-    if (spec.key.includes('.')) {
-      throw new Error(
-        `Session-scoped setting "${spec.key}" must not use a dotted key — ` +
-          'dotted session-scoped keys are not yet supported.',
-      );
-    }
+  if (spec.sessionScope === true && spec.key.includes('.')) {
+    throw new Error(
+      `Session-scoped setting "${spec.key}" must not use a dotted key — ` +
+        'dotted session-scoped keys are not yet supported.',
+    );
   }
 }
 

--- a/packages/settings/src/settings/settingsRegistry.ts
+++ b/packages/settings/src/settings/settingsRegistry.ts
@@ -24,23 +24,6 @@ import { REGISTRY_ENTRIES_PART_2 } from './registry/registry-entries-2.js';
 import { REGISTRY_ENTRIES_PART_3 } from './registry/registry-entries-3.js';
 import { isStrictNumericString } from './numericString.js';
 
-const ALIAS_NORMALIZATION_RULES: Record<string, string> = {
-  'max-tokens': 'max_tokens',
-  maxTokens: 'max_tokens',
-  'response-format': 'response_format',
-  responseFormat: 'response_format',
-  'tool-choice': 'tool_choice',
-  toolChoice: 'tool_choice',
-  'disabled-tools': 'tools.disabled',
-};
-
-const HEADER_PRESERVE_SET = new Set([
-  'user-agent',
-  'content-type',
-  'authorization',
-  'x-api-key',
-]);
-
 export const SETTINGS_REGISTRY: readonly SettingSpec[] = [
   ...REGISTRY_ENTRIES_PART_1,
   ...REGISTRY_ENTRIES_PART_2,
@@ -51,44 +34,23 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+/**
+ * Exact-match key canonicalization: returns `key` unchanged unless it is
+ * already a canonical registry key (in which case it is also returned
+ * unchanged). Legacy spellings are NOT resolved here — they are rewritten
+ * once at load time by `migrateLegacySettingKeys` (legacyKeyMigration.ts,
+ * issue #2533 Phase C1). Kept as an export for external callers, which are
+ * cleaned up in Phase C2.
+ */
 export function resolveAlias(key: string): string {
-  const normalizedAlias = ALIAS_NORMALIZATION_RULES[key];
-  if (typeof normalizedAlias === 'string') {
-    return normalizedAlias;
-  }
-
-  for (const spec of SETTINGS_REGISTRY) {
-    if (spec.aliases?.includes(key) === true) {
-      return spec.key;
-    }
-  }
-
-  for (const spec of SETTINGS_REGISTRY) {
-    if (spec.key === key) {
-      return key;
-    }
-  }
-
-  const lowerKey = key.toLowerCase();
-  if (HEADER_PRESERVE_SET.has(lowerKey)) {
-    return key;
-  }
-
-  return key.replace(/-/g, '_');
+  // Exact semantics: every registry key resolves to itself; any other key
+  // (including legacy spellings) is returned unchanged.
+  const isRegistryKey = SETTINGS_REGISTRY.some((spec) => spec.key === key);
+  return isRegistryKey ? key : key;
 }
 
 export function getSettingSpec(key: string): SettingSpec | undefined {
-  // Direct canonical-key match first (fast path)
-  const direct = SETTINGS_REGISTRY.find((s) => s.key === key);
-  if (direct) {
-    return direct;
-  }
-  // Resolve alias to canonical key and look up the spec
-  const resolved = resolveAlias(key);
-  if (resolved !== key) {
-    return SETTINGS_REGISTRY.find((s) => s.key === resolved);
-  }
-  return undefined;
+  return SETTINGS_REGISTRY.find((s) => s.key === key);
 }
 
 export function normalizeSetting(key: string, value: unknown): unknown {
@@ -155,12 +117,6 @@ for (const spec of SETTINGS_REGISTRY) {
       throw new Error(
         `Session-scoped setting "${spec.key}" must not use a dotted key — ` +
           'dotted session-scoped keys are not yet supported.',
-      );
-    }
-    if (spec.aliases !== undefined && spec.aliases.length > 0) {
-      throw new Error(
-        `Session-scoped setting "${spec.key}" must not declare aliases — ` +
-          'aliased session-scoped keys are not yet supported.',
       );
     }
   }
@@ -683,16 +639,9 @@ export function getAutocompleteSuggestions(
 }
 
 function collectProviderConfigKeys(): string[] {
-  const keys: string[] = [];
-  for (const spec of SETTINGS_REGISTRY) {
-    if (spec.category === 'provider-config') {
-      keys.push(spec.key);
-      if (spec.aliases) {
-        keys.push(...spec.aliases);
-      }
-    }
-  }
-  return keys;
+  return SETTINGS_REGISTRY.filter(
+    (spec) => spec.category === 'provider-config',
+  ).map((spec) => spec.key);
 }
 
 export function getProtectedSettingKeys(): string[] {
@@ -702,10 +651,7 @@ export function getProtectedSettingKeys(): string[] {
 }
 
 const SENSITIVE_SETTING_KEYS: ReadonlySet<string> = new Set(
-  SETTINGS_REGISTRY.filter((s) => s.sensitive === true).flatMap((s) => [
-    s.key,
-    ...(s.aliases ?? []),
-  ]),
+  SETTINGS_REGISTRY.filter((s) => s.sensitive === true).map((s) => s.key),
 );
 
 export const REDACTED_VALUE = '[REDACTED]';

--- a/packages/tools/src/formatters/toolGovernanceUtils.test.ts
+++ b/packages/tools/src/formatters/toolGovernanceUtils.test.ts
@@ -166,7 +166,6 @@ describe('tool governance blocking', () => {
         ephemerals: {
           'tools.allowed': 'read_file',
           'tools.disabled': 'write_file',
-          'disabled-tools': 'glob',
         },
       }),
     );
@@ -202,17 +201,17 @@ describe('tool governance blocking', () => {
     );
   });
 
-  it('supports legacy disabled-tools ephemeral key', () => {
+  it('ignores the legacy disabled-tools ephemeral key', () => {
     const governance = buildToolGovernance(
       createConfig({
         ephemerals: { 'disabled-tools': ['run_shell_command'] },
       }),
     );
 
-    expect(isToolBlocked('run_shell_command', governance)).toBe(true);
+    expect(isToolBlocked('run_shell_command', governance)).toBe(false);
   });
 
-  it('prefers tools.disabled over the legacy disabled-tools key', () => {
+  it('reads only tools.disabled when the legacy key is also present', () => {
     const governance = buildToolGovernance(
       createConfig({
         ephemerals: {

--- a/packages/tools/src/formatters/toolGovernanceUtils.ts
+++ b/packages/tools/src/formatters/toolGovernanceUtils.ts
@@ -115,14 +115,9 @@ export function buildToolGovernance(
   const allowedExplicit = isStringArray(allowedValue);
   const allowedRaw: string[] = allowedExplicit ? allowedValue : [];
 
-  let disabledRaw: string[];
-  if (isStringArray(ephemerals['tools.disabled'])) {
-    disabledRaw = ephemerals['tools.disabled'];
-  } else if (isStringArray(ephemerals['disabled-tools'])) {
-    disabledRaw = ephemerals['disabled-tools'];
-  } else {
-    disabledRaw = [];
-  }
+  const disabledRaw: string[] = isStringArray(ephemerals['tools.disabled'])
+    ? ephemerals['tools.disabled']
+    : [];
 
   const excludeValue =
     typeof config.getExcludeTools === 'function'

--- a/packages/tools/src/formatters/toolNameUtils.ts
+++ b/packages/tools/src/formatters/toolNameUtils.ts
@@ -171,7 +171,9 @@ export function canonicalizePolicyToolEntry(entry: string): string {
   }
 
   const openParen = trimmed.indexOf('(');
-  const base = (openParen === -1 ? trimmed : trimmed.slice(0, openParen)).trim();
+  const base = (
+    openParen === -1 ? trimmed : trimmed.slice(0, openParen)
+  ).trim();
   if (!base) {
     return '';
   }

--- a/packages/tools/src/formatters/toolNameUtils.ts
+++ b/packages/tools/src/formatters/toolNameUtils.ts
@@ -139,6 +139,53 @@ export function canonicalizeToolName(rawName: string): string {
 }
 
 /**
+ * Legacy policy/CLI spellings mapped to canonical registry names.
+ *
+ * Keys are compared against the lowercased, arg-stripped entry, so both
+ * 'ShellTool' and 'shelltool' decode to the registry name.
+ */
+export const LEGACY_TOOL_NAME_ALIASES: ReadonlyMap<string, string> = new Map([
+  ['shelltool', 'run_shell_command'],
+]);
+
+/**
+ * Decode one user-authored policy/allowlist entry to its canonical registry
+ * name (issue #2533: external input is decoded once at the boundary).
+ *
+ * Order of operations:
+ * 1. Trim; blank input decodes to ''.
+ * 2. Wildcard entries (containing '*') are returned verbatim — policy
+ *    wildcard semantics, not tool names.
+ * 3. Strip a trailing parenthesized arg list ('Tool(args)' -> 'Tool').
+ * 4. Map legacy spellings via {@link LEGACY_TOOL_NAME_ALIASES}.
+ * 5. Otherwise canonicalize via {@link canonicalizeToolName}; unusable names
+ *    decode to '' (never {@link INVALID_TOOL_NAME}).
+ */
+export function canonicalizePolicyToolEntry(entry: string): string {
+  const trimmed = entry.trim();
+  if (!trimmed) {
+    return '';
+  }
+  if (trimmed.includes('*')) {
+    return trimmed;
+  }
+
+  const openParen = trimmed.indexOf('(');
+  const base = (openParen === -1 ? trimmed : trimmed.slice(0, openParen)).trim();
+  if (!base) {
+    return '';
+  }
+
+  const alias = LEGACY_TOOL_NAME_ALIASES.get(base.toLowerCase());
+  if (alias) {
+    return alias;
+  }
+
+  const canonical = canonicalizeToolName(base);
+  return canonical === INVALID_TOOL_NAME ? '' : canonical;
+}
+
+/**
  * Convert string to snake_case.
  */
 export function toSnakeCase(value: string): string {

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -99,6 +99,8 @@ export {
   isValidToolName as isValidFormatterToolName,
   findMatchingTool,
   canonicalizeToolName,
+  canonicalizePolicyToolEntry,
+  LEGACY_TOOL_NAME_ALIASES,
   INVALID_TOOL_NAME,
 } from './formatters/toolNameUtils.js';
 

--- a/packages/tools/src/interfaces/ISubagentService.ts
+++ b/packages/tools/src/interfaces/ISubagentService.ts
@@ -21,8 +21,6 @@ export interface SubagentRequest {
   cwd?: string;
   /** Additional behavioural prompts to append after the primary prompt. */
   behaviourPrompts?: string[];
-  /** American-spelling alias for behaviourPrompts. */
-  behaviorPrompts?: string[];
   /** Optional tool whitelist for the subagent runtime. */
   toolWhitelist?: string[];
   /** Whether the request included an explicit whitelist even if it was empty. */

--- a/project-plans/issue2533-naming-standard.md
+++ b/project-plans/issue2533-naming-standard.md
@@ -328,7 +328,31 @@ model response (`smoke.log`, stepfun-37 haiku).
   At this documentation update, typecheck and lint logs exist; test, build,
   and smoke logs are not yet present. Full-cycle completion is not claimed here.
 
+## OCR round 2 + CodeRabbit follow-up (2026-09-11)
+
+OCR round 2 (against 4cf04db23) posted 10 findings; CodeRabbit re-review
+posted 1. Five fixed, five dismissed with evidence:
+
+| ID | Finding | Disposition |
+|---|---|---|
+| R2-1 | `/set unset modelparam max-tokens` bypassed legacy-key rejection (modelparam branch returned before the check) | Fixed: rejectLegacySettingKey at branch top, before clearActiveModelParam; regression asserts neither runtime write fires |
+| R2-2 | Rule missed case-only probes on single concatenated lowercase words (`a.oldname ?? a.oldName`) | Fixed: same-object comparison now flags case-insensitive equality OR word-fold equality; substring folding stays out (olderSibling/rise/contour still clean) |
+| R2-3 | validateToolParamValues read canonical members without rejecting legacy spellings first | Fixed (actual site: task.ts): validateCanonicalTaskParamSpellings runs first and its error is returned; normalizeTaskParams throw retained for direct callers |
+| R2-4 | combined canonical+legacy test fixtures used strings for object-typed output params | Fixed: typed fixtures (string maps for expected_outputs/output_spec) |
+| R2-5 | settingsSeparation test asserted legacy absence without ever exercising legacy writes | Fixed: apiKey/api-key writes now attempted and asserted rejected naming auth-key; snapshot carries neither |
+| R2-6 | setCommand unset partial-commit (clear succeeds, ephemeral unset throws) | Dismissed: R2-1 rejects legacy keys before any side effect; remaining failure mode is storage IO mid-sequence, where fail-fast surfacing (no compensating rollback) is the chosen design |
+| R2-7 | security/high: `/set disabled-tools` governance bypass in non-interactive mode | Dismissed: setEphemeralSetting delegates to SettingsService.set, which calls assertCanonicalSettingKey and throws before any governance effect — fails closed on every path |
+| R2-8/9 | toolEntryDecoderDrift imports normalizeToolName "not exported" from policy | Dismissed: packages/policy/src/index.ts:30 exports it; test passes (3/3) locally and in CI core shard |
+| R2-10 | max-output-tokens migration "maps to wrong canonical key" | Dismissed: pre-PR registry declared max_output_tokens alias ['max-output-tokens'] and maxOutputTokens alias ['max-output']; migration preserves those exact relationships |
+
+Verification: 154 targeted tests pass (setCommand 29, rule 28, task trio 86,
+settingsSeparation 11), eslint guard exit 0, prettier clean on all seven
+touched files, smoke green (tmp/verify2533-r2/, full typecheck/lint/test logs
+therein). OCR budget (2 rounds) exhausted; any further findings become
+documented follow-ups, not new cycles.
+
 ## Known follow-ups (deferred, out of scope here)
+
 
 - packages/core/src/prompt-config/prompt-resolver.ts private toSnakeCase is not
   byte-equivalent to the shared packages/tools implementation (consecutive-capitals

--- a/project-plans/issue2533-naming-standard.md
+++ b/project-plans/issue2533-naming-standard.md
@@ -217,3 +217,32 @@ settings/profile, completion, provider adapter.
 Max 2 deepthinker review rounds; max 2 OCR rounds. Findings triaged
 Blocker-Fix / In-scope-Fix / Reject / Defer. Completion only with behavioral
 evidence, green verification + CI, triaged reviews, conflict-free PR.
+
+## Review log (final)
+
+- Round 1 (compliance): verdict FAIL with 1 Blocker + 4 In-scope findings + 3 Defers.
+  All five actionable findings remediated in the same working tree:
+  1. OpenAI request-param alias map + kebab→snake fallback deleted
+     (openaiRequestParams.ts now exact canonical-set filtering); stateless test
+     rewritten to canonical max_tokens + legacy-absence assertion.
+  2. Legacy ephemerals['max-tokens'] reads removed from OpenAIRequestPreparation.ts
+     and vercelRequestParams.ts (canonical modelParams['max_tokens'] only).
+  3. /mcp list accepts only desc/nodesc/schema (descriptions/nodescriptions aliases
+     removed; schema-edge test asserts rejection; docs swept).
+  4. docs settings examples teach auth-key (configuration.md, emoji-filter.md).
+  5. naming-standard.md Enforcement reworded: boundary table = full register;
+     BOUNDARY_EXCEPTIONS = machine-enforced subset. Plus settingsLoader import fold.
+- Round 2 (findings-only follow-up): verdict ALL-RESOLVED, no regressions.
+  Logs: tmp/verify2533-review/, tmp/verify2533-review2/, remediation tmp/verify2533-h1/.
+
+## Known follow-ups (deferred, out of scope here)
+
+- packages/core/src/prompt-config/prompt-resolver.ts private toSnakeCase is not
+  byte-equivalent to the shared packages/tools implementation (consecutive-capitals
+  handling; no -/space folding). Unify behind the shared export with a corpus drift
+  test, or document as a distinct filesystem-naming helper.
+- packages/settings/src/settings/settingsRegistry.ts resolveAlias is now a permanent
+  identity export; inline it away and drop the forward-referencing comment.
+- Gate failures proven pre-existing on main (not branch-owned): proactive-renewal
+  fake-timer suite (identical 4 pass/7 fail on main), SecureStore OS-keyring tests,
+  #3619 vi.mock cross-file pollution, bun solo-run node:fs/promises quirk.

--- a/project-plans/issue2533-naming-standard.md
+++ b/project-plans/issue2533-naming-standard.md
@@ -1,0 +1,219 @@
+# Issue #2533 — One canonical naming standard; prohibit LLxprt-owned alias probes
+
+Branch: `issue2533` · Label: Code Quality / Modularization · Milestone: 0.12.0
+
+## Objective
+
+Rip-and-replace every LLxprt-owned naming alias: one name per concept per
+boundary, one tool-name canonicalization implementation, one settings-key
+spelling (with one-time load migration for legacy spellings), one slash-command
+literal, and an AST lint rule that rejects new alias probes while permitting
+narrowly documented third-party wire adaptation.
+
+## Decisions (canonical choices)
+
+| Boundary | Canonical choice | Rationale |
+|---|---|---|
+| TaskTool wire params (model-facing JSON) | snake_case, exactly: `subagent_name`, `goal_prompt`, `behaviour_prompts`, `tool_whitelist`, `expected_outputs`, `timeout_seconds`, `grace_period_seconds`, `max_turns`, `async`, `context` | Current model-facing schema is already snake_case with `additionalProperties:false`; #2255 direction (`expected_outputs`); no new aliases; never `model_param` (#1821). `output_spec` alias is REMOVED. |
+| Internal TS after boundary | camelCase (`TaskToolInvocationParams`: subagentName, goalPrompt, behaviourPrompts, toolWhitelist, outputSpec, context, maxTurns, async) | Already exists; single normalization site in `normalizeTaskParams`. |
+| `ISubagentService.SubagentRequest` | `behaviourPrompts` only (drop `behaviorPrompts`) | Internal interface; British spelling matches the wire name `behaviour_prompts`. |
+| Tool-name canonicalization | `packages/tools/src/formatters/toolNameUtils.ts` + `toolGovernanceUtils.ts` (already exported, dependency-free) | Only complete implementation (casing + `Tool`-suffix + dotted namespaces + sentinel); already consumed by agents/core. |
+| Persisted settings keys | One spelling per registry entry = the registry's PRIMARY name today (no mass rename of primaries). Model-param keys stay provider-wire snake (`max_tokens`); other keys stay as declared (`auth-key`, `tools.disabled`, …). New non-model-param keys: kebab-case with dotted namespaces. | Kills the alias matrix without rewriting every user's settings file; model params are provider wire passthrough. |
+| Legacy settings spellings | One-time destructive load migration (the `settingsLegacy.ts` pattern): known legacy spellings → canonical, legacy key deleted. | Issue: "legitimate migration normalizes once at load". |
+| Provider config field | `baseURL` (declared in `IProvider.ts:73`, `BaseProvider`) | LLxprt-owned canonical; `baseUrl`/`BaseUrl`/`BaseURL` are legacy spellings migrated once at load. |
+| `/tools` subcommands | `desc` is canonical; remove `descriptions` alias option + dispatch branch | Alias labeled "Alias for desc" today. |
+| Env vars | UPPER_SNAKE_CASE (document; verify existing readers conform) | Issue requirement. |
+| New ESLint rule | `eslint-rules/no-alias-probes.js`, wired as `custom/no-alias-probes`: error for `packages/**/*.{js,jsx,ts,tsx}` | Follows the three existing rules' `.js` convention (flat-config import); tests are TS/bun. |
+
+## Behavioral acceptance criteria
+
+Each criterion lists behavior, boundary cases, and the tests that prove it.
+
+### AC1 — Naming standard document
+
+`dev-docs/naming-standard.md` exists and defines, per boundary, with examples:
+TS camelCase values / PascalCase types; model-facing tool params snake_case;
+slash commands one literal; persisted settings one canonical spelling per key +
+load-time migration policy; env vars UPPER_SNAKE_CASE; tool names from one
+manifest (`packages/tools` formatters); provider wire spelling only in adapters
+mapped immediately to LLxprt types; the prohibited alias forms; and the
+boundary-exception policy (explicit entries with owner, reason, removal
+condition; no broad directory exemption). Follows dev-docs style; NOT in
+`dev-docs/plans/` (checked by `scripts/check-doc-placement.ts`).
+
+### AC2 — TaskTool has exactly one parameter vocabulary
+
+Behavior: `TaskToolParams` (TS) declares exactly the canonical snake_case wire
+members; `taskToolSchema` drops `output_spec`; validation/normalization
+(`validateToolParamValues`, `normalizeTaskParams`/`resolveOutputSpec`) read
+only snake_case members; the `??` camelCase probes and `firstDefined` alias
+chains are gone. camelCase or legacy spellings are rejected (unknown-property
+error naming the canonical member), not silently accepted.
+
+Boundary cases: programmatic callers that previously passed camelCase now get
+type errors; `output_spec` from a model is an unknown-property validation
+error; `expected_outputs`, `context` continue to work; `async: true`,
+`max_turns`, timeouts unaffected.
+
+Tests: rewrite `packages/agents/src/tools/task.output-naming.test.ts` to assert
+`expected_outputs` only (and `output_spec` rejection); task.test.ts and the
+rest of the task suite (snake_case) pass unchanged; new assertions that
+`subagentName`/`goalPrompt`/`expectedOutputs`/`outputSpec`/`context_vars`/
+`behavior_prompts` produce validation errors.
+
+### AC3 — Subagent service interface single spelling
+
+Behavior: `SubagentRequest` keeps only `behaviourPrompts`;
+`CoreSubagentServiceAdapter.ts:369-370` and `coreSubagentServiceHelpers.ts:85`
+drop the `?? behaviorPrompts` probes.
+
+Tests: existing `CoreSubagentServiceAdapter.test.ts` passes; adapter test
+covers single-field read.
+
+### AC4 — One tool-name canonicalization implementation
+
+Behavior: the local duplicate normalizers are deleted and their call sites
+import from `@vybestack/llxprt-code-tools` (or the agents re-export shim):
+- `packages/cli/src/config/toolGovernance.ts` (`normalizeToolNameForPolicy`,
+  `buildNormalizedToolSet` ShellTool parsing)
+- `packages/cli/src/ui/commands/toolsCommand.ts:32`
+- `packages/cli/src/ui/components/messages/ToolGroupMessage.tsx:55-62`
+- `packages/policy/src/config.ts:106-114` and
+  `packages/core/src/policy/config.ts:291-300` (identical twins)
+- `packages/core/src/runtime/AgentRuntimeLoader.ts:117-160` (local
+  `buildToolGovernance`/`isToolPermitted` → shared `buildToolGovernance`/
+  `isToolBlocked` with candidates layer)
+- `packages/core/src/prompt-config/prompt-resolver.ts:288` (private toSnakeCase
+  if it duplicates shared casing logic)
+
+Boundary case: user-authored policy entries (`ShellTool(npm test)`,
+CamelCase names) still normalize to registry names at policy load — that is
+external input adapted once at the boundary (allowed, documented). Behavior
+improvement is expected: `ReadFileTool` now canonicalizes to `read_file`
+instead of the never-matching `readfiletool`.
+
+Tests: governance/policy suites (`toolGovernance.test.ts`,
+`toolGovernanceUtils.test.ts`, policy config tests) updated to the shared
+behavior; `/tools` enable/disable/status tests match registry names.
+
+### AC5 — Settings: one spelling per key, migration once at load
+
+Behavior:
+- `ALIAS_NORMALIZATION_RULES`, registry `aliases` arrays (15 entries), and the
+  kebab→snake global fallback in `resolveAlias` are removed; key lookup is
+  exact-match against the registry primary name.
+- A one-time destructive load migration (settingsLegacy.ts pattern, extend it
+  or sibling module) maps the known legacy spellings (`max-tokens`, `maxTokens`,
+  `apiKey`, `api-key`, `apiKeyfile`, `api-keyfile`, `tool-format`,
+  `tool-format-override`, `disabled-tools`, `max-output-tokens`,
+  `max-output`, `response-format`, `responseFormat`, `tool-choice`,
+  `toolChoice`, `User-Agent`, `streamIdleTimeoutMs`,
+  `streamFirstResponseTimeoutMs`, `baseUrl`/`BaseUrl`/`BaseURL` for providers,
+  `tools_allowed`) to canonical and deletes the legacy key.
+- `disabled-tools` is dead: every dual-read
+  (`toolGovernanceUtils.ts:118-123`, `clientToolGovernance.ts:63-65`,
+  `subagentSettingsPopulation.ts:40-45,126-136`,
+  `postConfigRuntime.ts:602-607`, `toolsCommand.ts:83-121`,
+  `SettingsService.ts:493-503,552`, `ProfileManager.ts:393,410-417,452`) reads
+ /writes only `tools.disabled`; `useToolsDialog.ts` switches from legacy-only
+  to `tools.disabled`; `profiles/types.ts:120` drops the `disabled-tools` field.
+- `/set` accepts only canonical keys; a legacy spelling is rejected with an
+  error naming the canonical key (rejection + guidance, not acceptance).
+- Provider runtime: `ephemeralSettings.ts`, `profileSnapshot.ts:153-170`
+  (alias-scan loop), `providerSwitch.ts:682-696` (15-variant enumeration),
+  `providerMutations.ts:96-134` use canonical keys/`baseURL` only.
+- Env-var derivation of settings still works with canonical keys.
+
+Boundary cases: a settings.json written by an older LLxprt containing
+`max-tokens`/`disabled-tools` loads correctly after one migration and is
+rewritten canonically; profiles exported by older versions import cleanly
+(migration applies); unknown keys remain unknown-key errors (no fuzzy
+acceptance).
+
+Tests: rewrite `settingsRegistry.test.ts` (exact-match + rejection of
+aliases), `settingsRegistry.issue2182.test.ts` / `.issue2607.test.ts`
+(canonical spelling + migration), `toolGovernanceUtils.test.ts`,
+`clientToolGovernance.test.ts` (canonical only), new migration tests for
+legacy → canonical rewrite-and-delete, ProfileManager round-trip, provider
+runtime `baseURL` tests, `/set` rejection-with-guidance test.
+
+### AC6 — Slash commands: one literal
+
+Behavior: `/tools` drops the `descriptions` subcommand alias (option entry +
+dispatch branch); `desc` remains. All other command literals verified
+consistent across schema/completion/dispatch/usage/docs (already consistent
+per research).
+
+Tests: toolsCommand tests updated (`descriptions` no longer dispatches,
+`desc` does); docs/cli/commands.md checked.
+
+### AC7 — ESLint rule `custom/no-alias-probes`
+
+Behavior: new `eslint-rules/no-alias-probes.js` flags, in
+`packages/**/*.{js,jsx,ts,tsx}`:
+- `a.oldName || a.newName`, `a.old_name ?? a.newName`,
+  `obj['old-name'] ?? obj.oldName`, `params.foo_bar ?? params.fooBar`
+- Detection: both operands of `||`/`??` are (computed-literal or dot) member
+  expressions on the *same textual object source*, with property spellings
+  that differ raw but compare equal after case-folding and stripping `_`/`-`.
+- Allows: literal RHS (`x.name ?? 'default'`, `x.flag || false`),
+  different-object defaulting (`cfg.x ?? defaults.x`), genuinely different
+  fields, allowlisted boundary files.
+- Structured allowlist in the rule: `{ file, owner, reason,
+  removalCondition }` entries only — no directory globs. Target: zero or
+  near-zero entries after cleanup (expected entries, if any survive: genuinely
+  third-party response decoding in provider adapters).
+- Wired `error` in `eslint.config.js`; `npm run lint` passes repo-wide with
+  the rule active.
+
+Tests: first bun test for an eslint rule in this repo
+(e.g. `eslint-rules/no-alias-probes.test.ts` or `scripts/tests/…`, importing
+the rule via the `Linter` API — no RuleTester framework assumptions): valid
+cases (boolean fallback, default literal, different fields, different
+objects, allowlisted boundary), invalid cases (all four representative forms
++ case-only variants like `baseUrl/baseURL`), allowlist-metadata test.
+
+### AC8 — Alias-only tests deleted or rewritten
+
+The 7 alias-asserting test files (see catalog §6) are rewritten to assert
+canonical-only behavior + explicit rejection; none may continue to assert
+that two spellings both work.
+
+### AC9 — Help/docs/prompts/schema expose canonical names only
+
+Grep-sweep `docs/`, prompt templates, help text, and `schemas/` for removed
+spellings (`output_spec` as TaskTool param, `disabled-tools`,
+`descriptions` subcommand, camelCase TaskTool params, alias mentions).
+`schemas/settings.schema.json` must not advertise removed alias spellings.
+Note: `docs/token-usage-log.md` documents the token-usage wire log
+(`subagent_name` snake) — that is a different, canonical wire format; leave
+it. MCP `streamable-http` enum value and Zed tool-name mapping are
+third-party boundary entries — leave them, document as boundary exceptions.
+
+### AC10 — Functionality retained
+
+Full verification cycle green: `npm run test`, `npm run lint`,
+`npm run typecheck`, `npm run format`, `npm run build`, and smoke
+`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.
+Explicit suites: lint-rule test, TaskTool schema, governance/policy,
+settings/profile, completion, provider adapter.
+
+## Prohibited / out of scope
+
+- No new TaskTool alias (#2255); no `model_param` (#1821).
+- No backward-compat shims beyond the one-time load migrations specified.
+- No renaming of registry-primary settings keys (only alias removal).
+- No redesign of read-only-tool classification or policy semantics; only
+  dedupe of copy-pasted name lists where a single owner exists or can be
+  imported without new package cycles (e.g. SHELL_TOOL_NAMES twins,
+  `self_emitvalue` literal copies → the exported constant).
+- No broad directory exemptions in the lint rule.
+- No new .js files except `eslint-rules/no-alias-probes.js`, which follows the
+  established eslint-rules convention (flat-config ESM import); its tests are
+  TS/bun.
+
+## Review policy
+
+Max 2 deepthinker review rounds; max 2 OCR rounds. Findings triaged
+Blocker-Fix / In-scope-Fix / Reject / Defer. Completion only with behavioral
+evidence, green verification + CI, triaged reviews, conflict-free PR.

--- a/project-plans/issue2533-naming-standard.md
+++ b/project-plans/issue2533-naming-standard.md
@@ -235,6 +235,99 @@ evidence, green verification + CI, triaged reviews, conflict-free PR.
 - Round 2 (findings-only follow-up): verdict ALL-RESOLVED, no regressions.
   Logs: tmp/verify2533-review/, tmp/verify2533-review2/, remediation tmp/verify2533-h1/.
 
+## OCR round 1 + CI remediation (2026-09-11)
+
+Remediation covers 9 CI failures on head `b086d5058`, 13 OCR findings,
+and 4 CodeRabbit threads. CI causes: prettier reformat on four files;
+tracked-JS allowlist missing `eslint-rules/no-alias-probes.js`; test-file
+coverage guard missing the new rule test; #2174 type escape in
+`settingsLoader.ts`; six tests retaining legacy expectations
+(`settings.part2`/`settings.part3` apiKey env resolution, diagnosticsCommand
+apiKey masking, profileCommand.lb protected stripping, profile-system baseUrl
+round-trip, gemini.stateless max-output-tokens). Write boundaries
+(`SettingsService.set`, `setEphemeralSetting` through its settings write path,
+and `setProviderSetting`) now reject known legacy spellings with guidance
+naming the required key. No read-side aliases were restored; load-time
+migration remains the only legacy acceptance path. `normalizeTaskParams`
+now calls `validateCanonicalTaskParamSpellings` itself and throws on a spelling
+error before normalization, including mixed current/legacy input. This is a
+throwing normalizer, not an atomic full validate-and-normalize API.
+
+| ID | Area | Action |
+|---|---|---|
+| A1 | Formatting | Reformatted `policy/src/config.ts`, `toolNameUtils.ts`, `providerMutations.ts`, and `providerSwitch.ts`; the latter's protected-key list is unchanged semantically. |
+| A2 | Tracked JS | Added `eslint-rules/no-alias-probes.js` to `scripts/no-new-js-allowlist.json`; sorted affected entries. |
+| A3 | Test coverage | Added the `eslint-rules` Bun root with storage-isolation preload; moved `SCRIPTS_SHARD_ROOTS` to `test-shards.ts`, included the new root, and imported/re-exported it in `test.ts`. |
+| A4 | Settings loader | Replaced the double assertion in `settingsLoader.ts` with `isPlainRecord` narrowing before migration (#2174). |
+| A5 | Settings env resolution | `settings.part2.test.ts` now supplies and checks `auth-key` for resolved environment variables. |
+| A6 | Unresolved settings env | `settings.part3.test.ts` now supplies and checks `auth-key` while preserving unresolved-variable behavior. |
+| A7 | Diagnostics | `diagnosticsCommand.edges.spec.ts` now asserts `SettingsService.set('apiKey', ...)` rejects with guidance naming `auth-key` and leaves no legacy key; existing `auth-key` masking coverage retained. |
+| A8 | Load-balancer profiles | `profileCommand.lb.test.ts` rejects legacy `apiKey`/`apiKeyfile` writes; stripping fixtures use `auth-key`, `auth-keyfile`, and `toolFormat`, without alias-acceptance assertions. |
+| A9 | Profile round-trip | Current diff in `profile-system.integration.test.ts` changes the Azure fixture from `tool-format` to `toolFormat`; no additional `baseUrl` edit is present in this remediation diff. |
+| A10 | Gemini stateless | Replaced `max-output-tokens` fixtures with `max_output_tokens` for global, provider, and invocation settings; removed obsolete alias-normalization comments. |
+| B1 | Lint folding | Replaced substring-based `ALIAS_FOLDS` with `ALIAS_WORD_FOLDS`: tokenize identifier words, fold exact words, then join. Substrings inside longer words are no longer rewritten. |
+| B2 | Lint regressions | Added clean cases for `olderSibling/newerSibling`, `rise/rize`, and `contour/contor` in `no-alias-probes.test.ts`. |
+| B3 | Task normalization | `normalizeTaskParams` validates removed spellings and throws before reading fields; shared error helper supplies replacement-key guidance. |
+| B4 | Task output validation | `validateOutputParams` rejects `output_spec`, `outputSpec`, and `expectedOutputs` before its absent-output early return. |
+| B5 | Task rejection tests | `task.output-naming.test.ts` exercises direct output validation, direct normalization of removed spellings, and mixed current/legacy fields. |
+| B6 | Task runtime schema | Tests inspect `createTool().schema.parametersJsonSchema`, including property vocabulary and unknown-property rejection; build assertions use the actual invocation return shape. |
+| B7 | Settings writes | `SettingsService.set` and `setProviderSetting` call `assertCanonicalSettingKey` before mutation; `SettingsService.test.ts` replaces legacy event acceptance with write/clear rejection assertions. |
+| B8 | Settings request separation | `settingsRegistry.ts` drops known legacy keys rather than forwarding them into request buckets; registry test checks `apiKey` enters neither CLI settings nor model params. |
+| B9 | Shared settings assertion | Added `assertCanonicalSettingKey` beside the load migration map in `legacyKeyMigration.ts` and exported it from `packages/settings/src/index.ts`. No migration occurs at writes. |
+| B10 | `/set unset modelparam` | `setCommand.ts` separates active-model clearing from ephemeral clearing; added a test for the distinct ephemeral-clear error and absence of a success response. |
+| B11 | Tools dialog | No remediation diff, new comment, or new test in `useToolsDialog.ts`; existing reads and writes already use `tools.disabled`. |
+| B12 | Runtime write fallout | `subagentSettingsPopulation.ts` writes `toolFormatOverride`; `providerMutations.ts` writes `toolFormat` ephemerals, including `auto`. |
+| C1 | Vercel documentation | Added JSDoc stating that max-output resolution reads only `modelParams['max_tokens']`, not metadata or legacy ephemerals. |
+| C2 | Policy decoder drift | `toolEntryDecoderDrift.test.ts` now checks the MCP wildcard through `canonicalizePolicyToolEntry`; updated the explanatory comment. |
+| C3 | Provider policy fallout | `BaseProvider.test.ts` now tests stripping `auth-key`/`auth-keyfile`; `providerCallOptions.test.ts` uses `max_tokens` instead of `maxTokens`. |
+| C4 | Provider policy fallout | `openaiResponses.stateless.test.ts` uses `max_output_tokens` in fixtures and outgoing-request assertions; `providerMutations.issue1943.test.ts` expects `toolFormat` persistence. |
+
+### Verification
+
+- Targeted suite: 17 files, final all pass. Four needed a fix-retry:
+  `profileCommand.lb`, `gemini.stateless`, `settingsRegistry`, and
+  `openaiResponses.stateless`.
+- Guards: check-no-new-js-files 18 pass; eslint-guard 465 pass;
+  test-file coverage 13 pass. No-alias-probes rule tests: 23 pass.
+- Prettier check clean on all changed files in the remediation pass.
+- Full `npm run test`, lint, typecheck, build, and smoke are run by the
+  driver, with logs under `tmp/verify2533-resume/`: `typecheck3.log`,
+  `lint-full.log`, `test-full.log`, `build.log`, and `smoke.log`.
+
+### Full-suite census round 2 (stream-timeout / model-param regressions)
+
+The first post-remediation full run (`tmp/verify2533-resume/test-full.log`)
+cleared all 63 baseline failures but exposed 31 new ones. Root causes, fixed
+in round k1 (logs `tmp/verify2533-k1/`):
+
+- Read-side camelCase ephemeral alias for stream timeouts survived the
+  original PR: the `streamIdleTimeout` resolver documented a
+  'streamIdleTimeoutMs' ephemeral fallback, `postConfigRuntime` wrote both
+  spellings, and `agentConfig.adapter` forwarded the typed API field names as
+  ephemeral keys. Now one canonical kebab ephemeral write per setting
+  ('stream-idle-timeout-ms' / 'stream-first-response-timeout-ms'); typed
+  camelCase API fields map at the boundary. Tests assert the canonical key and
+  that no legacy key exists.
+- `BaseProvider` converted `max_tokens` to `maxTokens` before the settings
+  write and swallowed the resulting rejection, silently dropping the value.
+  Conversion and swallow removed; snake model params round-trip.
+- Fixtures updated to canonical spellings (provider-multi-runtime `base-url`,
+  ProviderManager.guard `auth-key`, core-api/CLI profile-load `max_tokens`).
+
+Verification after k1: 21 targeted files all pass (116 combined timeout/model
+rerun); CLI subprocess suites needed `--timeout 90000` on this loaded box;
+three skills suites require isolated HOME (host HOME injects 55 real user
+skills — environmental, not branch-owned); grep exact-limit and Podman #3534
+files pass solo (load flakes, #3619 class). Final gates: typecheck exit 0
+(`typecheck5.log`), lint exit 0 (`lint-final.log`), build exit 0
+(`build-final.log`), full test (`test-final.log`: 1755 files, 10 unique
+`(fail)` lines, all environmental — 1 webfetch 5MiB passes solo in 5s,
+7 skills suites pass with isolated HOME, 2 are adversarial fixture echoes
+from passing runner-lifecycle suites), and startup smoke green with a real
+model response (`smoke.log`, stepfun-37 haiku).
+  At this documentation update, typecheck and lint logs exist; test, build,
+  and smoke logs are not yet present. Full-cycle completion is not claimed here.
+
 ## Known follow-ups (deferred, out of scope here)
 
 - packages/core/src/prompt-config/prompt-resolver.ts private toSnakeCase is not

--- a/scripts/bun-test-roots.ts
+++ b/scripts/bun-test-roots.ts
@@ -235,6 +235,12 @@ export const BUN_TEST_ROOTS: readonly BunTestRoot[] = [
     ],
   },
   {
+    root: 'eslint-rules',
+    cwd: '.',
+    directories: ['eslint-rules'],
+    preload: ['scripts/tests/storage-isolation-guard.ts'],
+  },
+  {
     root: 'evals',
     cwd: 'evals',
     pattern: /\.eval\.ts$/,

--- a/scripts/no-new-js-allowlist.json
+++ b/scripts/no-new-js-allowlist.json
@@ -1,13 +1,14 @@
 {
   "files": [
-    "eslint.config.js",
     "eslint-rules/ink-text-color-required.js",
+    "eslint-rules/no-alias-probes.js",
     "eslint-rules/no-inline-deps.js",
     "eslint-rules/react-render-safety.js",
+    "eslint.config.js",
     "packages/cli/bin/llxprt.mjs",
-    "packages/vscode-ide-companion/eslint.config.mjs",
     "packages/cli/src/commands/extensions/examples/hooks/scripts/on-start.js",
     "packages/cli/src/commands/extensions/examples/mcp-server/example.js",
+    "packages/vscode-ide-companion/eslint.config.mjs",
     "project-plans/issue1585/analysis/capture-pre-extraction-fixtures.mjs",
     "project-plans/issue1586/scripts/verify-auth-extraction-gate.js",
     "project-plans/issue2285/analysis/boundary-checker-characterization-proof.mjs",

--- a/scripts/test-shards.ts
+++ b/scripts/test-shards.ts
@@ -97,6 +97,15 @@ export const TEST_SHARDS: readonly ShardDefinition[] = [
   },
 ];
 
+/**
+ * Bun-native roots owned by the scripts shard. Keep these names synchronized
+ * with `scripts/bun-test-roots.ts`.
+ */
+export const SCRIPTS_SHARD_ROOTS: readonly string[] = [
+  'scripts-tests',
+  'eslint-rules',
+];
+
 /** Name of the special script-harness shard. */
 export const SCRIPTS_SHARD_NAME = 'scripts';
 

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -43,9 +43,11 @@ import { propertyValue } from './utils/error-guards.ts';
 import {
   TEST_SHARDS,
   SCRIPTS_SHARD_NAME,
+  SCRIPTS_SHARD_ROOTS,
   expandShard,
   findShard,
 } from './test-shards.ts';
+export { SCRIPTS_SHARD_ROOTS } from './test-shards.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -252,16 +254,6 @@ function createRunnerWithPATH(rootDir: string): CommandRunner {
 // the script harness needs. It is no longer a separate root: it is discovered
 // alongside every other scripts/tests file and receives its larger timeout via
 // a per-file timeout override on the scripts-tests root (issue #2780).
-/**
- * Bun-native roots owned by the scripts shard, in execution order.
- *
- * These belong to no workspace, so nothing else would run them. Exported as
- * the single source of truth: `scripts/tests/bun-test-root-ownership.bun.test.ts`
- * reads this list to prove every root has exactly one executor, and the root
- * `test:scripts` script delegates here rather than restating it.
- */
-export const SCRIPTS_SHARD_ROOTS: readonly string[] = ['scripts-tests'];
-
 export function scriptsRootCommand(root: string): string {
   return `bun scripts/run_bun_tests.ts --root ${root}`;
 }

--- a/scripts/tests/bun-test-roots.bun.test.ts
+++ b/scripts/tests/bun-test-roots.bun.test.ts
@@ -102,6 +102,7 @@ describe('BUN_TEST_ROOTS structural guarantees', () => {
       'lsp',
       'zed-acp',
       'scripts-tests',
+      'eslint-rules',
       'evals',
       'integration-tests',
     ]);


### PR DESCRIPTION
## TLDR

Establishes one canonical naming standard for every LLxprt-owned boundary and makes CI reject new alias probes (`a.oldName || a.newName` spelling coalescing). Rip-and-replace, no read-side aliases: one name per concept per boundary; legacy spellings migrate once, destructively, at load. Adds the `custom/no-alias-probes` ESLint rule with a six-entry boundary-exception allowlist and `dev-docs/naming-standard.md` as the standard.

## Dive Deeper

- **Naming standard** (`dev-docs/naming-standard.md`): per-boundary conventions — camelCase TS values / PascalCase types, snake_case model-facing tool params with `additionalProperties: false`, one slash-command literal, one canonical spelling per settings key with one-time load migration, UPPER_SNAKE_CASE env vars, one tool-name algorithm, provider wire spellings only inside adapters — plus the boundary-exception register (owner, reason, removal condition per entry).
- **New ESLint rule `custom/no-alias-probes`** (`eslint-rules/no-alias-probes.js` + bun tests): flags `a.oldName || a.newName`, `a.old_name ?? a.newName`, `obj['old-name'] ?? obj.oldName`, case-only and British/American variants across `packages/**`; allows boolean/literal fallbacks and different objects. Enforcement uses a frozen six-entry `BOUNDARY_EXCEPTIONS` allowlist ({file, owner, reason, removalCondition}; exact-or-suffix filename match) — no directory exemptions, no inline `eslint-disable` (the repo-wide `eslint-comments/no-use` ban stays). `npm run lint` passes with the rule at `error`.
- **TaskTool / subagents**: single snake_case wire vocabulary (`expected_outputs`, never `output_spec`; no `model_param` per #1821, no new TaskTool alias per #2255); single internal `behaviourPrompts` spelling.
- **Settings**: registry is exact-match only — `ALIAS_NORMALIZATION_RULES`, per-spec alias arrays, and the kebab→snake fallback are deleted; nineteen legacy spellings (`disabled-tools`, `maxTokens`, `apiKey`, `baseUrl` variants, …) migrate once at load/profile import; `/set` rejects legacy spellings with guidance naming the canonical key.
- **Provider runtime**: ephemeral settings validate exact registry keys; provider switching protects five canonical keys instead of fifteen variants; `baseURL` only. Includes the #2182 separation: modelParams stay free of leaked general settings.
- **Request params**: `OPENAI_PARAM_KEY_ALIASES` and the kebab→snake fallback deleted in favor of an exact allowed-key set; Vercel reads `modelParams['max_tokens']` only.
- **Slash commands**: `/tools desc` (no `descriptions`), `/mcp list desc|nodesc|schema` only; legacy spellings rejected with guidance.
- **Tool governance**: shared `canonicalizeToolName`/`canonicalizePolicyToolEntry`/`buildToolGovernance` from `packages/tools`; the copy-pasted local normalizers in cli/policy/core are gone; user-authored policy entries decode once at the boundary (`ReadFileTool` now correctly canonicalizes to `read_file`).
- **Tests/docs**: alias-asserting tests rewritten to assert canonical behavior + explicit rejection; docs swept (`ShellTool`→`run_shell_command` examples, `apiKey`→`auth-key`, `disabled-tools`→`tools.disabled`).

## Reviewer Test Plan

- `bun test eslint-rules/no-alias-probes.test.ts` — 20 rule tests (probe forms, variants, allowed fallbacks, allowlist metadata).
- `bun test packages/agents/src/tools/task.test.ts packages/agents/src/tools/task.output-naming.test.ts` — snake_case wire vocabulary; `output_spec` rejected.
- `bun test packages/settings/src/settings/settingsRegistry.test.ts` — exact-match lookup + legacy migration (legacy key deleted after rewrite).
- `bun test packages/providers/src/__tests__/ProviderManager.settingsSeparation.test.ts packages/core/src/runtime/__tests__/RuntimeInvocationContext.separation.test.ts` — #2182 separation with canonical keys.
- `/set max-tokens 4096` → rejected with guidance naming `max_tokens`; `/mcp list descriptions` → rejected naming `desc`; `/tools descriptions` likewise.
- Set `tools.disabled` via `/tools disable read_file`, restart: only `tools.disabled` is read/written.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | -   | -   | -   |
| Seatbelt | ❓  | -   | -   |

Linux `npm run` results: lint exit 0 (rule active), typecheck clean, build exit 0, scoped prettier exit 0 (no rewrites). Full `npm run test`: failure census diffed before/after remediation — all 12 branch-owned failures fixed, zero new; the 5 failing workspaces (storage, core, providers, cli, vscode-ide-companion) carry environment-only classes (OS keyring, docker-unavailable, fake-timer suites) proven identical on main. Known pre-existing flakes tracked in #3619.

### Environment caveats (dev box, not CI)

- `npm run format` (prettier `--experimental-cli --write .`) is OOM-killed in the dev container; all PR-changed files pass `prettier --write` with zero rewrites.
- The startup smoke (`bun scripts/start.ts --profile-load stepfun-37 …`) cannot authenticate from inside the sandboxed dev container (credential-proxy capability token is held by the outer session): identical failure reproduced on `main`.

## Linked issues / bugs

Closes #2533
Related to #2182 (modelParams/ephemerals separation included), #2255 and #1821 (constraints honored: no new TaskTool alias, no `model_param`).
Pre-existing test-pollution flake documented during verification: #3619.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Legacy configuration keys are migrated at load time, while direct writes using obsolete spellings are rejected with canonical-key guidance.
  * Task tool parameters now require canonical snake_case names, including `expected_outputs`.
  * Tool disabling now uses `tools.disabled`; legacy keys are ignored.
  * Provider parameters and timeout settings use canonical names only.
  * CLI command aliases for tool descriptions are no longer accepted.
  * Added validation for ambiguous property fallbacks during development.

* **Documentation**
  * Updated configuration, enterprise, and tool examples with current setting and tool names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->