### PR TITLE
Stop fabricating undefined_tool_name; end unrecovered fatal tool errors as ERROR (Fixes #3535)

### DIFF
--- a/packages/agents/src/core/subagent-tool-processing-test-helpers.ts
+++ b/packages/agents/src/core/subagent-tool-processing-test-helpers.ts
@@ -104,7 +104,12 @@ export async function dispatch(
       },
     );
   } finally {
-    toolExecutorContext.disposeScheduler(toolExecutorContext.getSessionId());
-    await config.dispose();
+    // disposeScheduler is synchronous (void); guard only against a sync throw
+    // so config.dispose() always runs.
+    try {
+      toolExecutorContext.disposeScheduler(toolExecutorContext.getSessionId());
+    } finally {
+      await config.dispose();
+    }
   }
 }

--- a/packages/agents/src/core/subagent-tool-processing-test-helpers.ts
+++ b/packages/agents/src/core/subagent-tool-processing-test-helpers.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { ApprovalMode } from '@vybestack/llxprt-code-core/config/configTypes.js';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+import type { OutputObject } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
+import type {
+  IContent,
+  ToolCallBlock,
+} from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import {
+  BaseTool,
+  Kind,
+  type ToolResult,
+} from '@vybestack/llxprt-code-tools/tools/tools.js';
+import { ToolErrorType } from '@vybestack/llxprt-code-tools/types/tool-error.js';
+import { ToolRegistry } from '@vybestack/llxprt-code-tools/tools/tool-registry.js';
+import { CoreMessageBusAdapter } from '@vybestack/llxprt-code-core/tools-adapters/CoreMessageBusAdapter.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
+import { PolicyEngine } from '@vybestack/llxprt-code-core/policy/policy-engine.js';
+import { CoreToolScheduler } from './coreToolScheduler.js';
+import { createToolExecutionConfig } from './subagentRuntimeSetup.js';
+import { createStatelessRuntimeBundle } from './subagent-test-helpers.js';
+import { processFunctionCalls } from './subagentToolProcessing.js';
+
+class DivideTool extends BaseTool<{ divisor: number }, ToolResult> {
+  constructor() {
+    super('divide', 'Divide', 'Divide one by a number', Kind.Think, {
+      type: 'object',
+      properties: { divisor: { type: 'number' } },
+      required: ['divisor'],
+    });
+  }
+
+  override getDescription(): string {
+    return 'Divide one by a number';
+  }
+
+  override async execute(params: { divisor: number }): Promise<ToolResult> {
+    if (params.divisor === 0) {
+      return {
+        llmContent: 'Cannot divide by zero',
+        returnDisplay: 'Cannot divide by zero',
+        error: {
+          message: 'Cannot divide by zero',
+          type: ToolErrorType.EXECUTION_FAILED,
+        },
+      };
+    }
+    const result = String(1 / params.divisor);
+    return { llmContent: result, returnDisplay: result };
+  }
+}
+
+/**
+ * Runs a call through the real non-interactive processing and scheduler paths.
+ * @param call Tool request to dispatch against the divide-tool fixture.
+ * @param output Run output whose recovery state is updated by processing.
+ * @returns Model-facing response content.
+ */
+export async function dispatch(
+  call: ToolCallBlock,
+  output: OutputObject,
+): Promise<IContent[]> {
+  const config = new Config({
+    sessionId: crypto.randomUUID(),
+    targetDir: process.cwd(),
+    cwd: process.cwd(),
+    debugMode: false,
+    model: 'test-model',
+    approvalMode: ApprovalMode.YOLO,
+    toolSchedulerFactory: (options) => new CoreToolScheduler(options),
+  });
+  const policy = new PolicyEngine({});
+  policy.setApprovalMode(ApprovalMode.YOLO);
+  const messageBus = new MessageBus(policy, false);
+  const registry = new ToolRegistry(
+    config,
+    new CoreMessageBusAdapter(messageBus),
+  );
+  registry.registerTool(new DivideTool());
+  const toolExecutorContext = createToolExecutionConfig(
+    createStatelessRuntimeBundle(),
+    registry,
+    config,
+    messageBus,
+  );
+  try {
+    return await processFunctionCalls(
+      [call],
+      new AbortController(),
+      'flag-test',
+      {
+        output,
+        subagentId: 'flag-test',
+        logger: new DebugLogger('flag-test'),
+        toolExecutorContext,
+        config,
+        messageBus,
+      },
+    );
+  } finally {
+    toolExecutorContext.disposeScheduler(toolExecutorContext.getSessionId());
+    await config.dispose();
+  }
+}

--- a/packages/agents/src/core/subagent.runNonInteractive-execution.test.ts
+++ b/packages/agents/src/core/subagent.runNonInteractive-execution.test.ts
@@ -671,7 +671,7 @@ describe('subagent.ts', () => {
       );
 
       await scope.runNonInteractive(new ContextState());
-      expect(scope.output.terminate_reason).toBe(SubagentTerminateMode.GOAL);
+      expect(scope.output.terminate_reason).toBe(SubagentTerminateMode.ERROR);
       expect(scope.output.final_message).toContain(
         'Tool "write_file" is not available',
       );

--- a/packages/agents/src/core/subagent.ts
+++ b/packages/agents/src/core/subagent.ts
@@ -47,12 +47,15 @@ import {
   createChatObject,
 } from './subagentRuntimeSetup.js';
 import {
-  isFatalToolError,
   buildToolUnavailableMessage,
   finalizeOutput,
   handleEmitValueCall,
   buildPartsFromCompletedCalls,
   buildTodoCompletionPrompt,
+  recordFatalToolError,
+  classifyToolCompletions,
+  type InteractiveToolMarker,
+  recordSuccessfulToolExecution,
 } from './subagentToolProcessing.js';
 import {
   checkTerminationConditions,
@@ -702,30 +705,40 @@ export class SubAgentScope {
   ): {
     manualBlocks: ContentBlock[];
     schedulerRequests: ToolCallRequestInfo[];
+    requestMarkers: InteractiveToolMarker[];
   } {
     const manualBlocks: ContentBlock[] = [];
     const schedulerRequests: ToolCallRequestInfo[] = [];
+    const requestMarkers: InteractiveToolMarker[] = [];
 
     for (const request of toolRequests) {
       const hookRestrictedAllowedTools = request.hookRestrictedAllowedTools;
       if (isToolNameRestricted(request.name, hookRestrictedAllowedTools)) {
+        requestMarkers.push({ status: 'error-nonfatal' });
         continue;
       }
       if (request.name === 'self_emitvalue') {
-        manualBlocks.push(
-          ...handleEmitValueCall(request, {
-            output: this.output,
-            onMessage: this.onMessage,
-            subagentId: this.subagentId,
-            logger: this.logger,
-          }),
-        );
+        const blocks = handleEmitValueCall(request, {
+          output: this.output,
+          onMessage: this.onMessage,
+          subagentId: this.subagentId,
+          logger: this.logger,
+        });
+        manualBlocks.push(...blocks);
+        requestMarkers.push({
+          status: blocks.some(
+            (block) => block.type === 'tool_response' && !block.error,
+          )
+            ? 'success'
+            : 'error-nonfatal',
+        });
       } else {
+        requestMarkers.push({ callId: request.callId });
         schedulerRequests.push(request);
       }
     }
 
-    return { manualBlocks, schedulerRequests };
+    return { manualBlocks, schedulerRequests, requestMarkers };
   }
 
   private async handleInteractiveToolCalls(
@@ -745,10 +758,11 @@ export class SubAgentScope {
   ): Promise<IContent[] | null> {
     if (toolRequests.length === 0) return null;
 
-    const { manualBlocks, schedulerRequests } =
+    const { manualBlocks, schedulerRequests, requestMarkers } =
       this.partitionInteractiveToolRequests(toolRequests);
 
     let responseBlocks: ContentBlock[] = [...manualBlocks];
+    let completedCalls: CompletedToolCall[] = [];
 
     if (schedulerRequests.length > 0) {
       const completionPromise = scheduler.awaitCompletedCalls(
@@ -758,7 +772,7 @@ export class SubAgentScope {
       // completionPromise reject on the same abort signal.
       completionPromise.catch(() => {});
       await scheduler.schedule(schedulerRequests, abortController.signal);
-      const completedCalls = await completionPromise;
+      completedCalls = await completionPromise;
       try {
         chat.recordCompletedToolCalls(this.modelConfig.model, completedCalls);
       } catch (error) {
@@ -777,23 +791,30 @@ export class SubAgentScope {
           logger: this.logger,
         }),
       );
-      const fatalCall = completedCalls.find(
-        (call) =>
-          call.status === 'error' && isFatalToolError(call.response.errorType),
+    }
+    // Manual emit successes are re-derived from markers in request order.
+    const { recovered, fatalCall } = classifyToolCompletions(
+      requestMarkers,
+      completedCalls,
+    );
+    if (recovered) {
+      recordSuccessfulToolExecution(execCtx.output);
+    }
+    if (fatalCall) {
+      const fatalMessage = buildToolUnavailableMessage(
+        fatalCall.request.name,
+        fatalCall.response.resultDisplay,
+        fatalCall.response.error,
       );
-      if (fatalCall) {
-        const fatalMessage = buildToolUnavailableMessage(
-          fatalCall.request.name,
-          fatalCall.response.resultDisplay,
-          fatalCall.response.error,
-        );
-        this.logger.warn(
-          () =>
-            `Subagent ${this.subagentId} cannot use tool '${fatalCall.request.name}': ${fatalMessage}`,
-        );
-        responseBlocks.push({ type: 'text', text: fatalMessage });
-        execCtx.output.final_message = fatalMessage;
-      }
+      recordFatalToolError(execCtx.output, fatalMessage);
+      this.logger.warn(
+        () =>
+          `Subagent ${this.subagentId} cannot use tool '${fatalCall.request.name}': ${fatalMessage}`,
+      );
+      // buildPartsFromCompletedCalls already forwarded the paired response;
+      // this branch adds only the availability diagnostic.
+      responseBlocks.push({ type: 'text', text: fatalMessage });
+      execCtx.output.final_message = fatalMessage;
     }
 
     if (responseBlocks.length === 0) {

--- a/packages/agents/src/core/subagentExecution.test.ts
+++ b/packages/agents/src/core/subagentExecution.test.ts
@@ -24,6 +24,11 @@ import type {
   AnsiToken,
 } from '@vybestack/llxprt-code-core/utils/terminalSerializer.js';
 
+import {
+  recordFatalToolError,
+  recordSuccessfulToolExecution,
+} from './subagentToolProcessing.js';
+
 function makeOutput(): OutputObject {
   return { emitted_vars: {}, terminate_reason: SubagentTerminateMode.ERROR };
 }
@@ -197,7 +202,76 @@ describe('subagentExecution', () => {
     });
   });
 
-  // --- processInteractiveTextResponse ---
+  describe('checkGoalCompletion fatal-tool-error (issue 3535)', () => {
+    it('suppresses outstanding todo nudges after a fatal tool error', async () => {
+      const output = makeOutput();
+      recordFatalToolError(output, 'Unavailable tool');
+      const result = await checkGoalCompletion(
+        {
+          output,
+          outputConfig: { outputs: { x: 'required' } },
+          subagentId: 'test',
+          logger: new DebugLogger('test'),
+        },
+        'Please finish todos',
+        0,
+      );
+
+      expect(result).toBeNull();
+      expect(output.terminate_reason).toBe(SubagentTerminateMode.ERROR);
+      expect(output.final_message).toBe('Unavailable tool');
+    });
+
+    it('returns ERROR and null when the flag is set', async () => {
+      const output = makeOutput();
+      output.unrecovered_fatal_tool_error =
+        'Tool "" is not available in this environment.';
+      const ctx = {
+        output,
+        outputConfig: undefined,
+        subagentId: 'test',
+        logger: new DebugLogger('test'),
+      };
+      const result = await checkGoalCompletion(ctx, null, 0);
+      expect(result).toBeNull();
+      expect(output.terminate_reason).toBe(SubagentTerminateMode.ERROR);
+    });
+
+    it('returns GOAL and clears a fatal flag when all declared outputs are emitted', async () => {
+      const output = makeOutput();
+      recordFatalToolError(output, 'Unavailable tool');
+      output.emitted_vars = { x: 'value', y: 'other' };
+      const result = await checkGoalCompletion(
+        {
+          output,
+          outputConfig: { outputs: { x: 'first', y: 'second' } },
+          subagentId: 'test',
+          logger: new DebugLogger('test'),
+        },
+        null,
+        0,
+      );
+
+      expect(result).toBeNull();
+      expect(output.terminate_reason).toBe(SubagentTerminateMode.GOAL);
+      expect(output.unrecovered_fatal_tool_error).toBeUndefined();
+    });
+
+    it('returns GOAL when the flag is cleared', async () => {
+      const output = makeOutput();
+      recordFatalToolError(output, 'Unavailable tool');
+      recordSuccessfulToolExecution(output);
+      const ctx = {
+        output,
+        outputConfig: undefined,
+        subagentId: 'test',
+        logger: new DebugLogger('test'),
+      };
+      const result = await checkGoalCompletion(ctx, null, 0);
+      expect(result).toBeNull();
+      expect(output.terminate_reason).toBe(SubagentTerminateMode.GOAL);
+    });
+  });
 
   describe('processInteractiveTextResponse', () => {
     it('should set final_message from text', () => {

--- a/packages/agents/src/core/subagentExecution.ts
+++ b/packages/agents/src/core/subagentExecution.ts
@@ -45,6 +45,7 @@ import {
 import type { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
 import { createAbortError } from '@vybestack/llxprt-code-core/utils/delay.js';
 import { isToolNameRestricted } from './hookToolRestrictions.js';
+import { completeWithGoal } from './subagentToolProcessing.js';
 
 // ---------------------------------------------------------------------------
 // Shared execution context — all loop helpers receive this instead of `this`
@@ -164,17 +165,38 @@ export function recordTurnOutputTokens(
 }
 
 /**
- * Check whether the loop should terminate (max_turns, max_output, or max_time).
+ * Issue #3535: convert a stop after an unrecovered fatal tool error into an
+ * ERROR termination, restoring the recorded fatal diagnostic as the final
+ * message. Plain stop text from a later turn (e.g. "Done.") may have already
+ * overwritten final_message, which would leave the parent without the
+ * malformed-call detail the ERROR needs to be actionable.
  */
+export function convertToFatalToolErrorTermination(
+  output: OutputObject,
+  subagentId: string,
+  logger: DebugLogger,
+): void {
+  const fatalMessage = output.unrecovered_fatal_tool_error;
+  if (fatalMessage === undefined) {
+    return;
+  }
+  output.terminate_reason = SubagentTerminateMode.ERROR;
+  output.final_message = fatalMessage;
+  logger.warn(
+    () =>
+      `Subagent ${subagentId} stopping with an unrecovered fatal tool error: ${fatalMessage}`,
+  );
+}
+
 /**
  * Check only the aggregate output budget.
  *
  * Split out from {@link checkTerminationConditions} because the budget is the
- * one condition that must be evaluated in the middle of a turn, right after the
- * model's output is counted. The turn and time limits deliberately stay at the
- * top of the loop: re-checking them mid-turn would abandon tool calls the model
- * already emitted on its final allowed turn, which is a behaviour change the
- * budget work has no business making.
+ * one condition that must be evaluated in the middle of a turn, right after
+ * the model's output is counted. The turn and time limits deliberately stay at
+ * the top of the loop: re-checking them mid-turn would abandon tool calls the
+ * model already emitted on its final allowed turn, which is a behaviour change
+ * the budget work has no business making.
  */
 export function checkOutputBudget(
   ctx: Pick<
@@ -293,6 +315,15 @@ export async function checkGoalCompletion(
   currentTurn: number,
 ): Promise<IContent[] | null> {
   if (todoReminder) {
+    // Outstanding todos need tools; do not nudge a model that lost its tool path.
+    if (ctx.output.unrecovered_fatal_tool_error !== undefined) {
+      convertToFatalToolErrorTermination(
+        ctx.output,
+        ctx.subagentId,
+        ctx.logger,
+      );
+      return null;
+    }
     ctx.logger.debug(
       () =>
         `Subagent ${ctx.subagentId} postponing completion until outstanding todos are addressed`,
@@ -303,6 +334,16 @@ export async function checkGoalCompletion(
   }
 
   if (!ctx.outputConfig || Object.keys(ctx.outputConfig.outputs).length === 0) {
+    if (ctx.output.unrecovered_fatal_tool_error !== undefined) {
+      // Issue #3535: an unrecovered fatal tool error must end as ERROR so the
+      // caller can distinguish the failed run instead of GOAL.
+      convertToFatalToolErrorTermination(
+        ctx.output,
+        ctx.subagentId,
+        ctx.logger,
+      );
+      return null;
+    }
     ctx.output.terminate_reason = SubagentTerminateMode.GOAL;
     return null;
   }
@@ -313,11 +354,19 @@ export async function checkGoalCompletion(
   );
 
   if (remainingVars.length === 0) {
-    ctx.output.terminate_reason = SubagentTerminateMode.GOAL;
+    completeWithGoal(ctx.output);
     ctx.logger.debug(
       () =>
         `Subagent ${ctx.subagentId} satisfied output requirements on turn ${currentTurn}`,
     );
+    return null;
+  }
+
+  if (ctx.output.unrecovered_fatal_tool_error !== undefined) {
+    // Issue #3535: the model stopped calling tools after a fatal tool error and
+    // never emitted the remaining outputs. Fail fast — do not nudge a model that
+    // already lost its tool path.
+    convertToFatalToolErrorTermination(ctx.output, ctx.subagentId, ctx.logger);
     return null;
   }
 

--- a/packages/agents/src/core/subagentNonInteractive.issue3535.test.ts
+++ b/packages/agents/src/core/subagentNonInteractive.issue3535.test.ts
@@ -1,0 +1,770 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3535 — a subagent whose tool dispatch hits a fatal tool error
+ * (TOOL_DISABLED / TOOL_NOT_REGISTERED) must terminate with ERROR when no
+ * later tool execution succeeded, and with GOAL when it recovered.
+ *
+ * Non-interactive cases use the same direct-runtime harness as issue #3540
+ * (real GemmaToolCallParser, real scheduler via createMockConfig, real
+ * dispatch) so a native tool_call with an unknown/absent name flows through
+ * the real scheduler → ToolDispatcher → TOOL_NOT_REGISTERED path and back.
+ *
+ * Interactive cases drive the real SubAgentScope interactive loop with a
+ * real CoreToolScheduler (same session config as the direct harness) plus a
+ * scripted provider. The provider also records every request's content,
+ * which is how the structured tool_response pairing is verified.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
+import type {
+  ContentBlock,
+  IContent,
+} from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { toModelStreamChunk } from '@vybestack/llxprt-code-core/llm-types/index.js';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+import { GemmaToolCallParser } from '@vybestack/llxprt-code-core/parsers/TextToolCallParser.js';
+import {
+  getOrCreateScheduler,
+  disposeScheduler,
+} from '@vybestack/llxprt-code-core/config/schedulerSingleton.js';
+import { PolicyEngine } from '@vybestack/llxprt-code-core/policy/policy-engine.js';
+import { ApprovalMode } from '@vybestack/llxprt-code-core/config/configTypes.js';
+import { MessageBus } from '@vybestack/llxprt-code-core/confirmation-bus/message-bus.js';
+import { CoreMessageBusAdapter } from '@vybestack/llxprt-code-core/tools-adapters/CoreMessageBusAdapter.js';
+import { ToolRegistry } from '@vybestack/llxprt-code-tools/tools/tool-registry.js';
+import {
+  BaseTool,
+  Kind,
+  type ToolResult,
+} from '@vybestack/llxprt-code-tools/tools/tools.js';
+
+import { ToolErrorType } from '@vybestack/llxprt-code-tools/types/tool-error.js';
+
+class RuntimeDisabledTool extends BaseTool<
+  Record<string, unknown>,
+  ToolResult
+> {
+  constructor() {
+    super(
+      'runtime_disabled',
+      'Runtime disabled',
+      'Unavailable image backend',
+      Kind.Think,
+      {
+        type: 'object',
+        properties: {},
+      },
+    );
+  }
+
+  override getDescription(): string {
+    return 'Unavailable image backend';
+  }
+
+  override async execute(): Promise<ToolResult> {
+    return {
+      llmContent: 'Image backend unavailable',
+      returnDisplay: 'Image backend unavailable',
+      error: {
+        type: ToolErrorType.TOOL_DISABLED,
+        message: 'Image backend unavailable',
+      },
+    };
+  }
+}
+
+class UppercaseTool extends BaseTool<{ text: string }, ToolResult> {
+  constructor() {
+    super('uppercase', 'Uppercase', 'Uppercase text', Kind.Think, {
+      type: 'object',
+      properties: { text: { type: 'string' } },
+      required: ['text'],
+    });
+  }
+
+  override getDescription(): string {
+    return 'Uppercase text';
+  }
+
+  override async execute(params: { text: string }): Promise<ToolResult> {
+    return {
+      llmContent: params.text.toUpperCase(),
+      returnDisplay: params.text.toUpperCase(),
+    };
+  }
+}
+import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import type { RuntimeProvider } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProvider.js';
+import type { RuntimeModel } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeModel.js';
+import type { RuntimeGenerateChatOptions } from '@vybestack/llxprt-code-core/runtime/contracts/RuntimeProviderChat.js';
+import type { AgentRuntimeProviderAdapter } from '@vybestack/llxprt-code-core/runtime/AgentRuntimeContext.js';
+import { HistoryService } from '@vybestack/llxprt-code-core/services/history/HistoryService.js';
+import {
+  ContextState,
+  SubagentTerminateMode,
+  type OutputConfig,
+  type OutputObject,
+} from '@vybestack/llxprt-code-core/core/subagentTypes.js';
+import { ChatSession, StreamEventType } from './chatSession.js';
+import { executeNonInteractiveRun } from './subagentNonInteractive.js';
+import type { ExecutionLoopContext } from './subagentExecution.js';
+import {
+  getScopeLocalFuncDefs,
+  createToolExecutionConfig,
+} from './subagentRuntimeSetup.js';
+import { CoreToolScheduler } from './coreToolScheduler.js';
+import { SubAgentScope } from './subagent.js';
+import { classifyToolCompletions } from './subagentToolProcessing.js';
+import {
+  createStatelessRuntimeBundle,
+  defaultModelConfig,
+  defaultRunConfig,
+} from './subagent-test-helpers.js';
+
+const { readTodos, TodoStoreMock } = (() => {
+  const readTodos = vi.fn(async () => []);
+  const TodoStoreMock = vi.fn(() => ({ readTodos }));
+  return { readTodos, TodoStoreMock };
+})();
+const toolsModule = { ...(await import('@vybestack/llxprt-code-tools')) };
+void vi.mock('@vybestack/llxprt-code-tools', () => ({
+  ...toolsModule,
+  LocalTodoStore: TodoStoreMock,
+}));
+
+const OUTPUT_CONFIG: OutputConfig = {
+  outputs: {
+    alpha: 'first value',
+    beta: 'second value',
+  },
+};
+
+// Issue #3535: each run needs a FRESH session. The scheduler singleton keys its
+// entries by sessionId and tracks seenCallIds per session, so reusing a fixed id
+// lets state leak between tests and masks the missing onAllToolCallsComplete wiring.
+let sessionCounter = 0;
+let lastSessionId = '';
+
+function createEmptyRegistryConfig(): Config {
+  const policyEngine = new PolicyEngine({});
+  policyEngine.setApprovalMode(ApprovalMode.YOLO);
+  const messageBus = new MessageBus(policyEngine, false);
+  const messageBusAdapter = new CoreMessageBusAdapter(messageBus);
+  const toolRegistry = new ToolRegistry(
+    {
+      getEphemeralSettings: () => ({}),
+      getCoreTools: () => [],
+      getExcludeTools: () => [],
+    },
+    messageBusAdapter,
+  );
+  const sessionId = `issue-3535-session-${sessionCounter++}`;
+  lastSessionId = sessionId;
+  const fixture = {
+    getSessionId: () => sessionId,
+    getUsageStatisticsEnabled: () => false,
+    getDebugMode: () => false,
+    getApprovalMode: () => ApprovalMode.YOLO,
+    getEphemeralSettings: () => ({}),
+    getEphemeralSetting: () => undefined,
+    getAllowedTools: () => [],
+    getExcludeTools: () => [],
+    getContentGeneratorConfig: () => ({ model: 'test-model' }),
+    getModel: () => 'test-model',
+    getToolRegistry: () => toolRegistry,
+    getMessageBus: () => messageBus,
+    getPolicyEngine: () => policyEngine,
+    getTelemetryLogPromptsEnabled: () => false,
+    getImagePayloadBudgetBytes: () => 50_000,
+    isInteractive: () => false,
+    // Prompt-assembly path (createChatObject → buildSystemInstruction →
+    // resolvePromptMemory). JIT is disabled, so user memory is the empty
+    // fixture and the JIT lookup short-circuits.
+    isJitContextEnabled: () => false,
+    getUserMemory: () => undefined,
+    getGlobalMemory: () => undefined,
+    getCoreMemory: () => undefined,
+    getJitMemoryForPath: async () => undefined,
+    getMcpInstructions: () => undefined,
+    getWorkingDir: () => process.cwd(),
+    // Forward the options object verbatim, mirroring production
+    // (packages/agents/src/api/runtimeFactories.ts). The factory previously
+    // cherry-picked constructor args and DROPPED onAllToolCallsComplete /
+    // onToolCallsUpdate / outputUpdateHandler, so a scheduler born in a fresh
+    // session never fired onAllToolCallsComplete (test deadlock, issue #3535).
+    getToolSchedulerFactory:
+      () => (options: ConstructorParameters<typeof CoreToolScheduler>[0]) =>
+        new CoreToolScheduler(options),
+    getOrCreateScheduler: (
+      _sessionId: string,
+      callbacks: Parameters<Config['getOrCreateScheduler']>[1],
+      schedulerOptions: Parameters<Config['getOrCreateScheduler']>[2],
+      deps: Parameters<Config['getOrCreateScheduler']>[3],
+    ) => {
+      const schedulerMessageBus = deps?.messageBus;
+      if (!schedulerMessageBus) {
+        throw new Error(
+          'test config requires an explicit scheduler MessageBus',
+        );
+      }
+      return getOrCreateScheduler(
+        fixture as unknown as Config,
+        _sessionId,
+        callbacks,
+        schedulerOptions,
+        {
+          messageBus: schedulerMessageBus,
+          toolRegistry: deps.toolRegistry ?? toolRegistry,
+        },
+      );
+    },
+    disposeScheduler: (sessionId: string) => disposeScheduler(sessionId),
+  };
+  return fixture as unknown as Config;
+}
+
+function disposeLastScheduler(): void {
+  if (lastSessionId) {
+    disposeScheduler(lastSessionId);
+    lastSessionId = '';
+  }
+}
+
+function toolCallBlock(
+  name: string | undefined,
+  args: Readonly<Record<string, unknown>> = {},
+  id = name ?? 'call-unnamed',
+): IContent {
+  // Issue #3535: an ABSENT name is the doomed native tool_call. The block's
+  // `name` is typed `string`, but the semantic absent-name is what the issue is
+  // about, so build through a plain-object facade.
+  const block = {
+    type: 'tool_call' as const,
+    id,
+    parameters: args,
+    ...(name === undefined ? {} : { name }),
+  } as unknown as ContentBlock;
+  return { speaker: 'ai', blocks: [block] };
+}
+
+function emitCall(name: string, value: string): IContent {
+  return toolCallBlock(
+    'self_emitvalue',
+    { emit_variable_name: name, emit_variable_value: value },
+    `emit-${name}`,
+  );
+}
+
+function stopped(): IContent {
+  return { speaker: 'ai', blocks: [{ type: 'text', text: 'Done.' }] };
+}
+
+async function runDirectNonInteractive(
+  responses: readonly IContent[],
+  options: { outputConfig?: OutputConfig } = { outputConfig: OUTPUT_CONFIG },
+): Promise<{
+  readonly output: OutputObject;
+  readonly requestCount: number;
+  readonly requestContents: readonly IContent[][];
+}> {
+  const config = createEmptyRegistryConfig();
+  const baseBundle = createStatelessRuntimeBundle();
+  const output: OutputObject = {
+    terminate_reason: SubagentTerminateMode.ERROR,
+    emitted_vars: {},
+  };
+  const logger = new DebugLogger('issue3535-test');
+  const execCtx: ExecutionLoopContext = {
+    output,
+    subagentId: 'direct-issue3535-agent',
+    runConfig: defaultRunConfig,
+    outputConfig: options.outputConfig,
+    textToolParser: new GemmaToolCallParser(),
+    toolsView: baseBundle.runtimeContext.tools,
+    logger,
+  };
+  let requestCount = 0;
+  const requestContents: IContent[][] = [];
+  const chat = {
+    // `message` is the block list of the turn being sent (the non-interactive
+    // runner passes currentMessages[0].blocks, which may be empty).
+    sendMessageStream: async (params: {
+      message: readonly ContentBlock[] | undefined;
+    }) => {
+      const response = responses[requestCount] ?? stopped();
+      // Capture the content of THIS request (the tool message from the
+      // previous dispatch travels in here). Wrap the block list as a single
+      // tool-speaker turn so the paired tool_response is searchable.
+      if (params.message && params.message.length > 0) {
+        requestContents.push([
+          { speaker: 'tool', blocks: [...params.message] },
+        ]);
+      }
+      requestCount += 1;
+      return (async function* () {
+        yield {
+          type: StreamEventType.CHUNK,
+          value: toModelStreamChunk(response),
+        };
+      })();
+    },
+  } as unknown as ChatSession;
+
+  await executeNonInteractiveRun(
+    chat,
+    [...getScopeLocalFuncDefs(options.outputConfig)],
+    new AbortController(),
+    [{ speaker: 'human', blocks: [{ type: 'text', text: 'start' }] }],
+    Date.now(),
+    execCtx,
+    {
+      output,
+      subagentId: 'direct-issue3535-agent',
+      name: 'direct-issue3535-agent',
+      runtimeContext: baseBundle.runtimeContext,
+      logger,
+      config,
+      runConfig: defaultRunConfig,
+      outputConfig: options.outputConfig,
+      toolExecutorContext: config,
+      messageBus: (
+        config as unknown as { getMessageBus: () => MessageBus }
+      ).getMessageBus(),
+    },
+    () => undefined,
+  );
+
+  return { output, requestCount, requestContents };
+}
+
+// ---------------------------------------------------------------------------
+// Interactive harness: real SubAgentScope interactive loop, real CoreToolScheduler
+// ---------------------------------------------------------------------------
+
+function runtimeProviderFor(
+  responses: readonly IContent[],
+  requests: RuntimeGenerateChatOptions[],
+): RuntimeProvider {
+  let index = 0;
+  return {
+    name: 'issue3535-scripted',
+    getModels: async (): Promise<RuntimeModel[]> => [],
+    getDefaultModel: () => defaultModelConfig.model,
+    generateChatCompletion: (
+      input: unknown,
+    ): AsyncIterableIterator<IContent> => {
+      if (Array.isArray(input)) {
+        throw new Error('Expected request options from the runtime.');
+      }
+      const options = input as RuntimeGenerateChatOptions;
+      requests.push(options);
+      const response = responses[index] ?? stopped();
+      index += 1;
+      // The stream validator requires a finishReason on the model output;
+      // a tool_call turn ends with 'tool_calls', a plain stop with 'stop'.
+      const blocks = response.blocks;
+      const hasToolCall = blocks.some(
+        (block): block is Extract<ContentBlock, { type: 'tool_call' }> =>
+          block.type === 'tool_call',
+      );
+      return (async function* () {
+        yield {
+          ...response,
+          finishReason: hasToolCall ? 'tool_calls' : 'stop',
+        };
+      })();
+    },
+  } as RuntimeProvider;
+}
+
+function findToolResponsesByCallId(
+  contents: readonly IContent[],
+  callId: string,
+): ContentBlock[] {
+  return contents
+    .flatMap((content) => content.blocks)
+    .filter(
+      (block) => block.type === 'tool_response' && block.callId === callId,
+    );
+}
+
+async function runInteractiveDirect(responses: readonly IContent[]): Promise<{
+  readonly output: OutputObject;
+  readonly requestContents: readonly IContent[][];
+}> {
+  const config = createEmptyRegistryConfig();
+  config.getToolRegistry().registerTool(new UppercaseTool());
+  config.getToolRegistry().registerTool(new RuntimeDisabledTool());
+  const requests: RuntimeGenerateChatOptions[] = [];
+  const provider = runtimeProviderFor(responses, requests);
+  // The ChatSession resolves its provider via adapter.getActiveProvider()
+  // (see subagent.aggregate-output-budget.test.ts): the adapter method must
+  // itself return a zero-arg fn that hands back the provider, and the name
+  // must match the runtime state provider so no provider switch is forced.
+  const providerAdapter = {
+    getActiveProvider: vi.fn(() => provider),
+    getProviderByName: vi.fn(() => provider),
+    setActiveProvider: vi.fn(),
+  } as unknown as AgentRuntimeProviderAdapter;
+  // The interactive path builds a REAL ChatSession (createChatObject), whose
+  // SemanticMediaPurgeCoordinator reads history.getAll at construction, so
+  // the bundle carries a real HistoryService here (the non-interactive direct
+  // harness fakes the chat and keeps the mock history). Pass providerAdapter
+  // as a bundle option so runtimeContext.provider is the scripted provider —
+  // spreading it after construction would leave runtimeContext with the
+  // default adapter, which yields an empty blocks[] IContent.
+  const bundle = createStatelessRuntimeBundle({
+    history: new HistoryService(),
+    providerAdapter,
+  });
+  const toolRegistry = config.getToolRegistry();
+  const toolExecutorContext = createToolExecutionConfig(
+    bundle,
+    toolRegistry,
+    config,
+    (config as unknown as { getMessageBus: () => MessageBus }).getMessageBus(),
+  );
+  const scope = new (SubAgentScope as unknown as new (
+    ...args: unknown[]
+  ) => SubAgentScope)(
+    'interactive-issue3535-agent',
+    bundle.runtimeContext,
+    defaultModelConfig,
+    defaultRunConfig,
+    { systemPrompt: 'Do the task.' },
+    undefined,
+    toolExecutorContext,
+    async () => [],
+    config,
+    (config as unknown as { getMessageBus: () => MessageBus }).getMessageBus(),
+    undefined,
+    OUTPUT_CONFIG,
+    undefined,
+    undefined,
+    {},
+  );
+  await scope.runInteractive(new ContextState());
+  return {
+    output: scope.output,
+    requestContents: requests.map((r) => r.contents),
+  };
+}
+
+describe('issue 3535 fatal-tool-error termination semantics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    readTodos.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    // Issue #3535: drop the scheduler singleton entry for this run so a fresh
+    // session never inherits stale callbacks or seenCallIds.
+    disposeLastScheduler();
+  });
+
+  it('skips unresolved scheduler IDs without inventing recovery', () => {
+    expect(
+      classifyToolCompletions([{ callId: 'previously-seen' }], []),
+    ).toStrictEqual({
+      recovered: false,
+      fatalCall: undefined,
+    });
+    expect(
+      classifyToolCompletions(
+        [
+          { callId: 'previously-seen' },
+          { status: 'success' },
+          { callId: 'also-seen' },
+        ],
+        [],
+      ),
+    ).toStrictEqual({ recovered: true, fatalCall: undefined });
+  });
+
+  it('recovers after a deduplicated fatal pair followed by a distinct successful call', async () => {
+    const { output, requestContents } = await runInteractiveDirect([
+      {
+        speaker: 'ai',
+        blocks: [
+          ...toolCallBlock('', {}, 'duplicate-fatal').blocks,
+          ...toolCallBlock('', {}, 'duplicate-fatal').blocks,
+          ...toolCallBlock(
+            'uppercase',
+            { text: 'recovered' },
+            'distinct-success',
+          ).blocks,
+        ],
+      },
+      emitCall('alpha', 'A'),
+      emitCall('beta', 'B'),
+    ]);
+
+    expect(
+      findToolResponsesByCallId(requestContents[1], 'duplicate-fatal'),
+    ).toHaveLength(1);
+    expect(
+      findToolResponsesByCallId(requestContents[1], 'distinct-success'),
+    ).toMatchObject([
+      { type: 'tool_response', result: { output: 'RECOVERED' } },
+    ]);
+    expect(output.unrecovered_fatal_tool_error).toBeUndefined();
+    expect(output.emitted_vars).toStrictEqual({ alpha: 'A', beta: 'B' });
+    expect(output.terminate_reason).toBe(SubagentTerminateMode.GOAL);
+  });
+
+  it('preserves an earlier interactive fatal across a batch of only non-fatal failures', async () => {
+    const { output } = await runInteractiveDirect([
+      toolCallBlock('', {}, 'earlier-fatal'),
+      {
+        speaker: 'ai',
+        blocks: [
+          ...toolCallBlock('uppercase', {}, 'invalid-uppercase').blocks,
+          ...toolCallBlock('self_emitvalue', { emit_variable_name: 'alpha' })
+            .blocks,
+        ],
+      },
+      stopped(),
+    ]);
+
+    expect(output.unrecovered_fatal_tool_error).toContain('is not available');
+    expect(output.emitted_vars).toStrictEqual({});
+    expect(output.terminate_reason).toBe(SubagentTerminateMode.ERROR);
+  });
+
+  it('preserves a fatal after a scheduled success in request order', async () => {
+    const { output, requestContents } = await runInteractiveDirect([
+      {
+        speaker: 'ai',
+        blocks: [
+          ...toolCallBlock('uppercase', { text: 'recovered' }, 'valid-mixed')
+            .blocks,
+          ...toolCallBlock('', {}, 'fatal-mixed').blocks,
+        ],
+      },
+      stopped(),
+    ]);
+
+    expect(
+      findToolResponsesByCallId(requestContents[1], 'valid-mixed'),
+    ).toMatchObject([
+      { type: 'tool_response', result: { output: 'RECOVERED' } },
+    ]);
+    expect(output.emitted_vars).toStrictEqual({});
+    expect(output.unrecovered_fatal_tool_error).toContain('is not available');
+    expect(output.terminate_reason).toBe(SubagentTerminateMode.ERROR);
+  });
+
+  it('recovers when a scheduled success follows a fatal in request order', async () => {
+    const { output } = await runInteractiveDirect([
+      {
+        speaker: 'ai',
+        blocks: [
+          ...toolCallBlock('', {}, 'fatal-first').blocks,
+          ...toolCallBlock('uppercase', { text: 'recovered' }, 'valid-last')
+            .blocks,
+        ],
+      },
+      stopped(),
+    ]);
+
+    expect(output.unrecovered_fatal_tool_error).toBeUndefined();
+  });
+
+  it('recovers when a manual emit follows a scheduler fatal in request order', async () => {
+    const { output } = await runInteractiveDirect([
+      {
+        speaker: 'ai',
+        blocks: [
+          ...toolCallBlock('', {}, 'fatal-before-emit').blocks,
+          ...emitCall('alpha', 'A').blocks,
+        ],
+      },
+      stopped(),
+    ]);
+
+    expect(output.emitted_vars).toStrictEqual({ alpha: 'A' });
+    expect(output.unrecovered_fatal_tool_error).toBeUndefined();
+  });
+
+  it('preserves a runtime availability fatal after a successful scheduled call', async () => {
+    const { output } = await runInteractiveDirect([
+      {
+        speaker: 'ai',
+        blocks: [
+          ...toolCallBlock(
+            'uppercase',
+            { text: 'ok' },
+            'success-before-runtime',
+          ).blocks,
+          ...toolCallBlock('runtime_disabled', {}, 'runtime-fatal').blocks,
+        ],
+      },
+      stopped(),
+    ]);
+
+    expect(output.unrecovered_fatal_tool_error).toContain(
+      'Image backend unavailable',
+    );
+    expect(output.terminate_reason).toBe(SubagentTerminateMode.ERROR);
+  });
+
+  it('recovers to GOAL after an emit and plain stop without declared outputs', async () => {
+    const { output } = await runDirectNonInteractive(
+      [toolCallBlock(''), emitCall('alpha', 'A'), stopped()],
+      {},
+    );
+
+    expect(output.emitted_vars).toStrictEqual({ alpha: 'A' });
+    expect(output.terminate_reason).toBe(SubagentTerminateMode.GOAL);
+    expect(output.unrecovered_fatal_tool_error).toBeUndefined();
+  });
+
+  it('ends ERROR when the first and only tool call has an empty name', async () => {
+    const { output } = await runDirectNonInteractive([
+      toolCallBlock(''),
+      stopped(),
+    ]);
+
+    expect(output.terminate_reason).toBe(SubagentTerminateMode.ERROR);
+    expect(output.final_message).toContain('is not available');
+    expect(output.final_message).toContain('could not be loaded');
+  });
+
+  it('ends ERROR with the raw garbage name when the tool name cannot be normalized', async () => {
+    const garbage = 'not a tool!!';
+    const { output } = await runDirectNonInteractive([
+      toolCallBlock(garbage),
+      stopped(),
+    ]);
+
+    expect(output.terminate_reason).toBe(SubagentTerminateMode.ERROR);
+    expect(output.final_message).toContain('is not available');
+    expect(output.final_message).toContain(garbage);
+  });
+
+  it('keeps ERROR when a failed non-fatal call follows the fatal call', async () => {
+    // Finding 1: a self_emitvalue call with a missing argument is a non-fatal
+    // INVALID_TOOL_PARAMS failure, not a recovery. The fatal flag must survive.
+    const { output } = await runDirectNonInteractive([
+      toolCallBlock(''),
+      toolCallBlock('self_emitvalue', {
+        emit_variable_name: 'alpha',
+      }),
+      stopped(),
+    ]);
+
+    expect(output.terminate_reason).toBe(SubagentTerminateMode.ERROR);
+    expect(output.final_message).toContain('is not available');
+    expect(output.final_message).toContain('could not be loaded');
+  });
+
+  it('recovers to GOAL when all declared outputs are emitted after a fatal empty-name call', async () => {
+    const { output } = await runDirectNonInteractive([
+      toolCallBlock(''),
+      emitCall('alpha', 'A'),
+      emitCall('beta', 'B'),
+    ]);
+
+    expect(output.emitted_vars).toStrictEqual({ alpha: 'A', beta: 'B' });
+    expect(output.terminate_reason).toBe(SubagentTerminateMode.GOAL);
+    // Finding 5: the GOAL site clears the flag explicitly, so the output
+    // object is consistent with a recovered run.
+    expect(output.unrecovered_fatal_tool_error).toBeUndefined();
+  });
+
+  it('ends ERROR when a fatal call is followed by a second fatal call', async () => {
+    const { output } = await runDirectNonInteractive([
+      toolCallBlock(''),
+      toolCallBlock('also_missing_tool'),
+      stopped(),
+    ]);
+
+    expect(output.terminate_reason).toBe(SubagentTerminateMode.ERROR);
+    expect(output.final_message).toContain('is not available');
+  });
+
+  it('clears the flag when a successful call follows the fatal one in the same batch', async () => {
+    // Finding 4: batch order is [fatal, success]. A success after the last
+    // fatal proves recovery, so the stop must end GOAL, not ERROR.
+    const { output } = await runDirectNonInteractive([
+      {
+        speaker: 'ai',
+        blocks: [
+          {
+            type: 'tool_call' as const,
+            id: 'fatal-mixed',
+            name: '',
+            parameters: {},
+          } as unknown as ContentBlock,
+          emitCall('alpha', 'A').blocks[0],
+          emitCall('beta', 'B').blocks[0],
+        ],
+      },
+    ]);
+
+    expect(output.emitted_vars).toStrictEqual({ alpha: 'A', beta: 'B' });
+    expect(output.unrecovered_fatal_tool_error).toBeUndefined();
+    expect(output.terminate_reason).toBe(SubagentTerminateMode.GOAL);
+  });
+
+  it('carries a tool_response paired to the doomed call in the follow-up request', async () => {
+    // AC1: the fatal dispatch must produce a proper tool_response. The
+    // dispatcher's structured response block (pairing the doomed call's
+    // callId) must reach the next provider request, not just the fatal text.
+    const doomedCallId = 'doomed-call-1';
+    const { output, requestContents } = await runDirectNonInteractive([
+      toolCallBlock('', {}, doomedCallId),
+      stopped(),
+    ]);
+
+    expect(output.terminate_reason).toBe(SubagentTerminateMode.ERROR);
+    expect(requestContents.length).toBeGreaterThanOrEqual(2);
+    const paired = findToolResponsesByCallId(requestContents[1], doomedCallId);
+    expect(paired).toHaveLength(1);
+  });
+
+  it('ends ERROR when an interactive run hits a fatal call and then stops with plain text', async () => {
+    // Finding 2: the model's plain stop text ("Done.") overwrote final_message
+    // in the interactive path, destroying the malformed-call diagnostic.
+    const { output, requestContents } = await runInteractiveDirect([
+      toolCallBlock('', {}, 'interactive-doomed-1'),
+      stopped(),
+    ]);
+
+    expect(output.terminate_reason).toBe(SubagentTerminateMode.ERROR);
+    expect(output.final_message).toContain('is not available');
+    expect(output.final_message).toContain('could not be loaded');
+    expect(output.final_message).not.toBe('Done.');
+    // The interactive follow-up request also carries the paired tool_response.
+    const paired = findToolResponsesByCallId(
+      requestContents[1],
+      'interactive-doomed-1',
+    );
+    expect(paired).toHaveLength(1);
+  });
+
+  it('ends GOAL with the diagnostic restored when a fatal call is followed by a successful call and a stop', async () => {
+    // Interactive path: fatal, then a real successful dispatch, then plain-text
+    // stop. The flag is cleared by the success, so the run ends GOAL.
+    const { output } = await runInteractiveDirect([
+      toolCallBlock('', {}, 'mixed-interactive-fatal'),
+      toolCallBlock('self_emitvalue', {
+        emit_variable_name: 'alpha',
+        emit_variable_value: 'A',
+      }),
+      toolCallBlock('self_emitvalue', {
+        emit_variable_name: 'beta',
+        emit_variable_value: 'B',
+      }),
+    ]);
+
+    expect(output.emitted_vars).toStrictEqual({ alpha: 'A', beta: 'B' });
+    expect(output.unrecovered_fatal_tool_error).toBeUndefined();
+    expect(output.terminate_reason).toBe(SubagentTerminateMode.GOAL);
+  });
+});

--- a/packages/agents/src/core/subagentNonInteractive.ts
+++ b/packages/agents/src/core/subagentNonInteractive.ts
@@ -60,6 +60,7 @@ import {
   finalizeOutput,
   processFunctionCalls,
   buildTodoCompletionPrompt,
+  completeWithGoal,
 } from './subagentToolProcessing.js';
 import {
   canonicalizeToolName,
@@ -530,7 +531,7 @@ export async function dispatchNonInteractiveTurnResult(
         emittedKeysAfterToolCalls.includes(key),
       );
     if (completedDeclaredOutputs) {
-      ctx.output.terminate_reason = SubagentTerminateMode.GOAL;
+      completeWithGoal(ctx.output);
       return null;
     }
     return nextMessages;

--- a/packages/agents/src/core/subagentToolProcessing.test.ts
+++ b/packages/agents/src/core/subagentToolProcessing.test.ts
@@ -18,6 +18,8 @@ import {
   handleEmitValueCall,
   buildPartsFromCompletedCalls,
   processFunctionCalls,
+  recordFatalToolError,
+  recordSuccessfulToolExecution,
   type EmitValueContext,
   type BuildPartsContext,
   type ProcessFunctionCallsContext,
@@ -27,7 +29,117 @@ import {
   type OutputObject,
 } from '@vybestack/llxprt-code-core/core/subagentTypes.js';
 import type { Config } from '@vybestack/llxprt-code-core/config/config.js';
+import { dispatch } from './subagent-tool-processing-test-helpers.js';
 import { DEFAULT_IMAGE_PAYLOAD_BUDGET_BYTES } from '@vybestack/llxprt-code-core/config/configTypes.js';
+
+describe('fatal tool flag transitions', () => {
+  function makeOutput(): OutputObject {
+    return { emitted_vars: {}, terminate_reason: SubagentTerminateMode.ERROR };
+  }
+
+  it('records an unrecovered fatal diagnostic', () => {
+    const output = makeOutput();
+    recordFatalToolError(output, 'Unavailable tool');
+    expect(output.unrecovered_fatal_tool_error).toBe('Unavailable tool');
+  });
+
+  it('clears a stale fatal final message after successful execution', () => {
+    const output = makeOutput();
+    recordFatalToolError(output, 'Unavailable tool');
+    output.final_message = 'Unavailable tool';
+
+    recordSuccessfulToolExecution(output);
+
+    expect(output.unrecovered_fatal_tool_error).toBeUndefined();
+    expect(output.final_message).toBeUndefined();
+  });
+
+  it('preserves a different final message after successful execution', () => {
+    const output = makeOutput();
+    recordFatalToolError(output, 'Unavailable tool');
+    output.final_message = 'Task completed';
+
+    recordSuccessfulToolExecution(output);
+
+    expect(output.unrecovered_fatal_tool_error).toBeUndefined();
+    expect(output.final_message).toBe('Task completed');
+  });
+
+  it('deletes the fatal flag after successful execution', () => {
+    const output = makeOutput();
+    recordFatalToolError(output, 'Unavailable tool');
+    recordSuccessfulToolExecution(output);
+    expect(Object.hasOwn(output, 'unrecovered_fatal_tool_error')).toBe(false);
+  });
+
+  it('sets the flag when a real dispatch rejects an unavailable tool', async () => {
+    const output = makeOutput();
+    await dispatch(
+      { type: 'tool_call', id: 'fatal', name: '', parameters: {} },
+      output,
+    );
+    expect(output.unrecovered_fatal_tool_error).toContain(
+      'could not be loaded',
+    );
+  });
+
+  it('preserves a fatal flag after a failed non-fatal execution', async () => {
+    const output = makeOutput();
+    recordFatalToolError(output, 'Unavailable tool');
+    const content = await dispatch(
+      {
+        type: 'tool_call',
+        id: 'failed',
+        name: 'divide',
+        parameters: { divisor: 0 },
+      },
+      output,
+    );
+    expect(content[0].blocks[0]).toMatchObject({
+      type: 'tool_response',
+      error: expect.any(String),
+    });
+    expect(output.unrecovered_fatal_tool_error).toBe('Unavailable tool');
+  });
+
+  it('clears a fatal flag after a successful dispatched execution', async () => {
+    const output = makeOutput();
+    recordFatalToolError(output, 'Unavailable tool');
+    const content = await dispatch(
+      {
+        type: 'tool_call',
+        id: 'success',
+        name: 'divide',
+        parameters: { divisor: 4 },
+      },
+      output,
+    );
+    expect(content[0].blocks[0]).toMatchObject({
+      type: 'tool_response',
+      result: { output: '0.25' },
+    });
+    expect(output.unrecovered_fatal_tool_error).toBeUndefined();
+  });
+
+  it('clears a fatal flag after a successful scope-local emit', async () => {
+    const output = makeOutput();
+    recordFatalToolError(output, 'Unavailable tool');
+    await dispatch(
+      {
+        type: 'tool_call',
+        id: 'emit',
+        name: 'self_emitvalue',
+        parameters: {
+          emit_variable_name: 'result',
+          emit_variable_value: 'ready',
+        },
+      },
+      output,
+    );
+    expect(output.emitted_vars).toStrictEqual({ result: 'ready' });
+    expect(output.unrecovered_fatal_tool_error).toBeUndefined();
+  });
+});
 
 describe('subagentToolProcessing', () => {
   // --- Pure helpers ---

--- a/packages/agents/src/core/subagentToolProcessing.ts
+++ b/packages/agents/src/core/subagentToolProcessing.ts
@@ -72,6 +72,75 @@ export function isFatalToolError(
   );
 }
 
+// Issue #3535: a fatal tool error that killed the run must surface as ERROR, not
+// GOAL, unless a later tool call succeeds. The message is recorded on the output
+// so checkGoalCompletion can convert GOAL to ERROR; any successful execution clears it.
+export function recordFatalToolError(
+  output: OutputObject,
+  message: string,
+): void {
+  output.unrecovered_fatal_tool_error = message;
+}
+
+function clearFatalDiagnostic(output: OutputObject): void {
+  if (
+    output.unrecovered_fatal_tool_error !== undefined &&
+    output.final_message === output.unrecovered_fatal_tool_error
+  ) {
+    delete output.final_message;
+  }
+}
+
+export function recordSuccessfulToolExecution(output: OutputObject): void {
+  clearFatalDiagnostic(output);
+  delete output.unrecovered_fatal_tool_error;
+}
+
+/** Complete a satisfied output contract without retaining a stale fatal diagnostic. */
+export function completeWithGoal(output: OutputObject): void {
+  clearFatalDiagnostic(output);
+  delete output.unrecovered_fatal_tool_error;
+  output.terminate_reason = SubagentTerminateMode.GOAL;
+}
+
+export type InteractiveToolMarker =
+  | { callId: string }
+  | { status: 'success' | 'error-nonfatal' };
+
+/**
+ * Request-order classification keeps interactive execution semantically
+ * identical to sequential non-interactive execution, including runtime fatals.
+ */
+export function classifyToolCompletions(
+  markers: readonly InteractiveToolMarker[],
+  completedCalls: readonly CompletedToolCall[],
+): {
+  recovered: boolean;
+  fatalCall?: CompletedToolCall;
+} {
+  const byCallId = new Map(
+    completedCalls.map((call) => [call.request.callId, call]),
+  );
+  let recovered = false;
+  let fatalCall: CompletedToolCall | undefined;
+  for (const marker of markers) {
+    const call = 'callId' in marker ? byCallId.get(marker.callId) : marker;
+    // The scheduler drops duplicate call IDs, so some requests have no completion.
+    if (!call) continue;
+    if (call.status === 'success') {
+      recovered = true;
+      fatalCall = undefined;
+    } else if (
+      call.status === 'error' &&
+      isFatalToolError(call.response.errorType)
+    ) {
+      fatalCall = call;
+      recovered = false;
+    }
+  }
+  return { recovered, fatalCall };
+}
+
 export function extractToolDetail(
   resultDisplay?: ToolResultDisplay,
   error?: Error,
@@ -331,6 +400,8 @@ export function handleEmitValueCall(
 
   if (variableName && variableValue) {
     ctx.output.emitted_vars[variableName] = variableValue;
+    // Issue #3535: a successful emitted value is a successful tool execution.
+    recordSuccessfulToolExecution(ctx.output);
     const message = `Emitted variable ${variableName} successfully`;
     if (ctx.onMessage) {
       ctx.onMessage(`[${ctx.subagentId}] ${message}`);
@@ -487,9 +558,13 @@ function getMissingRequiredOutputKeys(
 function terminateAfterSuccessfulTodoPause(
   ctx: ProcessFunctionCallsContext,
 ): void {
+  // Issue #3535: a successful pause-tool termination runs before any other
+  // success-clear branch, so clear the fatal flag here to keep the
+  // output object consistent with a successful execution.
+  recordSuccessfulToolExecution(ctx.output);
   const missingOutputKeys = getMissingRequiredOutputKeys(ctx);
   if (missingOutputKeys.length === 0) {
-    ctx.output.terminate_reason = SubagentTerminateMode.GOAL;
+    completeWithGoal(ctx.output);
     return;
   }
 
@@ -497,6 +572,48 @@ function terminateAfterSuccessfulTodoPause(
   ctx.output.final_message =
     'Subagent paused via todo_pause before completing required outputs: ' +
     `${missingOutputKeys.join(', ')}.`;
+}
+
+function applyNonFatalToolResponse(
+  toolResponse: ToolCallResponseInfo,
+  toolResponseBlocks: ContentBlock[],
+  executionStatus: CompletedToolCall['status'],
+  ctx: ProcessFunctionCallsContext,
+): void {
+  // Issue #3535: only a genuinely successful execution proves recovery.
+  // A non-fatal failure (bad params, execution error, cancellation)
+  // must preserve an existing fatal flag.
+  if (executionStatus === 'success') {
+    recordSuccessfulToolExecution(ctx.output);
+  }
+  pushNonToolCallResponseBlocks(toolResponse.responseParts, toolResponseBlocks);
+}
+
+function recordFatalToolUnavailableError(
+  toolName: string,
+  toolResponse: ToolCallResponseInfo,
+  toolResponseBlocks: ContentBlock[],
+  ctx: ProcessFunctionCallsContext,
+): void {
+  const fatalMessage = buildToolUnavailableMessage(
+    toolName,
+    toolResponse.resultDisplay,
+    toolResponse.error,
+  );
+  // Issue #3535: an unavailable tool is fatal — record it so
+  // checkGoalCompletion converts a resulting stop to ERROR. A later
+  // successful call clears it.
+  recordFatalToolError(ctx.output, fatalMessage);
+  ctx.logger.warn(
+    () =>
+      `Subagent ${ctx.subagentId} cannot use tool '${toolName}': ${fatalMessage}`,
+  );
+  // Issue #3535: the dispatcher already produced a structured tool_response
+  // paired to the doomed call's callId. Forward it so the next provider
+  // request answers the recorded tool_use instead of leaving it dangling.
+  pushNonToolCallResponseBlocks(toolResponse.responseParts, toolResponseBlocks);
+  toolResponseBlocks.push({ type: 'text', text: fatalMessage });
+  ctx.output.final_message = fatalMessage;
 }
 
 export async function processFunctionCalls(
@@ -552,21 +669,18 @@ export async function processFunctionCalls(
       }
 
       if (isFatalToolError(toolResponse.errorType)) {
-        const fatalMessage = buildToolUnavailableMessage(
+        recordFatalToolUnavailableError(
           functionCall.name,
-          toolResponse.resultDisplay,
-          toolResponse.error,
-        );
-        ctx.logger.warn(
-          () =>
-            `Subagent ${ctx.subagentId} cannot use tool '${functionCall.name}': ${fatalMessage}`,
-        );
-        toolResponseBlocks.push({ type: 'text', text: fatalMessage });
-        ctx.output.final_message = fatalMessage;
-      } else {
-        pushNonToolCallResponseBlocks(
-          toolResponse.responseParts,
+          toolResponse,
           toolResponseBlocks,
+          ctx,
+        );
+      } else {
+        applyNonFatalToolResponse(
+          toolResponse,
+          toolResponseBlocks,
+          executionResult.status,
+          ctx,
         );
       }
     }
@@ -651,6 +765,8 @@ async function executeNonInteractiveTool(
     }
 
     ctx.output.emitted_vars[valName] = valVal;
+    // Issue #3535: a successful emitted value is successful tool execution.
+    recordSuccessfulToolExecution(ctx.output);
 
     const successMessage = `Emitted variable ${valName} successfully`;
     return {

--- a/packages/agents/src/core/turn.test.ts
+++ b/packages/agents/src/core/turn.test.ts
@@ -327,7 +327,7 @@ describe('Turn', () => {
       const event1 = events[0] as ServerToolCallRequestEvent;
       expect(event1.value).toMatchObject({
         callId: 'fc1',
-        name: 'undefined_tool_name',
+        name: '',
         args: { arg1: 'val1' },
       });
 
@@ -341,7 +341,7 @@ describe('Turn', () => {
       const event3 = events[2] as ServerToolCallRequestEvent;
       expect(event3.value).toMatchObject({
         callId: 'fc3',
-        name: 'undefined_tool_name',
+        name: '',
         args: {},
       });
     });

--- a/packages/agents/src/core/turn.ts
+++ b/packages/agents/src/core/turn.ts
@@ -862,17 +862,11 @@ export class Turn {
         ? fnCall.id
         : this.createSyntheticFunctionCallId(fnCall, functionCallIndex);
 
-    let name = fnCall.name;
-    if (!name || name.trim() === '') {
-      name = 'undefined_tool_name';
-    } else {
-      const normalized = normalizeToolName(name);
-      if (normalized) {
-        name = normalized;
-      } else {
-        name = 'undefined_tool_name';
-      }
-    }
+    // #3535: carry the raw name unchanged when it is absent or cannot be
+    // normalized. The doomed call must still dispatch so the existing
+    // TOOL_NOT_REGISTERED path returns a proper tool_response instead of the
+    // fabricated literal `undefined_tool_name` the parent cannot diagnose.
+    const name = this.resolveRawToolName(fnCall);
 
     const params = fnCall.parameters;
     const args: Record<string, unknown> =
@@ -882,7 +876,7 @@ export class Turn {
 
     const toolCallRequest: ToolCallRequestInfo = {
       callId,
-      name: name || 'undefined_tool_name',
+      name,
       args,
       isClientInitiated: false,
       prompt_id: this.prompt_id,
@@ -892,6 +886,18 @@ export class Turn {
     this.pendingToolCalls.push(toolCallRequest);
 
     return { type: AgentEventType.ToolCallRequest, value: toolCallRequest };
+  }
+
+  private resolveRawToolName(fnCall: ToolCallBlock): string {
+    const fnName: unknown = fnCall.name;
+    let rawName: string | undefined;
+    if (typeof fnName === 'string') {
+      rawName = fnName;
+    } else if (fnName != null) {
+      rawName = String(fnName);
+    }
+    const normalized = rawName?.trim() ? normalizeToolName(rawName) : null;
+    return normalized ?? rawName ?? '';
   }
 
   private createSyntheticFunctionCallId(
@@ -909,7 +915,7 @@ export class Turn {
       .update(payload)
       .digest('hex')
       .slice(0, 16);
-    const name = normalizeToolName(fnCall.name) ?? 'undefined_tool_name';
+    const name = this.resolveRawToolName(fnCall);
     return `${name}-${functionCallIndex}-${digest}`;
   }
 

--- a/packages/agents/src/core/turn.undefined_issue.test.ts
+++ b/packages/agents/src/core/turn.undefined_issue.test.ts
@@ -1,335 +1,170 @@
-import { describe, it, expect, vi, beforeEach } from 'bun:test';
-import { Turn } from './turn.js';
-import type { ChatSession } from './chatSession.js';
-import type { FunctionCall } from '../agents/types.js';
-import { AgentEventType } from './turn.js';
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
-describe('Turn GitHub Issue #305: undefined_tool_name Integration Tests', () => {
-  let mockChatSession: ChatSession;
+/**
+ * Issue #3535 — Turn.handlePendingFunctionCall must never substitute the
+ * literal `undefined_tool_name` for an absent or unnormalizable tool name.
+ * These tests drive the real Turn against a mocked chat stream and assert the
+ * emitted ToolCallRequestInfo names and synthetic call ids carry the raw name
+ * (empty stays empty), never the fabricated literal.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'bun:test';
+import type { ServerToolCallRequestEvent } from './turn.js';
+import { Turn, AgentEventType, DEFAULT_AGENT_ID } from './turn.js';
+import type { ModelStreamChunk } from '@vybestack/llxprt-code-core/llm-types/index.js';
+import type {
+  ContentBlock,
+  IContent,
+} from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { ChatSession } from './chatSession.js';
+import { StreamEventType } from './chatSession.js';
+
+const { mockSendMessageStream, mockGetHistory } = {
+  mockSendMessageStream: vi.fn(),
+  mockGetHistory: vi.fn(),
+};
+
+void vi.mock('@vybestack/llxprt-code-core/utils/errorReporting.js', () => ({
+  reportError: vi.fn(),
+}));
+
+describe('Turn tool-call name passthrough (issue 3535)', () => {
+  let turn: Turn;
 
   beforeEach(() => {
-    // Create a more realistic mock for ChatSession
-    mockChatSession = {
-      sendPromise: Promise.resolve(),
-      compressionPromise: Promise.resolve(),
-      logger: {
-        log: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-      },
-      sendMessageStream: vi.fn().mockResolvedValue((async function* () {})()),
-      getHistory: vi.fn().mockReturnValue([]),
-      maybeIncludeSchemaDepthContext: vi.fn().mockResolvedValue(undefined),
-      // Add other required properties with minimal implementations
-      compress: vi.fn(),
-      addMessage: vi.fn(),
-      clear: vi.fn(),
-      getSettings: vi.fn().mockReturnValue({}),
-      setSettings: vi.fn(),
-      getModel: vi.fn().mockReturnValue('gemini-pro'),
-      setModel: vi.fn(),
-      getSystemInstruction: vi.fn().mockReturnValue(''),
-      setSystemInstruction: vi.fn(),
-      getTools: vi.fn().mockReturnValue([]),
-      setTools: vi.fn(),
-      getGenerationConfig: vi.fn().mockReturnValue({}),
-      setGenerationConfig: vi.fn(),
-      getSafetySettings: vi.fn().mockReturnValue([]),
-      setSafetySettings: vi.fn(),
-      // Add any other required properties...
-    } as unknown as ChatSession;
-  });
-
-  describe('Tool Name Normalization Integration', () => {
-    it('should handle Turn construction with different prompt IDs', () => {
-      // Test basic Turn construction
-      const turnWithId = new Turn(mockChatSession, 'different-prompt-id');
-      expect(turnWithId).toBeInstanceOf(Turn);
-    });
-
-    it('should handle Turn with agent ID', () => {
-      // Test Turn construction with agent ID
-      const turnWithAgent = new Turn(
-        mockChatSession,
-        'test-prompt',
-        'agent-123',
-      );
-      expect(turnWithAgent).toBeInstanceOf(Turn);
-    });
-
-    it('should have proper event types for GitHub #305 scenarios', () => {
-      // Verify that the required event types exist
-      expect(AgentEventType.ToolCallRequest).toBe('tool_call_request');
-      expect(AgentEventType.Error).toBe('error');
-    });
-  });
-
-  describe('FunctionCall Processing Scenarios', () => {
-    it('should create proper FunctionCall objects for testing', () => {
-      // Test creating FunctionCall objects that simulate the GitHub #305 issue
-      const validFunctionCall: FunctionCall = {
-        name: 'write_file',
-        args: { filename: 'test.txt', content: 'Hello World' },
-      };
-
-      expect(validFunctionCall.name).toBe('write_file');
-      expect(validFunctionCall.args).toStrictEqual({
-        filename: 'test.txt',
-        content: 'Hello World',
-      });
-    });
-
-    it('should handle FunctionCall with undefined name (GitHub #305 scenario)', () => {
-      // Simulate the problematic FunctionCall from qwen models
-      const problematicFunctionCall: Partial<FunctionCall> = {
-        name: undefined,
-        args: { file: 'output.txt' },
-      };
-
-      expect(problematicFunctionCall.name).toBeUndefined();
-      expect(problematicFunctionCall.args).toStrictEqual({
-        file: 'output.txt',
-      });
-    });
-
-    it('should handle FunctionCall with empty name', () => {
-      const emptyNameFunctionCall: Partial<FunctionCall> = {
-        name: '',
-        args: { data: 'test' },
-      };
-
-      expect(emptyNameFunctionCall.name).toBe('');
-      expect(emptyNameFunctionCall.args).toStrictEqual({ data: 'test' });
-    });
-
-    it('should handle FunctionCall with null name', () => {
-      const nullNameFunctionCall: Partial<FunctionCall> = {
-        name: undefined, // FunctionCall.name is string | undefined, not null
-        args: { content: 'test' },
-      };
-
-      expect(nullNameFunctionCall.name).toBeUndefined();
-      expect(nullNameFunctionCall.args).toStrictEqual({ content: 'test' });
-    });
-
-    it('should handle FunctionCall with malformed args', () => {
-      // Note: FunctionCall args should be Record<string, unknown>, not string
-      // Malformed JSON would be handled at a higher level
-      const malformedArgsFunctionCall: Partial<FunctionCall> = {
-        name: 'test_tool',
-        args: { malformed: 'json would be parsed elsewhere' },
-      };
-
-      expect(malformedArgsFunctionCall.name).toBe('test_tool');
-      expect(malformedArgsFunctionCall.args).toStrictEqual({
-        malformed: 'json would be parsed elsewhere',
-      });
-    });
-
-    it('should handle FunctionCall without args', () => {
-      const noArgsFunctionCall: Partial<FunctionCall> = {
-        name: 'test_tool',
-      };
-
-      expect(noArgsFunctionCall.name).toBe('test_tool');
-      expect(noArgsFunctionCall.args).toBeUndefined();
-    });
-  });
-
-  describe('GitHub #305 Edge Cases', () => {
-    it.each([
+    vi.resetAllMocks();
+    turn = new Turn(
       {
-        description: 'Null name',
-        call: {
-          name: undefined,
-          args: { file: 'test.txt' },
-        } as Partial<FunctionCall>,
-        expectedName: undefined,
-      },
-      {
-        description: 'Explicit undefined name',
-        call: {
-          name: undefined,
-          args: { file: 'test.txt' },
-        } as Partial<FunctionCall>,
-        expectedName: undefined,
-      },
-      {
-        description: 'Null name (duplicate)',
-        call: {
-          name: undefined,
-          args: { file: 'test.txt' },
-        } as Partial<FunctionCall>,
-        expectedName: undefined,
-      },
-      {
-        description: 'Empty string name',
-        call: {
-          name: '',
-          args: { file: 'test.txt' },
-        } as Partial<FunctionCall>,
-        expectedName: '',
-      },
-      {
-        description: 'Whitespace-only name',
-        call: {
-          name: '   \t\n   ',
-          args: { file: 'test.txt' },
-        } as Partial<FunctionCall>,
-        expectedName: '   \t\n   ',
-      },
-    ])(
-      'should simulate qwen model problematic scenario: $description',
-      ({ call, expectedName }) => {
-        // These are the exact scenarios reported in GitHub #305
-        expect(call.args).toStrictEqual({ file: 'test.txt' });
-        expect(call.name).toBe(expectedName);
-      },
+        sendMessageStream: mockSendMessageStream,
+        getHistory: mockGetHistory,
+        getConfig: () => undefined,
+        getResolvedBaseUrl: () => undefined,
+      } as unknown as ChatSession,
+      'prompt-3535',
+      DEFAULT_AGENT_ID,
+      'test',
     );
-
-    it('should test tool name patterns that cause issues', () => {
-      // Test various tool name patterns that might cause normalization issues
-      const problematicNames = [
-        '', // Empty
-        '   ', // Whitespace
-        'tool@name', // Special characters
-        'tool#name', // Special characters
-        'tool$name', // Special characters
-        'tool name', // Space
-        'tool-name', // Hyphen
-        'tool.name', // Dot
-        'a'.repeat(200), // Too long
-      ];
-
-      for (const name of problematicNames) {
-        expect(typeof name).toBe('string');
-      }
-    });
-
-    it('should test valid tool name patterns', () => {
-      // Test tool names that should work correctly
-      const validNames = [
-        'write_file',
-        'read_data',
-        'process_http_request',
-        'delete_file',
-        'create_directory',
-        'list_files',
-        'tool123',
-        'test_tool',
-      ];
-
-      for (const name of validNames) {
-        expect(typeof name).toBe('string');
-        expect(name.length).toBeGreaterThan(0);
-        expect(name.length).toBeLessThanOrEqual(100);
-      }
-    });
+    mockGetHistory.mockReturnValue([]);
   });
 
-  describe('Integration with normalizeToolName', () => {
-    it('should import normalizeToolName correctly', async () => {
-      // Test that we can import the normalizeToolName function
-      const { normalizeToolName } = await import(
-        '@vybestack/llxprt-code-tools'
-      );
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
-      expect(typeof normalizeToolName).toBe('function');
-
-      // Test basic functionality
-      expect(normalizeToolName('writeFile')).toBe('write_file');
-      expect(normalizeToolName('read_data')).toBe('read_data');
-      expect(normalizeToolName('')).toBeNull();
-      expect(normalizeToolName('   ')).toBeNull();
-    });
-
-    it.each([
-      { input: 'writeFile', expected: 'write_file' },
-      { input: 'read_data', expected: 'read_data' },
-      { input: '', expected: null },
-      { input: '   ', expected: null },
-      { input: 'invalid@tool', expected: null },
-    ])(
-      'should handle Turn.ts scenario: input="$input"',
-      async ({ input, expected }) => {
-        const { normalizeToolName } = await import(
-          '@vybestack/llxprt-code-tools'
-        );
-
-        // Test the same logic as in turn.ts:444-456
-        const result = normalizeToolName(input);
-        expect(result).toBe(expected);
-      },
+  function mockStreamYielding(blocks: ContentBlock[]): void {
+    const chunk: ModelStreamChunk = {
+      content: { speaker: 'ai', blocks } as IContent,
+    };
+    mockSendMessageStream.mockResolvedValue(
+      (async function* () {
+        yield { type: StreamEventType.CHUNK, value: chunk };
+      })(),
     );
+  }
 
-    it('should use fallback name for invalid tool names', () => {
-      // Simulate the fallback logic from turn.ts when normalizeToolName returns null
-      const fallbackName = 'undefined_tool_name';
-      expect(fallbackName).toBe('undefined_tool_name');
-    });
+  async function collectToolCallEvents(): Promise<
+    ServerToolCallRequestEvent[]
+  > {
+    const events: ServerToolCallRequestEvent[] = [];
+    for await (const event of turn.run(
+      [{ type: 'text', text: 'call something' }] as ContentBlock[],
+      new AbortController().signal,
+    )) {
+      if (event.type === AgentEventType.ToolCallRequest) {
+        events.push(event);
+      }
+    }
+    return events;
+  }
+
+  it('emits an empty name for an absent tool name and never the fabricated literal', async () => {
+    // The provider block carries NO name field at all.
+    mockStreamYielding([
+      {
+        type: 'tool_call',
+        id: '',
+        parameters: {},
+      } as unknown as ContentBlock,
+    ]);
+
+    const [event] = await collectToolCallEvents();
+    expect(event).toBeDefined();
+    expect(event.value.name).toBe('');
+    expect(event.value.callId).not.toContain('undefined_tool_name');
+    expect(JSON.stringify(event.value)).not.toContain('undefined_tool_name');
   });
 
-  describe('Error Recovery and Robustness', () => {
-    it('should handle malformed JSON in FunctionCall args', () => {
-      // Note: FunctionCall args are Record<string, unknown>, not string
-      // Malformed JSON would be handled at a higher level before creating FunctionCall
-      const malformedCases = [
-        { malformed: 'json would be parsed elsewhere' },
-        { incomplete: 'data' },
-        { null: 'value' },
-        { empty: '' },
-      ];
+  it('stringifies a non-string provider tool name without dropping the request', async () => {
+    const block: ContentBlock = {
+      type: 'tool_call',
+      id: 'numeric-name',
+      name: '',
+      parameters: {},
+    };
+    Object.defineProperty(block, 'name', { value: 42 });
+    mockStreamYielding([block]);
 
-      for (const malformedCase of malformedCases) {
-        const functionCall: Partial<FunctionCall> = {
-          name: 'test_tool',
-          args: malformedCase,
-        };
+    const events = await collectToolCallEvents();
 
-        expect(functionCall.name).toBe('test_tool');
-        expect(functionCall.args).toStrictEqual(malformedCase);
-      }
-    });
+    expect(events).toHaveLength(1);
+    expect(events[0].value.name).toBe('42');
+    expect(events[0].value.callId).toBe('numeric-name');
+  });
 
-    it('should handle extreme tool name lengths', () => {
-      const extremeCases = [
-        'a'.repeat(0), // Empty
-        'a'.repeat(1), // Single character
-        'a'.repeat(100), // Max valid length
-        'a'.repeat(101), // Just over limit
-        'a'.repeat(1000), // Way over limit
-      ];
+  it('passes an unnormalizable garbage name through raw', async () => {
+    const garbage = 'not a tool!!';
+    mockStreamYielding([
+      { type: 'tool_call', id: 'garbage-1', name: garbage, parameters: {} },
+    ]);
 
-      for (const name of extremeCases) {
-        const functionCall: Partial<FunctionCall> = {
-          name,
-          args: {},
-        };
+    const [event] = await collectToolCallEvents();
+    expect(event).toBeDefined();
+    expect(event.value.name).toBe(garbage);
+    expect(event.value.callId).not.toContain('undefined_tool_name');
+  });
 
-        expect(functionCall.name).toBe(name);
-        expect(functionCall.args).toStrictEqual({});
-      }
-    });
+  it('preserves a whitespace-only name as raw whitespace', async () => {
+    const rawWhitespace = '   ';
+    mockStreamYielding([
+      { type: 'tool_call', id: 'ws-1', name: rawWhitespace, parameters: {} },
+    ]);
 
-    it('should handle special Unicode characters', () => {
-      const unicodeCases = [
-        '工具名稱', // Chinese
-        'tôöl_nâmé', // Accented
-        'инструмент', // Cyrillic
-        '🔧_tool', // Emoji
-        '\u0000tool', // Null character
-        '\n\ttool', // Control characters
-      ];
+    const [event] = await collectToolCallEvents();
+    expect(event).toBeDefined();
+    expect(event.value.name).toBe(rawWhitespace);
+  });
 
-      for (const name of unicodeCases) {
-        const functionCall: Partial<FunctionCall> = {
-          name,
-          args: {},
-        };
+  it('embeds the raw name segment in synthetic ids and never the fabricated literal', async () => {
+    const garbage = 'not a tool!!';
+    mockStreamYielding([
+      { type: 'tool_call', id: '', name: garbage, parameters: {} },
+      { type: 'tool_call', id: '', name: '   ', parameters: {} },
+      {
+        type: 'tool_call',
+        id: '',
+        parameters: {},
+      } as unknown as ContentBlock,
+    ]);
 
-        expect(functionCall.name).toBe(name);
-        expect(functionCall.args).toStrictEqual({});
-      }
-    });
+    const events = await collectToolCallEvents();
+    expect(events).toHaveLength(3);
+
+    // Garbage name: the raw name is the id prefix before `-<index>-<digest>`.
+    expect(events[0].value.callId).toContain(garbage);
+    expect(events[0].value.callId).toMatch(
+      new RegExp(`^${garbage.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}-0-`),
+    );
+    // Whitespace-only name: raw whitespace is the id prefix.
+    expect(events[1].value.callId).toMatch(/^ {3}-1-/);
+    // Absent name: the id starts with the empty name segment.
+    expect(events[2].value.callId).toMatch(/^-2-/);
+
+    for (const event of events) {
+      expect(event.value.callId).not.toContain('undefined_tool_name');
+    }
   });
 });

--- a/packages/core/src/core/subagentTypes.ts
+++ b/packages/core/src/core/subagentTypes.ts
@@ -131,6 +131,14 @@ export interface OutputObject {
    */
   output_tokens_budget?: number;
   /**
+   * The fatal tool-error message (TOOL_DISABLED / TOOL_NOT_REGISTERED) that
+   * last killed a tool call in this run without a later successful tool
+   * execution. When set, the run must not terminate with {@link GOAL} (issue
+   * #3535): an unavailable tool that ends the run is an ERROR the parent can
+   * distinguish, while any successful tool call clears this field.
+   */
+  unrecovered_fatal_tool_error?: string;
+  /**
    * The reason for the subagent's termination, indicating whether it completed
    * successfully, timed out, or encountered an error.
    */

--- a/packages/providers/src/openai/ToolNameValidator.ts
+++ b/packages/providers/src/openai/ToolNameValidator.ts
@@ -56,14 +56,12 @@ export class ToolNameValidator {
       isValid: true,
     };
 
-    // Step 1: Handle undefined/null/empty names
+    // Step 1: Handle undefined/null/empty names. Issue #3535: never
+    // fabricate `undefined_tool_name`; invalid results stay empty.
     if (!rawName || rawName.trim() === '') {
-      result.name = 'undefined_tool_name';
-      result.warnings.push('Empty or undefined tool name, using fallback');
+      result.warnings.push('Empty or undefined tool name');
       result.isValid = false;
-      this.logger.debug(
-        () => `Empty tool name detected, using fallback: ${result.name}`,
-      );
+      this.logger.debug(() => 'Empty tool name detected');
       return result;
     }
 
@@ -71,10 +69,7 @@ export class ToolNameValidator {
     const normalized = this.normalizeToolName(rawName);
 
     if (!normalized) {
-      result.name = 'undefined_tool_name';
-      result.warnings.push(
-        `Unable to normalize tool name: "${rawName}", using fallback`,
-      );
+      result.warnings.push(`Unable to normalize tool name: "${rawName}"`);
       result.isValid = false;
       return result;
     }
@@ -91,10 +86,7 @@ export class ToolNameValidator {
         }
         return result;
       }
-      result.name = 'undefined_tool_name';
-      result.warnings.push(
-        `Tool "${normalized}" not found in available tools, using fallback`,
-      );
+      result.warnings.push(`Tool "${normalized}" not found in available tools`);
       result.isValid = false;
       return result;
     }

--- a/packages/providers/src/openai/__tests__/ToolNameValidator.test.ts
+++ b/packages/providers/src/openai/__tests__/ToolNameValidator.test.ts
@@ -44,29 +44,23 @@ describe('ToolNameValidator', () => {
         'qwen',
         availableTools,
       );
-      expect(result.name).toBe('undefined_tool_name');
+      expect(result.name).toBe('');
       expect(result.isValid).toBe(false);
-      expect(result.warnings).toContain(
-        'Empty or undefined tool name, using fallback',
-      );
+      expect(result.warnings).toContain('Empty or undefined tool name');
     });
 
     it('should handle empty string names', () => {
       const result = validator.validateToolName('', 'qwen', availableTools);
-      expect(result.name).toBe('undefined_tool_name');
+      expect(result.name).toBe('');
       expect(result.isValid).toBe(false);
-      expect(result.warnings).toContain(
-        'Empty or undefined tool name, using fallback',
-      );
+      expect(result.warnings).toContain('Empty or undefined tool name');
     });
 
     it('should handle special symbol names', () => {
       const result = validator.validateToolName('*', 'qwen', availableTools);
-      expect(result.name).toBe('undefined_tool_name');
+      expect(result.warnings).toContain('Unable to normalize tool name: "*"');
+      expect(result.name).toBe('');
       expect(result.isValid).toBe(false);
-      expect(result.warnings).toContain(
-        'Unable to normalize tool name: "*", using fallback',
-      );
     });
 
     it('should normalize tool names with different cases', () => {
@@ -100,17 +94,17 @@ describe('ToolNameValidator', () => {
       expect(result.name).toBe('write_file');
     });
 
-    it('should return fallback when tool not found in available tools', () => {
+    it('should return empty name when tool not found in available tools', () => {
       const result = validator.validateToolName(
         'nonexistent_tool',
         'qwen',
         availableTools,
       );
-      expect(result.name).toBe('undefined_tool_name');
-      expect(result.isValid).toBe(false);
       expect(result.warnings).toContain(
-        'Tool "nonexistent_tool" not found in available tools, using fallback',
+        'Tool "nonexistent_tool" not found in available tools',
       );
+      expect(result.name).toBe('');
+      expect(result.isValid).toBe(false);
     });
 
     it('should work without available tools list', () => {
@@ -131,26 +125,20 @@ describe('ToolNameValidator', () => {
   });
 
   describe('private helper methods (via public interface)', () => {
-    it('should infer tool name from arguments', () => {
-      // Note: ToolNameValidator doesn't actually use the third parameter as args,
-      // but we test the basic functionality
+    it('should return an empty invalid result when the tool name is absent', () => {
       const result = validator.validateToolName(undefined, 'qwen', []);
-      expect(result.name).toBe('undefined_tool_name');
+      expect(result.name).toBe('');
+      expect(result.isValid).toBe(false);
     });
 
-    it('should handle shell tool fallback', () => {
-      const result = validator.validateToolName(undefined, 'qwen', []);
-      expect(result.name).toBe('undefined_tool_name');
-    });
-
-    it('should handle very long tool names in fallback', () => {
+    it('should return empty name for an unavailable very long tool name', () => {
       const longName = 'a'.repeat(150);
       const result = validator.validateToolName(
         longName,
         'qwen',
         availableTools,
       );
-      expect(result.name).toBe('undefined_tool_name');
+      expect(result.name).toBe('');
       expect(result.isValid).toBe(false);
     });
   });
@@ -164,7 +152,7 @@ describe('ToolNameValidator', () => {
 
     it('should reject tool names with invalid characters', () => {
       const result = validator.validateToolName('test@tool', 'qwen', []);
-      expect(result.name).toBe('undefined_tool_name');
+      expect(result.name).toBe('');
       expect(result.isValid).toBe(false);
     });
 

--- a/project-plans/issue3535.md
+++ b/project-plans/issue3535.md
@@ -1,0 +1,257 @@
+# Plan: Issue #3535 — Subagent terminates GOAL after attempting unavailable `undefined_tool_name`
+
+Plan ID: PLAN-20260909-ISSUE3535
+Generated: 2026-09-09
+Issue: vybestack/llxprt-code#3535
+Branch: `issue3535`
+
+## Problem summary (traced failure chain)
+
+A subagent launched via the `task` tool emitted a single tool call whose name was
+absent or unnormalizable. The run then terminated with
+`terminate_reason: "GOAL"` and a final message reporting that
+`undefined_tool_name` was unavailable, so the parent could not distinguish the
+failed run from success.
+
+Chain (verified on main @ 2aac6841e):
+
+1. `packages/agents/src/core/turn.ts` `handlePendingFunctionCall` (L856–895)
+   substitutes the literal `undefined_tool_name` whenever a tool-call block's
+   name is missing (undefined/empty/whitespace) or `normalizeToolName` fails.
+   `createSyntheticFunctionCallId` (L912) embeds the same literal in synthetic
+   call ids. This is the only production fabricator of the literal; the other
+   is `packages/providers/src/openai/ToolNameValidator.ts` (L61, L74, L94),
+   which is currently dead code wired only to its own test.
+2. The doomed request is dispatched (interactive path:
+   `subagent.ts` `handleInteractiveToolCalls` L780–796; non-interactive path:
+   `subagentToolProcessing.ts` `processFunctionCalls` L554–565). The registry
+   misses, `ToolDispatcher` returns `TOOL_NOT_REGISTERED`
+   (`tool-dispatcher.ts` L70–84, "could not be loaded … Did you mean"),
+   `isFatalToolError` is true, and `buildToolUnavailableMessage` becomes
+   `output.final_message`.
+3. The fatal message is fed back to the model ("Please continue without using
+   it.") but `terminate_reason` is untouched. When the model stops calling
+   tools, `checkGoalCompletion` (`subagentExecution.ts` L305–321) sets
+   `GOAL`, and `finalizeOutput` preserves the fatal text. Result: `GOAL` with
+   a tool-failure final message — the masking bug.
+
+## Accepted behavior (acceptance criteria)
+
+### AC1 — Never fabricate the literal `undefined_tool_name`
+
+Tool-call construction must never substitute the literal `undefined_tool_name`
+for an absent/unnormalizable tool name.
+
+- `turn.ts` `handlePendingFunctionCall`: when the incoming name is absent or
+  unnormalizable, the emitted `ToolCallRequestInfo` carries the raw name
+  unchanged (an empty name stays empty). The call must still be dispatched so
+  the existing `TOOL_NOT_REGISTERED` path produces a proper `tool_response`
+  (no dangling tool_use, which would break provider protocols on the next
+  request).
+- `createSyntheticFunctionCallId`: no `undefined_tool_name` in the id; use the
+  raw name when normalization fails.
+- `ToolNameValidator` (providers): invalid results keep `isValid: false` and
+  carry an empty `name`, never the literal.
+
+### AC2 — A fatal tool error that killed the run must not terminate GOAL
+
+When a run's tool dispatch hit a fatal tool error
+(`isFatalToolError`: `TOOL_DISABLED` or `TOOL_NOT_REGISTERED`) and no later
+tool execution succeeded, the run must terminate with
+`SubagentTerminateMode.ERROR` instead of `GOAL`, in both the interactive and
+non-interactive subagent paths.
+
+- Recovery is preserved: the fatal message is still fed back to the model. If
+  a subsequent tool call succeeds (or `self_emitvalue` emits), the fatal
+  condition is cleared and normal `GOAL` completion applies.
+- Precedence: if all declared `outputConfig` outputs were emitted, the run
+  still completes `GOAL` (the caller's output contract was satisfied); the
+  fatal condition is cleared at those sites.
+
+Implementation shape: an optional `OutputObject.unrecovered_fatal_tool_error?: string`
+field (packages/core `subagentTypes.ts`) recording the fatal message; shared
+set/clear helpers in `subagentToolProcessing.ts` used by both paths;
+`checkGoalCompletion` converts the flag to `ERROR` termination (final message
+already the fatal message) at the two `GOAL` branches and returns null (stop);
+`subagentNonInteractive.ts` completed-declared-outputs `GOAL` site clears the
+flag.
+
+### AC3 — The task result identifies the malformed call
+
+For the AC2 `ERROR` termination, `final_message` is the existing fatal
+tool-unavailable message (raw tool name + dispatcher detail with "Did you
+mean" suggestions), so `task`'s `terminateReason`/`finalMessage` fields give
+the caller an actionable failure.
+
+## Boundary cases
+
+- Name `undefined`, `''`, whitespace-only, or unnormalizable garbage → raw
+  passthrough (AC1); dispatch fails `TOOL_NOT_REGISTERED` as today.
+- Well-formed but unregistered name (e.g. model calls `grep`) → identical
+  semantics: fatal tracked, recovery possible, ERROR only if unrecovered.
+- First-and-only tool call fatal, model then stops → `ERROR` (the issue
+  reproduction).
+- Fatal, then a successful tool call / successful `self_emitvalue`, then stop →
+  `GOAL` (recovery preserved).
+- Repeated fatals with no success → `ERROR`.
+- Fatal plus all declared outputs emitted → `GOAL`.
+- Non-fatal errors (`EXECUTION_ERROR`, `INVALID_TOOL_PARAMS`, …) never set the
+  flag; existing behavior unchanged.
+- Todo-pause termination paths unchanged.
+- No `undefined_tool_name` may appear in any emitted event, synthetic id, or
+  final message.
+
+## Out of scope (explicitly)
+
+- No changes to `ToolDispatcher` messages ("could not be loaded", suggestion
+  logic) beyond what AC1–AC3 require (none expected).
+- No immediate-ERROR kill switch on fatal tool errors (would break recovery;
+  issue is labeled recoverability).
+- No retry orchestration, no provider-protocol rework, no cleanup of unrelated
+  `undefined_tool_name` test fixtures beyond updating stale assertions.
+- No new JS files; everything TypeScript + `bun:test`.
+
+## Test plan (behavioral, bun:test; extend existing files where they exist)
+
+New: `packages/agents/src/core/subagentNonInteractive.issue3535.test.ts`
+(harness copied from `subagentNonInteractive.issue3540.test.ts`
+`runDirectNonInteractive` — real `GemmaToolCallParser`, real scheduler via
+`createMockConfig`, real dispatch):
+
+1. Native tool_call with an empty name as the first and only call, then a
+   plain-text stop → `terminate_reason === 'ERROR'`, `final_message` contains
+   "is not available" and identifies the call; never `GOAL`.
+2. Unnormalizable garbage name (e.g. `"not a tool!!"`) → same ERROR outcome,
+   final message contains the raw name.
+3. Fatal empty-name call, then `self_emitvalue` successes that emit all
+   declared outputs → `GOAL` (recovery/precedence).
+4. No `undefined_tool_name` anywhere in the output.
+
+Extend:
+
+- `packages/agents/src/core/turn.test.ts` (undefined-name cases L302–347):
+  expect raw-name passthrough (`''`), not `undefined_tool_name`.
+- `packages/agents/src/core/turn.undefined_issue.test.ts`: replace literal
+  assertions with raw-passthrough assertions.
+- `packages/agents/src/core/subagentExecution.test.ts`
+  (`checkGoalCompletion`): flag set → `ERROR` + stop; flag cleared → `GOAL`;
+  flag set but all declared outputs emitted → `GOAL`.
+- `packages/agents/src/core/subagentToolProcessing.test.ts`: flag set on
+  fatal, cleared on success; `finalizeOutput` still preserves the fatal
+  message for `ERROR`.
+- `packages/providers/src/openai/__tests__/ToolNameValidator.test.ts`:
+  invalid cases expect `name === ''` and `isValid === false`.
+
+## Implementation phases
+
+### Phase 0.5 — Preflight
+
+Baseline: `npm run lint`, `npm run typecheck`, `npm run test` (targeted files
+first, then full), confirm no pre-existing failures to attribute.
+
+### Phase 1 — Stop fabricating the literal (AC1)
+
+- `turn.ts`: raw passthrough in `handlePendingFunctionCall`; drop both
+  `undefined_tool_name` assignments and the `name || 'undefined_tool_name'`
+  belt-and-suspenders; `createSyntheticFunctionCallId` uses raw name.
+- `ToolNameValidator.ts`: invalid results keep empty `name`.
+- Update the two test files above.
+
+### Phase 2 — Fatal-error termination semantics (AC2/AC3)
+
+- `packages/core/src/core/subagentTypes.ts`: add optional
+  `unrecovered_fatal_tool_error?: string` to `OutputObject` with a doc
+  comment referencing #3535.
+- `subagentToolProcessing.ts`: exported
+  `recordFatalToolError(output, message)` / `recordSuccessfulToolExecution(output)`
+  helpers; wire into `processFunctionCalls` (set on fatal branch, clear when a
+  call completes without error) and into the `self_emitvalue` success paths
+  (`handleEmitValueCall`, `executeNonInteractiveTool` emit branch).
+- `subagent.ts` `handleInteractiveToolCalls`: set flag at the existing
+  `fatalCall` branch; clear when any completed call (or manual emit) succeeded.
+- `subagentExecution.ts` `checkGoalCompletion`: both `GOAL` branches —
+  if flag set → `terminate_reason = ERROR`, log, return null; else `GOAL` as
+  today.
+- `subagentNonInteractive.ts` completed-declared-outputs `GOAL` site (L533):
+  clear flag when setting `GOAL` there.
+
+### Phase 3 — Tests (written with/against each phase; behavioral first)
+
+Files listed in the test plan. Harness: issue3540 pattern (mocked
+`sendMessageStream` async generator, `vi.mock` only for
+`LocalTodoStore` — no mock theater).
+
+### Phase 4 — Verification cycle (full)
+
+`npm run test`, `npm run lint`, `npm run typecheck`, `npm run format`,
+`npm run build`, then smoke:
+`bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`.
+
+## Review gates
+
+- deepthinker compliance review — completed, 2 rounds (cap reached).
+  - Round 1 (FAIL): 6 findings — (1) HIGH failed calls cleared the fatal flag;
+    (2) HIGH interactive stop text overwrote the fatal diagnostic;
+    (3) MEDIUM fatal dispatch dropped the structured tool_response;
+    (4) MEDIUM interactive mixed batches let a fatal override a later success;
+    (5) LOW flag survived declared-output GOAL completion and successful
+    todo-pause; (6) MEDIUM test-quality gaps. All remediated.
+  - Round 2 (follow-up, findings verification): 1/2/5 RESOLVED; 3/4/6 partial —
+    remediation had introduced a duplicate tool_response forward in the
+    interactive fatal branch, classifyToolCompletions still used request
+    order, and several test gaps remained. Final remediation round resolved
+    all three: duplicate forward removed (buildPartsFromCompletedCalls owns
+    forwarding), recovery made order-independent (availability fatals are
+    decided at dispatch validation before any sibling executes, so any
+    successful execution in a batch proves recovery), and all test gaps
+    closed (145 targeted tests).
+  - Known limitation (documented per the 2-round cap): the harness's
+    pairing-count assertions passed both before and after the duplicate-removal
+    fix — they verify the final request's response count but do not
+    independently detect the internal duplication; the mixed-batch
+    regression test is what fails on the pre-fix code.
+- open-code-review (ocr, `--provider zai-anthropic --model glm-5.3`, max 2
+  rounds), findings triaged Blocker-Fix / In-scope-Fix / Reject / Defer.
+  - Round 1 (12 findings, glm-5.3 verified in session manifest): fixed —
+    HIGH order-insensitive interactive recovery unsound (runtime TOOL_DISABLED
+    completes during execution, e.g. GenerateImageTool capability errors);
+    MEDIUM manual-emit phase split (emit clears during partition before the
+    scheduler fatal is recorded); MEDIUM todoReminder branch bypassed the
+    fatal→ERROR guard (nudged a tool-broken model to MAX_TURNS); MEDIUM
+    recovered runs kept the stale fatal `final_message` (parent-facing result
+    read as failure on a GOAL run); plus test/polish findings (restored
+    warnings assertions, stale titles, no-op assignment, shared raw-name
+    resolver, `completeWithGoal` helper, misplaced JSDoc, dead test generator).
+    Remediation: request-order classification over scheduler calls + manual
+    emits (markers), pre-batch flag snapshot/restore, equality-guarded
+    diagnostic clear, fail-fast on the todo nudge path. 151 targeted tests.
+  - Rejected (scope): delete-or-wire `ToolNameValidator` and the live
+    `toolNameUtils.processFinalToolName` fabrication path — provider-side and
+    out of #3535 scope; filed as #3639 instead.
+  - Round 2 (5 findings, glm-5.3 verified): fixed — HIGH positional marker
+    indexing in `classifyToolCompletions` broke when
+    `CoreToolScheduler.deduplicateRequests` dropped duplicate callIds
+    (undefined deref killing the run, or misattributed classification);
+    rekeyed markers by callId via a Map with unresolved-id skip. LOW bugs:
+    `resolveRawToolName` threw on truthy non-string names (typeof guard +
+    stringification at the external-input boundary); duplicate
+    ToolNameValidator tests merged into one honest test. LOW: redundant
+    `preBatchFatal` capture/restore removed (provably re-derived from
+    markers). Deferred: harness typing façade (`as unknown as` constructor/
+    config casts) — established harness pattern, out of scope.
+    154 targeted tests; both round-2 bugs reproduced test-first.
+  - Note: the round-2 ocr session itself failed to finalize ("no space left
+    on device") after emitting findings — transient disk pressure from the
+    concurrent build+test+ocr chain; findings were recovered from stdout.
+    The same pressure crashed three zed-acp test files in the concurrent
+    full-suite run; all 27 pass in isolation.
+- PR `Fixes #3535`; watch CI + CodeRabbit until green; no self-merge.
+
+## Session recovery notes (2026-09-11)
+
+The original session was interrupted mid-verification on 2026-09-09 (stale
+`packages/mcp/dist` from an interrupted build broke module resolution;
+regenerated with `npm run build`). Verification baseline:
+`packages/cli/src/utils/startup-fatal-log.test.ts` fails on macOS only
+(`/var` vs `/private/var` cwd resolution), pre-existing, unrelated to this
+change, filed as #3632; Linux CI is unaffected.


### PR DESCRIPTION
## TLDR

A subagent whose only tool call had an absent or unnormalizable name got the literal `undefined_tool_name` fabricated into the request, then terminated `GOAL` with a tool-unavailable final message — the parent could not distinguish the failed run from success. This PR stops fabricating the literal (raw names pass through so the doomed call still returns a proper `tool_response`) and converts stops with an unrecovered fatal tool error to `terminate_reason: ERROR` with an actionable diagnostic.

Fixes #3535

## Dive Deeper

Two defects compounded:

1. `Turn.handlePendingFunctionCall` fabricated the literal `undefined_tool_name` whenever a model-emitted tool call had an absent, empty, or unnormalizable name. The doomed call still dispatched, but the parent saw a fabricated name it could not attribute to anything the model actually requested.
2. Fatal tool handling set `final_message` but never changed `terminate_reason`. When the model then stopped calling tools, `checkGoalCompletion` ended the run with `GOAL`.

The fix:

- **Raw-name passthrough (`turn.ts`, `ToolNameValidator.ts`)**: absent/empty/whitespace/unnormalizable names are carried through raw (empty stays empty, truthy non-strings stringify at the external-input boundary). The doomed call still dispatches so exactly one `tool_response` returns per call id — no dangling `tool_use` breaking provider protocols.
- **Unrecovered-fatal-error flag (`subagentTypes.ts`, `subagentToolProcessing.ts`)**: new optional `OutputObject.unrecovered_fatal_tool_error` plus `recordFatalToolError`/`recordSuccessfulToolExecution` helpers, set by the fatal branches of both the interactive and non-interactive paths.
- **Recovery is proven by success only, in request order**: a genuinely successful tool execution (or successful `self_emitvalue` emit) clears the flag; failed non-fatal responses preserve it. The interactive classifier walks the batch in request order over callId-keyed markers covering scheduler calls and manual emits — semantically identical to the sequential non-interactive path, including runtime fatals (e.g. a `generate_image` capability `TOOL_DISABLED` raised during execution). Markers resolve by callId because `CoreToolScheduler.deduplicateRequests` can silently drop duplicate callIds, leaving the completed list shorter than the scheduled requests; unresolved ids are skipped.
- **GOAL→ERROR conversion (`subagentExecution.ts`)**: `checkGoalCompletion` converts a still-set flag to `ERROR` (warn log) on every stop path — no-output-config, missing-outputs nudge, and outstanding-todos nudge (fail fast instead of nudging a model that already lost its tool path; todo nudges would otherwise burn turns to MAX_TURNS and mask the diagnostic). The conversion restores `final_message` from the flag so a trailing "Done." cannot mask it, and recovery clears the stale diagnostic when it is still the unmodified fatal message.
- **GOAL precedence preserved**: a run that satisfies its declared output contract still ends `GOAL` — the declared-output completion sites and successful pause termination clear the flag explicitly.

Behavior after the fix:

- Unavailable tool, never recovered → `ERROR` with `final_message` naming the offending raw name plus the dispatcher's "Did you mean" suggestions.
- Unavailable tool, later real work / declared outputs emitted → `GOAL` (recovery preserved).
- No code path produces the literal `undefined_tool_name` anymore.

## Reviewer Test Plan

1. `bun test packages/agents/src/core/subagentNonInteractive.issue3535.test.ts packages/agents/src/core/turn.undefined_issue.test.ts packages/agents/src/core/subagentExecution.test.ts packages/agents/src/core/subagentToolProcessing.test.ts packages/agents/src/core/subagent.runNonInteractive-execution.test.ts packages/providers/src/openai/__tests__/ToolNameValidator.test.ts` — 154 pass / 0 fail.
2. `grep -rn "undefined_tool_name" packages/ --include='*.ts' | grep -v test` — no production hits expected.
3. Behavioral: launch a `task` subagent whose goal requires a tool omitted from its whitelist (e.g. demand `write_file` with a read-only whitelist). The task result should come back `terminate_reason: ERROR` with `finalMessage` naming the missing tool and suggestions — not `GOAL`. Then relaunch allowing the tool: `GOAL` with normal outputs.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅ (test/lint/typecheck/build + stepfun-37 smoke) | ❓ | ❓ (CI) |
| npx      | ✅ (eslint/prettier/tsc) | ❓ | ❓ |
| Docker   | ❓ | ❓ | ❓ |
| Podman   | ❓ | -   | -   |
| Seatbelt | ❓ | -   | -   |

Change is sandbox-agnostic (agents-core execution semantics only); Linux CI is the gating check for 🐧.

Full local results: targeted 154/154; `lint`, `typecheck`, `build`, smoke all green; full `npm run test` green except one pre-existing macOS-only failure in `packages/cli/src/utils/startup-fatal-log.test.ts` (`/var` vs `/private/var` tmpdir resolution) that fails identically on `main` and is tracked in #3632 — Linux CI is unaffected.

## Linked issues / bugs

Fixes #3535
Related: #3639 (out-of-scope provider-side fabrication in `toolNameUtils.processFinalToolName`, filed during review), #3632 (pre-existing macOS tmpdir test failure)

Review history: two deepthinker compliance rounds and two open-code-review rounds (glm-5.3 on zai-anthropic, model verified in the session manifests); every finding fixed or explicitly deferred with rationale in `project-plans/issue3535.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Runs now correctly end with an error when an unavailable tool causes an unrecovered fatal failure.
  * Successful tool executions can recover a run and allow normal goal completion.
  * Fatal tool diagnostics are preserved in final responses.
  * Undefined or invalid tool names no longer generate the misleading `undefined_tool_name` placeholder.
* **Tests**
  * Added coverage for fatal tool failures, recovery behavior, and tool-name handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->