### PR TITLE
fix(shell): confirm process-group termination before timeout results resolve (Fixes #3517)

### DIFF
--- a/packages/core/src/services/shellCpExecution.test.ts
+++ b/packages/core/src/services/shellCpExecution.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it, vi } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -131,6 +131,49 @@ describe.skipIf(isWindows)(
           reapGroup(handle.pid);
         }
       }, 20000);
+
+      it('flags survivingGroupMembersOnAbort when the group outlives the SIGKILL escalation', async () => {
+        // The established process.kill mock pattern (see
+        // shellExecutionService.main.test.ts), survivor variant: every group
+        // liveness probe (signal 0 on -pid) keeps reporting live members even
+        // after the SIGKILL, so the bounded reap window must expire. Real
+        // signals pass through so the child genuinely exits and the
+        // finalizer's gate runs.
+        const realKill = process.kill;
+        let pgid: number | undefined;
+        const killSpy = vi
+          .spyOn(process, 'kill')
+          .mockImplementation((pid: number, signal?: string | number) => {
+            if (signal === 0 && pid < 0) {
+              return true;
+            }
+            return signal === undefined ? realKill(pid) : realKill(pid, signal);
+          });
+
+        try {
+          const abortController = new AbortController();
+          const handle = await ShellExecutionService.execute(
+            'sleep 30',
+            os.tmpdir(),
+            () => undefined,
+            abortController.signal,
+            false,
+          );
+          pgid = handle.pid;
+          // Let the command reach its steady state before aborting.
+          await new Promise((resolve) => setTimeout(resolve, 300));
+          abortController.abort();
+          const result: ShellExecutionResult = await handle.result;
+
+          expect(result.aborted).toBe(true);
+          // The bounded reap window expired with (probed) live members, so
+          // the result must carry the survivor flag for the tool layer.
+          expect(result.survivingGroupMembersOnAbort).toBe(true);
+        } finally {
+          killSpy.mockRestore();
+          reapGroup(pgid);
+        }
+      }, 30000);
     });
   },
 );

--- a/packages/core/src/services/shellCpExecution.test.ts
+++ b/packages/core/src/services/shellCpExecution.test.ts
@@ -4,8 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it, vi } from 'bun:test';
+import { describe, expect, it, vi, mock } from 'bun:test';
 import fs from 'node:fs';
+import * as childProcess from 'node:child_process';
+import { ChildProcess } from 'node:child_process';
+import { createCpResultPromise } from './shellCpExecution.js';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -177,3 +180,39 @@ describe.skipIf(isWindows)(
     });
   },
 );
+
+describe('Windows abort result', () => {
+  it('does not report POSIX survivors when taskkill spawn throws', async () => {
+    const child = new ChildProcess();
+    Object.defineProperties(child, {
+      pid: { value: 4321 },
+      stdout: { value: null },
+      stderr: { value: null },
+    });
+    const originalModule = { ...childProcess };
+    void mock.module('node:child_process', () => ({
+      ...originalModule,
+      spawn: () => {
+        throw new Error('taskkill spawn failed');
+      },
+    }));
+    try {
+      const abortController = new AbortController();
+      const resultPromise = createCpResultPromise(
+        child,
+        true,
+        () => undefined,
+        abortController.signal,
+        undefined,
+        undefined,
+      );
+      abortController.abort();
+      child.emit('exit', 1, null);
+      const result = await resultPromise;
+      expect(result.aborted).toBe(true);
+      expect(result.survivingGroupMembersOnAbort).toBeUndefined();
+    } finally {
+      void mock.module('node:child_process', () => originalModule);
+    }
+  });
+});

--- a/packages/core/src/services/shellCpExecution.test.ts
+++ b/packages/core/src/services/shellCpExecution.test.ts
@@ -65,68 +65,72 @@ function reapGroup(pgid: number | undefined): void {
 describe.skipIf(isWindows)(
   'child_process abort group reap (POSIX, issue #3517)',
   () => {
-    it('resolves the abort result only after a TERM-immune grandchild is dead', async () => {
-      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cp-abort-'));
-      const marker = path.join(dir, 'grandchild.pid');
-      // The subshell stays in the spawned group; `trap '' TERM` sets SIG_IGN,
-      // a disposition that survives `exec sleep 30`. The foreground `sleep
-      // 30` keeps the direct child alive until the abort fires.
-      const command = `( trap '' TERM; exec sleep 30 ) & echo $! > ${marker}; sleep 30`;
-      const abortController = new AbortController();
-      const handle = await ShellExecutionService.execute(
-        command,
-        dir,
-        () => undefined,
-        abortController.signal,
-        false,
-      );
-      try {
-        const grandchildPid = Number(await waitForMarker(marker, 8000));
-        expect(grandchildPid).toBeGreaterThan(0);
+    // jest/require-top-level-describe does not recognize bun's
+    // describe.skipIf form, so the cases sit in a plain describe block.
+    describe('foreground abort', () => {
+      it('resolves the abort result only after a TERM-immune grandchild is dead', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cp-abort-'));
+        const marker = path.join(dir, 'grandchild.pid');
+        // The subshell stays in the spawned group; `trap '' TERM` sets SIG_IGN,
+        // a disposition that survives `exec sleep 30`. The foreground `sleep
+        // 30` keeps the direct child alive until the abort fires.
+        const command = `( trap '' TERM; exec sleep 30 ) & echo $! > ${marker}; sleep 30`;
+        const abortController = new AbortController();
+        const handle = await ShellExecutionService.execute(
+          command,
+          dir,
+          () => undefined,
+          abortController.signal,
+          false,
+        );
+        try {
+          const grandchildPid = Number(await waitForMarker(marker, 8000));
+          expect(grandchildPid).toBeGreaterThan(0);
 
-        abortController.abort();
-        const result: ShellExecutionResult = await handle.result;
+          abortController.abort();
+          const result: ShellExecutionResult = await handle.result;
 
-        expect(result.aborted).toBe(true);
-        // Escalation succeeded within the reap window: no survivor flag.
-        expect(result.survivingGroupMembersOnAbort).toBeUndefined();
-        // THE assertion (AC2): the grandchild is dead by the time the result
-        // exists. It was reparented when the direct child died, so a
-        // signal-0 probe proves real death.
-        expect(isPidAlive(grandchildPid)).toBe(false);
-      } finally {
-        reapGroup(handle.pid);
-        fs.rmSync(dir, { recursive: true, force: true });
-      }
-    }, 30000);
+          expect(result.aborted).toBe(true);
+          // Escalation succeeded within the reap window: no survivor flag.
+          expect(result.survivingGroupMembersOnAbort).toBeUndefined();
+          // THE assertion (AC2): the grandchild is dead by the time the result
+          // exists. It was reparented when the direct child died, so a
+          // signal-0 probe proves real death.
+          expect(isPidAlive(grandchildPid)).toBe(false);
+        } finally {
+          reapGroup(handle.pid);
+          fs.rmSync(dir, { recursive: true, force: true });
+        }
+      }, 30000);
 
-    it('resolves a prompt abort with no survivor field when the group dies on SIGTERM', async () => {
-      const abortController = new AbortController();
-      const handle = await ShellExecutionService.execute(
-        'sleep 30',
-        os.tmpdir(),
-        () => undefined,
-        abortController.signal,
-        false,
-      );
-      try {
-        // Let the command reach its steady state before aborting, as a real
-        // timeout would.
-        await new Promise((resolve) => setTimeout(resolve, 300));
-        const start = Date.now();
-        abortController.abort();
-        const result = await handle.result;
-        const elapsed = Date.now() - start;
+      it('resolves a prompt abort with no survivor field when the group dies on SIGTERM', async () => {
+        const abortController = new AbortController();
+        const handle = await ShellExecutionService.execute(
+          'sleep 30',
+          os.tmpdir(),
+          () => undefined,
+          abortController.signal,
+          false,
+        );
+        try {
+          // Let the command reach its steady state before aborting, as a real
+          // timeout would.
+          await new Promise((resolve) => setTimeout(resolve, 300));
+          const start = Date.now();
+          abortController.abort();
+          const result = await handle.result;
+          const elapsed = Date.now() - start;
 
-        expect(result.aborted).toBe(true);
-        expect(result.survivingGroupMembersOnAbort).toBeUndefined();
-        // The whole group dies on SIGTERM, so resolution must not pay the
-        // full reap window (AC4): only the escalation grace plus a
-        // first-poll confirmation.
-        expect(elapsed).toBeLessThan(2000);
-      } finally {
-        reapGroup(handle.pid);
-      }
-    }, 20000);
+          expect(result.aborted).toBe(true);
+          expect(result.survivingGroupMembersOnAbort).toBeUndefined();
+          // The whole group dies on SIGTERM, so resolution must not pay the
+          // full reap window (AC4): only the escalation grace plus a
+          // first-poll confirmation.
+          expect(elapsed).toBeLessThan(2000);
+        } finally {
+          reapGroup(handle.pid);
+        }
+      }, 20000);
+    });
   },
 );

--- a/packages/core/src/services/shellCpExecution.test.ts
+++ b/packages/core/src/services/shellCpExecution.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { ShellExecutionService } from './shellExecutionService.js';
+import type { ShellExecutionResult } from './shellExecutionTypes.js';
+
+const isWindows = os.platform() === 'win32';
+
+/** Signal-0 existence check. */
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Poll until `markerPath` exists and contains non-whitespace. */
+async function waitForMarker(
+  markerPath: string,
+  timeoutMs = 8000,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const content = fs.readFileSync(markerPath, 'utf8').trim();
+      if (content !== '') return content;
+    } catch {
+      // Not written yet.
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`Marker ${markerPath} not written within ${timeoutMs}ms`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
+/** Kill an entire detached process group (no-op if already gone). POSIX only. */
+function reapGroup(pgid: number | undefined): void {
+  // Guard the cleanup path: a spawn that produced no pid yields 0 here, and
+  // `process.kill(-0)` is `process.kill(0)` — a signal to the TEST RUNNER's
+  // own process group.
+  if (pgid === undefined || !Number.isInteger(pgid) || pgid <= 0) return;
+  try {
+    process.kill(-pgid, 'SIGKILL');
+  } catch {
+    // Already gone.
+  }
+}
+
+/**
+ * Service-level child_process abort behavior (Issue #3517). A foreground
+ * abort must not produce a result while the spawned process group still has
+ * live members, and escalation must kill a grandchild that survives SIGTERM.
+ */
+describe.skipIf(isWindows)(
+  'child_process abort group reap (POSIX, issue #3517)',
+  () => {
+    it('resolves the abort result only after a TERM-immune grandchild is dead', async () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cp-abort-'));
+      const marker = path.join(dir, 'grandchild.pid');
+      // The subshell stays in the spawned group; `trap '' TERM` sets SIG_IGN,
+      // a disposition that survives `exec sleep 30`. The foreground `sleep
+      // 30` keeps the direct child alive until the abort fires.
+      const command = `( trap '' TERM; exec sleep 30 ) & echo $! > ${marker}; sleep 30`;
+      const abortController = new AbortController();
+      const handle = await ShellExecutionService.execute(
+        command,
+        dir,
+        () => undefined,
+        abortController.signal,
+        false,
+      );
+      try {
+        const grandchildPid = Number(await waitForMarker(marker, 8000));
+        expect(grandchildPid).toBeGreaterThan(0);
+
+        abortController.abort();
+        const result: ShellExecutionResult = await handle.result;
+
+        expect(result.aborted).toBe(true);
+        // Escalation succeeded within the reap window: no survivor flag.
+        expect(result.survivingGroupMembersOnAbort).toBeUndefined();
+        // THE assertion (AC2): the grandchild is dead by the time the result
+        // exists. It was reparented when the direct child died, so a
+        // signal-0 probe proves real death.
+        expect(isPidAlive(grandchildPid)).toBe(false);
+      } finally {
+        reapGroup(handle.pid);
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    }, 30000);
+
+    it('resolves a prompt abort with no survivor field when the group dies on SIGTERM', async () => {
+      const abortController = new AbortController();
+      const handle = await ShellExecutionService.execute(
+        'sleep 30',
+        os.tmpdir(),
+        () => undefined,
+        abortController.signal,
+        false,
+      );
+      try {
+        // Let the command reach its steady state before aborting, as a real
+        // timeout would.
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        const start = Date.now();
+        abortController.abort();
+        const result = await handle.result;
+        const elapsed = Date.now() - start;
+
+        expect(result.aborted).toBe(true);
+        expect(result.survivingGroupMembersOnAbort).toBeUndefined();
+        // The whole group dies on SIGTERM, so resolution must not pay the
+        // full reap window (AC4): only the escalation grace plus a
+        // first-poll confirmation.
+        expect(elapsed).toBeLessThan(2000);
+      } finally {
+        reapGroup(handle.pid);
+      }
+    }, 20000);
+  },
+);

--- a/packages/core/src/services/shellCpExecution.test.ts
+++ b/packages/core/src/services/shellCpExecution.test.ts
@@ -79,14 +79,17 @@ describe.skipIf(isWindows)(
         // 30` keeps the direct child alive until the abort fires.
         const command = `( trap '' TERM; exec sleep 30 ) & echo $! > ${marker}; sleep 30`;
         const abortController = new AbortController();
-        const handle = await ShellExecutionService.execute(
-          command,
-          dir,
-          () => undefined,
-          abortController.signal,
-          false,
-        );
+        let handle:
+          | Awaited<ReturnType<typeof ShellExecutionService.execute>>
+          | undefined;
         try {
+          handle = await ShellExecutionService.execute(
+            command,
+            dir,
+            () => undefined,
+            abortController.signal,
+            false,
+          );
           const grandchildPid = Number(await waitForMarker(marker, 8000));
           expect(grandchildPid).toBeGreaterThan(0);
 
@@ -101,21 +104,26 @@ describe.skipIf(isWindows)(
           // signal-0 probe proves real death.
           expect(isPidAlive(grandchildPid)).toBe(false);
         } finally {
-          reapGroup(handle.pid);
+          if (handle) {
+            reapGroup(handle.pid);
+          }
           fs.rmSync(dir, { recursive: true, force: true });
         }
       }, 30000);
 
       it('resolves a prompt abort with no survivor field when the group dies on SIGTERM', async () => {
         const abortController = new AbortController();
-        const handle = await ShellExecutionService.execute(
-          'sleep 30',
-          os.tmpdir(),
-          () => undefined,
-          abortController.signal,
-          false,
-        );
+        let handle:
+          | Awaited<ReturnType<typeof ShellExecutionService.execute>>
+          | undefined;
         try {
+          handle = await ShellExecutionService.execute(
+            'sleep 30',
+            os.tmpdir(),
+            () => undefined,
+            abortController.signal,
+            false,
+          );
           // Let the command reach its steady state before aborting, as a real
           // timeout would.
           await new Promise((resolve) => setTimeout(resolve, 300));
@@ -131,7 +139,9 @@ describe.skipIf(isWindows)(
           // first-poll confirmation.
           expect(elapsed).toBeLessThan(2000);
         } finally {
-          reapGroup(handle.pid);
+          if (handle) {
+            reapGroup(handle.pid);
+          }
         }
       }, 20000);
 
@@ -190,7 +200,7 @@ describe('Windows abort result', () => {
       stderr: { value: null },
     });
     const originalModule = { ...childProcess };
-    void mock.module('node:child_process', () => ({
+    await mock.module('node:child_process', () => ({
       ...originalModule,
       spawn: () => {
         throw new Error('taskkill spawn failed');
@@ -212,7 +222,7 @@ describe('Windows abort result', () => {
       expect(result.aborted).toBe(true);
       expect(result.survivingGroupMembersOnAbort).toBeUndefined();
     } finally {
-      void mock.module('node:child_process', () => originalModule);
+      await mock.module('node:child_process', () => originalModule);
     }
   });
 });

--- a/packages/core/src/services/shellCpExecution.ts
+++ b/packages/core/src/services/shellCpExecution.ts
@@ -86,9 +86,7 @@ export function createCpResultPromise(
     // confirmed empty (or no group reap applies); never rejects.
     let abortKillChain: Promise<boolean> | null = null;
     const armAbortKill = (): void => {
-      if (abortKillChain === null) {
-        abortKillChain = cpKillOnAbort(state, child);
-      }
+      abortKillChain ??= cpKillOnAbort(state, child);
     };
     setupCpInactivityHandler(
       state,
@@ -139,6 +137,45 @@ function isCpStreamSettled(
     return true;
   }
   return flags.destroyed === true || flags.readableEnded === true;
+}
+
+/**
+ * Wire the once-'end'/'close' settle listeners for still-open stdio streams
+ * so a pending exit finalizes when the last stream settles (or is proven
+ * already settled). Pure extraction from the finalizer's returned closure:
+ * identical listener registration and finalize condition, no behavior change.
+ */
+function armCpStreamSettleListeners(
+  state: CpExecState,
+  child: ChildProcess,
+  openStreams: Array<NonNullable<ChildProcess['stdout']>>,
+  code: number | null,
+  signal: NodeJS.Signals | null,
+  finalize: (code: number | null, signal: NodeJS.Signals | null) => void,
+  streamSettledListeners: Map<NonNullable<ChildProcess['stdout']>, () => void>,
+): void {
+  for (const stream of openStreams) {
+    const onSettled = (): void => {
+      // Remove both registrations: whichever of 'end'/'close' fires, the
+      // other may never arrive (Bun does not always emit 'close'), and a
+      // lingering once-listener would retain the finalizer closure.
+      stream.removeListener('close', onSettled);
+      stream.removeListener('end', onSettled);
+      streamSettledListeners.delete(stream);
+      if (state.hasResolved) {
+        return;
+      }
+      const stillOpen = [child.stdout, child.stderr].some(
+        (candidate) => candidate !== null && !isCpStreamSettled(candidate),
+      );
+      if (!stillOpen) {
+        finalize(code, signal);
+      }
+    };
+    streamSettledListeners.set(stream, onSettled);
+    stream.once('close', onSettled);
+    stream.once('end', onSettled);
+  }
 }
 
 /**
@@ -226,28 +263,15 @@ function createCpExitFinalizer(
       () => finalize(code, signal),
       CP_OUTPUT_DRAIN_GRACE_MS,
     );
-    for (const stream of openStreams) {
-      const onSettled = (): void => {
-        // Remove both registrations: whichever of 'end'/'close' fires, the
-        // other may never arrive (Bun does not always emit 'close'), and a
-        // lingering once-listener would retain the finalizer closure.
-        stream.removeListener('close', onSettled);
-        stream.removeListener('end', onSettled);
-        streamSettledListeners.delete(stream);
-        if (state.hasResolved) {
-          return;
-        }
-        const stillOpen = [child.stdout, child.stderr].some(
-          (candidate) => candidate !== null && !isCpStreamSettled(candidate),
-        );
-        if (!stillOpen) {
-          finalize(code, signal);
-        }
-      };
-      streamSettledListeners.set(stream, onSettled);
-      stream.once('close', onSettled);
-      stream.once('end', onSettled);
-    }
+    armCpStreamSettleListeners(
+      state,
+      child,
+      openStreams,
+      code,
+      signal,
+      finalize,
+      streamSettledListeners,
+    );
   };
 }
 

--- a/packages/core/src/services/shellCpExecution.ts
+++ b/packages/core/src/services/shellCpExecution.ts
@@ -14,6 +14,7 @@ import { makeInactivityTimer } from './shellOutputUtils.js';
 import {
   isKillablePid,
   killProcessWithEscalation,
+  reapProcessGroup,
 } from './shellProcessKill.js';
 import {
   type CpExecState,
@@ -79,17 +80,30 @@ export function createCpResultPromise(
   };
 
   return new Promise<ShellExecutionResult>((resolve) => {
+    // Armed by the first abort/inactivity kill. The finalizer awaits it so an
+    // abort result is never produced while the spawned process group may
+    // still have live members (Issue #3517). Resolves true when the group is
+    // confirmed empty (or no group reap applies); never rejects.
+    let abortKillChain: Promise<boolean> | null = null;
+    const armAbortKill = (): void => {
+      if (abortKillChain === null) {
+        abortKillChain = cpKillOnAbort(state, child);
+      }
+    };
     setupCpInactivityHandler(
       state,
-      child,
       inactivityTimeoutMs,
       resetInactivityTimer,
+      armAbortKill,
     );
-    const abortHandler = setupCpAbortHandler(state, child);
+    const abortHandler = (): void => {
+      armAbortKill();
+    };
     const handleExit = createCpExitFinalizer(
       state,
       child,
       abortHandler,
+      () => abortKillChain,
       resolve,
     );
 
@@ -148,6 +162,7 @@ function createCpExitFinalizer(
   state: CpExecState,
   child: ChildProcess,
   abortHandler: () => void,
+  getAbortKillChain: () => Promise<boolean> | null,
   resolve: (value: ShellExecutionResult) => void,
 ): (code: number | null, signal: NodeJS.Signals | null) => void {
   const streamSettledListeners = new Map<
@@ -169,10 +184,27 @@ function createCpExitFinalizer(
     }
     streamSettledListeners.clear();
     const { finalBuffer } = cleanupCpResources(state, child, abortHandler);
-    const result = buildCpExitResult(state, child, code, signal, finalBuffer);
-    state.rawCollector = null;
-    state.sniffBuffer = null;
-    resolve(result);
+    const resolveFromKillChain = (groupConfirmedEmpty: boolean): void => {
+      const result = buildCpExitResult(state, child, code, signal, finalBuffer);
+      if (!groupConfirmedEmpty) {
+        // The bounded reap window expired with live group members: carry
+        // that fact so the tool layer can tell the caller children may
+        // still be running (Issue #3517).
+        result.survivingGroupMembersOnAbort = true;
+      }
+      state.rawCollector = null;
+      state.sniffBuffer = null;
+      resolve(result);
+    };
+    const abortKillChain = getAbortKillChain();
+    if (abortKillChain === null) {
+      resolveFromKillChain(true);
+      return;
+    }
+    // Abort/inactivity kill in flight: gate the result on the bounded
+    // group-reap confirmation. The chain never rejects, so resolution cannot
+    // stall past the reap window (Issue #3517).
+    void abortKillChain.then(resolveFromKillChain);
   };
 
   return (code: number | null, signal: NodeJS.Signals | null): void => {
@@ -225,15 +257,15 @@ function createCpExitFinalizer(
  */
 function setupCpInactivityHandler(
   state: CpExecState,
-  child: ChildProcess,
   inactivityTimeoutMs: number | undefined,
   resetInactivityTimer: () => void,
+  armAbortKill: () => void,
 ): void {
   if (inactivityTimeoutMs === undefined || inactivityTimeoutMs <= 0) {
     return;
   }
   const inactivityAbortHandler = () => {
-    void cpKillOnAbort(state, child);
+    armAbortKill();
   };
   state.inactivityAbortHandler = inactivityAbortHandler;
   state.inactivityAbortController.signal.addEventListener(
@@ -244,29 +276,33 @@ function setupCpInactivityHandler(
   resetInactivityTimer();
 }
 
-function setupCpAbortHandler(
-  state: CpExecState,
-  child: ChildProcess,
-): () => void {
-  return () => {
-    void cpKillOnAbort(state, child);
-  };
-}
-
-/** Kill the child process group on abort or inactivity timeout. */
+/**
+ * Kill the child process group on abort or inactivity timeout, then confirm
+ * within a bounded window that the group has no live members. Resolves false
+ * only when members outlived the SIGTERM→SIGKILL escalation and the reap
+ * window (Issue #3517). Never rejects.
+ */
 async function cpKillOnAbort(
   state: CpExecState,
   child: ChildProcess,
-): Promise<void> {
+): Promise<boolean> {
   // Guard the pid before it can reach process.kill(-pid): pid 0 would signal
   // the caller's own process group. isKillablePid also rejects negative and
   // non-finite pids, which the previous `!== 0` check let through.
-  if (isKillablePid(child.pid) && !state.exitedGuard.isExited()) {
-    await killProcessWithEscalation(
-      child.pid,
-      state.isWindows,
-      () => child.kill('SIGKILL'),
-      state.exitedGuard,
-    );
+  if (!isKillablePid(child.pid) || state.exitedGuard.isExited()) {
+    return true;
   }
+  const pid = child.pid;
+  await killProcessWithEscalation(
+    pid,
+    state.isWindows,
+    () => child.kill('SIGKILL'),
+    state.exitedGuard,
+  );
+  if (state.isWindows) {
+    // The Windows abort uses taskkill /f /t, which already walks the tree;
+    // there is no POSIX process group to reap here.
+    return true;
+  }
+  return reapProcessGroup(pid);
 }

--- a/packages/core/src/services/shellCpExecution.ts
+++ b/packages/core/src/services/shellCpExecution.ts
@@ -86,7 +86,13 @@ export function createCpResultPromise(
     // confirmed empty (or no group reap applies); never rejects.
     let abortKillChain: Promise<boolean> | null = null;
     const armAbortKill = (): void => {
-      abortKillChain ??= cpKillOnAbort(state, child);
+      // Enforce the never-rejecting contract at the arm site: a rejection
+      // from the escalation/reap chain (e.g. a synchronous taskkill spawn
+      // throw on Windows) is converted to `false` — group not confirmed
+      // empty — so the finalizer's gate can always resolve the result.
+      abortKillChain ??= cpKillOnAbort(state, child).catch(
+        (): boolean => false,
+      );
     };
     setupCpInactivityHandler(
       state,

--- a/packages/core/src/services/shellCpExecution.ts
+++ b/packages/core/src/services/shellCpExecution.ts
@@ -229,8 +229,8 @@ function createCpExitFinalizer(
     const { finalBuffer } = cleanupCpResources(state, child, abortHandler);
     const resolveFromKillChain = (groupConfirmedEmpty: boolean): void => {
       const result = buildCpExitResult(state, child, code, signal, finalBuffer);
-      if (!groupConfirmedEmpty) {
-        // The bounded reap window expired with live group members: carry
+      if (!state.isWindows && !groupConfirmedEmpty) {
+        // The POSIX reap window expired with live group members: carry
         // that fact so the tool layer can tell the caller children may
         // still be running (Issue #3517).
         result.survivingGroupMembersOnAbort = true;

--- a/packages/core/src/services/shellExecutionService.fallback.test.ts
+++ b/packages/core/src/services/shellExecutionService.fallback.test.ts
@@ -13,6 +13,8 @@ import {
   expect,
   beforeEach,
   afterEach,
+  afterAll,
+  mock,
   type Mock,
 } from 'bun:test';
 import EventEmitter from 'events';
@@ -35,6 +37,19 @@ const mockGetPty = vi.fn();
 void vi.mock('@lydell/node-pty', () => ({
   spawn: mockPtySpawn,
 }));
+// Captured before the vi.mock calls below execute (bun runs vi.mock in
+// statement order). Bun resolves every file in one shared process and
+// default-import bindings snapshot at load time, so the os factory below
+// spreads the real module and stubs only platform/homedir: a leaked hollow
+// os surface would break later files (shellProcessKill.test.ts needs
+// os.tmpdir).
+const actualOsModule = await import('os');
+const realOsSurface = { ...actualOsModule.default };
+const stubOsSurface = () => ({
+  ...realOsSurface,
+  platform: mockPlatform,
+  homedir: () => '/tmp/test-home',
+});
 const actual = { ...(await import('child_process')) };
 void vi.mock('child_process', () => ({
   ...actual,
@@ -43,33 +58,34 @@ void vi.mock('child_process', () => ({
 void vi.mock('../utils/textUtils.js', () => ({
   isBinary: mockIsBinary,
 }));
-void vi.mock('os', () => ({
-  default: {
-    platform: mockPlatform,
-    homedir: () => '/tmp/test-home',
-    constants: {
-      signals: {
-        SIGTERM: 15,
-        SIGKILL: 9,
-      },
-    },
-  },
-  platform: mockPlatform,
-  homedir: () => '/tmp/test-home',
-  constants: {
-    signals: {
-      SIGTERM: 15,
-      SIGKILL: 9,
-    },
-  },
-}));
+void vi.mock('os', () => ({ ...stubOsSurface(), default: stubOsSurface() }));
 void vi.mock('../utils/getPty.js', () => ({
   getPty: mockGetPty,
 }));
 
+/**
+ * Group pids that have received SIGKILL. Signal-0 liveness probes from the
+ * abort group-reap confirmation (issue #3517) answer "alive" until the
+ * group's SIGKILL is delivered, then ESRCH, mirroring a real process group
+ * dying.
+ */
+const killedGroupPids = new Set<number>();
 const mockProcessKill = vi
   .spyOn(process, 'kill')
-  .mockImplementation(() => true);
+  .mockImplementation((pid: number, signal?: NodeJS.Signals | number) => {
+    if (signal === 0) {
+      if (killedGroupPids.has(pid)) {
+        throw Object.assign(new Error(`process group ${pid} not found`), {
+          code: 'ESRCH',
+        });
+      }
+      return true;
+    }
+    if (signal === 'SIGKILL') {
+      killedGroupPids.add(pid);
+    }
+    return true;
+  });
 
 const stubProcessPlatform = (platform: NodeJS.Platform): void => {
   setGlobal('process', { ...process, env: process.env, platform });
@@ -81,6 +97,7 @@ describe('ShellExecutionService child_process fallback', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    killedGroupPids.clear();
     stubProcessPlatform('linux');
 
     mockIsBinary.mockReturnValue(false);
@@ -107,6 +124,22 @@ describe('ShellExecutionService child_process fallback', () => {
 
   afterEach(() => {
     restoreGlobals();
+  });
+
+  // Bun runs every test file in this invocation in one shared process. The
+  // module-level process.kill spy and the vi.mock module replacements leak
+  // into later files, so this file leaves them behaviorally real: the spy is
+  // restored, the leaked platform stub passes through to the real platform,
+  // and child_process is re-registered with the real spawn for live named
+  // bindings resolved after this point (default-import bindings snapshot at
+  // load time, which is why the os factory itself must stay passthrough-real).
+  afterAll(() => {
+    mockProcessKill.mockRestore();
+    mockPlatform.mockReset();
+    mockPlatform.mockImplementation(() => realOsSurface.platform());
+    const realChildProcess = () => ({ ...actual, spawn: actual.spawn });
+    void mock.module('child_process', realChildProcess);
+    void mock.module('node:child_process', realChildProcess);
   });
 
   // Default shell execution config for tests
@@ -390,46 +423,57 @@ describe('ShellExecutionService child_process fallback', () => {
     it('should gracefully attempt SIGKILL on linux if SIGTERM fails', async () => {
       mockPlatform.mockReturnValue('linux');
       vi.useFakeTimers();
+      try {
+        // Don't await the result inside the simulation block for this specific
+        // test. We need to control the timeline manually.
+        const abortController = new AbortController();
+        const handle = await ShellExecutionService.execute(
+          'unresponsive_process',
+          '/test/dir',
+          onOutputEventMock,
+          abortController.signal,
+          true,
+          defaultShellConfig,
+        );
 
-      // Don't await the result inside the simulation block for this specific test.
-      // We need to control the timeline manually.
-      const abortController = new AbortController();
-      const handle = await ShellExecutionService.execute(
-        'unresponsive_process',
-        '/test/dir',
-        onOutputEventMock,
-        abortController.signal,
-        true,
-        defaultShellConfig,
-      );
+        abortController.abort();
 
-      abortController.abort();
+        // Check the first kill signal
+        expect(mockProcessKill).toHaveBeenCalledWith(
+          -mockChildProcess.pid!,
+          'SIGTERM',
+        );
 
-      // Check the first kill signal
-      expect(mockProcessKill).toHaveBeenCalledWith(
-        -mockChildProcess.pid!,
-        'SIGTERM',
-      );
+        // Now, advance time past the timeout
+        await advanceTimersByTimeAsync(250);
 
-      // Now, advance time past the timeout
-      await advanceTimersByTimeAsync(250);
+        // Check the second kill signal
+        expect(mockProcessKill).toHaveBeenCalledWith(
+          -mockChildProcess.pid!,
+          'SIGKILL',
+        );
 
-      // Check the second kill signal
-      expect(mockProcessKill).toHaveBeenCalledWith(
-        -mockChildProcess.pid!,
-        'SIGKILL',
-      );
+        // Finally, simulate the process exiting and await the result
+        mockChildProcess.emit('exit', null, 'SIGKILL');
+        const result = await handle.result;
 
-      // Finally, simulate the process exiting and await the result
-      mockChildProcess.emit('exit', null, 'SIGKILL');
-      const result = await handle.result;
-
-      vi.useRealTimers();
-
-      expect(result.aborted).toBe(true);
-      expect(result.signal).toBe(9);
-      // The individual kill calls were already asserted above.
-      expect(mockProcessKill).toHaveBeenCalledTimes(2);
+        expect(result.aborted).toBe(true);
+        expect(result.signal).toBe(9);
+        // The individual kill calls were already asserted above. Signal-0
+        // liveness probes from the group-reap confirmation (issue #3517) are
+        // not signal deliveries, so count real signals only.
+        const deliveredSignals = mockProcessKill.mock.calls.filter(
+          (call) => call[1] !== 0,
+        );
+        expect(deliveredSignals).toHaveLength(2);
+      } finally {
+        // A failing or stuck body must not leave fake timers installed for
+        // the rest of the file: every later await (including Bun's own
+        // per-test timeout, which is itself a faked timer) would then hang
+        // until the per-file budget — the twice-identical 300s timeout seen
+        // under run-bun-tests.ts.
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/packages/core/src/services/shellExecutionService.fallback.test.ts
+++ b/packages/core/src/services/shellExecutionService.fallback.test.ts
@@ -64,7 +64,8 @@ void vi.mock('../utils/getPty.js', () => ({
 }));
 
 /**
- * Group pids that have received SIGKILL. Signal-0 liveness probes from the
+ * Group pids that have received SIGKILL (string or numeric 9). Signal-0
+ * liveness probes from the
  * abort group-reap confirmation (issue #3517) answer "alive" until the
  * group's SIGKILL is delivered, then ESRCH, mirroring a real process group
  * dying.
@@ -81,7 +82,7 @@ const mockProcessKill = vi
       }
       return true;
     }
-    if (signal === 'SIGKILL') {
+    if (signal === 'SIGKILL' || signal === 9) {
       killedGroupPids.add(pid);
     }
     return true;

--- a/packages/core/src/services/shellExecutionService.main.test.ts
+++ b/packages/core/src/services/shellExecutionService.main.test.ts
@@ -4,7 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { vi, describe, it, expect, beforeEach, type Mock } from 'bun:test';
+import {
+  vi,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterAll,
+  mock,
+  type Mock,
+} from 'bun:test';
 import EventEmitter from 'events';
 import type {
   ShellOutputEvent,
@@ -31,26 +40,20 @@ void vi.mock('child_process', () => ({
 void vi.mock('../utils/textUtils.js', () => ({
   isBinary: mockIsBinary,
 }));
-void vi.mock('os', () => ({
-  default: {
-    platform: mockPlatform,
-    homedir: () => '/tmp/test-home',
-    constants: {
-      signals: {
-        SIGTERM: 15,
-        SIGKILL: 9,
-      },
-    },
-  },
+// Captured before the vi.mock calls below execute (bun runs vi.mock in
+// statement order). Bun resolves every file in one shared process and
+// default-import bindings snapshot at load time, so the os factory below
+// spreads the real module and stubs only platform/homedir: a leaked hollow
+// os surface would break later files (shellProcessKill.test.ts needs
+// os.tmpdir).
+const actualOsModule = await import('os');
+const realOsSurface = { ...actualOsModule.default };
+const stubOsSurface = () => ({
+  ...realOsSurface,
   platform: mockPlatform,
   homedir: () => '/tmp/test-home',
-  constants: {
-    signals: {
-      SIGTERM: 15,
-      SIGKILL: 9,
-    },
-  },
-}));
+});
+void vi.mock('os', () => ({ ...stubOsSurface(), default: stubOsSurface() }));
 void vi.mock('../utils/runtime.js', () => ({
   isWindows: () => mockPlatform() === 'win32',
 }));
@@ -58,9 +61,34 @@ void vi.mock('../utils/getPty.js', () => ({
   getPty: mockGetPty,
 }));
 
+/**
+ * Group pids that have received SIGKILL. Signal-0 liveness probes from the
+ * abort group-reap confirmation (issue #3517) answer "alive" until the
+ * group's SIGKILL is delivered, then ESRCH, mirroring a real process group
+ * dying.
+ */
+const killedGroupPids = new Set<number>();
+const probeOrDeliver = (
+  pid: number,
+  signal?: NodeJS.Signals | number,
+): boolean => {
+  if (signal === 0) {
+    if (killedGroupPids.has(pid)) {
+      throw Object.assign(new Error(`process group ${pid} not found`), {
+        code: 'ESRCH',
+      });
+    }
+    return true;
+  }
+  if (signal === 'SIGKILL') {
+    killedGroupPids.add(pid);
+  }
+  return true;
+};
+
 const mockProcessKill = vi
   .spyOn(process, 'kill')
-  .mockImplementation(() => true);
+  .mockImplementation(probeOrDeliver);
 
 const shellExecutionConfig: ShellExecutionConfig = {
   terminalWidth: 80,
@@ -81,6 +109,7 @@ describe('ShellExecutionService', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    killedGroupPids.clear();
 
     mockIsBinary.mockReturnValue(false);
     mockPlatform.mockReturnValue('linux');
@@ -106,6 +135,22 @@ describe('ShellExecutionService', () => {
     mockPtyProcess.write = vi.fn();
 
     mockPtySpawn.mockReturnValue(mockPtyProcess);
+  });
+
+  // Bun runs every test file in this invocation in one shared process. The
+  // module-level process.kill spy and the vi.mock module replacements leak
+  // into later files, so this file leaves them behaviorally real: the spy is
+  // restored, the leaked platform stub passes through to the real platform,
+  // and child_process is re-registered with the real spawn for live named
+  // bindings resolved after this point (default-import bindings snapshot at
+  // load time, which is why the os factory itself must stay passthrough-real).
+  afterAll(() => {
+    mockProcessKill.mockRestore();
+    mockPlatform.mockReset();
+    mockPlatform.mockImplementation(() => realOsSurface.platform());
+    const realChildProcess = () => ({ ...actual, spawn: actual.spawn });
+    void mock.module('child_process', realChildProcess);
+    void mock.module('node:child_process', realChildProcess);
   });
 
   // Default shell execution config for tests
@@ -145,14 +190,16 @@ describe('ShellExecutionService', () => {
     new Promise<void>((resolve) => {
       mockProcessKill.mockImplementation((pid, signal) => {
         if (signal === 'SIGKILL' && pid === -mockPtyProcess.pid) resolve();
-        return true;
+        return probeOrDeliver(pid, signal);
       });
     });
 
+  // Signal-0 liveness probes from the group-reap confirmation (issue #3517)
+  // are not signal deliveries: ordering is asserted among real signals only.
   const killCallIndex = (signal: NodeJS.Signals): number =>
-    mockProcessKill.mock.calls.findIndex(
-      (call) => call[0] === -mockPtyProcess.pid && call[1] === signal,
-    );
+    mockProcessKill.mock.calls
+      .filter((call) => call[0] === -mockPtyProcess.pid && call[1] !== 0)
+      .findIndex((call) => call[1] === signal);
 
   const emitOutputWhenReady = (): void => {
     mockPtyProcess.onData.mock.calls[0][0]('output\n');

--- a/packages/core/src/services/shellExecutionService.main.test.ts
+++ b/packages/core/src/services/shellExecutionService.main.test.ts
@@ -62,7 +62,8 @@ void vi.mock('../utils/getPty.js', () => ({
 }));
 
 /**
- * Group pids that have received SIGKILL. Signal-0 liveness probes from the
+ * Group pids that have received SIGKILL (string or numeric 9). Signal-0
+ * liveness probes from the
  * abort group-reap confirmation (issue #3517) answer "alive" until the
  * group's SIGKILL is delivered, then ESRCH, mirroring a real process group
  * dying.
@@ -80,7 +81,7 @@ const probeOrDeliver = (
     }
     return true;
   }
-  if (signal === 'SIGKILL') {
+  if (signal === 'SIGKILL' || signal === 9) {
     killedGroupPids.add(pid);
   }
   return true;

--- a/packages/core/src/services/shellExecutionTypes.ts
+++ b/packages/core/src/services/shellExecutionTypes.ts
@@ -28,6 +28,14 @@ export interface ShellExecutionResult {
   aborted: boolean;
   /** Whether the command was killed due to an inactivity timeout. */
   inactivityTimedOut?: boolean;
+  /**
+   * True when an abort-timeout kill left live members in the spawned process
+   * group after the bounded reap window expired. Set only on the POSIX
+   * group-kill abort path; absent means the group was confirmed empty (or no
+   * group kill applies). Carried so the tool layer can tell the caller
+   * children may still be running (Issue #3517).
+   */
+  survivingGroupMembersOnAbort?: boolean;
   /** The process ID of the spawned shell. */
   pid: number | undefined;
   /** The method used to execute the shell command. */

--- a/packages/core/src/services/shellProcessKill.test.ts
+++ b/packages/core/src/services/shellProcessKill.test.ts
@@ -489,9 +489,8 @@ describe('ShellProcessKill platform behavior', () => {
         // Signal-0 probes say the group is gone after the SIGTERM grace, so
         // the escalation must stop: no kill(-pid, 'SIGKILL') may be issued.
         const realKill = process.kill;
-        const deliveredSignals: Array<
-          [pid: number, signal: string | number]
-        > = [];
+        const deliveredSignals: Array<[pid: number, signal: string | number]> =
+          [];
         const killSpy = vi
           .spyOn(process, 'kill')
           .mockImplementation((pid: number, signal?: string | number) => {

--- a/packages/core/src/services/shellProcessKill.test.ts
+++ b/packages/core/src/services/shellProcessKill.test.ts
@@ -14,6 +14,7 @@ import {
   boundedTaskkill,
   escalateKillUnix,
   isKillablePid,
+  reapProcessGroup,
   taskkillTree,
 } from './shellProcessKill.js';
 import { createExitGuard } from './shellExitGuard.js';
@@ -287,6 +288,105 @@ describe('ShellProcessKill platform behavior', () => {
       }
     }, 20000);
   });
+
+  // ---------------------------------------------------------------------------
+  // escalateKillUnix group escalation / reapProcessGroup — POSIX-only
+  // (production behavior is POSIX-gated) — Issue #3517
+  // ---------------------------------------------------------------------------
+
+  describe.skipIf(isWindows)(
+    'escalateKillUnix group escalation (POSIX, issue #3517)',
+    () => {
+      it('group SIGKILL still fires when the direct child is dead but a TERM-immune group member lives', async () => {
+        // Incident #3517: the direct child (bash wrapper) died from the group
+        // SIGTERM, the shared guard was marked exited, and the group SIGKILL
+        // was gated on that guard — leaving a TERM-immune grandchild alive in
+        // the group after termination was reported. Escalation must be gated
+        // on GROUP liveness, not on the direct child.
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'escalate-group-'));
+        const marker = path.join(dir, 'member.pid');
+        // The subshell stays in the leader's process group; `trap '' TERM`
+        // sets SIG_IGN, a disposition that survives `exec sleep 30`.
+        const leader = spawn(
+          'bash',
+          ['-c', `( trap '' TERM; exec sleep 30 ) & echo $! > ${marker}; exit 0`],
+          { detached: true, stdio: 'ignore' },
+        );
+        leader.on('error', () => {});
+        leader.unref();
+        // Attach before any await: the leader exits within a few ms, and an
+        // 'exit' listener attached after the event dispatched never fires.
+        const leaderExited = new Promise<void>((resolve) =>
+          leader.once('exit', () => resolve()),
+        );
+        const leaderPid = observedProcessPid(leader.pid);
+        expect(leaderPid).toBeGreaterThan(0);
+        try {
+          const memberPid = Number(await waitForMarker(marker, 8000));
+          expect(memberPid).toBeGreaterThan(0);
+          // Wait for the leader's exit through the handle: this process is
+          // its parent, so a signal-0 probe could observe an unreaped zombie
+          // instead of a dead group leader.
+          await leaderExited;
+          // Reproduce the incident's guard state: the direct child is dead
+          // and the guard knows it. The old predicate skipped the group
+          // SIGKILL from here.
+          const guard = createExitGuard();
+          guard.markExited();
+          await escalateKillUnix(leaderPid, guard, () => {});
+          // The member is NOT this process's child (it was reparented when
+          // the leader exited), so a signal-0 probe proves real death.
+          await waitForPidGone(memberPid, 8000);
+          expect(isPidAlive(memberPid)).toBe(false);
+        } finally {
+          reapGroup(leaderPid);
+          fs.rmSync(dir, { recursive: true, force: true });
+        }
+      }, 30000);
+    },
+  );
+
+  describe.skipIf(isWindows)(
+    'reapProcessGroup bounded confirmation (POSIX, issue #3517)',
+    () => {
+      it('resolves true promptly when the group is already gone', async () => {
+        const leader = spawn('bash', ['-c', 'exit 0'], {
+          detached: true,
+          stdio: 'ignore',
+        });
+        leader.on('error', () => {});
+        leader.unref();
+        // Attach before any await: see the escalation test for the
+        // missed-event race this ordering avoids.
+        const leaderExited = new Promise<void>((resolve) =>
+          leader.once('exit', () => resolve()),
+        );
+        const leaderPid = observedProcessPid(leader.pid);
+        expect(leaderPid).toBeGreaterThan(0);
+        try {
+          // A non-killable pid must be treated as reaped without ever being
+          // probed with a real signal target (pid 0 would be the caller's
+          // own group).
+          await expect(reapProcessGroup(0)).resolves.toBe(true);
+          await leaderExited;
+          const start = Date.now();
+          await expect(reapProcessGroup(leaderPid)).resolves.toBe(true);
+          expect(Date.now() - start).toBeLessThan(1000);
+        } finally {
+          reapGroup(leaderPid);
+        }
+      }, 20000);
+
+      it('resolves false when a probed group stays alive for the window', async () => {
+        // pid 1 always exists and never dies, so the probe window must
+        // expire. Signal-0 probes ONLY: sig 0 delivers no signal, so init is
+        // never actually signalled.
+        const start = Date.now();
+        await expect(reapProcessGroup(1, 300)).resolves.toBe(false);
+        expect(Date.now() - start).toBeGreaterThanOrEqual(250);
+      }, 20000);
+    },
+  );
 
   // ---------------------------------------------------------------------------
   // boundedTaskkill / taskkillTree — Windows-only (production behavior gated)

--- a/packages/core/src/services/shellProcessKill.test.ts
+++ b/packages/core/src/services/shellProcessKill.test.ts
@@ -309,7 +309,10 @@ describe('ShellProcessKill platform behavior', () => {
         // sets SIG_IGN, a disposition that survives `exec sleep 30`.
         const leader = spawn(
           'bash',
-          ['-c', `( trap '' TERM; exec sleep 30 ) & echo $! > ${marker}; exit 0`],
+          [
+            '-c',
+            `( trap '' TERM; exec sleep 30 ) & echo $! > ${marker}; exit 0`,
+          ],
           { detached: true, stdio: 'ignore' },
         );
         leader.on('error', () => {});

--- a/packages/core/src/services/shellProcessKill.test.ts
+++ b/packages/core/src/services/shellProcessKill.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it, vi } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -13,7 +13,9 @@ import { spawn } from 'node:child_process';
 import {
   boundedTaskkill,
   escalateKillUnix,
+  isGroupTargetPid,
   isKillablePid,
+  isProcessGroupAlive,
   reapProcessGroup,
   taskkillTree,
 } from './shellProcessKill.js';
@@ -100,6 +102,37 @@ describe('isKillablePid', () => {
     expect(isKillablePid(1)).toBe(true);
     expect(isKillablePid(1234)).toBe(true);
     expect(isKillablePid(process.pid)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isGroupTargetPid — the group-scoped chokepoint for process.kill(-pid, ...)
+// ---------------------------------------------------------------------------
+
+describe('isGroupTargetPid', () => {
+  it('rejects the POSIX broadcast special case (pid 1) and non-groups', () => {
+    // kill(-1, ...) signals every signalable process; kill(-0, ...) the
+    // caller's own group. Neither may be formed from a group target.
+    expect(isGroupTargetPid(1)).toBe(false);
+    expect(isGroupTargetPid(0)).toBe(false);
+    expect(isGroupTargetPid(-1)).toBe(false);
+    expect(isGroupTargetPid(-1234)).toBe(false);
+  });
+
+  it('rejects non-finite and non-integer values', () => {
+    expect(isGroupTargetPid(Number.NaN)).toBe(false);
+    expect(isGroupTargetPid(Number.POSITIVE_INFINITY)).toBe(false);
+    expect(isGroupTargetPid(1.5)).toBe(false);
+    expect(isGroupTargetPid(undefined)).toBe(false);
+  });
+
+  it('accepts whole pids greater than 1 while isKillablePid still accepts pid 1', () => {
+    // pid 1 stays a legitimate DIRECT kill target; only its negation is a
+    // broadcast and therefore rejected for group operations.
+    expect(isGroupTargetPid(2)).toBe(true);
+    expect(isGroupTargetPid(1234)).toBe(true);
+    expect(isKillablePid(1)).toBe(true);
+    expect(isGroupTargetPid(1)).toBe(false);
   });
 });
 
@@ -380,14 +413,112 @@ describe('ShellProcessKill platform behavior', () => {
         }
       }, 20000);
 
-      it('resolves false when a probed group stays alive for the window', async () => {
-        // pid 1 always exists and never dies, so the probe window must
-        // expire. Signal-0 probes ONLY: sig 0 delivers no signal, so init is
-        // never actually signalled.
-        const start = Date.now();
-        await expect(reapProcessGroup(1, 300)).resolves.toBe(false);
-        expect(Date.now() - start).toBeGreaterThanOrEqual(250);
+      it('resolves false when a real group stays alive for the window', async () => {
+        // A detached `sleep 5` leads its own process group and will not die
+        // within the short reap window, so the probes must outlive it. The
+        // old form probed pid 1: kill(-1, 0) asks about EVERY signalable
+        // process, which passed for the wrong reason, was semantically the
+        // broadcast special case, and was non-hermetic on minimal containers
+        // where pid 1 may not exist.
+        const leader = spawn('sleep', ['5'], {
+          detached: true,
+          stdio: 'ignore',
+        });
+        leader.on('error', () => {});
+        leader.unref();
+        const leaderPid = observedProcessPid(leader.pid);
+        expect(leaderPid).toBeGreaterThan(0);
+        try {
+          await waitForGroupAlive(leaderPid, 8000);
+          const start = Date.now();
+          await expect(reapProcessGroup(leaderPid, 300)).resolves.toBe(false);
+          expect(Date.now() - start).toBeGreaterThanOrEqual(250);
+        } finally {
+          reapGroup(leaderPid);
+        }
       }, 20000);
+
+      it('resolves true when the group dies mid-window (convergent reap)', async () => {
+        // Alive at the first probe, empty before the deadline: the
+        // production path for a group that dies during the reap window.
+        const leader = spawn('sleep', ['0.4'], {
+          detached: true,
+          stdio: 'ignore',
+        });
+        leader.on('error', () => {});
+        leader.unref();
+        // Attach before any await: the runtime reaps this direct child, and
+        // the listener keeps the exit observation registered.
+        leader.once('exit', () => undefined);
+        const leaderPid = observedProcessPid(leader.pid);
+        expect(leaderPid).toBeGreaterThan(0);
+        try {
+          await waitForGroupAlive(leaderPid, 8000);
+          await expect(reapProcessGroup(leaderPid, 2000)).resolves.toBe(true);
+        } finally {
+          reapGroup(leaderPid);
+        }
+      }, 20000);
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Liveness probe semantics + escalation skip path — POSIX-only, spy-based
+  // (deterministic: no foreign process required) — Issue #3517
+  // ---------------------------------------------------------------------------
+
+  describe.skipIf(isWindows)(
+    'liveness probe semantics (POSIX, issue #3517)',
+    () => {
+      it('isProcessGroupAlive maps EPERM to alive (a member exists that we may not signal)', async () => {
+        const killSpy = vi
+          .spyOn(process, 'kill')
+          .mockImplementation((_pid: number, _signal?: string | number) => {
+            throw Object.assign(new Error('operation not permitted'), {
+              code: 'EPERM',
+            });
+          });
+        try {
+          expect(isProcessGroupAlive(4242)).toBe(true);
+        } finally {
+          killSpy.mockRestore();
+        }
+      });
+
+      it('escalateKillUnix skips the group SIGKILL when the group dies during the grace window', async () => {
+        // Signal-0 probes say the group is gone after the SIGTERM grace, so
+        // the escalation must stop: no kill(-pid, 'SIGKILL') may be issued.
+        const realKill = process.kill;
+        const deliveredSignals: Array<
+          [pid: number, signal: string | number]
+        > = [];
+        const killSpy = vi
+          .spyOn(process, 'kill')
+          .mockImplementation((pid: number, signal?: string | number) => {
+            if (signal === undefined) {
+              return realKill(pid);
+            }
+            if (signal !== 0) {
+              deliveredSignals.push([pid, signal]);
+            }
+            if (signal === 0) {
+              throw Object.assign(new Error('no such process'), {
+                code: 'ESRCH',
+              });
+            }
+            return true;
+          });
+        try {
+          const guard = createExitGuard();
+          await escalateKillUnix(424242, guard, () => {});
+          const realSignals = deliveredSignals.filter(
+            ([, signal]) => signal !== 0,
+          );
+          expect(realSignals).toStrictEqual([[424242 * -1, 'SIGTERM']]);
+        } finally {
+          killSpy.mockRestore();
+        }
+      });
     },
   );
 
@@ -494,6 +625,23 @@ async function waitForPidGone(pid: number, timeoutMs: number): Promise<void> {
     if (!isPidAlive(pid)) return;
     await new Promise((resolve) => setTimeout(resolve, 150));
   }
+}
+
+/**
+ * Poll the signal-0 group probe until it reports the group alive. Readiness
+ * gate for real spawned groups: the detached child needs a moment to become
+ * observable as a process-group leader.
+ */
+async function waitForGroupAlive(
+  pgid: number,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (isProcessGroupAlive(pgid)) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Process group ${pgid} not alive within ${timeoutMs}ms`);
 }
 
 /**

--- a/packages/core/src/services/shellProcessKill.ts
+++ b/packages/core/src/services/shellProcessKill.ts
@@ -152,7 +152,7 @@ export function isProcessGroupAlive(pid: number): boolean {
     process.kill(-pid, 0);
     return true;
   } catch (error) {
-    return (error as NodeJS.ErrnoException)?.code === 'EPERM';
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
   }
 }
 

--- a/packages/core/src/services/shellProcessKill.ts
+++ b/packages/core/src/services/shellProcessKill.ts
@@ -125,9 +125,72 @@ export function boundedTaskkill(
 }
 
 /**
+ * Bounded window for confirming a killed process group has no live members
+ * before an abort result is produced (Issue #3517). Long enough for the
+ * kernel and the reaping parents (this runtime for the direct child, init
+ * for reparented grandchildren) to clear killed members; short enough that
+ * an unkillable survivor cannot stall the tool result.
+ */
+export const GROUP_REAP_WINDOW_MS = 1500;
+
+/** Poll interval for the bounded group-reap liveness probe. */
+export const GROUP_REAP_POLL_INTERVAL_MS = 50;
+
+/**
+ * Signal-0 liveness probe for a POSIX process group. Delivers no signal:
+ * sig 0 only asks the kernel whether the group exists and is signalable.
+ * EPERM still proves liveness (a member exists that we may not signal);
+ * every other failure means the group is gone.
+ */
+export function isProcessGroupAlive(pid: number): boolean {
+  if (!isKillablePid(pid)) {
+    // Rejected by the same chokepoint that guards every real signal: pid 0
+    // would probe the caller's own process group.
+    return false;
+  }
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException)?.code === 'EPERM';
+  }
+}
+
+/**
+ * Bounded, never-rejecting confirmation that a process group is empty. Polls
+ * a signal-0 probe (never a real signal) until the group is gone or the
+ * window expires. Resolves true when the group was confirmed empty, false
+ * when members may still be alive after the window (the caller must then say
+ * so in its result — Issue #3517).
+ */
+export async function reapProcessGroup(
+  pid: number,
+  windowMs: number = GROUP_REAP_WINDOW_MS,
+): Promise<boolean> {
+  if (!isKillablePid(pid)) {
+    return true;
+  }
+  const deadline = Date.now() + windowMs;
+  for (;;) {
+    if (!isProcessGroupAlive(pid)) {
+      return true;
+    }
+    if (Date.now() >= deadline) {
+      return false;
+    }
+    await new Promise((resolve) =>
+      setTimeout(resolve, GROUP_REAP_POLL_INTERVAL_MS),
+    );
+  }
+}
+
+/**
  * Send SIGTERM then, after a short grace period, SIGKILL to a Unix
- * process group, guarded by the shared {@link ExitGuard} so that a
- * process that exits during the grace period is not killed again.
+ * process group. Escalation is gated on GROUP liveness, not on the direct
+ * child the {@link ExitGuard} tracks: when the child dies from the SIGTERM
+ * but a grandchild ignores or traps it, the group is still alive and must
+ * still be escalated (Issue #3517). The guard remains authoritative for the
+ * catch/fallback path.
  */
 export async function escalateKillUnix(
   pid: number | undefined,
@@ -142,7 +205,7 @@ export async function escalateKillUnix(
   try {
     process.kill(-pid, 'SIGTERM');
     await new Promise((res) => setTimeout(res, SIGKILL_TIMEOUT_MS));
-    if (!exitedGuard.isExited()) {
+    if (isProcessGroupAlive(pid)) {
       process.kill(-pid, 'SIGKILL');
     }
   } catch {

--- a/packages/core/src/services/shellProcessKill.ts
+++ b/packages/core/src/services/shellProcessKill.ts
@@ -176,6 +176,10 @@ export function isProcessGroupAlive(pid: number): boolean {
  * window expires. Resolves true when the group was confirmed empty, false
  * when members may still be alive after the window (the caller must then say
  * so in its result — Issue #3517).
+ * Non-group-target pids 0 and 1 return true (treated as already reaped) by
+ * contract because there is no safe negated probe: kill(-1, 0) is the POSIX
+ * broadcast to every signalable process, and kill(-0, 0) probes the caller's
+ * own process group.
  */
 export async function reapProcessGroup(
   pid: number,

--- a/packages/core/src/services/shellProcessKill.ts
+++ b/packages/core/src/services/shellProcessKill.ts
@@ -25,6 +25,19 @@ export function isKillablePid(pid: unknown): pid is number {
 }
 
 /**
+ * Group-target variant of {@link isKillablePid} for every
+ * `process.kill(-pid, ...)` call site. `kill(-1, ...)` is the POSIX
+ * broadcast special case — every signalable process — which is the exact
+ * hazard the chokepoint exists to prevent, reintroduced via negation, so a
+ * group target must additionally be greater than 1. `isKillablePid(1)`
+ * deliberately stays true: pid 1 is a legitimate direct kill target, and
+ * that predicate is used for non-group kills.
+ */
+export function isGroupTargetPid(pid: unknown): pid is number {
+  return typeof pid === 'number' && Number.isInteger(pid) && pid > 1;
+}
+
+/**
  * Fire-and-forget taskkill on Windows.  The arguments are explicit and
  * fully controlled; `sonarjs/no-os-command-from-path` is centrally
  * disabled for this codebase.
@@ -143,9 +156,10 @@ export const GROUP_REAP_POLL_INTERVAL_MS = 50;
  * every other failure means the group is gone.
  */
 export function isProcessGroupAlive(pid: number): boolean {
-  if (!isKillablePid(pid)) {
-    // Rejected by the same chokepoint that guards every real signal: pid 0
-    // would probe the caller's own process group.
+  if (!isGroupTargetPid(pid)) {
+    // Rejected by the group-target chokepoint: pid 1 would broadcast to
+    // every signalable process and pid 0 would probe the caller's own
+    // process group.
     return false;
   }
   try {
@@ -167,7 +181,9 @@ export async function reapProcessGroup(
   pid: number,
   windowMs: number = GROUP_REAP_WINDOW_MS,
 ): Promise<boolean> {
-  if (!isKillablePid(pid)) {
+  if (!isGroupTargetPid(pid)) {
+    // Rejected by the group-target chokepoint: probing pid 1 would ask
+    // about every signalable process, and pid 0 the caller's own group.
     return true;
   }
   const deadline = Date.now() + windowMs;
@@ -197,9 +213,10 @@ export async function escalateKillUnix(
   exitedGuard: ExitGuard,
   killFallback: () => void,
 ): Promise<void> {
-  if (!isKillablePid(pid)) {
-    // A non-killable pid must never reach process.kill(-pid): pid 0 would
-    // signal the caller's own process group. Treat it as already gone.
+  if (!isGroupTargetPid(pid)) {
+    // A pid that is not a valid group target must never reach
+    // process.kill(-pid): pid 0 would signal the caller's own process group
+    // and pid 1 every signalable process. Treat it as already gone.
     return;
   }
   try {

--- a/packages/core/src/services/shellPtyLifecycle.test.ts
+++ b/packages/core/src/services/shellPtyLifecycle.test.ts
@@ -292,6 +292,97 @@ describe('ptyInactivityAbortAction pid validation', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Abort vs exit ordering (fake pty, issue #3517)
+// ---------------------------------------------------------------------------
+
+describe('PTY abort signal fidelity (fake pty, issue #3517)', () => {
+  it('real exit signal wins over the synthetic abort result when the exit fires before the group-reap chain settles', async () => {
+    // process.kill is stubbed for the whole test, so the fabricated pid is
+    // never aimed at a real process group (the suite's standing rule). The
+    // stub makes every signal-0 group probe report "alive" without throwing,
+    // which forces the bounded reap window to expire (the chain resolves
+    // false instead of confirming the group empty) while absorbing every
+    // real signal as a no-op.
+    const realProcessKill = process.kill;
+    const groupProbes: number[] = [];
+    process.kill = ((pid: number, signal?: string | number) => {
+      if (signal === 0) {
+        groupProbes.push(pid);
+      }
+      return true;
+    }) as unknown as typeof process.kill;
+
+    const killSignals: string[] = [];
+    let exitListener:
+      | ((event: { exitCode: number; signal?: number }) => void)
+      | undefined;
+    const ptyProcess = {
+      pid: 999998,
+      kill: (signal?: string | number): void => {
+        killSignals.push(signal === undefined ? '<none>' : String(signal));
+      },
+      onData: () => ({ dispose: () => undefined }),
+      onExit: (
+        listener: (event: { exitCode: number; signal?: number }) => void,
+      ) => {
+        exitListener = listener;
+        return { dispose: () => undefined };
+      },
+    } as unknown as IPty;
+
+    const abortController = new AbortController();
+    const activePtys = new Map<number, ActivePty>();
+    try {
+      const resultPromise = createPtyResultPromise(
+        ptyProcess,
+        false,
+        80,
+        30,
+        () => undefined,
+        abortController.signal,
+        { scrollback: 10 } as ShellExecutionConfig,
+        {
+          name: 'node-pty',
+          module: {},
+          supportsBackpressure: true,
+        } as NonNullable<PtyImplementation>,
+        activePtys,
+        { value: null },
+      );
+
+      // The abort listener runs armPtyGroupAbortKill's synchronous SIGTERM
+      // prefix (and its chain registration) before abort() returns; the real
+      // exit event is then delivered well before the chain settles inside
+      // its bounded kill + reap window.
+      abortController.abort();
+      if (exitListener === undefined) {
+        throw new Error('PTY exit handler was not registered');
+      }
+      exitListener({ exitCode: 137, signal: 9 });
+
+      const result = await resultPromise;
+
+      // The chain really ran: the group got the fake pty's SIGTERM and the
+      // stubbed probe kept reporting members, so the window expired.
+      expect(killSignals).toContain('SIGTERM');
+      expect(groupProbes.length).toBeGreaterThan(0);
+
+      // Ordering guarantee: ptyAbortAction saw exitedGuard marked by the
+      // real exit and deferred to the exit handler's chain continuation
+      // instead of resolving its synthetic (exitCode 1, signal null) result.
+      expect(result.exitCode).toBe(137);
+      expect(result.signal).toBe(9);
+      expect(result.aborted).toBe(true);
+      // The chain could not confirm the group empty, so the survivor flag
+      // must still reach the finalized result.
+      expect(result.survivingGroupMembersOnAbort).toBe(true);
+    } finally {
+      process.kill = realProcessKill;
+    }
+  }, 10000);
+});
+
+// ---------------------------------------------------------------------------
 // Real forkpty abort behavior (POSIX, issue #3517)
 // ---------------------------------------------------------------------------
 
@@ -326,7 +417,11 @@ async function waitForMarker(
 }
 
 /** Race a promise against a deadline, resolving `timeoutValue` on expiry. */
-function withDeadline<T>(promise: Promise<T>, ms: number, timeoutValue: T): Promise<T> {
+function withDeadline<T>(
+  promise: Promise<T>,
+  ms: number,
+  timeoutValue: T,
+): Promise<T> {
   return Promise.race([
     promise,
     new Promise<T>((resolve) => {
@@ -407,70 +502,74 @@ const forkptyBackend = isWindows ? null : await probeUsableForkptyPty();
 describe.skipIf(isWindows || forkptyBackend === null)(
   'PTY abort group reap (POSIX, forkpty backend, issue #3517)',
   () => {
-    it('kills a TERM-immune grandchild before the abort result resolves', async () => {
-      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pty-abort-'));
-      const marker = path.join(dir, 'grandchild.pid');
-      const { executable, argsPrefix, shell } = getShellConfiguration();
-      const guardedCommand = ensureNativeExitCodePropagated(
-        ensurePromptvarsDisabled(
-          // The subshell stays in the pty shell's process group; `trap '' TERM`
-          // sets SIG_IGN, a disposition that survives `exec sleep 30`. The
-          // foreground `sleep 30` keeps the pty leader alive until the abort.
-          `( trap '' TERM; exec sleep 30 ) & echo $! > ${marker}; sleep 30`,
+    // jest/require-top-level-describe does not recognize bun's
+    // describe.skipIf form, so the case sits in a plain describe block.
+    describe('foreground abort', () => {
+      it('kills a TERM-immune grandchild before the abort result resolves', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pty-abort-'));
+        const marker = path.join(dir, 'grandchild.pid');
+        const { executable, argsPrefix, shell } = getShellConfiguration();
+        const guardedCommand = ensureNativeExitCodePropagated(
+          ensurePromptvarsDisabled(
+            // The subshell stays in the pty shell's process group; `trap '' TERM`
+            // sets SIG_IGN, a disposition that survives `exec sleep 30`. The
+            // foreground `sleep 30` keeps the pty leader alive until the abort.
+            `( trap '' TERM; exec sleep 30 ) & echo $! > ${marker}; sleep 30`,
+            shell,
+          ),
           shell,
-        ),
-        shell,
-      );
-      const backend = forkptyBackend as NonNullable<PtyImplementation>;
-      const ptyProcess: IPty = backend.module.spawn(
-        executable,
-        [...argsPrefix, guardedCommand],
-        {
-          cwd: dir,
-          name: 'xterm-256color',
-          cols: 80,
-          rows: 30,
-          env: { ...process.env, TERM: 'xterm-256color' },
-        },
-      );
-      const abortController = new AbortController();
-      const activePtys = new Map<number, ActivePty>();
-      try {
-        const resultPromise = createPtyResultPromise(
-          ptyProcess,
-          false,
-          80,
-          30,
-          () => undefined,
-          abortController.signal,
-          { scrollback: 10 },
-          backend,
-          activePtys,
-          { value: null },
         );
-        const grandchildPid = Number(await waitForMarker(marker, 8000));
-        expect(grandchildPid).toBeGreaterThan(0);
+        const backend = forkptyBackend as NonNullable<PtyImplementation>;
+        const ptyProcess: IPty = backend.module.spawn(
+          executable,
+          [...argsPrefix, guardedCommand],
+          {
+            cwd: dir,
+            name: 'xterm-256color',
+            cols: 80,
+            rows: 30,
+            env: { ...process.env, TERM: 'xterm-256color' },
+          },
+        );
+        const abortController = new AbortController();
+        const activePtys = new Map<number, ActivePty>();
+        try {
+          const resultPromise = createPtyResultPromise(
+            ptyProcess,
+            false,
+            80,
+            30,
+            () => undefined,
+            abortController.signal,
+            { scrollback: 10 },
+            backend,
+            activePtys,
+            { value: null },
+          );
+          const grandchildPid = Number(await waitForMarker(marker, 8000));
+          expect(grandchildPid).toBeGreaterThan(0);
 
-        abortController.abort();
-        const result = await resultPromise;
+          abortController.abort();
+          const result = await resultPromise;
 
-        expect(result.aborted).toBe(true);
-        // Escalation succeeded within the reap window: no survivor flag.
-        expect(result.survivingGroupMembersOnAbort).toBeUndefined();
-        // THE assertion (AC1+AC2): the TERM-immune grandchild is dead by the
-        // time the abort result exists. It was reparented when the pty leader
-        // died, so a signal-0 probe proves real death.
-        expect(isPidAlive(grandchildPid)).toBe(false);
-      } finally {
-        if (Number.isInteger(ptyProcess.pid) && ptyProcess.pid > 0) {
-          try {
-            process.kill(-ptyProcess.pid, 'SIGKILL');
-          } catch {
-            // Already gone.
+          expect(result.aborted).toBe(true);
+          // Escalation succeeded within the reap window: no survivor flag.
+          expect(result.survivingGroupMembersOnAbort).toBeUndefined();
+          // THE assertion (AC1+AC2): the TERM-immune grandchild is dead by the
+          // time the abort result exists. It was reparented when the pty leader
+          // died, so a signal-0 probe proves real death.
+          expect(isPidAlive(grandchildPid)).toBe(false);
+        } finally {
+          if (Number.isInteger(ptyProcess.pid) && ptyProcess.pid > 0) {
+            try {
+              process.kill(-ptyProcess.pid, 'SIGKILL');
+            } catch {
+              // Already gone.
+            }
           }
+          fs.rmSync(dir, { recursive: true, force: true });
         }
-        fs.rmSync(dir, { recursive: true, force: true });
-      }
-    }, 30000);
+      }, 30000);
+    });
   },
 );

--- a/packages/core/src/services/shellPtyLifecycle.test.ts
+++ b/packages/core/src/services/shellPtyLifecycle.test.ts
@@ -297,6 +297,110 @@ describe('ptyInactivityAbortAction pid validation', () => {
 // ---------------------------------------------------------------------------
 
 describe('PTY abort signal fidelity (fake pty, issue #3517)', () => {
+  for (const scenario of [
+    {
+      name: 'inactivity kill without caller abort waits for group reaping and reports survivors (fake pty)',
+      groupSurvives: true,
+    },
+    {
+      name: 'inactivity kill resolves promptly with no survivor flag when the group dies (fake pty)',
+      groupSurvives: false,
+    },
+  ]) {
+    it.skipIf(isWindows)(
+      scenario.name,
+      async () => {
+        const groupSignals: Array<string | number | undefined> = [];
+        const groupProbes: number[] = [];
+        let inactivityStartedAt = 0;
+        let onData: ((data: string) => void) | undefined;
+        let onExit:
+          | ((event: { exitCode: number; signal?: number }) => void)
+          | undefined;
+        // Fabricated pids must never reach real groups, including signal-0
+        // probes. Deliver exit after the kill chain registers (Issue #3517).
+        const killSpy = vi
+          .spyOn(process, 'kill')
+          .mockImplementation((pid, signal) => {
+            if (signal === 0) {
+              groupProbes.push(pid);
+              if (!scenario.groupSurvives) {
+                throw Object.assign(new Error('Group is gone'), {
+                  code: 'ESRCH',
+                });
+              }
+            } else {
+              groupSignals.push(signal);
+              if (signal === 'SIGTERM') {
+                inactivityStartedAt = Date.now();
+                queueMicrotask(() => onExit?.({ exitCode: 143, signal: 15 }));
+              }
+            }
+            return true;
+          });
+        const { state } = makeFakeState({
+          pid: 999995,
+          isWindows: false,
+          supportsProcessGroupKill: true,
+        });
+        const activePtys = new Map<number, ActivePty>();
+        const ptyProcess: IPty = {
+          ...state.ptyProcess,
+          onData: (listener) => {
+            onData = listener;
+            return { dispose: () => undefined };
+          },
+          onExit: (listener) => {
+            onExit = listener;
+            return { dispose: () => undefined };
+          },
+        };
+        try {
+          const resultPromise = createPtyResultPromise(
+            ptyProcess,
+            false,
+            80,
+            30,
+            () => undefined,
+            new AbortController().signal,
+            { scrollback: 10, inactivityTimeoutMs: 10 },
+            state.ptyInfo,
+            activePtys,
+            { value: null },
+          );
+          if (onData === undefined || onExit === undefined) {
+            throw new Error('PTY handlers were not registered');
+          }
+          onData('output before inactivity');
+          const result = await resultPromise;
+          const elapsed = Date.now() - inactivityStartedAt;
+
+          expect(inactivityStartedAt).toBeGreaterThan(0);
+          expect(groupSignals).toContain('SIGTERM');
+          expect(groupProbes.length).toBeGreaterThan(0);
+          expect(result.aborted).toBe(false);
+          expect(result.exitCode).toBe(143);
+          expect(result.signal).toBe(15);
+          if (scenario.groupSurvives) {
+            expect(elapsed).toBeGreaterThanOrEqual(GROUP_REAP_WINDOW_MS);
+            expect(result.survivingGroupMembersOnAbort).toBe(true);
+            expect(groupSignals).toContain('SIGKILL');
+          } else {
+            expect(elapsed).toBeLessThan(GROUP_REAP_WINDOW_MS);
+            expect(result.survivingGroupMembersOnAbort).toBeUndefined();
+          }
+        } finally {
+          // Keep the signal stub installed until even an early resolution's
+          // escalation grace has passed, so the red test is safe as well.
+          await new Promise((resolve) => setTimeout(resolve, 250));
+          disposeFakeState(state);
+          killSpy.mockRestore();
+        }
+      },
+      10000,
+    );
+  }
+
   it.skipIf(isWindows)(
     'never broadcasts to pid -1 on abort or inactivity',
     async () => {

--- a/packages/core/src/services/shellPtyLifecycle.test.ts
+++ b/packages/core/src/services/shellPtyLifecycle.test.ts
@@ -5,6 +5,9 @@
  */
 
 import { afterEach, describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import type { IPty } from '@lydell/node-pty';
 import headless from '@xterm/headless';
 
@@ -15,16 +18,25 @@ import type {
 } from './shellExecutionTypes.js';
 import { createExitGuard } from './shellExitGuard.js';
 import {
+  createPtyResultPromise,
   ptyAbortAction,
   ptyInactivityAbortAction,
 } from './shellPtyLifecycle.js';
-import type { PtyImplementation } from '../utils/getPty.js';
+import type { ActivePty } from './shellPtyHelpers.js';
+import { loadNodePty, type PtyImplementation } from '../utils/getPty.js';
+import { getShellConfiguration } from '../utils/shell-utils.js';
+import {
+  ensureNativeExitCodePropagated,
+  ensurePromptvarsDisabled,
+} from './shellOutputUtils.js';
 import {
   BoundedCombinedCollector,
   createByteBudget,
 } from '@vybestack/llxprt-code-tools/acquisition.js';
 
 const { Terminal } = headless;
+
+const isWindows = os.platform() === 'win32';
 
 /**
  * The abort actions take an exhaustive state bag; only a handful of fields
@@ -278,3 +290,187 @@ describe('ptyInactivityAbortAction pid validation', () => {
     expect(killSignals.length).toBeGreaterThan(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Real forkpty abort behavior (POSIX, issue #3517)
+// ---------------------------------------------------------------------------
+
+/** Signal-0 existence check. */
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Poll until `markerPath` exists and contains non-whitespace. */
+async function waitForMarker(
+  markerPath: string,
+  timeoutMs = 8000,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const content = fs.readFileSync(markerPath, 'utf8').trim();
+      if (content !== '') return content;
+    } catch {
+      // Not written yet.
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`Marker ${markerPath} not written within ${timeoutMs}ms`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
+/** Race a promise against a deadline, resolving `timeoutValue` on expiry. */
+function withDeadline<T>(promise: Promise<T>, ms: number, timeoutValue: T): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((resolve) => {
+      const timer = setTimeout(() => resolve(timeoutValue), ms);
+      timer.unref();
+    }),
+  ]);
+}
+
+/**
+ * Deadline-bounded probe for a usable forkpty backend. Under Bun POSIX
+ * getPty() routes to bun-pty (no process groups, so the group-kill branch
+ * under test is unreachable there), which is why the lydell backend is
+ * loaded directly here. @lydell/node-pty can spawn children that exit
+ * without delivering any output under the Bun test runner
+ * (oven-sh/bun#25822), so a single-spawn check is not trustworthy: the
+ * probe requires PROBE_ROUNDS consecutive spawns that each deliver output
+ * within the deadline. The suite skips when any round fails.
+ */
+const PROBE_ROUNDS = 3;
+
+async function probeUsableForkptyPty(): Promise<PtyImplementation> {
+  const ptyInfo = await withDeadline(loadNodePty(), 5000, null);
+  if (ptyInfo === null) {
+    return null;
+  }
+  for (let round = 0; round < PROBE_ROUNDS; round++) {
+    const ok = await withDeadline(
+      new Promise<boolean>((resolve, reject) => {
+        let dataDisposable: { dispose(): void } | undefined;
+        let exitDisposable: { dispose(): void } | undefined;
+        let settled = false;
+        const settle = (ok: boolean, error?: unknown): void => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          dataDisposable?.dispose();
+          exitDisposable?.dispose();
+          if (error !== undefined) {
+            reject(error instanceof Error ? error : new Error(String(error)));
+            return;
+          }
+          resolve(ok);
+        };
+        try {
+          const probe = ptyInfo.module.spawn(
+            'bash',
+            ['-c', 'echo PTY_PROBE_OK'],
+            {
+              cols: 80,
+              rows: 30,
+              env: { ...process.env, TERM: 'xterm-256color' },
+            },
+          );
+          dataDisposable = probe.onData((chunk: string) => {
+            if (chunk.includes('PTY_PROBE_OK')) {
+              settle(true);
+            }
+          });
+          exitDisposable = probe.onExit(() => settle(false));
+        } catch (error) {
+          settle(false, error);
+        }
+      }),
+      5000,
+      false,
+    );
+    if (!ok) {
+      return null;
+    }
+  }
+  return ptyInfo;
+}
+
+const forkptyBackend = isWindows ? null : await probeUsableForkptyPty();
+
+describe.skipIf(isWindows || forkptyBackend === null)(
+  'PTY abort group reap (POSIX, forkpty backend, issue #3517)',
+  () => {
+    it('kills a TERM-immune grandchild before the abort result resolves', async () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pty-abort-'));
+      const marker = path.join(dir, 'grandchild.pid');
+      const { executable, argsPrefix, shell } = getShellConfiguration();
+      const guardedCommand = ensureNativeExitCodePropagated(
+        ensurePromptvarsDisabled(
+          // The subshell stays in the pty shell's process group; `trap '' TERM`
+          // sets SIG_IGN, a disposition that survives `exec sleep 30`. The
+          // foreground `sleep 30` keeps the pty leader alive until the abort.
+          `( trap '' TERM; exec sleep 30 ) & echo $! > ${marker}; sleep 30`,
+          shell,
+        ),
+        shell,
+      );
+      const backend = forkptyBackend as NonNullable<PtyImplementation>;
+      const ptyProcess: IPty = backend.module.spawn(
+        executable,
+        [...argsPrefix, guardedCommand],
+        {
+          cwd: dir,
+          name: 'xterm-256color',
+          cols: 80,
+          rows: 30,
+          env: { ...process.env, TERM: 'xterm-256color' },
+        },
+      );
+      const abortController = new AbortController();
+      const activePtys = new Map<number, ActivePty>();
+      try {
+        const resultPromise = createPtyResultPromise(
+          ptyProcess,
+          false,
+          80,
+          30,
+          () => undefined,
+          abortController.signal,
+          { scrollback: 10 },
+          backend,
+          activePtys,
+          { value: null },
+        );
+        const grandchildPid = Number(await waitForMarker(marker, 8000));
+        expect(grandchildPid).toBeGreaterThan(0);
+
+        abortController.abort();
+        const result = await resultPromise;
+
+        expect(result.aborted).toBe(true);
+        // Escalation succeeded within the reap window: no survivor flag.
+        expect(result.survivingGroupMembersOnAbort).toBeUndefined();
+        // THE assertion (AC1+AC2): the TERM-immune grandchild is dead by the
+        // time the abort result exists. It was reparented when the pty leader
+        // died, so a signal-0 probe proves real death.
+        expect(isPidAlive(grandchildPid)).toBe(false);
+      } finally {
+        if (Number.isInteger(ptyProcess.pid) && ptyProcess.pid > 0) {
+          try {
+            process.kill(-ptyProcess.pid, 'SIGKILL');
+          } catch {
+            // Already gone.
+          }
+        }
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    }, 30000);
+  },
+);

--- a/packages/core/src/services/shellPtyLifecycle.test.ts
+++ b/packages/core/src/services/shellPtyLifecycle.test.ts
@@ -17,6 +17,7 @@ import type {
   ShellExecutionResult,
 } from './shellExecutionTypes.js';
 import { createExitGuard } from './shellExitGuard.js';
+import { GROUP_REAP_WINDOW_MS } from './shellProcessKill.js';
 import {
   createPtyResultPromise,
   ptyAbortAction,
@@ -380,6 +381,99 @@ describe('PTY abort signal fidelity (fake pty, issue #3517)', () => {
       process.kill = realProcessKill;
     }
   }, 10000);
+
+  it('abort during natural-exit drain resolves only after the group-reap chain settles (fake pty)', async () => {
+    // process.kill is stubbed for the whole test, so the fabricated pid is
+    // never aimed at a real process group. Signal-0 probes report the group
+    // alive so the bounded reap window must expire; the result may only be
+    // produced after that chain settles.
+    const realProcessKill = process.kill;
+    const groupProbes: number[] = [];
+    process.kill = ((pid: number, signal?: string | number) => {
+      if (signal === 0) {
+        groupProbes.push(pid);
+      }
+      return true;
+    }) as unknown as typeof process.kill;
+
+    const killSignals: string[] = [];
+    let dataListener: ((data: string | Buffer) => void) | undefined;
+    let exitListener:
+      | ((event: { exitCode: number; signal?: number | null }) => void)
+      | undefined;
+    const ptyProcess = {
+      pid: 999997,
+      kill: (signal?: string | number): void => {
+        killSignals.push(signal === undefined ? '<none>' : String(signal));
+      },
+      onData: (listener: (data: string | Buffer) => void) => {
+        dataListener = listener;
+        return { dispose: () => undefined };
+      },
+      onExit: (
+        listener: (event: { exitCode: number; signal?: number | null }) => void,
+      ) => {
+        exitListener = listener;
+        return { dispose: () => undefined };
+      },
+    } as unknown as IPty;
+
+    const abortController = new AbortController();
+    const activePtys = new Map<number, ActivePty>();
+    try {
+      const resultPromise = createPtyResultPromise(
+        ptyProcess,
+        false,
+        80,
+        30,
+        () => undefined,
+        abortController.signal,
+        { scrollback: 10 } as ShellExecutionConfig,
+        {
+          name: 'node-pty',
+          module: {},
+          supportsBackpressure: true,
+        } as NonNullable<PtyImplementation>,
+        activePtys,
+        { value: null },
+      );
+      if (dataListener === undefined || exitListener === undefined) {
+        throw new Error('PTY data/exit handlers were not registered');
+      }
+
+      // Pending output processing: xterm processes writes asynchronously, so
+      // delivering data and then the exit event without an intervening await
+      // leaves processingChain unsettled when the race is armed.
+      dataListener('draining output\n');
+      // Natural exit while the caller signal is not yet aborted: the exit
+      // race runs with processingComplete still pending.
+      exitListener({ exitCode: 0, signal: null });
+      // The caller abort lands during the drain and wins the race. The exit
+      // handler already detached the regular abort handler, so the race's
+      // abort-win arm must kill the group itself.
+      const abortTime = Date.now();
+      abortController.abort();
+
+      const result = await resultPromise;
+
+      // The result was gated on the bounded group-reap chain (escalation
+      // grace + reap window with lying-alive probes), so it cannot have
+      // resolved early.
+      expect(Date.now() - abortTime).toBeGreaterThanOrEqual(
+        GROUP_REAP_WINDOW_MS,
+      );
+      // The chain really ran: the group was TERMed and probed.
+      expect(killSignals).toContain('SIGTERM');
+      expect(groupProbes.length).toBeGreaterThan(0);
+      // The natural-exit values win, and the chain outcome (window expired,
+      // group not confirmed empty) is carried on the result.
+      expect(result.exitCode).toBe(0);
+      expect(result.aborted).toBe(true);
+      expect(result.survivingGroupMembersOnAbort).toBe(true);
+    } finally {
+      process.kill = realProcessKill;
+    }
+  }, 20000);
 });
 
 // ---------------------------------------------------------------------------
@@ -497,7 +591,18 @@ async function probeUsableForkptyPty(): Promise<PtyImplementation> {
   return ptyInfo;
 }
 
-const forkptyBackend = isWindows ? null : await probeUsableForkptyPty();
+// A probe rejection (e.g. a synchronous forkpty spawn throw surfacing through
+// the withDeadline race) must skip only the real-PTY suite below: letting it
+// propagate would fail the whole file and lose the deterministic fake-pty
+// tests too. The probe itself is unchanged and stays as strict as before.
+let forkptyBackend: PtyImplementation | null = null;
+if (!isWindows) {
+  try {
+    forkptyBackend = await probeUsableForkptyPty();
+  } catch {
+    forkptyBackend = null;
+  }
+}
 
 describe.skipIf(isWindows || forkptyBackend === null)(
   'PTY abort group reap (POSIX, forkpty backend, issue #3517)',

--- a/packages/core/src/services/shellPtyLifecycle.test.ts
+++ b/packages/core/src/services/shellPtyLifecycle.test.ts
@@ -297,6 +297,74 @@ describe('ptyInactivityAbortAction pid validation', () => {
 // ---------------------------------------------------------------------------
 
 describe('PTY abort signal fidelity (fake pty, issue #3517)', () => {
+  it.skipIf(isWindows)(
+    'non-group-target pid gets direct-only escalation, never a group signal (fake pty, issue #3517)',
+    async () => {
+      const processSignals: Array<
+        [number, NodeJS.Signals | number | undefined]
+      > = [];
+      const killSignals: Array<string | undefined> = [];
+      const killSpy = vi
+        .spyOn(process, 'kill')
+        .mockImplementation((pid: number, signal?: NodeJS.Signals | number) => {
+          processSignals.push([pid, signal]);
+          return true;
+        });
+      const { state } = makeFakeState({
+        pid: 1,
+        isWindows: false,
+        supportsProcessGroupKill: true,
+      });
+      let exitListener:
+        | ((event: { exitCode: number; signal?: number }) => void)
+        | undefined;
+      const ptyProcess: IPty = {
+        ...state.ptyProcess,
+        kill: (signal) => {
+          killSignals.push(signal);
+        },
+        onData: () => ({ dispose: () => undefined }),
+        onExit: (listener) => {
+          exitListener = listener;
+          return { dispose: () => undefined };
+        },
+      };
+      const abortController = new AbortController();
+      const activePtys = new Map<number, ActivePty>();
+      try {
+        const resultPromise = createPtyResultPromise(
+          ptyProcess,
+          false,
+          80,
+          30,
+          () => undefined,
+          abortController.signal,
+          { scrollback: 10 },
+          state.ptyInfo,
+          activePtys,
+          { value: null },
+        );
+        if (exitListener === undefined) {
+          throw new Error('PTY exit handler was not registered');
+        }
+        abortController.abort();
+        const result = await resultPromise;
+
+        expect(result.aborted).toBe(true);
+        expect(result.survivingGroupMembersOnAbort).toBeUndefined();
+        expect(killSignals).toContain('SIGTERM');
+        expect(killSignals).toContain('SIGKILL');
+        expect(processSignals.every(([pid]) => pid !== -1)).toBe(true);
+      } finally {
+        // Keep the signal stub installed until even an early resolution's
+        // escalation grace has passed, so the red test is safe as well.
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        disposeFakeState(state);
+        killSpy.mockRestore();
+      }
+    },
+  );
+
   for (const scenario of [
     {
       name: 'inactivity kill without caller abort waits for group reaping and reports survivors (fake pty)',
@@ -400,6 +468,37 @@ describe('PTY abort signal fidelity (fake pty, issue #3517)', () => {
       10000,
     );
   }
+
+  it.skipIf(isWindows)(
+    'inactivity kill with a non-group-target pid still kills the PTY directly (fake pty, issue #3517)',
+    async () => {
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+      const inputs = { pid: 1, isWindows, supportsProcessGroupKill: true };
+      const { state, killSignals } = makeFakeState(inputs);
+      try {
+        const result = await createPtyResultPromise(
+          state.ptyProcess,
+          false,
+          80,
+          30,
+          () => undefined,
+          new AbortController().signal,
+          { scrollback: 10, inactivityTimeoutMs: 10 },
+          state.ptyInfo,
+          new Map(),
+          { value: null },
+        );
+
+        expect(result.aborted).toBe(false);
+        expect(result.survivingGroupMembersOnAbort).toBeUndefined();
+        expect(killSignals.slice(0, 2)).toStrictEqual(['SIGTERM', 'SIGKILL']);
+        expect(killSpy.mock.calls.some(([pid]) => pid === -1)).toBe(false);
+      } finally {
+        disposeFakeState(state);
+        killSpy.mockRestore();
+      }
+    },
+  );
 
   it.skipIf(isWindows)(
     'never broadcasts to pid -1 on abort or inactivity',
@@ -692,8 +791,8 @@ function isPidAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
-    return false;
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code !== 'ESRCH';
   }
 }
 

--- a/packages/core/src/services/shellPtyLifecycle.test.ts
+++ b/packages/core/src/services/shellPtyLifecycle.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { afterEach, describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it, vi } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -297,6 +297,109 @@ describe('ptyInactivityAbortAction pid validation', () => {
 // ---------------------------------------------------------------------------
 
 describe('PTY abort signal fidelity (fake pty, issue #3517)', () => {
+  it.skipIf(isWindows)(
+    'never broadcasts to pid -1 on abort or inactivity',
+    async () => {
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+      const { state } = makeFakeState({
+        pid: 1,
+        isWindows: false,
+        supportsProcessGroupKill: true,
+      });
+      try {
+        await ptyAbortAction(state, () => undefined);
+        await ptyInactivityAbortAction(state, () => undefined);
+        expect(killSpy.mock.calls.some(([pid]) => pid === -1)).toBe(false);
+      } finally {
+        disposeFakeState(state);
+        killSpy.mockRestore();
+      }
+    },
+  );
+
+  it.skipIf(isWindows)(
+    'never broadcasts to pid -1 when abort wins the exit drain race',
+    async () => {
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+      const { state } = makeFakeState({
+        pid: 1,
+        isWindows: false,
+        supportsProcessGroupKill: true,
+      });
+      let onData: ((data: string) => void) | undefined;
+      let onExit:
+        | ((event: { exitCode: number; signal?: number }) => void)
+        | undefined;
+      const ptyProcess: IPty = {
+        ...state.ptyProcess,
+        onData: (listener) => {
+          onData = listener;
+          return { dispose: () => undefined };
+        },
+        onExit: (listener) => {
+          onExit = listener;
+          return { dispose: () => undefined };
+        },
+      };
+      try {
+        const abortController = new AbortController();
+        const resultPromise = createPtyResultPromise(
+          ptyProcess,
+          false,
+          80,
+          30,
+          () => undefined,
+          abortController.signal,
+          { scrollback: 10 },
+          state.ptyInfo,
+          new Map(),
+          { value: null },
+        );
+        if (onData === undefined || onExit === undefined) {
+          throw new Error('PTY handlers were not registered');
+        }
+        onData('draining output');
+        onExit({ exitCode: 0 });
+        abortController.abort();
+        const result = await resultPromise;
+        expect(result.exitCode).toBe(0);
+        expect(result.aborted).toBe(true);
+        expect(killSpy.mock.calls.some(([pid]) => pid === -1)).toBe(false);
+      } finally {
+        disposeFakeState(state);
+        killSpy.mockRestore();
+      }
+    },
+  );
+
+  it.skipIf(isWindows)(
+    'inactivity during caller abort waits for group reaping and reports survivors',
+    async () => {
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+      const { state } = makeFakeState({
+        pid: 999996,
+        isWindows: false,
+        supportsProcessGroupKill: true,
+      });
+      const completed = Promise.withResolvers<ShellExecutionResult>();
+      const startedAt = Date.now();
+      const abortAction = ptyAbortAction(state, completed.resolve);
+      try {
+        await ptyInactivityAbortAction(state, completed.resolve);
+        const result = await completed.promise;
+        expect(Date.now() - startedAt).toBeGreaterThanOrEqual(
+          GROUP_REAP_WINDOW_MS,
+        );
+        expect(result.survivingGroupMembersOnAbort).toBe(true);
+      } finally {
+        await abortAction;
+        disposeFakeState(state);
+        killSpy.mockRestore();
+      }
+    },
+    10000,
+  );
+
   it('real exit signal wins over the synthetic abort result when the exit fires before the group-reap chain settles', async () => {
     // process.kill is stubbed for the whole test, so the fabricated pid is
     // never aimed at a real process group (the suite's standing rule). The

--- a/packages/core/src/services/shellPtyLifecycle.ts
+++ b/packages/core/src/services/shellPtyLifecycle.ts
@@ -418,11 +418,8 @@ export async function ptyInactivityAbortAction(
     return;
   }
   if (state.supportsProcessGroupKill) {
-    if (!isGroupTargetPid(pid)) {
-      return;
-    }
-    // Share caller-abort group confirmation so a dead leader cannot hide
-    // surviving descendants after inactivity termination (Issue #3517).
+    // Share caller-abort escalation, including direct-only kills for non-group
+    // targets, so inactivity termination cannot leave survivors (Issue #3517).
     const groupConfirmedEmpty = await armPtyGroupAbortKill(state, pid);
     if (state.hasResolved) {
       return;
@@ -527,13 +524,39 @@ const abortGroupReapChains = new WeakMap<PtyExecState, Promise<boolean>>();
  * suppress the group SIGKILL, letting a TERM-immune grandchild keep running
  * after the tool reported termination, Issue #3517). Resolves true when the
  * group is confirmed empty within the bounded reap window. Never rejects.
+ * Non-group-target pids get direct-only escalation (leader TERM → grace →
+ * SIGKILL) with no group-directed signals.
  */
 function armPtyGroupAbortKill(
   state: PtyExecState,
   pid: number,
 ): Promise<boolean> {
   if (!isGroupTargetPid(pid)) {
-    return Promise.resolve(true);
+    // A pid that is not a valid group target (in practice pid 1) must
+    // never receive group-directed signals — kill(-1, ...) is the POSIX
+    // broadcast — but the direct PTY still has to die before the
+    // synthetic abort result may claim termination: escalate against the
+    // leader only (Issue #3517). No group semantics apply, so the chain
+    // resolves confirmed-empty.
+    clearPendingAbortFallback(state);
+    const directChain = (async (): Promise<boolean> => {
+      try {
+        state.ptyProcess.kill('SIGTERM');
+      } catch {
+        // PTY may already be terminated.
+      }
+      await new Promise((res) => setTimeout(res, SIGKILL_TIMEOUT_MS));
+      if (!state.exitedGuard.isExited()) {
+        try {
+          state.ptyProcess.kill('SIGKILL');
+        } catch {
+          // PTY may already be terminated.
+        }
+      }
+      return true;
+    })();
+    abortGroupReapChains.set(state, directChain);
+    return directChain;
   }
   // A fallback timer armed by a prior inactivity kill would resolve the
   // result before this chain's bounded group-reap confirmation settles;

--- a/packages/core/src/services/shellPtyLifecycle.ts
+++ b/packages/core/src/services/shellPtyLifecycle.ts
@@ -421,23 +421,29 @@ export async function ptyInactivityAbortAction(
     if (!isGroupTargetPid(pid)) {
       return;
     }
-    try {
-      process.kill(-pid, 'SIGTERM');
-      await new Promise((res) => setTimeout(res, SIGKILL_TIMEOUT_MS));
-      if (!state.exitedGuard.isExited()) {
-        process.kill(-pid, 'SIGKILL');
-      }
-    } catch {
-      if (!state.exitedGuard.isExited()) {
-        state.ptyProcess.kill('SIGKILL');
-      }
+    // Share caller-abort group confirmation so a dead leader cannot hide
+    // surviving descendants after inactivity termination (Issue #3517).
+    const groupConfirmedEmpty = await armPtyGroupAbortKill(state, pid);
+    if (state.hasResolved) {
+      return;
     }
-  } else {
-    state.ptyProcess.kill('SIGTERM');
-    await new Promise((res) => setTimeout(res, SIGKILL_TIMEOUT_MS));
-    if (!state.exitedGuard.isExited()) {
-      state.ptyProcess.kill('SIGKILL');
+    if (state.exitedGuard.isExited()) {
+      // The exit handler's later continuation preserves the real exit
+      // values and carries the survivor flag (Issue #3517).
+      return;
     }
+    ptyRenderFn(state);
+    const result = buildPtyResult(state, 1, null, state.abortSignal.aborted);
+    if (!groupConfirmedEmpty) {
+      result.survivingGroupMembersOnAbort = true;
+    }
+    resolveResult(result);
+    return;
+  }
+  state.ptyProcess.kill('SIGTERM');
+  await new Promise((res) => setTimeout(res, SIGKILL_TIMEOUT_MS));
+  if (!state.exitedGuard.isExited()) {
+    state.ptyProcess.kill('SIGKILL');
   }
   finalizeInactivityKill(state, resolveResult);
 }
@@ -681,11 +687,11 @@ function registerPtyExitHandler(
       state.exitedGuard.markExited();
       state.abortSignal.removeEventListener('abort', abortHandler);
 
+      const reapChain = abortGroupReapChains.get(state);
       if (state.abortSignal.aborted) {
         // An abort kill is mid-flight: its bounded group-reap chain owns the
         // confirmation that the group is empty before the abort result is
         // produced (Issue #3517).
-        const reapChain = abortGroupReapChains.get(state);
         if (reapChain !== undefined) {
           void reapChain.then((groupConfirmedEmpty) => {
             finalizeResult(exitCode, normalizedSignal, !groupConfirmedEmpty);
@@ -693,6 +699,16 @@ function registerPtyExitHandler(
           return;
         }
         finalizeResult(exitCode, normalizedSignal);
+        return;
+      }
+
+      if (reapChain !== undefined) {
+        // Inactivity termination owns group confirmation even without a
+        // caller abort. Preserve natural-exit values and flag survivors
+        // instead of resolving during the kill chain (Issue #3517).
+        void reapChain.then((groupConfirmedEmpty) => {
+          finalizeResult(exitCode, normalizedSignal, !groupConfirmedEmpty);
+        });
         return;
       }
 

--- a/packages/core/src/services/shellPtyLifecycle.ts
+++ b/packages/core/src/services/shellPtyLifecycle.ts
@@ -571,6 +571,19 @@ export async function ptyAbortAction(
     if (state.hasResolved) {
       return;
     }
+    if (state.exitedGuard.isExited()) {
+      // The real PTY exit fired while the chain ran. This continuation was
+      // registered on the chain before the exit handler's, so it runs first:
+      // resolving here would race ahead of the exit-handler continuation and
+      // overwrite the real exitCode/signal with a synthetic (1, null) result
+      // (the incident transcript's "Signal: 15" depends on the real exit
+      // event winning). The exit handler finalizes with the true values and
+      // already carries the survivingGroupMembersOnAbort flag.
+      return;
+    }
+    // Forward-progress fallback: the PTY never reported an exit. Only this
+    // path resolves the synthetic result, still gated on the bounded
+    // group-reap confirmation (Issue #3517).
     ptyRenderFn(state);
     const result = buildPtyResult(state, 1, null, aborted);
     if (!groupConfirmedEmpty) {
@@ -665,7 +678,11 @@ function ptyExitRace(
   state: PtyExecState,
   exitCode: number,
   signal: number | null,
-  finalizeResult: (exitCode: number, signal?: number | null) => void,
+  finalizeResult: (
+    exitCode: number,
+    signal?: number | null,
+    survivingGroupMembers?: boolean,
+  ) => void,
 ): void {
   const processingComplete = state.processingChain.then(() => 'processed');
   let raceAbortListener: (() => void) | null = null;
@@ -693,8 +710,32 @@ function ptyExitRace(
   });
 
   Promise.race([processingComplete, abortFired])
-    .then(() => {
+    .then((winner) => {
       cleanupRaceListener();
+      if (
+        winner === 'aborted' &&
+        !state.isWindows &&
+        state.supportsProcessGroupKill &&
+        isKillablePid(state.ptyProcess.pid)
+      ) {
+        // An abort landed while natural-exit output was still draining.
+        // onExit already detached the caller abort handler, so nothing else
+        // will kill the group: arm the same bounded group-reap chain
+        // ptyAbortAction's group branch uses (sharing any in-flight chain
+        // instance, never duplicating it) and gate this result on its
+        // confirmation, flagging survivors when the window expires
+        // (Issue #3517). The chain never rejects and is time-bounded.
+        const reapChain =
+          abortGroupReapChains.get(state) ??
+          armPtyGroupAbortKill(state, state.ptyProcess.pid);
+        void reapChain.then((groupConfirmedEmpty) => {
+          if (state.hasResolved) {
+            return;
+          }
+          finalizeResult(exitCode, signal ?? null, !groupConfirmedEmpty);
+        });
+        return;
+      }
       finalizeResult(exitCode, signal ?? null);
     })
     .catch(() => {

--- a/packages/core/src/services/shellPtyLifecycle.ts
+++ b/packages/core/src/services/shellPtyLifecycle.ts
@@ -17,6 +17,8 @@ import { makeInactivityTimer } from './shellOutputUtils.js';
 import {
   SIGKILL_TIMEOUT_MS,
   isKillablePid,
+  isProcessGroupAlive,
+  reapProcessGroup,
   taskkillTree,
 } from './shellProcessKill.js';
 import type { PtyExecState } from './shellPtyState.js';
@@ -487,6 +489,62 @@ function setupPtyAbortHandler(
   };
 }
 
+/**
+ * In-flight group-abort kill chains keyed by execution state, so the PTY
+ * exit handler can gate its abort-branch resolution on the same bounded
+ * group-reap confirmation instead of resolving while group members are still
+ * alive (Issue #3517). Held in a module WeakMap because the state bag is
+ * owned by shellPtyState.ts; entries die with the state object.
+ */
+const abortGroupReapChains = new WeakMap<PtyExecState, Promise<boolean>>();
+
+/**
+ * Escalate a PTY abort against the process group: SIGTERM to the group and
+ * the leader, a short grace, then a group SIGKILL gated on GROUP liveness
+ * (not direct-child liveness — the leader dying from the SIGTERM used to
+ * suppress the group SIGKILL, letting a TERM-immune grandchild keep running
+ * after the tool reported termination, Issue #3517). Resolves true when the
+ * group is confirmed empty within the bounded reap window. Never rejects.
+ */
+function armPtyGroupAbortKill(
+  state: PtyExecState,
+  pid: number,
+): Promise<boolean> {
+  const chain = (async (): Promise<boolean> => {
+    try {
+      process.kill(-pid, 'SIGTERM');
+    } catch {
+      // Process group may already be terminated.
+    }
+    try {
+      state.ptyProcess.kill('SIGTERM');
+    } catch {
+      // PTY may already be terminated.
+    }
+
+    await new Promise((res) => setTimeout(res, SIGKILL_TIMEOUT_MS));
+    try {
+      if (isProcessGroupAlive(pid)) {
+        process.kill(-pid, 'SIGKILL');
+      }
+    } catch {
+      // Process group may already be terminated.
+    }
+    if (!state.exitedGuard.isExited()) {
+      try {
+        state.ptyProcess.kill('SIGKILL');
+      } catch {
+        // PTY may already be terminated.
+      }
+    }
+    return reapProcessGroup(pid);
+  })();
+  // Arm before yielding: the synchronous prefix (both SIGTERMs) runs before
+  // the first await, so any exit event dispatched later finds the chain.
+  abortGroupReapChains.set(state, chain);
+  return chain;
+}
+
 export async function ptyAbortAction(
   state: PtyExecState,
   resolveResult: (resultValue: ShellExecutionResult) => void,
@@ -505,12 +563,26 @@ export async function ptyAbortAction(
   }
 
   if (state.supportsProcessGroupKill) {
-    try {
-      process.kill(-pid, 'SIGTERM');
-    } catch {
-      // Process group may already be terminated.
+    // The group-kill branch owns its resolution: escalate, confirm the group
+    // is empty within the bounded window, then resolve. The direct child
+    // having exited no longer suppresses the group SIGKILL, and the exit
+    // handler awaits the same chain before resolving (Issue #3517).
+    const groupConfirmedEmpty = await armPtyGroupAbortKill(state, pid);
+    if (state.hasResolved) {
+      return;
     }
+    ptyRenderFn(state);
+    const result = buildPtyResult(state, 1, null, aborted);
+    if (!groupConfirmedEmpty) {
+      result.survivingGroupMembersOnAbort = true;
+    }
+    resolveResult(result);
+    return;
   }
+
+  // bun-pty (no process group): direct-kill only, unchanged. No group reap
+  // is possible here — waiting would stall every abort without being able to
+  // kill anything (Issue #3517 documents, not changes, this limitation).
   try {
     state.ptyProcess.kill('SIGTERM');
   } catch {
@@ -522,13 +594,6 @@ export async function ptyAbortAction(
     return;
   }
 
-  if (state.supportsProcessGroupKill) {
-    try {
-      process.kill(-pid, 'SIGKILL');
-    } catch {
-      // Process group may already be terminated.
-    }
-  }
   try {
     state.ptyProcess.kill('SIGKILL');
   } catch {
@@ -543,19 +608,28 @@ function registerPtyExitHandler(
   resolveResult: (resultValue: ShellExecutionResult) => void,
   abortHandler: () => void,
 ): void {
-  const finalizeResult = (exitCode: number, signal?: number | null) => {
+  const finalizeResult = (
+    exitCode: number,
+    signal?: number | null,
+    survivingGroupMembers = false,
+  ) => {
     if (state.hasResolved) {
       return;
     }
     ptyRenderFn(state);
-    resolveResult(
-      buildPtyResult(
-        state,
-        exitCode,
-        signal ?? null,
-        state.abortSignal.aborted,
-      ),
+    const result = buildPtyResult(
+      state,
+      exitCode,
+      signal ?? null,
+      state.abortSignal.aborted,
     );
+    if (survivingGroupMembers) {
+      // Bounded group-reap window expired with live members after an abort
+      // kill: the result must say so instead of implying full termination
+      // (Issue #3517).
+      result.survivingGroupMembersOnAbort = true;
+    }
+    resolveResult(result);
   };
 
   state.activePtyEntry.onExitDisposable = state.ptyProcess.onExit(
@@ -568,6 +642,16 @@ function registerPtyExitHandler(
       state.abortSignal.removeEventListener('abort', abortHandler);
 
       if (state.abortSignal.aborted) {
+        // An abort kill is mid-flight: its bounded group-reap chain owns the
+        // confirmation that the group is empty before the abort result is
+        // produced (Issue #3517).
+        const reapChain = abortGroupReapChains.get(state);
+        if (reapChain !== undefined) {
+          void reapChain.then((groupConfirmedEmpty) => {
+            finalizeResult(exitCode, normalizedSignal, !groupConfirmedEmpty);
+          });
+          return;
+        }
         finalizeResult(exitCode, normalizedSignal);
         return;
       }

--- a/packages/core/src/services/shellPtyLifecycle.ts
+++ b/packages/core/src/services/shellPtyLifecycle.ts
@@ -17,6 +17,7 @@ import { makeInactivityTimer } from './shellOutputUtils.js';
 import {
   SIGKILL_TIMEOUT_MS,
   isKillablePid,
+  isGroupTargetPid,
   isProcessGroupAlive,
   reapProcessGroup,
   taskkillTree,
@@ -417,6 +418,9 @@ export async function ptyInactivityAbortAction(
     return;
   }
   if (state.supportsProcessGroupKill) {
+    if (!isGroupTargetPid(pid)) {
+      return;
+    }
     try {
       process.kill(-pid, 'SIGTERM');
       await new Promise((res) => setTimeout(res, SIGKILL_TIMEOUT_MS));
@@ -482,7 +486,7 @@ function finalizeInactivityKill(
   state: PtyExecState,
   resolveResult: (resultValue: ShellExecutionResult) => void,
 ): void {
-  if (state.exitedGuard.isExited()) {
+  if (state.exitedGuard.isExited() || abortGroupReapChains.has(state)) {
     return;
   }
   schedulePtyAbortFallback(
@@ -522,6 +526,9 @@ function armPtyGroupAbortKill(
   state: PtyExecState,
   pid: number,
 ): Promise<boolean> {
+  if (!isGroupTargetPid(pid)) {
+    return Promise.resolve(true);
+  }
   // A fallback timer armed by a prior inactivity kill would resolve the
   // result before this chain's bounded group-reap confirmation settles;
   // single ownership requires clearing it before arming (Issue #3517).
@@ -736,7 +743,7 @@ function ptyExitRace(
         winner === 'aborted' &&
         !state.isWindows &&
         state.supportsProcessGroupKill &&
-        isKillablePid(state.ptyProcess.pid)
+        isGroupTargetPid(state.ptyProcess.pid)
       ) {
         // An abort landed while natural-exit output was still draining.
         // onExit already detached the caller abort handler, so nothing else

--- a/packages/core/src/services/shellPtyLifecycle.ts
+++ b/packages/core/src/services/shellPtyLifecycle.ts
@@ -439,6 +439,20 @@ export async function ptyInactivityAbortAction(
 }
 
 /**
+ * Clear a pending abort-fallback resolution timer. Single-owner hand-off: a
+ * fallback armed by a prior inactivity kill would resolve the result after
+ * SIGKILL_TIMEOUT_MS, before the caller-abort group-reap chain settles —
+ * bypassing the confirmation gate — so every path that arms that chain must
+ * clear the stale fallback first (Issue #3517).
+ */
+function clearPendingAbortFallback(state: PtyExecState): void {
+  if (state.abortFinalizeTimeout !== null) {
+    clearTimeout(state.abortFinalizeTimeout);
+    state.abortFinalizeTimeout = null;
+  }
+}
+
+/**
  * Schedule the post-escalation fallback resolution. Single-owner: a pending
  * fallback is cleared first so staggered abort/inactivity chains cannot leak
  * timers past one another. The callback re-checks hasResolved before
@@ -454,9 +468,7 @@ function schedulePtyAbortFallback(
   resolveResult: (resultValue: ShellExecutionResult) => void,
   getAborted: () => boolean,
 ): void {
-  if (state.abortFinalizeTimeout !== null) {
-    clearTimeout(state.abortFinalizeTimeout);
-  }
+  clearPendingAbortFallback(state);
   state.abortFinalizeTimeout = setTimeout(() => {
     state.abortFinalizeTimeout = null;
     if (state.hasResolved) {
@@ -510,6 +522,10 @@ function armPtyGroupAbortKill(
   state: PtyExecState,
   pid: number,
 ): Promise<boolean> {
+  // A fallback timer armed by a prior inactivity kill would resolve the
+  // result before this chain's bounded group-reap confirmation settles;
+  // single ownership requires clearing it before arming (Issue #3517).
+  clearPendingAbortFallback(state);
   const chain = (async (): Promise<boolean> => {
     try {
       process.kill(-pid, 'SIGTERM');
@@ -537,7 +553,11 @@ function armPtyGroupAbortKill(
         // PTY may already be terminated.
       }
     }
-    return reapProcessGroup(pid);
+    // Enforce the "Never rejects" contract locally: consumers use bare
+    // `.then(...)` with no `.catch`, so a rejection escaping the reap would
+    // go unhandled and stall their resolution. Resolve false (group not
+    // confirmed empty) instead.
+    return reapProcessGroup(pid).catch((): boolean => false);
   })();
   // Arm before yielding: the synchronous prefix (both SIGTERMs) runs before
   // the first await, so any exit event dispatched later finds the chain.

--- a/packages/core/src/tools-adapters/CoreShellToolHostAdapter.ts
+++ b/packages/core/src/tools-adapters/CoreShellToolHostAdapter.ts
@@ -166,6 +166,7 @@ export class CoreShellToolHostAdapter implements IShellToolHost {
       aborted: result.aborted,
       pid: result.pid,
       outputTruncation: result.outputTruncation,
+      survivingGroupMembersOnAbort: result.survivingGroupMembersOnAbort,
     };
   }
 

--- a/packages/tools/src/__tests__/shell-tool.test.ts
+++ b/packages/tools/src/__tests__/shell-tool.test.ts
@@ -613,6 +613,7 @@ describe('shell result contracts @plan:issue1995 @plan:issue3200', () => {
      */
     function createTimeoutAbortingHost(
       resultFields: Partial<ShellExecutionResult>,
+      onEntered: () => void = () => undefined,
     ): IShellToolHost {
       const base = createFakeHostWithBackground(() => {
         throw new Error(
@@ -633,6 +634,7 @@ describe('shell result contracts @plan:issue1995 @plan:issue3200', () => {
         ...base,
         executeShellCommand: (_command, _cwd, _onOutput, signal) =>
           new Promise<ShellExecutionResult>((resolve) => {
+            onEntered();
             if (signal.aborted) {
               resolve(buildResult());
               return;
@@ -674,8 +676,12 @@ describe('shell result contracts @plan:issue1995 @plan:issue3200', () => {
       // Cancel via the USER signal, not the timeout controller, so the tool
       // takes the user-cancel branch (timeoutTriggered === false).
       const userAbort = new AbortController();
+      const entered = Promise.withResolvers<void>();
       const tool = new ShellTool(
-        createTimeoutAbortingHost({ survivingGroupMembersOnAbort: true }),
+        createTimeoutAbortingHost(
+          { survivingGroupMembersOnAbort: true },
+          entered.resolve,
+        ),
         createFakeMessageBus(ToolConfirmationOutcome.ProceedOnce),
       );
 
@@ -684,7 +690,7 @@ describe('shell result contracts @plan:issue1995 @plan:issue3200', () => {
         { command: 'sleep 60' },
         userAbort.signal,
       );
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await entered.promise;
       userAbort.abort();
       const result = await resultPromise;
 
@@ -734,6 +740,45 @@ describe('shell result contracts @plan:issue1995 @plan:issue3200', () => {
       expect(llm).toContain('SUMMARIZED OUTPUT');
       expect(llm).toContain('may still be running');
       expect(llm).toContain('kill -9 -- -4321');
+      expect(String(result.returnDisplay)).toContain('kill -9 -- -4321');
+    });
+
+    it.each([1, Number.NaN])(
+      'uses a generic survivor warning for unsafe pgid %s',
+      async (pgid) => {
+        const tool = new ShellTool(
+          createTimeoutAbortingHost({
+            pgid,
+            survivingGroupMembersOnAbort: true,
+          }),
+          createFakeMessageBus(ToolConfirmationOutcome.ProceedOnce),
+        );
+        const result = await executeToolForBehavioralAssertion(tool, {
+          command: 'sleep 60',
+          timeout_seconds: 0.01,
+        });
+        for (const content of [result.llmContent, result.returnDisplay]) {
+          expect(String(content)).toContain(
+            'may still be running; they could not be fully terminated.',
+          );
+          expect(String(content)).not.toContain('kill -9');
+        }
+      },
+    );
+
+    it('does not show POSIX cleanup instructions on Windows', async () => {
+      mockPlatform.mockReturnValue('win32');
+      const tool = new ShellTool(
+        createTimeoutAbortingHost({ survivingGroupMembersOnAbort: true }),
+        createFakeMessageBus(ToolConfirmationOutcome.ProceedOnce),
+      );
+      const result = await executeToolForBehavioralAssertion(tool, {
+        command: 'sleep 60',
+        timeout_seconds: 0.01,
+      });
+      expect(String(result.llmContent)).toContain('timed out');
+      expect(String(result.llmContent)).not.toContain('kill -9');
+      expect(String(result.returnDisplay)).not.toContain('kill -9');
     });
 
     it('a clean timeout result carries no survivor warning', async () => {

--- a/packages/tools/src/__tests__/shell-tool.test.ts
+++ b/packages/tools/src/__tests__/shell-tool.test.ts
@@ -33,6 +33,7 @@ import type {
   HostShellJobInfo,
   HostShellJobTailResult,
   BackgroundPromotionResult,
+  ShellExecutionResult,
 } from '../interfaces/index.js';
 import { executeToolForBehavioralAssertion } from './red-test-helpers.js';
 
@@ -599,5 +600,85 @@ describe('shell result contracts @plan:issue1995 @plan:issue3200', () => {
     // The error must be caught and surfaced, not silently degraded.
     expect(result.error).toBeDefined();
     expect(result.error?.message).toContain('not supported');
+  });
+
+  describe('timeout survivor warning formatting @plan:issue3517', () => {
+    /**
+     * Builds a host whose foreground execution resolves with an aborted
+     * result only when the combined timeout/user signal fires, so the tool
+     * computes a genuine timeout-triggered abort path the way production
+     * does.
+     */
+    function createTimeoutAbortingHost(
+      resultFields: Partial<ShellExecutionResult>,
+    ): IShellToolHost {
+      const base = createFakeHostWithBackground(() => {
+        throw new Error(
+          'Foreground execution must not launch a background job',
+        );
+      });
+      const buildResult = (): ShellExecutionResult => ({
+        output: 'partial output',
+        exitCode: null,
+        signal: '15',
+        error: null,
+        aborted: true,
+        pid: 4321,
+        ...resultFields,
+      });
+      return {
+        ...base,
+        executeShellCommand: (_command, _cwd, _onOutput, signal) =>
+          new Promise<ShellExecutionResult>((resolve) => {
+            if (signal.aborted) {
+              resolve(buildResult());
+              return;
+            }
+            signal.addEventListener(
+              'abort',
+              () => {
+                resolve(buildResult());
+              },
+              { once: true },
+            );
+          }),
+      };
+    }
+
+    it('a timeout result with surviving group members includes the kill -9 cleanup instruction', async () => {
+      const tool = new ShellTool(
+        createTimeoutAbortingHost({ survivingGroupMembersOnAbort: true }),
+        createFakeMessageBus(ToolConfirmationOutcome.ProceedOnce),
+      );
+
+      const result = await executeToolForBehavioralAssertion(tool, {
+        command: 'sleep 60',
+        timeout_seconds: 0.5,
+      });
+
+      const llm = String(result.llmContent);
+      expect(llm).toContain('timed out');
+      expect(llm).toContain('may still be running');
+      // The cleanup instruction names the process group id (the resolved pgid
+      // falls back to result.pid, the detached group leader on POSIX).
+      expect(llm).toContain('kill -9 -- -4321');
+    });
+
+    it('a clean timeout result carries no survivor warning', async () => {
+      const tool = new ShellTool(
+        createTimeoutAbortingHost({}),
+        createFakeMessageBus(ToolConfirmationOutcome.ProceedOnce),
+      );
+
+      const result = await executeToolForBehavioralAssertion(tool, {
+        command: 'sleep 60',
+        timeout_seconds: 0.5,
+      });
+
+      const llm = String(result.llmContent);
+      expect(llm).toContain('timed out');
+      expect(llm).not.toContain('may still be running');
+      expect(llm).not.toContain('kill -9');
+    });
   });
 });

--- a/packages/tools/src/__tests__/shell-tool.test.ts
+++ b/packages/tools/src/__tests__/shell-tool.test.ts
@@ -606,8 +606,10 @@ describe('shell result contracts @plan:issue1995 @plan:issue3200', () => {
     /**
      * Builds a host whose foreground execution resolves with an aborted
      * result only when the combined timeout/user signal fires, so the tool
-     * computes a genuine timeout-triggered abort path the way production
-     * does.
+     * computes a genuine abort path (timeout-triggered or user-cancelled)
+     * the way production does. The fake result carries its pgid verbatim so
+     * collectProcessInfo never falls through to a real `ps` lookup for the
+     * fabricated pid.
      */
     function createTimeoutAbortingHost(
       resultFields: Partial<ShellExecutionResult>,
@@ -624,6 +626,7 @@ describe('shell result contracts @plan:issue1995 @plan:issue3200', () => {
         error: null,
         aborted: true,
         pid: 4321,
+        pgid: 4321,
         ...resultFields,
       });
       return {
@@ -662,6 +665,75 @@ describe('shell result contracts @plan:issue1995 @plan:issue3200', () => {
       // The cleanup instruction names the process group id (the resolved pgid
       // falls back to result.pid, the detached group leader on POSIX).
       expect(llm).toContain('kill -9 -- -4321');
+      // The timeout branch is user-facing too: the human display must carry
+      // the cleanup instruction, not just the model-facing content.
+      expect(String(result.returnDisplay)).toContain('kill -9 -- -4321');
+    });
+
+    it('a user-cancelled result with surviving group members shows the warning in llmContent and returnDisplay', async () => {
+      // Cancel via the USER signal, not the timeout controller, so the tool
+      // takes the user-cancel branch (timeoutTriggered === false).
+      const userAbort = new AbortController();
+      const tool = new ShellTool(
+        createTimeoutAbortingHost({ survivingGroupMembersOnAbort: true }),
+        createFakeMessageBus(ToolConfirmationOutcome.ProceedOnce),
+      );
+
+      const resultPromise = executeToolForBehavioralAssertion(
+        tool,
+        { command: 'sleep 60' },
+        userAbort.signal,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      userAbort.abort();
+      const result = await resultPromise;
+
+      const llm = String(result.llmContent);
+      expect(llm).toContain('cancelled by user');
+      expect(llm).toContain('may still be running');
+      expect(llm).toContain('kill -9 -- -4321');
+      // The non-debug display path drops the llmContent, so the warning must
+      // be appended to the display string itself.
+      expect(String(result.returnDisplay)).toContain('kill -9 -- -4321');
+    });
+
+    it('an inactivity-style result (aborted: false) with survivors keeps the warning in the final llmContent even when summarization replaces the output', async () => {
+      const base = createFakeHostWithBackground(() => {
+        throw new Error(
+          'Foreground execution must not launch a background job',
+        );
+      });
+      // Inactivity-killed CP commands resolve aborted: false, so the content
+      // IS summarized before the result is built — a warning appended during
+      // formatting would be lost with it.
+      const host: IShellToolHost = {
+        ...base,
+        getSummarizeConfig: () => ({ tokenBudget: 100 }),
+        trySummarizeOutput: async () => 'SUMMARIZED OUTPUT',
+        executeShellCommand: async () => ({
+          output: 'partial output',
+          exitCode: null,
+          signal: '9',
+          error: null,
+          aborted: false,
+          pid: 4321,
+          pgid: 4321,
+          survivingGroupMembersOnAbort: true,
+        }),
+      };
+
+      const result = await executeToolForBehavioralAssertion(
+        new ShellTool(
+          host,
+          createFakeMessageBus(ToolConfirmationOutcome.ProceedOnce),
+        ),
+        { command: 'sleep 60' },
+      );
+
+      const llm = String(result.llmContent);
+      expect(llm).toContain('SUMMARIZED OUTPUT');
+      expect(llm).toContain('may still be running');
+      expect(llm).toContain('kill -9 -- -4321');
     });
 
     it('a clean timeout result carries no survivor warning', async () => {
@@ -679,6 +751,7 @@ describe('shell result contracts @plan:issue1995 @plan:issue3200', () => {
       expect(llm).toContain('timed out');
       expect(llm).not.toContain('may still be running');
       expect(llm).not.toContain('kill -9');
+      expect(String(result.returnDisplay)).not.toContain('kill -9');
     });
   });
 });

--- a/packages/tools/src/interfaces/IShellToolHost.ts
+++ b/packages/tools/src/interfaces/IShellToolHost.ts
@@ -44,8 +44,10 @@ export interface ShellExecutionResult {
   pgid?: number | null;
   /**
    * True when an abort-timeout kill left live members in the spawned process
-   * group after the executor's bounded reap window expired (Issue #3517).
-   * Absent means the group was confirmed empty (or no group kill applies).
+   * group after the bounded reap window expired. Set only on the POSIX
+   * group-kill abort path; absent means the group was confirmed empty (or no
+   * group kill applies). Carried so the tool layer can tell the caller
+   * children may still be running (Issue #3517).
    */
   survivingGroupMembersOnAbort?: boolean;
   /**

--- a/packages/tools/src/interfaces/IShellToolHost.ts
+++ b/packages/tools/src/interfaces/IShellToolHost.ts
@@ -43,6 +43,12 @@ export interface ShellExecutionResult {
   /** Process group ID discovered for non-Windows shells. */
   pgid?: number | null;
   /**
+   * True when an abort-timeout kill left live members in the spawned process
+   * group after the executor's bounded reap window expired (Issue #3517).
+   * Absent means the group was confirmed empty (or no group kill applies).
+   */
+  survivingGroupMembersOnAbort?: boolean;
+  /**
    * Acquisition-time truncation metadata when output exceeded the retention
    * byte budget. Present (with `truncated: true`) when the output was bounded
    * during acquisition. The tools layer surfaces this so the model-facing

--- a/packages/tools/src/tools/shell-helpers.ts
+++ b/packages/tools/src/tools/shell-helpers.ts
@@ -163,7 +163,11 @@ export function appendAbortSurvivorWarning(
     return content;
   }
   const cleanupPgid = pgid ?? result.pid;
-  if (cleanupPgid === undefined) {
+  if (
+    cleanupPgid === undefined ||
+    !Number.isInteger(cleanupPgid) ||
+    cleanupPgid <= 1
+  ) {
     return `${content}\n\nWarning: child processes from the aborted command may still be running; they could not be fully terminated.`;
   }
   return (
@@ -178,7 +182,7 @@ export function appendAbortSurvivorWarning(
  * lossy processing (summarization, token limiting), following the clamp
  * notice pattern: the warning must survive even when the underlying
  * content is replaced (Issue #3517). Also appended to `returnDisplay` on
- * aborted results so the human UI shows it. No-op without the flag, so
+ * flagged results so the human UI shows it. No-op without the flag, so
  * clean results stay byte-identical.
  */
 export function appendSurvivorNoticeToResult(
@@ -189,13 +193,14 @@ export function appendSurvivorNoticeToResult(
   if (result.survivingGroupMembersOnAbort !== true) {
     return toolResult;
   }
-  const appendDisplay = result.aborted === true;
   return {
     ...toolResult,
     llmContent: appendAbortSurvivorWarning(toolResult.llmContent, result, pgid),
-    returnDisplay: appendDisplay
-      ? appendAbortSurvivorWarning(toolResult.returnDisplay, result, pgid)
-      : toolResult.returnDisplay,
+    returnDisplay: appendAbortSurvivorWarning(
+      toolResult.returnDisplay,
+      result,
+      pgid,
+    ),
   };
 }
 

--- a/packages/tools/src/tools/shell-helpers.ts
+++ b/packages/tools/src/tools/shell-helpers.ts
@@ -147,6 +147,9 @@ ${clamp}`;
  * instruction is the actionable cleanup the caller can be given. The pgid is
  * the one already resolved via collectProcessInfo; on POSIX the detached
  * spawn makes result.pid the process-group id, so it is the fallback.
+ * POSIX-only: core never sets the flag on Windows (taskkill walks the tree),
+ * and a Windows host that ever sets it must not be shown a bash `kill -9`
+ * instruction to run in PowerShell.
  */
 export function appendAbortSurvivorWarning(
   content: string,
@@ -154,6 +157,9 @@ export function appendAbortSurvivorWarning(
   pgid: number | null,
 ): string {
   if (result.survivingGroupMembersOnAbort !== true) {
+    return content;
+  }
+  if (os.platform() === 'win32') {
     return content;
   }
   const cleanupPgid = pgid ?? result.pid;
@@ -165,6 +171,32 @@ export function appendAbortSurvivorWarning(
     `running (process group ${cleanupPgid} could not be fully terminated). ` +
     `Kill them with \`kill -9 -- -${cleanupPgid}\`.`
   );
+}
+
+/**
+ * Appends the durable survivor warning to a foreground result AFTER all
+ * lossy processing (summarization, token limiting), following the clamp
+ * notice pattern: the warning must survive even when the underlying
+ * content is replaced (Issue #3517). Also appended to `returnDisplay` on
+ * aborted results so the human UI shows it. No-op without the flag, so
+ * clean results stay byte-identical.
+ */
+export function appendSurvivorNoticeToResult(
+  toolResult: StringContentToolResult,
+  result: ShellExecutionResult,
+  pgid: number | null,
+): StringContentToolResult {
+  if (result.survivingGroupMembersOnAbort !== true) {
+    return toolResult;
+  }
+  const appendDisplay = result.aborted === true;
+  return {
+    ...toolResult,
+    llmContent: appendAbortSurvivorWarning(toolResult.llmContent, result, pgid),
+    returnDisplay: appendDisplay
+      ? appendAbortSurvivorWarning(toolResult.returnDisplay, result, pgid)
+      : toolResult.returnDisplay,
+  };
 }
 
 export function isShellToolHost(

--- a/packages/tools/src/tools/shell-helpers.ts
+++ b/packages/tools/src/tools/shell-helpers.ts
@@ -140,6 +140,33 @@ ${clamp}`;
   };
 }
 
+/**
+ * Survivor warning appended to an aborted result when the executor's bounded
+ * group-reap window expired with live process-group members (Issue #3517).
+ * Foreground commands have no managed task id, so the explicit kill
+ * instruction is the actionable cleanup the caller can be given. The pgid is
+ * the one already resolved via collectProcessInfo; on POSIX the detached
+ * spawn makes result.pid the process-group id, so it is the fallback.
+ */
+export function appendAbortSurvivorWarning(
+  content: string,
+  result: ShellExecutionResult,
+  pgid: number | null,
+): string {
+  if (result.survivingGroupMembersOnAbort !== true) {
+    return content;
+  }
+  const cleanupPgid = pgid ?? result.pid;
+  if (cleanupPgid === undefined) {
+    return `${content}\n\nWarning: child processes from the aborted command may still be running; they could not be fully terminated.`;
+  }
+  return (
+    `${content}\n\nWarning: child processes from the aborted command may still be ` +
+    `running (process group ${cleanupPgid} could not be fully terminated). ` +
+    `Kill them with \`kill -9 -- -${cleanupPgid}\`.`
+  );
+}
+
 export function isShellToolHost(
   host: IShellToolHost | IShellExecutionService,
 ): host is IShellToolHost {

--- a/packages/tools/src/tools/shell.ts
+++ b/packages/tools/src/tools/shell.ts
@@ -39,6 +39,7 @@ import type {
 } from '../interfaces/IShellToolHost.js';
 import {
   applyOutputFilters,
+  appendAbortSurvivorWarning,
   buildShellSchema,
   collectProcessInfo,
   createShellToolHostFromExecutionService,
@@ -677,7 +678,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
       ? result.error.message.replace(commandToExecute, this.params.command)
       : '(none)';
 
-    const llmContent = [
+    let llmContent = [
       `Command: ${this.params.command}`,
       `Directory: ${stringOrDefault(this.getDirPath(), '(root)')}`,
       `Stdout: ${stringOrDefault(filteredOutput, '(empty)')}`,
@@ -690,6 +691,10 @@ export class ShellToolInvocation extends BaseToolInvocation<
       }`,
       `Process Group PGID: ${pgid ?? result.pid ?? '(none)'}`,
     ].join('\n');
+    // Inactivity-killed CP commands resolve aborted: false (the caller
+    // signal never fired), so the survivor flag set by the executor would
+    // otherwise be dropped here (Issue #3517). No-op without the flag.
+    llmContent = appendAbortSurvivorWarning(llmContent, result, pgid);
 
     let returnDisplayMessage = '';
     if (this.host.getDebugMode()) {
@@ -770,33 +775,6 @@ export class ShellToolInvocation extends BaseToolInvocation<
   private isInvocationAllowlisted(command: string): boolean {
     return this.host.isShellInvocationAllowlisted(command, ShellTool.Name);
   }
-}
-
-/**
- * Survivor warning appended to an aborted result when the executor's bounded
- * group-reap window expired with live process-group members (Issue #3517).
- * Foreground commands have no managed task id, so the explicit kill
- * instruction is the actionable cleanup the caller can be given. The pgid is
- * the one already resolved via collectProcessInfo; on POSIX the detached
- * spawn makes result.pid the process-group id, so it is the fallback.
- */
-function appendAbortSurvivorWarning(
-  content: string,
-  result: ShellExecutionResult,
-  pgid: number | null,
-): string {
-  if (result.survivingGroupMembersOnAbort !== true) {
-    return content;
-  }
-  const cleanupPgid = pgid ?? result.pid;
-  if (cleanupPgid === undefined) {
-    return `${content}\n\nWarning: child processes from the aborted command may still be running; they could not be fully terminated.`;
-  }
-  return (
-    `${content}\n\nWarning: child processes from the aborted command may still be ` +
-    `running (process group ${cleanupPgid} could not be fully terminated). ` +
-    `Kill them with \`kill -9 -- -${cleanupPgid}\`.`
-  );
 }
 
 export class ShellTool extends BaseDeclarativeTool<

--- a/packages/tools/src/tools/shell.ts
+++ b/packages/tools/src/tools/shell.ts
@@ -39,7 +39,7 @@ import type {
 } from '../interfaces/IShellToolHost.js';
 import {
   applyOutputFilters,
-  appendAbortSurvivorWarning,
+  appendSurvivorNoticeToResult,
   buildShellSchema,
   collectProcessInfo,
   createShellToolHostFromExecutionService,
@@ -458,9 +458,15 @@ export class ShellToolInvocation extends BaseToolInvocation<
         result.outputTruncation,
       );
 
-      // Append the durable clamp notice AFTER summarization and token
-      // limiting so it survives lossy processing (Issue #3031).
-      return appendClampNoticeToResult(toolResult, resolution);
+      // Durable notices are applied after buildToolResult because
+      // summarizeIfNeeded (not skipped on the aborted:false inactivity
+      // branch) and limitOutputTokens can replace the formatted content
+      // wholesale; only a post-processing append is guaranteed to reach the
+      // model (Issues #3031 and #3517).
+      return appendClampNoticeToResult(
+        appendSurvivorNoticeToResult(toolResult, result, pgid),
+        resolution,
+      );
     } finally {
       fs.rmSync(tempFilePath, { force: true });
     }
@@ -631,7 +637,6 @@ export class ShellToolInvocation extends BaseToolInvocation<
         } else {
           llmContent += ' There was no output before timeout.';
         }
-        llmContent = appendAbortSurvivorWarning(llmContent, result, pgid);
         returnDisplayMessage = llmContent;
       } else {
         llmContent = 'Command was cancelled by user before it could complete.';
@@ -641,7 +646,6 @@ export class ShellToolInvocation extends BaseToolInvocation<
         } else {
           llmContent += ' There was no output before it was cancelled.';
         }
-        llmContent = appendAbortSurvivorWarning(llmContent, result, pgid);
 
         if (this.host.getDebugMode()) {
           returnDisplayMessage = llmContent;
@@ -678,7 +682,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
       ? result.error.message.replace(commandToExecute, this.params.command)
       : '(none)';
 
-    let llmContent = [
+    const llmContent = [
       `Command: ${this.params.command}`,
       `Directory: ${stringOrDefault(this.getDirPath(), '(root)')}`,
       `Stdout: ${stringOrDefault(filteredOutput, '(empty)')}`,
@@ -691,10 +695,6 @@ export class ShellToolInvocation extends BaseToolInvocation<
       }`,
       `Process Group PGID: ${pgid ?? result.pid ?? '(none)'}`,
     ].join('\n');
-    // Inactivity-killed CP commands resolve aborted: false (the caller
-    // signal never fired), so the survivor flag set by the executor would
-    // otherwise be dropped here (Issue #3517). No-op without the flag.
-    llmContent = appendAbortSurvivorWarning(llmContent, result, pgid);
 
     let returnDisplayMessage = '';
     if (this.host.getDebugMode()) {

--- a/packages/tools/src/tools/shell.ts
+++ b/packages/tools/src/tools/shell.ts
@@ -630,6 +630,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
         } else {
           llmContent += ' There was no output before timeout.';
         }
+        llmContent = appendAbortSurvivorWarning(llmContent, result, pgid);
         returnDisplayMessage = llmContent;
       } else {
         llmContent = 'Command was cancelled by user before it could complete.';
@@ -639,6 +640,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
         } else {
           llmContent += ' There was no output before it was cancelled.';
         }
+        llmContent = appendAbortSurvivorWarning(llmContent, result, pgid);
 
         if (this.host.getDebugMode()) {
           returnDisplayMessage = llmContent;
@@ -768,6 +770,33 @@ export class ShellToolInvocation extends BaseToolInvocation<
   private isInvocationAllowlisted(command: string): boolean {
     return this.host.isShellInvocationAllowlisted(command, ShellTool.Name);
   }
+}
+
+/**
+ * Survivor warning appended to an aborted result when the executor's bounded
+ * group-reap window expired with live process-group members (Issue #3517).
+ * Foreground commands have no managed task id, so the explicit kill
+ * instruction is the actionable cleanup the caller can be given. The pgid is
+ * the one already resolved via collectProcessInfo; on POSIX the detached
+ * spawn makes result.pid the process-group id, so it is the fallback.
+ */
+function appendAbortSurvivorWarning(
+  content: string,
+  result: ShellExecutionResult,
+  pgid: number | null,
+): string {
+  if (result.survivingGroupMembersOnAbort !== true) {
+    return content;
+  }
+  const cleanupPgid = pgid ?? result.pid;
+  if (cleanupPgid === undefined) {
+    return `${content}\n\nWarning: child processes from the aborted command may still be running; they could not be fully terminated.`;
+  }
+  return (
+    `${content}\n\nWarning: child processes from the aborted command may still be ` +
+    `running (process group ${cleanupPgid} could not be fully terminated). ` +
+    `Kill them with \`kill -9 -- -${cleanupPgid}\`.`
+  );
 }
 
 export class ShellTool extends BaseDeclarativeTool<

--- a/project-plans/20260908-issue3517-group-reap/plan.md
+++ b/project-plans/20260908-issue3517-group-reap/plan.md
@@ -349,3 +349,37 @@ prettier clean on all six touched files.
   main). format:check initially flagged one line-wrap in
   `shellProcessKill.test.ts` (the widened tuple annotation); fixed by
   the repo formatter, file re-verified green.
+
+### CodeRabbit review outcome (PR #3637) — 1 actionable finding, fixed
+
+- Finding (Major, core, `shellPtyLifecycle.ts`): on a pure inactivity kill
+  (caller never aborts), the POSIX group branch still ran the OLD inline
+  sequence — group SIGKILL skipped once the direct child exited — never
+  armed the group-reap chain, and the exit handler only gated on the chain
+  when `state.abortSignal.aborted`; `ptyExitRace`'s non-abort winner
+  resolved immediately with no group confirmation and no survivor flag
+  while TERM-immune descendants kept running. Exactly the incident shape
+  on the inactivity path, which AC4 claims inherits the gate —
+  **In-scope-Fix**. This fully supersedes the round-1 compliance defer of
+  `ptyInactivityAbortAction` (Windows taskkill confirmation stays
+  deferred). Fix: the inactivity group branch now awaits
+  `armPtyGroupAbortKill` (shared chain, group-liveness-gated SIGKILL,
+  bounded reap) and mirrors `ptyAbortAction`'s resolution tail
+  (hasResolved/exitedGuard early returns; synthetic forward-progress
+  result stamped with the survivor flag); `registerPtyExitHandler`'s
+  onExit hoists the chain lookup and gates non-aborted resolution on an
+  in-flight chain too (natural-exit values win, survivors flagged).
+  Implemented by fallbacktypescriptcoder (typescriptexpert provider down).
+- Tests: two POSIX-gated fake-pty cases through the REAL inactivity timer
+  (`createPtyResultPromise` + `inactivityTimeoutMs: 10`): surviving group
+  (probes alive → window expires → flag set, SIGKILL issued, elapsed ≥
+  window) and confirmed-empty group (probes ESRCH → prompt resolve, no
+  flag); both assert `aborted === false`, exit fidelity (143/15), and
+  TERM+probe delivery. Both failed before the production change.
+- Verification: targeted suite 15 pass/1 skip/0 fail; package typecheck,
+  eslint, prettier clean on the two files; full chain v7 run post-fix
+  (results below).
+- v7 (CodeRabbit-fix tree, final): build OK, tools OK, cli OK, lint OK,
+  typecheck OK, format:check OK, smoke OK (stepfun-37). Core 430/432 with
+  only the two #3631 skills files failing — identical to the v6 baseline;
+  no regression from the inactivity-path fix.

--- a/project-plans/20260908-issue3517-group-reap/plan.md
+++ b/project-plans/20260908-issue3517-group-reap/plan.md
@@ -164,3 +164,50 @@ compliance review (≤2 rounds), OCR (≤2 rounds), PR, CI watch.
 Findings will be classified Blocker-Fix / In-scope-Fix / Reject / Defer.
 Reviewer suggestions do not expand scope; anything beyond the accepted
 behavior above needs explicit approval before implementation.
+
+### Compliance review (round 1) outcome
+
+- Finding 1 (PTY exit-race window: an abort landing while natural-exit
+  output drains resolved immediately, bypassing the group-reap gate and the
+  survivor warning) — **In-scope-Fix**. Fixed in `ptyExitRace`: the
+  abort-win path now arms/shares the same bounded group-reap chain
+  (`abortGroupReapChains`) that `ptyAbortAction`'s group branch uses and
+  gates the result on it, flagging survivors via the widened
+  `finalizeResult` signature. Same hazard class as the incident, on a
+  foreground timeout/cancel path.
+- Finding 2 (CP inactivity kill set the survivor flag but
+  `formatNormalOutput` never rendered it, because inactivity results carry
+  `aborted: false`) — **In-scope-Fix**. One line: `formatNormalOutput`
+  appends `appendAbortSurvivorWarning`; clean results stay byte-identical.
+- Signal-fidelity pin (reviewer NIT, promoted): new fake-pty test
+  `PTY abort signal fidelity (fake pty, issue #3517)` asserts the real exit
+  signal (9) wins over the synthetic `(1, null)` abort result when the exit
+  fires before the reap chain settles, and that the survivor flag still
+  lands. Guards the fix for the deterministic `main.test.ts` failure.
+- Lint-driven refactors (`appendAbortSurvivorWarning` moved to
+  shell-helpers.ts, `armCpStreamSettleListeners` extraction, `??=`,
+  optional-chain removal) — **no action** (behavior-neutral, verified by
+  diff).
+- Real-process PTY probe skipping in this environment (documented
+  oven-sh/bun#25822 unreliability) — **no action** (legitimate skip; PTY
+  path covered by fake-pty suite plus reading).
+- `ptyInactivityAbortAction` and Windows taskkill confirmation — **Defer**
+  (pre-existing sibling hazards outside this issue's scope, unchanged by
+  this PR).
+
+### Verification results (candidate head)
+
+- Targeted core files: 87 pass / 0 fail / 5 skip (POSIX/Windows gates),
+  2 consecutive runs; tools `shell-tool.test.ts`: 19 pass.
+- Full chain (build → core → tools → cli → lint → typecheck → format):
+  build OK, lint OK, typecheck OK, format clean.
+- Core suite: only `gitService.test.ts` and `editor.test.ts` fail — both
+  reproduced failing on `main` (pre-existing).
+- CLI suite: only `docsCommand.test.ts` and
+  `sandbox-node-modules-preflight.test.ts` fail — both reproduced failing
+  on `main` (pre-existing).
+- Smoke test (`stepfun-37`): blocked by sandbox credential-proxy failure
+  (`Invalid or missing capability token`); reproduced identically on
+  `main`, so pre-existing/environmental, not this change. The sandbox no
+  longer exports `LLXPRT_CAPABILITY_TOKEN` to child processes and the
+  proxy rejects the token frozen in `/proc/1/environ`.

--- a/project-plans/20260908-issue3517-group-reap/plan.md
+++ b/project-plans/20260908-issue3517-group-reap/plan.md
@@ -195,6 +195,59 @@ behavior above needs explicit approval before implementation.
   (pre-existing sibling hazards outside this issue's scope, unchanged by
   this PR).
 
+### Open code review (round 1) outcome — 18 findings (glm-5.3, complete)
+
+16 **In-scope-Fix** (all addressed in the OCR-r1 remediation):
+
+- Finding 1 (survivor warning lost through `summarizeIfNeeded` on the
+  `aborted: false` inactivity path and through `limitOutputTokens` on every
+  path) — warning now appended AFTER `buildToolResult` by
+  `appendSurvivorNoticeToResult` (durable post-processing, same pattern as
+  the clamp notice, Issues #3031/#3517).
+- Finding 2 + 15 (formatting coverage gaps + env-dependent `pid: 4321`
+  resolution) — user-cancel and inactivity-style tests added; fake results
+  carry `pgid: 4321` verbatim so `collectProcessInfo` never hits a real
+  `ps` lookup.
+- Finding 3 (contract asymmetry on the tools-side field doc) — comment
+  rewritten to state the POSIX group-kill-abort-path restriction.
+- Finding 4 (cp kill-chain rejection could stall `handle.result` forever) —
+  never-reject contract enforced at the arm site:
+  `cpKillOnAbort(...).catch(() => false)`.
+- Finding 5 (cp survivor-branch never exercised) — new
+  `shellCpExecution.test.ts` case with the established `process.kill` spy
+  pattern (group probes keep reporting alive → window expires → flag set).
+- Findings 7 + 18 (PTY chain rejection contract + stale inactivity-kill
+  fallback timer resolving before the group-reap chain settles) —
+  `reapProcessGroup(pid).catch(() => false)` tail and
+  `clearPendingAbortFallback` called before arming the group chain.
+- Finding 8 (module-level `await probeUsableForkptyPty()` throw took down
+  the whole test file) — probe failure now skips only the real-PTY suite
+  (`forkptyBackend = null`), fake-pty tests preserved.
+- Finding 9 (ptyExitRace abort-during-drain branch untested) — new
+  deterministic fake-pty test gates the result on the group-reap chain and
+  asserts exit values win + survivor flag lands.
+- Findings 10 + 12 + 13 + 14 (`kill(-1, ...)` broadcast footgun via
+  negation, pid-1 probe test passing for the wrong reason, EPERM→alive and
+  skip-path unpinned, convergent reap untested) — new
+  `isGroupTargetPid` chokepoint (`pid > 1`) shared by
+  `isProcessGroupAlive`/`reapProcessGroup`/`escalateKillUnix` with unit
+  tests; reap tests now use real detached groups (`waitForGroupAlive`
+  readiness gate) instead of pid-1 probes; spy-based EPERM and
+  skip-the-group-SIGKILL tests; convergent mid-window-death test.
+- Findings 16 + 17 (warning dropped from `returnDisplay`; POSIX-only
+  `kill -9` instruction emitted unconditionally) — `returnDisplay`
+  appended on aborted results; `appendAbortSurvivorWarning` is a no-op on
+  win32.
+
+2 **Defer** (documented known follow-ups, no behavioral risk):
+
+- Finding 6 (mock infra duplicated between
+  `shellExecutionService.main.test.ts` and `.fallback.test.ts`) —
+  test-infra dedup refactor across files this PR does not otherwise touch.
+- Finding 11 (zombie-leader can hold `kill(-pgid, 0)` alive until reaped;
+  worst case adds one reap window of latency before the survivor warning) —
+  accepted limitation, same class as the already-accepted PID-reuse races.
+
 ### Verification results (candidate head)
 
 - Targeted core files: 87 pass / 0 fail / 5 skip (POSIX/Windows gates),
@@ -211,3 +264,31 @@ behavior above needs explicit approval before implementation.
   `main`, so pre-existing/environmental, not this change. The sandbox no
   longer exports `LLXPRT_CAPABILITY_TOKEN` to child processes and the
   proxy rejects the token frozen in `/proc/1/environ`.
+
+### Verification results (OCR-r1 remediation tree, chain v3/v4)
+
+- v3 (remediation as left by the crashed session): build OK, tools OK
+  (21 pass shell-tool), cli OK (743/743 files, 9581 cases — the two v2
+  cli failures did not recur), format OK, **smoke OK** (the v2
+  credential-proxy failure was transient and resolved).
+- v3 core: FAIL, but only `skillManager.test.ts` +
+  `extensionSkillRefresh.test.ts` — reproduced identically on `main`
+  (worktree run: 19 pass / 2 fail, same files). Machine-state dependent
+  (real global user skills leak into the assertions; 55 discovered).
+  Filed as #3631. The v2-era `gitService`/`editor` failures did not
+  recur this run.
+- v3 caught real gaps the crashed session left: 2 lint errors
+  (prefer-const on the now-unreassigned `llmContent`; shell.ts at 822
+  lines vs 800 max) and 4 typecheck errors (mock signatures on
+  `vi.spyOn(process,'kill')` in 3 files; `signal: null` vs
+  `signal?: number` in the fake-pty drain test). Fixed by
+  typescriptexpert: `const`, `appendSurvivorNoticeToResult` moved to
+  shell-helpers.ts as an exported pure function, mock annotations
+  matched to `process.kill`'s type, exit-listener event widened to
+  `signal?: number | null` (mirroring the existing fake-pty test).
+- v4/v5 (post-fix chains): build OK, targeted core shell tests OK
+  (16 pass/4 skip in shellProcessKill alone; 29 pass/5 skip across the
+  three files), full tools suite OK (133/133 isolated files + runner
+  suites), lint OK (both shell.ts errors gone), format OK, root
+  typecheck exit 0 after one knock-on tuple-annotation fix
+  (`deliveredSignals` widened to `signal: string | number`).

--- a/project-plans/20260908-issue3517-group-reap/plan.md
+++ b/project-plans/20260908-issue3517-group-reap/plan.md
@@ -1,0 +1,166 @@
+# Plan: Foreground shell timeout must terminate and confirm the whole process group (Issue #3517)
+
+Branch: `issue3517`. Milestone 0.12.0. Labels: Tooling, recoverability.
+
+## Root cause analysis
+
+Incident: a foreground `run_shell_command` with `timeout_seconds` reported
+`Signal: 15` while its `bun test` grandchild kept running in the spawned
+process group and kept writing to a redirected log.
+
+The foreground POSIX path spawns `bash -c <cmd>` with `detached: true`, so the
+child leads its own process group (`child.pid == pgid`). On timeout the tool
+aborts an `AbortController`; the abort listener runs
+`cpKillOnAbort` → `killProcessWithEscalation` → `escalateKillUnix`
+(`packages/core/src/services/shellProcessKill.ts`), which:
+
+1. Sends `SIGTERM` to the group.
+2. Waits `SIGKILL_TIMEOUT_MS` (200 ms).
+3. Sends `SIGKILL` to the group only `if (!exitedGuard.isExited())`.
+
+`exitedGuard` tracks ONLY the direct child (the `bash` wrapper). When `bash`
+dies from the SIGTERM, the guard is marked exited, so step 3 is skipped. A
+grandchild that survives SIGTERM (the incident's `bun test`) is never
+escalated to SIGKILL. The result promise resolves on the direct child's
+`exit` event (plus a ≤500 ms stdio drain grace in `shellCpExecution.ts`), so
+the tool returns claiming termination while group members are still alive.
+Nothing in `ShellExecutionResult` or the tool output tells the caller that
+survivors remain.
+
+The PTY abort path (`ptyAbortAction` in `shellPtyLifecycle.ts`) has the same
+shape: after the SIGTERM round it returns early when
+`state.exitedGuard.isExited()`, skipping the group SIGKILL, and
+`schedulePtyAbortFallback` resolves the result after a fixed 200 ms timer
+with no confirmation that the group is empty.
+
+## Acceptance criteria
+
+- **AC1 — Escalation is gated on group liveness, not the direct child.**
+  On POSIX, when a foreground execution is aborted (timeout or user cancel),
+  after the group SIGTERM + grace period the executor sends SIGKILL to the
+  entire process group whenever the group still has live members — even if
+  the direct child has already exited. A grandchild that ignores or traps
+  SIGTERM must be killed by the escalation.
+- **AC2 — Bounded reap before the result is produced.**
+  On POSIX, when an abort-timeout result is about to be resolved, the
+  executor waits a small bounded window (constant, on the order of 1–2 s,
+  short poll interval) until the spawned process group has no live members
+  (`process.kill(-pgid, 0)` throws `ESRCH`). The result must not be produced
+  while group members are still alive, unless the reap window expires.
+- **AC3 — Honest reporting when survivors remain.**
+  If the reap window expires with live group members, `ShellExecutionResult`
+  carries that fact (new optional field), and the `run_shell_command` output
+  for that execution explicitly states that child processes may still be
+  running and gives the explicit cleanup instruction
+  (`kill -9 -- -<PGID>`). Foreground commands have no managed task id, so
+  the cleanup instruction is the mechanism the issue allows.
+- **AC4 — No regression on unaffected paths.**
+  - Normal completion (no abort): unchanged behavior, no added latency, no
+    new waits.
+  - Abort where the whole group dies promptly (the common case): resolves
+    promptly with the existing timeout/cancel messaging and no survivor
+    warning (group already empty → reap returns immediately).
+  - Background jobs (`is_background` / trailing `&`, `shellJobManager`) are
+    out of scope and untouched. `timeout_seconds` does not apply to them.
+  - Inactivity timeout uses the same kill helpers, so it inherits the same
+    confirm-before-resolve behavior; no separate handling.
+
+## Boundary cases
+
+- Group leader (direct child) dead, grandchild alive → escalation still
+  fires and reaps (the incident).
+- Whole group dead before the reap check → immediate resolution, no delay.
+- Grandchild ignores SIGTERM but not SIGKILL (`trap '' TERM` dispositions
+  survive `exec`) → killed by AC1, clean result.
+- Truly unkillable survivor (permission edge) → reap window expires, AC3
+  warning. At helper level this is exercised by polling a pid that exists
+  and will not die (e.g. pid 1) without ever signaling it.
+- `bun-pty` backend (`supportsProcessGroupKill === false`): group kill is
+  not possible; keep existing direct-kill behavior and do NOT add the reap
+  wait there (it would stall every abort without being able to kill
+  anything). No regression, documented limitation.
+- Windows: `taskkill /f /t` already walks the tree; keep `taskkillTree` as
+  the kill mechanism on abort. If a bounded confirmation is trivially
+  available via the existing `boundedTaskkill` primitive, wire it in and set
+  the same survivor flag on failure; tests for this are gated to Windows and
+  must not run on Linux CI. Optional — drop rather than expand scope.
+- PID-reuse races during the short poll window are accepted (existing
+  behavior already has this property; do not add pidfd machinery).
+
+## Out of scope (explicitly)
+
+- #3491 (sandbox session exit after intentional backgrounding) and #3514
+  (bun test orphan reaper crossing checkouts).
+- Any change to background job lifecycle, the job manager, or the shell tool
+  schema/descriptions beyond appending the survivor warning to the result
+  text of a timed-out foreground execution.
+- No new public abstraction beyond the one optional field on
+  `ShellExecutionResult` (core-internal type).
+
+## Test plan (bun tests, real processes, no mock theater)
+
+POSIX cases gated with `describe.skipIf(isWindows)` matching the existing
+style in `shellProcessKill.test.ts`.
+
+1. `packages/core/src/services/shellProcessKill.test.ts`
+   - Escalation with a dead group leader but a live TERM-immune group member
+     (guard pre-marked exited): group SIGKILL still fires and the member
+     dies within a deadline (AC1). Choreography: detached
+     `bash -c '( trap "" TERM; exec sleep 30 ) & ...; exit 0'` so the
+     direct child exits while the subshell (same group) survives SIGTERM.
+   - New `reapProcessGroup`-style helper: resolves promptly `true` when the
+     polled pids are gone; resolves `false` when a polled pid stays alive
+     for the window (poll pid 1 — signal-0 probes only, never signal it).
+2. `packages/core/src/services/shellCpExecution.test.ts` (new file if absent)
+   - Service-level: `ShellExecutionService.execute(..., shouldUseNodePty:
+     false)` runs a command that leaves a TERM-immune grandchild in the
+     group; abort after a short delay; the resolved result arrives only
+     after the grandchild is dead (`process.kill(pid, 0)` throws), and
+     `aborted === true` (AC1+AC2).
+   - Prompt-abort case: whole group dies on SIGTERM → result resolves with
+     no measurable reap delay and no survivor flag (AC4).
+3. `packages/core/src/services/shellPtyLifecycle.test.ts`
+   - PTY abort (lydell backend, POSIX): TERM-immune grandchild under the
+     pty shell is dead by the time the result resolves (AC1+AC2). Model on
+     the existing PTY bun tests; skip gracefully if no usable PTY in the
+     environment.
+4. `packages/tools/src/__tests__/shell-tool.test.ts`
+   - Formatting: a result carrying the survivor field rendered through the
+     timeout path includes the survivor warning naming the cleanup command;
+     a clean timeout result does not (AC3). Pure formatting assertions on
+     constructed results.
+
+## Implementation sketch (guidance, not mandate)
+
+- `shellProcessKill.ts`: add a bounded group-reap helper (poll
+  `process.kill(-pid, 0)` until it throws or the window expires); change the
+  escalation predicate in `escalateKillUnix` from `!exitedGuard.isExited()`
+  to group-liveness so a dead direct child no longer suppresses the group
+  SIGKILL (keep the guard for the fallback/error path).
+- `shellCpExecution.ts`: after the abort kill, and before the finalizer
+  resolves on the abort path, await the bounded reap; set the new
+  `ShellExecutionResult` field when survivors remain. Ensure the concurrent
+  escalation is not starved by `cleanupCpResources` marking the guard (it no
+  longer gates the group SIGKILL after the predicate change).
+- `shellPtyLifecycle.ts`: same treatment in `ptyAbortAction` (group-kill
+  branch only), replacing the fixed 200 ms fallback-only resolution with
+  kill → bounded reap → resolve, setting the same field on survivors.
+- `shellExecutionTypes.ts`: one optional field (name at implementer
+  discretion, e.g. `survivingGroupMembersOnAbort: boolean`).
+- `packages/tools/src/tools/shell.ts`: append the survivor warning (with
+  `kill -9 -- -PGID` instruction) to the timeout/abort `llmContent` when the
+  field is set. This is the "tools layer reports it" step; it does not
+  change the tool schema.
+
+## Verification
+
+Full cycle from the issue workflow: `npm run test`, `npm run lint`,
+`npm run typecheck`, `npm run format`, `npm run build`, then the
+`stepfun-37` smoke test via `bun scripts/start.ts`. Then deepthinker
+compliance review (≤2 rounds), OCR (≤2 rounds), PR, CI watch.
+
+## Review-finding triage
+
+Findings will be classified Blocker-Fix / In-scope-Fix / Reject / Defer.
+Reviewer suggestions do not expand scope; anything beyond the accepted
+behavior above needs explicit approval before implementation.

--- a/project-plans/20260908-issue3517-group-reap/plan.md
+++ b/project-plans/20260908-issue3517-group-reap/plan.md
@@ -383,3 +383,68 @@ prettier clean on all six touched files.
   typecheck OK, format:check OK, smoke OK (stepfun-37). Core 430/432 with
   only the two #3631 skills files failing — identical to the v6 baseline;
   no regression from the inactivity-path fix.
+
+## CI OpenCodeReview bot findings (PR #3637)
+
+The CI-side OpenCodeReview bot reviewed two pushed snapshots and opened
+inline threads; local OCR remained capped at 2/2 rounds and was not re-run.
+
+### Run 1 (first snapshot) — 3 threads
+
+- `ho2M_` (high) — non-group-target pids resolved `armPtyGroupAbortKill`
+  with no kill at all. **Fixed**: direct-only escalation chain (leader
+  TERM → grace → conditional SIGKILL, registered in
+  `abortGroupReapChains`, resolves confirmed-empty) plus a POSIX-gated
+  fake-pty regression test.
+- `ho2NG` — `shellExecutionService.main.test.ts` mock only matched string
+  `'SIGKILL'`; the escalation can emit numeric 9. **Fixed**: mock matches
+  both (`signal === 'SIGKILL' || signal === 9`), normalized in
+  `main.test.ts` + `fallback.test.ts`.
+- `ho2ND` — rejected: the pid==pgid assumption holds by construction for
+  `detached: true` spawns (child becomes group leader), and the existing
+  `pgid <= 0` guard covers the degenerate case.
+
+### Run 2 (snapshot 42d1bac94) — 11 threads
+
+Fixed (batch 2, subagent-verified, TDD red→green on the inactivity test):
+
+- `hpuYr` + `hpuYt` (high, duplicate pair) — `ptyInactivityAbortAction`
+  early-returned for non-group-target pids without killing anything. The
+  guard is removed; the path now flows into `armPtyGroupAbortKill`'s
+  direct-only escalation. New test: inactivity kill with pid 1 delivers
+  `['SIGTERM', 'SIGKILL']` to the PTY, resolves `aborted: false`, no
+  survivor flag, and never signals pid −1.
+- `hpuYu` + `hpuYw` — `shellCpExecution.test.ts`: `execute()` moved
+  inside `try` with `let handle` + guarded `reapGroup(handle.pid)` so a
+  synchronous throw cannot orphan the spawned group or temp dir.
+- `hpuY1` + `hpuY2` — `void mock.module(...)` → `await` (setup and
+  finally-restore) in the Windows taskkill test.
+- `hpuZI` — `isPidAlive` helper: `catch { return false }` →
+  EPERM-is-alive (`code !== 'ESRCH'`).
+- `hpuY-` — doc-only: `reapProcessGroup` now documents the
+  treat-as-reaped contract for pids 0/1 (no safe negated probe:
+  `kill(-1,0)` broadcasts, `kill(-0,0)` probes the caller's own group).
+- `hpuY5` — duplicate of `ho2NG` (already fixed in batch 1).
+
+Rejected:
+
+- `hpuY8` — EACCES→alive mapping: `kill(2)` documents only
+  EPERM/ESRCH/EINVAL; an EACCES branch is dead code.
+- `hpuZB` — relaxing the `pgid <= 1` guard on the cleanup instruction:
+  `kill -9 -- -1` is the POSIX broadcast and pgid 1 is init's group;
+  the guard was itself the fix for an earlier high-severity finding.
+
+### Verification (v8–v10)
+
+- v8: build/core/tools valid (core 430/432, failures = #3631 pair only);
+  cli/lint/typecheck/format/smoke steps **invalidated by a full disk** —
+  a sibling session's live 183 GB `tmp/verify3567/repo-db/` filled the
+  volume mid-chain (reported; not deleted). Freed ~800 MB of this
+  checkout's stale tmp dirs; APFS purgeable released the rest.
+- v9: deliberately aborted after build (tree was about to change).
+- v10 (final tree): build OK; core 430/432 (#3631 only — proven
+  pre-existing); tools OK; cli OK; lint OK; typecheck initially flagged
+  one inferred-type error in the new fake-pty spy (fixed with explicit
+  `(pid: number, signal?: NodeJS.Signals | number)` annotations; core
+  and root typecheck re-verified exit 0); format:check OK; stepfun-37
+  smoke OK.

--- a/project-plans/20260908-issue3517-group-reap/plan.md
+++ b/project-plans/20260908-issue3517-group-reap/plan.md
@@ -248,6 +248,57 @@ behavior above needs explicit approval before implementation.
   worst case adds one reap window of latency before the survivor warning) —
   accepted limitation, same class as the already-accepted PID-reuse races.
 
+### Open code review (round 2) outcome — 7 findings (glm-5.3, complete)
+
+Run against merge-base..HEAD including the OCR-r1 remediation (verified
+model glm-5.3 in the manifest after discarding a first host-side attempt
+that silently used the config default glm-5.2 — the named-provider config
+overrides OCR_LLM_MODEL; explicit `--provider zai-anthropic --model
+glm-5.3` flags are required on the host). All 7 findings **In-scope-Fix**
+(addressed in the OCR-r2 remediation; none deferred):
+
+- Finding 1 (HIGH, tools): cleanup instruction `kill -9 -- -PGID` had no
+  integer/>1 guard — pgid 1 would print `kill -9 -- -1` (broadcast) and a
+  NaN pgid from `tryResolvePgidFromPs` prints `-NaN`. `appendAbortSurvivorWarning`
+  now falls back to the generic warning unless
+  `Number.isInteger(pgid) && pgid > 1`; tests pin pgid 1 and NaN.
+- Finding 4 (HIGH, core): `armPtyGroupAbortKill` and the inactivity group
+  branch issued `process.kill(-pid, 'SIGTERM')` gated only on
+  `isKillablePid` (accepts pid 1) — the exact broadcast the
+  `isGroupTargetPid` chokepoint exists to prevent, missing at these new
+  call sites. Both paths now guard with `isGroupTargetPid`
+  (treat-as-already-gone semantics); `ptyExitRace` gate swapped to
+  `isGroupTargetPid`; POSIX-gated fake-pty tests assert pid 1 never
+  produces a `process.kill(-1, ...)` target. This supersedes the round-1
+  compliance defer of `ptyInactivityAbortAction`: the chokepoint contract
+  ("every `process.kill(-pid, ...)` call site") introduced in this PR
+  makes that branch in-scope.
+- Finding 5 (MEDIUM, core): a Windows taskkill spawn throw (converted to
+  `false` by the arm-site catch) stamped the survivor flag on Windows
+  results, violating the POSIX-only contract. Flag stamp now gated on
+  `!state.isWindows`; Windows regression test added via synchronous
+  taskkill-spawn failure.
+- Finding 6 (MEDIUM, tools): the `result.aborted === true` gate hid the
+  survivor warning from `returnDisplay` on inactivity kills
+  (`aborted: false` + flag) — the gate tracked who killed, not whether
+  children survived. Gate dropped; inactivity test now asserts the
+  display warning too.
+- Finding 7 (MEDIUM, core): `finalizeInactivityKill` could arm the 200 ms
+  fallback while a caller-abort group-reap chain was in flight, resolving
+  the synthetic result before the chain settled (dropping the survivor
+  flag and possibly overwriting late real exit values). It now skips
+  fallback scheduling when `abortGroupReapChains.has(state)`; overlapping
+  abort/inactivity regression test added.
+- Findings 2+3 (LOW, tools tests): win32 no-op branch of
+  `appendAbortSurvivorWarning` pinned with `mockPlatform('win32')`; the
+  user-cancel test's 50 ms sleep race made deterministic via an
+  entered-`executeShellCommand` signal awaited before abort.
+
+Scoped verification after fixes: core typecheck exit 0; shell service
+tests 33 pass/5 skip/0 fail; execution-service contract tests 61 pass/0
+fail; tools typecheck + shell-tool tests 24 pass/0 fail; eslint and
+prettier clean on all six touched files.
+
 ### Verification results (candidate head)
 
 - Targeted core files: 87 pass / 0 fail / 5 skip (POSIX/Windows gates),
@@ -292,3 +343,9 @@ behavior above needs explicit approval before implementation.
   suites), lint OK (both shell.ts errors gone), format OK, root
   typecheck exit 0 after one knock-on tuple-annotation fix
   (`deliveredSignals` widened to `signal: string | number`).
+- v6 (final, OCR-r2 remediation tree): build OK, tools OK, cli OK
+  (full suites), lint OK, typecheck OK, smoke OK (stepfun-37). Core
+  430/432 with only the two #3631 skills files failing (proven on
+  main). format:check initially flagged one line-wrap in
+  `shellProcessKill.test.ts` (the widened tuple annotation); fixed by
+  the repo formatter, file re-verified green.


### PR DESCRIPTION
## TLDR

A foreground `run_shell_command` timeout on POSIX reported `Signal: 15` while SIGTERM-immune grandchildren (the incident's `bun test`) kept running in the spawned process group and kept writing to redirected logs. The caller had no way to know the command was still alive and could start a concurrent run racing on shared output. This PR makes the executor kill and confirm the entire process group before the abort result resolves, and states clearly when survivors remain.

Fixes #3517

## Dive Deeper

**Root cause.** The foreground POSIX path spawns `bash -c <cmd>` detached, so the child leads its own process group. On timeout, `escalateKillUnix` sent SIGTERM to the group but skipped the group SIGKILL once the direct `bash` wrapper died, because the escalation predicate was the direct-child exit guard. The result promise resolved on the direct child's exit event, so the tool returned claiming termination while group members were still alive.

**Changes (three commits).**

1. Escalation gates on group liveness, not the direct child: `isProcessGroupAlive` (signal-0 probe on `-pgid`, EPERM counts as alive) decides whether the group SIGKILL fires. A grandchild that traps or ignores SIGTERM is now killed by escalation.
2. Bounded reap before the result is produced: `reapProcessGroup` (1500 ms window, 50 ms poll) is awaited on every POSIX abort resolution path: child_process abort, PTY abort, the PTY exit-race window (abort landing while natural-exit output drains), and the PTY inactivity kill interacting with a caller abort. The result is never produced while group members are still alive unless the window expires.
3. Honest reporting: new optional `survivingGroupMembersOnAbort` on `ShellExecutionResult`. When set, `run_shell_command` output appends a warning that child processes may still be running, with the explicit cleanup instruction `kill -9 -- -<PGID>`. The warning is applied after summarization and token limiting (following the clamp-notice pattern) so lossy processing cannot drop it, and it reaches `returnDisplay` so the human UI shows it too.
4. Review-hardening (both OCR rounds, 25 findings total, all addressed or triaged in `project-plans/20260908-issue3517-group-reap/plan.md`):
   - `isGroupTargetPid` chokepoint on every `process.kill(-pid, ...)` site (probe, reap, escalate, PTY arm, PTY inactivity, exit-race gate) so pid 1 can never become the `kill(-1, ...)` broadcast.
   - Cleanup instruction only prints for an integer pgid greater than 1; pgid 1 or a NaN pgid from `ps` parsing falls back to the generic warning.
   - Survivor flag stamped only on POSIX results, matching the documented contract.
   - Never-rejecting kill chains (arm-site and local `.catch`): a taskkill spawn throw can no longer stall `handle.result` forever.
   - Stale PTY abort-fallback timers are cleared when a group-reap chain is armed, so a synthetic result cannot resolve before the chain settles.
   - Windows: `taskkill /f /t` tree kill unchanged; warning formatting no-ops on win32.

**Out of scope by design:** background jobs (`shellJobManager`), #3491 (sandbox session exit after intentional backgrounding), #3514 (bun test orphan reaper crossing checkouts), Windows taskkill confirmation.

## Reviewer Test Plan

- `cd packages/core && bun test src/services/shellProcessKill.test.ts` (escalation gating, reap window semantics, broadcast guards)
- `cd packages/core && bun test src/services/shellCpExecution.test.ts src/services/shellPtyLifecycle.test.ts` (service-level abort gating, exit-race, overlap regression)
- `cd packages/tools && bun test src/__tests__/shell-tool.test.ts` (warning formatting across timeout, user-cancel, and inactivity branches)
- Manual reproduction of the incident shape: run a foreground command that leaves a TERM-immune grandchild, e.g. `bash -c '( trap "" TERM; exec sleep 30 ) & sleep 30'`, with `timeout_seconds` around 10. The result must arrive only after the grandchild is dead, or carry the survivor warning naming `kill -9 -- -<PGID>`. Confirm with `ps -o pid,pgid,stat,command` afterward.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

macOS (bun): build, full tools and cli suites, lint, typecheck, format:check, and the stepfun-37 smoke test all green. Core suite 430/432; the two failing files (`extensionSkillRefresh.test.ts`, `skillManager.test.ts`) are pre-existing on main and tracked in #3631. Windows-gated tests are included and skip on macOS.

## Linked issues / bugs

- Fixes #3517
- Related (explicitly out of scope): #3491, #3514
- Pre-existing failures documented: #3631

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shell command and PTY cancellation by checking process groups before returning results.
  - Added safer termination-to-force-kill escalation when group members remain active.
  - Prevented invalid process targets during abort and inactivity cleanup.

- **New Features**
  - Shell results now indicate when processes may remain after cancellation.
  - Added survivor warnings with POSIX cleanup instructions when applicable.
  - Preserved cancellation notices through output formatting and summarization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->