### PR TITLE
fix(providers): refresh prompt-envelope projection per retry attempt (Fixes #3444)

### DIFF
--- a/packages/providers/src/RetryOrchestrator.ts
+++ b/packages/providers/src/RetryOrchestrator.ts
@@ -325,7 +325,7 @@ export class RetryOrchestrator implements IProvider {
     let lastError: unknown;
     const retryState = createInitialRetryState(initialDelayMs);
     const envelopeRefresh = new RetryPromptEnvelopeRefresh(budget.used);
-    while (envelopeRefresh.canRetry(budget, maxAttempts)) {
+    while (envelopeRefresh.canRetry(budget)) {
       if (isSignalAborted(signal)) throw createAbortError(signal?.reason);
       request.recordTarget(this.name);
       const usedBefore = budget.used;

--- a/packages/providers/src/RetryOrchestrator.ts
+++ b/packages/providers/src/RetryOrchestrator.ts
@@ -65,6 +65,7 @@ import {
   createInitialRetryState,
   providerOwnsTransportAttempts,
 } from './retryTransportOwnership.js';
+import { RetryPromptEnvelopeRefresh } from './retryPromptEnvelopeRefresh.js';
 import { safeGetDefaultModel } from './utils/safeDefaultModel.js';
 import {
   classifyRetryError,
@@ -315,7 +316,6 @@ export class RetryOrchestrator implements IProvider {
     const requestOptions = request.options;
     const bucketFailoverHandler =
       getBucketFailoverHandlerFromOptions(requestOptions);
-    const ownsAttempts = providerOwnsTransportAttempts(this.wrappedProvider);
     const lifecycleObserver = getAttemptLifecycleObserver(
       requestOptions.metadata,
     );
@@ -324,15 +324,12 @@ export class RetryOrchestrator implements IProvider {
       safeGetDefaultModel(this.wrappedProvider);
     let lastError: unknown;
     const retryState = createInitialRetryState(initialDelayMs);
-    while (budget.used < budget.limit) {
+    const envelopeRefresh = new RetryPromptEnvelopeRefresh();
+    while (envelopeRefresh.canRetry(budget, maxAttempts)) {
       if (isSignalAborted(signal)) throw createAbortError(signal?.reason);
       request.recordTarget(this.name);
       const usedBefore = budget.used;
       const linked = createLinkedAbortController(signal);
-      const attemptOptions = withRequestSignal(
-        requestOptions,
-        linked.controller.signal,
-      );
       const notification = this.createAttemptNotification(
         lifecycleObserver,
         budget.used,
@@ -343,24 +340,21 @@ export class RetryOrchestrator implements IProvider {
       let terminalStatus: AttemptStatus = 'aborted';
       try {
         yield* this.executeRawAttempt(
-          ownsAttempts,
           request,
-          attemptOptions,
+          envelopeRefresh,
           linked,
           retryState,
           bucketFailoverHandler,
-          budget,
         );
         terminalStatus = 'success';
         return;
       } catch (error) {
         attemptError = error;
-        lastError = error;
         terminalStatus = this.resolveTerminalStatus(error);
       } finally {
         this.finalizeAttempt(
           linked,
-          attemptOptions,
+          envelopeRefresh.options,
           budget,
           usedBefore,
           notification,
@@ -368,7 +362,13 @@ export class RetryOrchestrator implements IProvider {
           attemptError,
           request,
         );
+        await envelopeRefresh.settle(
+          budget.used - usedBefore,
+          terminalStatus === 'success',
+          attemptError,
+        );
       }
+      lastError = attemptError;
       if (attemptError === undefined) continue;
       const action = await this.handleRetryError(
         attemptError,
@@ -381,7 +381,7 @@ export class RetryOrchestrator implements IProvider {
         1,
         bucketFailoverHandler,
         authRetryTimeoutMs,
-        budget,
+        envelopeRefresh.recoveryConsumption,
       );
       if (action.type === 'throw') throw action.error;
     }
@@ -390,9 +390,8 @@ export class RetryOrchestrator implements IProvider {
   }
 
   private async *executeRawAttempt(
-    ownsAttempts: boolean,
     request: RetryRequestContext,
-    attemptOptions: GenerateChatOptions,
+    envelopeRefresh: RetryPromptEnvelopeRefresh,
     linked: { controller: AbortController },
     retryState: {
       attempt: number;
@@ -403,9 +402,20 @@ export class RetryOrchestrator implements IProvider {
       consecutiveServerErrors: number;
     },
     bucketFailoverHandler: BucketFailoverHandler | undefined,
-    budget: { used: number; limit: number },
   ): AsyncIterableIterator<IContent> {
-    beginProviderTransportAttempt(ownsAttempts, attemptOptions);
+    const { budget } = request;
+    const attemptOptions = await envelopeRefresh.prepare(
+      this,
+      request.options,
+      linked.controller.signal,
+    );
+    if (linked.controller.signal.aborted) {
+      throw createAbortError(linked.controller.signal.reason);
+    }
+    beginProviderTransportAttempt(
+      providerOwnsTransportAttempts(this.wrappedProvider),
+      attemptOptions,
+    );
     const stream = this.wrappedProvider.generateChatCompletion(attemptOptions);
     const producedContent =
       this.config.streamingTimeoutMs > 0
@@ -439,7 +449,7 @@ export class RetryOrchestrator implements IProvider {
 
   private finalizeAttempt(
     linked: { controller: AbortController; dispose(): void },
-    attemptOptions: GenerateChatOptions,
+    attemptOptions: GenerateChatOptions | undefined,
     budget: TransportAttemptBudget,
     usedBefore: number,
     notification: AttemptNotificationContext,
@@ -449,6 +459,16 @@ export class RetryOrchestrator implements IProvider {
   ): void {
     linked.controller.abort();
     linked.dispose();
+    // A failed prompt-envelope refresh (#3444) aborts the attempt before any
+    // options reach the provider, so there is no provider attempt to account.
+    if (attemptOptions === undefined) {
+      notification.notifyEnd(
+        terminalStatus,
+        resolveAttemptErrorMessage(terminalStatus, attemptError),
+        this.buildFailureReport(request, terminalStatus, attemptError),
+      );
+      return;
+    }
     accountProviderAttempt(
       this.wrappedProvider,
       attemptOptions,
@@ -598,9 +618,9 @@ export class RetryOrchestrator implements IProvider {
     failoverThreshold: number,
     bucketFailoverHandler: BucketFailoverHandler | undefined,
     authRetryTimeoutMs: number,
-    budget: { used: number; limit: number },
+    recoveryAttempt: number,
   ): Promise<{ type: 'throw'; error: unknown } | { type: 'continue' }> {
-    state.attempt = budget.used;
+    state.attempt = recoveryAttempt;
     const committedFailure = await this.resolveCommittedFailureAction(
       error,
       request,

--- a/packages/providers/src/RetryOrchestrator.ts
+++ b/packages/providers/src/RetryOrchestrator.ts
@@ -324,7 +324,7 @@ export class RetryOrchestrator implements IProvider {
       safeGetDefaultModel(this.wrappedProvider);
     let lastError: unknown;
     const retryState = createInitialRetryState(initialDelayMs);
-    const envelopeRefresh = new RetryPromptEnvelopeRefresh();
+    const envelopeRefresh = new RetryPromptEnvelopeRefresh(budget.used);
     while (envelopeRefresh.canRetry(budget, maxAttempts)) {
       if (isSignalAborted(signal)) throw createAbortError(signal?.reason);
       request.recordTarget(this.name);

--- a/packages/providers/src/__tests__/RetryOrchestrator.promptEnvelopeRetry.issue3444.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.promptEnvelopeRetry.issue3444.test.ts
@@ -21,10 +21,11 @@
 
 import { describe, it, expect } from 'bun:test';
 import { RetryOrchestrator } from '../RetryOrchestrator.js';
-import type {
-  IProvider,
-  GenerateChatOptions,
-} from '../IProvider.js';
+import {
+  tryConsumeTransportAttempt,
+  attachTransportAttemptBudget,
+} from '../transportAttemptBudget.js';
+import type { IProvider, GenerateChatOptions } from '../IProvider.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import type { IModel } from '../IModel.js';
 import type { PromptEnvelopeProjection } from '@vybestack/llxprt-code-core/runtime/contracts/PromptEstimation.js';
@@ -32,8 +33,8 @@ import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-util
 
 interface OneShotEnvelope {
   readonly token: object;
-  attemptReleases: number;
-  unsentReleases: number;
+  attemptDisposals: number;
+  unsentDisposals: number;
   released: boolean;
 }
 
@@ -53,15 +54,10 @@ function createRateLimitError(): Error {
 
 interface OneShotProviderConfig {
   readonly failFirstSend: boolean;
-  readonly refreshProjection:
-    | 'fresh'
-    | 'undefined'
-    | { readonly error: Error };
+  readonly refreshProjection: 'fresh' | 'undefined' | { readonly error: Error };
 }
 
-function createOneShotProjectedProvider(
-  config: OneShotProviderConfig,
-): {
+function createOneShotProjectedProvider(config: OneShotProviderConfig): {
   provider: IProvider;
   envelopes: OneShotEnvelope[];
   attempts: RecordedAttempt[];
@@ -76,21 +72,18 @@ function createOneShotProjectedProvider(
     name: 'one-shot-projected-provider',
     async projectPromptEnvelope(
       options: GenerateChatOptions,
-    ): Promise<PromptEnvelopeProjection> {
+    ): Promise<PromptEnvelopeProjection | undefined> {
       projectionCalls += 1;
-      if (
-        projectionCalls > 1 &&
-        config.refreshProjection !== 'fresh'
-      ) {
+      if (projectionCalls > 1 && config.refreshProjection !== 'fresh') {
         if (config.refreshProjection === 'undefined') {
-          return undefined as unknown as PromptEnvelopeProjection;
+          return undefined;
         }
         throw config.refreshProjection.error;
       }
       const envelope: OneShotEnvelope = {
         token: Object.freeze({ sequence: envelopes.length }),
-        attemptReleases: 0,
-        unsentReleases: 0,
+        attemptDisposals: 0,
+        unsentDisposals: 0,
         released: false,
       };
       envelopes.push(envelope);
@@ -107,30 +100,32 @@ function createOneShotProjectedProvider(
           sequence: envelopes.length,
         }),
         legacyEstimate: () => Promise.resolve(1),
-        releaseIfUnsent: () => {
-          envelope.unsentReleases += 1;
+        releaseIfUnsent: async () => {
+          if (envelope.released) return;
           envelope.released = true;
-          return Promise.resolve();
+          envelope.unsentDisposals += 1;
         },
       };
     },
     async *generateChatCompletion(
-      options: GenerateChatOptions,
+      optionsOrContents: GenerateChatOptions | IContent[],
     ): AsyncIterableIterator<IContent> {
+      const options: GenerateChatOptions = Array.isArray(optionsOrContents)
+        ? { contents: optionsOrContents }
+        : optionsOrContents;
       const token = options.promptEnvelopeTransportToken;
-      const envelope = token === undefined ? undefined : envelopeByToken.get(token);
+      const envelope =
+        token === undefined ? undefined : envelopeByToken.get(token);
       if (token !== undefined && envelope === undefined) {
         throw new Error('Unknown prompt-envelope transport token');
       }
       let error: unknown;
       let succeeded = false;
       try {
-        if (envelope !== undefined) {
-          if (envelope.released) {
-            throw new Error(
-              'Cannot consume media request contents after release',
-            );
-          }
+        if (envelope?.released === true) {
+          throw new Error(
+            'Cannot consume media request contents after release',
+          );
         }
         const sendIndex = attempts.length;
         if (config.failFirstSend && sendIndex === 0) {
@@ -143,9 +138,9 @@ function createOneShotProjectedProvider(
         throw error;
       } finally {
         attempts.push({ token, error, succeeded });
-        if (envelope !== undefined) {
-          envelope.attemptReleases += 1;
+        if (envelope !== undefined && !envelope.released) {
           envelope.released = true;
+          envelope.attemptDisposals += 1;
         }
       }
     },
@@ -163,6 +158,25 @@ function createOneShotProjectedProvider(
     attempts,
     projectionCalls: () => projectionCalls,
   };
+}
+
+/**
+ * Mint a projection through the fake provider with the optional-method
+ * narrowing the orchestrator performs at runtime.
+ */
+async function mintEnvelope(
+  provider: IProvider,
+  options: GenerateChatOptions,
+): Promise<PromptEnvelopeProjection> {
+  const project = provider.projectPromptEnvelope;
+  if (project === undefined) {
+    throw new Error('test provider cannot project prompt envelopes');
+  }
+  const projection = await project.call(provider, options);
+  if (projection === undefined) {
+    throw new Error('test provider declined to mint a prompt envelope');
+  }
+  return projection;
 }
 
 function buildOptions(token: object | undefined): GenerateChatOptions {
@@ -199,6 +213,254 @@ function errorMessage(error: unknown): string {
 }
 
 describe('RetryOrchestrator prompt-envelope retry contract (@issue:3444)', () => {
+  it.each([
+    'preflight rejection',
+    'returned before starting',
+    'cancel during preparation',
+  ])(
+    'disposes the fresh envelope once after %s without entering its body',
+    async (mode) => {
+      const { provider, envelopes, attempts } = createOneShotProjectedProvider({
+        failFirstSend: true,
+        refreshProjection: 'fresh',
+      });
+      const original = await mintEnvelope(provider, buildOptions(undefined));
+      const generate = provider.generateChatCompletion.bind(provider);
+      const controller = new AbortController();
+      const failure = new Error('adapter preparation failed');
+      let calls = 0;
+      let bodies = 0;
+      provider.generateChatCompletion = (options) => {
+        if (Array.isArray(options)) throw new Error('Expected request options');
+        calls += 1;
+        if (calls === 1) return generate(options);
+        const body = (async function* (): AsyncIterableIterator<IContent> {
+          bodies += 1;
+          yield* generate(options);
+        })();
+        const preparation = async (): Promise<void> => {
+          if (mode === 'preflight rejection') throw failure;
+          if (mode === 'returned before starting') {
+            await body.return?.();
+            throw failure;
+          }
+          await new Promise<void>((resolve) => {
+            controller.signal.addEventListener('abort', () => resolve(), {
+              once: true,
+            });
+            controller.abort(failure);
+          });
+          throw failure;
+        };
+        let pending: Promise<void> | undefined;
+        return {
+          [Symbol.asyncIterator]() {
+            return this;
+          },
+          async next() {
+            pending ??= preparation();
+            await pending;
+            return body.next();
+          },
+          async return() {
+            await body.return?.();
+            return { done: true, value: undefined };
+          },
+        };
+      };
+      const { error } = await drain(
+        new RetryOrchestrator(provider, {
+          maxAttempts: 2,
+          initialDelayMs: 0,
+        }).generateChatCompletion(
+          buildOptions(original.transportToken),
+          undefined,
+          controller.signal,
+        ),
+      );
+      const observedError =
+        mode === 'cancel during preparation' && error instanceof Error
+          ? error.name
+          : error;
+      expect(observedError).toBe(
+        mode === 'cancel during preparation' ? 'AbortError' : failure,
+      );
+      expect(calls).toBe(2);
+      expect(bodies).toBe(0);
+      expect(attempts).toHaveLength(1);
+      expect(envelopes).toHaveLength(2);
+      for (const envelope of envelopes) {
+        expect(envelope.attemptDisposals + envelope.unsentDisposals).toBe(1);
+        expect(envelope.released).toBe(true);
+      }
+    },
+  );
+
+  it('stops after two provider-owned sends and one failed refresh exhaust the combined cap', async () => {
+    const { provider } = createOneShotProjectedProvider({
+      failFirstSend: true,
+      refreshProjection: 'fresh',
+    });
+    const original = await mintEnvelope(provider, buildOptions(undefined));
+    const attached = attachTransportAttemptBudget(
+      buildOptions(original.transportToken),
+      3,
+    );
+    const refreshError = Object.assign(new Error('refresh quota exhausted'), {
+      status: 429,
+    });
+    let sends = 0;
+    let refreshes = 0;
+    provider.transportAttemptOwnership = 'provider';
+    provider.generateChatCompletion = async function* (options) {
+      if (Array.isArray(options)) throw new Error('Expected request options');
+      for (let index = 0; index < 2; index += 1) {
+        if (tryConsumeTransportAttempt(options)) sends += 1;
+      }
+      await original.releaseIfUnsent?.();
+      yield await Promise.reject<IContent>(createRateLimitError());
+    };
+    provider.projectPromptEnvelope = async () => {
+      refreshes += 1;
+      throw refreshError;
+    };
+    try {
+      const options = attached.options;
+      const { error } = await drain(
+        new RetryOrchestrator(provider, {
+          maxAttempts: 3,
+          initialDelayMs: 0,
+        }).generateChatCompletion({
+          ...options,
+          invocation:
+            options.invocation === undefined
+              ? undefined
+              : {
+                  ...options.invocation,
+                  ephemerals: { retries: 3, retrywait: 0 },
+                },
+        }),
+      );
+      expect(error instanceof Error ? error.cause : undefined).toBe(
+        refreshError,
+      );
+      expect(sends).toBe(2);
+      expect(refreshes).toBe(1);
+      expect(attached.budget.used).toBe(2);
+    } finally {
+      attached.release();
+    }
+  });
+  it.each([false, true])(
+    'releases a refresh resolved after cancellation without starting another provider body (release rejects: %s)',
+    async (releaseRejects) => {
+      const { provider, envelopes, attempts } = createOneShotProjectedProvider({
+        failFirstSend: true,
+        refreshProjection: 'fresh',
+      });
+      const options = buildOptions(undefined);
+      const original = await mintEnvelope(provider, options);
+      let resolveFresh: ((value: PromptEnvelopeProjection) => void) | undefined;
+      const pending = new Promise<PromptEnvelopeProjection>((resolve) => {
+        resolveFresh = resolve;
+      });
+      let notifyStarted: (() => void) | undefined;
+      const started = new Promise<void>((resolve) => {
+        notifyStarted = resolve;
+      });
+      const project = provider.projectPromptEnvelope;
+      if (project === undefined) throw new Error('Missing projection seam');
+      provider.projectPromptEnvelope = () => {
+        if (notifyStarted === undefined)
+          throw new Error('Missing start resolver');
+        notifyStarted();
+        return pending;
+      };
+      const controller = new AbortController();
+      const orchestrator = new RetryOrchestrator(provider, {
+        maxAttempts: 2,
+        initialDelayMs: 0,
+      });
+      const result = drain(
+        orchestrator.generateChatCompletion(
+          {
+            ...options,
+            promptEnvelopeTransportToken: original.transportToken,
+          },
+          undefined,
+          controller.signal,
+        ),
+      );
+      await started;
+      controller.abort();
+      const fresh = await project.call(provider, options);
+      if (fresh === undefined) throw new Error('Missing fresh projection');
+      if (resolveFresh === undefined)
+        throw new Error('Missing refresh resolver');
+      resolveFresh({
+        ...fresh,
+        releaseIfUnsent: async () => {
+          await fresh.releaseIfUnsent?.();
+          if (releaseRejects) throw new Error('unsent release failed');
+        },
+      });
+      const { error } = await result;
+      expect(error).toBeInstanceOf(Error);
+      expect(error instanceof Error && error.name).toBe('AbortError');
+      expect(attempts).toHaveLength(1);
+      expect(envelopes[1].unsentDisposals).toBe(1);
+      expect(envelopes[1].attemptDisposals).toBe(0);
+      expect(envelopes[1].released).toBe(true);
+    },
+  );
+
+  it.each([2, 3])(
+    'bounds retryable refresh failures at %s attempts and preserves the last projection error',
+    async (limit) => {
+      const { provider, attempts } = createOneShotProjectedProvider({
+        failFirstSend: true,
+        refreshProjection: 'fresh',
+      });
+      const options = buildOptions(undefined);
+      const original = await mintEnvelope(provider, options);
+      const failures: Error[] = [];
+      provider.projectPromptEnvelope = async () => {
+        const failure = Object.assign(
+          new Error(`refresh rate limit ${failures.length + 1}`),
+          { status: 429 },
+        );
+        failures.push(failure);
+        // Fail deterministically instead of leaving a broken retry loop running.
+        if (failures.length >= limit)
+          throw new Error('recovery limit exceeded');
+        throw failure;
+      };
+      const orchestrator = new RetryOrchestrator(provider, {
+        maxAttempts: limit,
+        initialDelayMs: 0,
+      });
+      const { error } = await drain(
+        orchestrator.generateChatCompletion({
+          ...options,
+          invocation:
+            options.invocation === undefined
+              ? undefined
+              : {
+                  ...options.invocation,
+                  ephemerals: { retries: limit, retrywait: 0 },
+                },
+          promptEnvelopeTransportToken: original.transportToken,
+        }),
+      );
+      expect(failures).toHaveLength(limit - 1);
+      expect(error instanceof Error ? error.cause : undefined).toBe(
+        failures[limit - 2],
+      );
+      expect(errorMessage(error)).toContain(failures[limit - 2].message);
+      expect(attempts).toHaveLength(1);
+    },
+  );
+
   it('retries with a freshly projected transport token instead of the spent one', async () => {
     const { provider, envelopes, attempts, projectionCalls } =
       createOneShotProjectedProvider({
@@ -212,7 +474,8 @@ describe('RetryOrchestrator prompt-envelope retry contract (@issue:3444)', () =>
 
     // The caller (agent seam) mints the original projection, exactly as the
     // production entry point does before handing options + token over.
-    const firstProjection = await provider.projectPromptEnvelope(
+    const firstProjection = await mintEnvelope(
+      provider,
       buildOptions(undefined),
     );
     const originalToken = firstProjection.transportToken;
@@ -235,9 +498,9 @@ describe('RetryOrchestrator prompt-envelope retry contract (@issue:3444)', () =>
     expect(projectionCalls()).toBe(2);
     // No attempt ever observed the release error.
     for (const attempt of attempts) {
-      expect(attempt.error).not.toMatchObject({
-        message: 'Cannot consume media request contents after release',
-      });
+      expect(errorMessage(attempt.error)).not.toContain(
+        'Cannot consume media request contents after release',
+      );
     }
   });
 
@@ -251,7 +514,8 @@ describe('RetryOrchestrator prompt-envelope retry contract (@issue:3444)', () =>
       initialDelayMs: 0,
     });
 
-    const firstProjection = await provider.projectPromptEnvelope(
+    const firstProjection = await mintEnvelope(
+      provider,
       buildOptions(undefined),
     );
     const { error } = await drain(
@@ -265,8 +529,8 @@ describe('RetryOrchestrator prompt-envelope retry contract (@issue:3444)', () =>
     // Both envelopes were consumed by a provider attempt, which is the sole
     // releaser on the success path (no unsent-release double fire).
     for (const envelope of envelopes) {
-      expect(envelope.attemptReleases).toBe(1);
-      expect(envelope.unsentReleases).toBe(0);
+      expect(envelope.attemptDisposals).toBe(1);
+      expect(envelope.unsentDisposals).toBe(0);
       expect(envelope.released).toBe(true);
     }
   });
@@ -281,7 +545,8 @@ describe('RetryOrchestrator prompt-envelope retry contract (@issue:3444)', () =>
       initialDelayMs: 0,
     });
 
-    const firstProjection = await provider.projectPromptEnvelope(
+    const firstProjection = await mintEnvelope(
+      provider,
       buildOptions(undefined),
     );
     const { chunks, error } = await drain(
@@ -309,7 +574,8 @@ describe('RetryOrchestrator prompt-envelope retry contract (@issue:3444)', () =>
       initialDelayMs: 0,
     });
 
-    const firstProjection = await provider.projectPromptEnvelope(
+    const firstProjection = await mintEnvelope(
+      provider,
       buildOptions(undefined),
     );
     const { error } = await drain(
@@ -318,7 +584,8 @@ describe('RetryOrchestrator prompt-envelope retry contract (@issue:3444)', () =>
       ),
     );
 
-    expect(error).toBeDefined();
+    expect(error).toBe(projectionFailure);
+    expect(errorMessage(error)).toBe(projectionFailure.message);
     // The refresh failure surfaces (or is classified terminally), never the
     // media release error.
     expect(errorMessage(error)).not.toContain(
@@ -348,9 +615,7 @@ describe('RetryOrchestrator prompt-envelope retry contract (@issue:3444)', () =>
     expect(error).toBeUndefined();
     expect(chunks).toHaveLength(1);
     expect(attempts).toHaveLength(2);
-    expect(attempts.every((attempt) => attempt.token === undefined)).toBe(
-      true,
-    );
+    expect(attempts.every((attempt) => attempt.token === undefined)).toBe(true);
     expect(projectionCalls()).toBe(0);
   });
 });

--- a/packages/providers/src/__tests__/RetryOrchestrator.promptEnvelopeRetry.issue3444.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.promptEnvelopeRetry.issue3444.test.ts
@@ -1,0 +1,356 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @plan PLAN-20260909-ISSUE3444
+ *
+ * Issue #3444 — RetryOrchestrator must never replay a spent
+ * promptEnvelopeTransportToken. Providers treat that token as a one-shot
+ * prepared envelope: the media request it carries is released when the
+ * attempt that consumed it finishes. A retry that replays the token hits
+ * `Cannot consume media request contents after release` and masks the real
+ * transport error.
+ *
+ * The fake provider below implements the same one-shot contract the real
+ * providers implement (attempt-scoped release of the prepared envelope), so
+ * these tests exercise the orchestrator contract without provider internals.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { RetryOrchestrator } from '../RetryOrchestrator.js';
+import type {
+  IProvider,
+  GenerateChatOptions,
+} from '../IProvider.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { IModel } from '../IModel.js';
+import type { PromptEnvelopeProjection } from '@vybestack/llxprt-code-core/runtime/contracts/PromptEstimation.js';
+import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
+
+interface OneShotEnvelope {
+  readonly token: object;
+  attemptReleases: number;
+  unsentReleases: number;
+  released: boolean;
+}
+
+interface RecordedAttempt {
+  readonly token: object | undefined;
+  readonly error: unknown | undefined;
+  readonly succeeded: boolean;
+}
+
+function createRateLimitError(): Error {
+  const error = new Error('Rate limit exceeded') as Error & {
+    status?: number;
+  };
+  error.status = 429;
+  return error;
+}
+
+interface OneShotProviderConfig {
+  readonly failFirstSend: boolean;
+  readonly refreshProjection:
+    | 'fresh'
+    | 'undefined'
+    | { readonly error: Error };
+}
+
+function createOneShotProjectedProvider(
+  config: OneShotProviderConfig,
+): {
+  provider: IProvider;
+  envelopes: OneShotEnvelope[];
+  attempts: RecordedAttempt[];
+  projectionCalls: () => number;
+} {
+  const envelopes: OneShotEnvelope[] = [];
+  const attempts: RecordedAttempt[] = [];
+  const envelopeByToken = new Map<object, OneShotEnvelope>();
+  let projectionCalls = 0;
+
+  const provider: IProvider = {
+    name: 'one-shot-projected-provider',
+    async projectPromptEnvelope(
+      options: GenerateChatOptions,
+    ): Promise<PromptEnvelopeProjection> {
+      projectionCalls += 1;
+      if (
+        projectionCalls > 1 &&
+        config.refreshProjection !== 'fresh'
+      ) {
+        if (config.refreshProjection === 'undefined') {
+          return undefined as unknown as PromptEnvelopeProjection;
+        }
+        throw config.refreshProjection.error;
+      }
+      const envelope: OneShotEnvelope = {
+        token: Object.freeze({ sequence: envelopes.length }),
+        attemptReleases: 0,
+        unsentReleases: 0,
+        released: false,
+      };
+      envelopes.push(envelope);
+      envelopeByToken.set(envelope.token, envelope);
+      return {
+        model: options.resolved?.model ?? 'test-model',
+        protocol: 'openai-responses',
+        method: 'responses/v1',
+        projectionRevision: 1,
+        unsupportedMedia: [],
+        transportToken: envelope.token,
+        finalizedProjection: Object.freeze({
+          kind: 'test-envelope',
+          sequence: envelopes.length,
+        }),
+        legacyEstimate: () => Promise.resolve(1),
+        releaseIfUnsent: () => {
+          envelope.unsentReleases += 1;
+          envelope.released = true;
+          return Promise.resolve();
+        },
+      };
+    },
+    async *generateChatCompletion(
+      options: GenerateChatOptions,
+    ): AsyncIterableIterator<IContent> {
+      const token = options.promptEnvelopeTransportToken;
+      const envelope = token === undefined ? undefined : envelopeByToken.get(token);
+      if (token !== undefined && envelope === undefined) {
+        throw new Error('Unknown prompt-envelope transport token');
+      }
+      let error: unknown;
+      let succeeded = false;
+      try {
+        if (envelope !== undefined) {
+          if (envelope.released) {
+            throw new Error(
+              'Cannot consume media request contents after release',
+            );
+          }
+        }
+        const sendIndex = attempts.length;
+        if (config.failFirstSend && sendIndex === 0) {
+          throw createRateLimitError();
+        }
+        succeeded = true;
+        yield { speaker: 'ai', blocks: [{ type: 'text', text: 'ok' }] };
+      } catch (caught) {
+        error = caught;
+        throw error;
+      } finally {
+        attempts.push({ token, error, succeeded });
+        if (envelope !== undefined) {
+          envelope.attemptReleases += 1;
+          envelope.released = true;
+        }
+      }
+    },
+    async getModels(): Promise<IModel[]> {
+      return [];
+    },
+    getDefaultModel(): string {
+      return 'test-model';
+    },
+  };
+
+  return {
+    provider,
+    envelopes,
+    attempts,
+    projectionCalls: () => projectionCalls,
+  };
+}
+
+function buildOptions(token: object | undefined): GenerateChatOptions {
+  const base = createProviderCallOptions({
+    providerName: 'one-shot-projected-provider',
+    contents: [
+      {
+        speaker: 'human',
+        blocks: [{ type: 'text', text: 'hello' }],
+      },
+    ],
+    ephemerals: { retries: 2, retrywait: 0 },
+  } as Parameters<typeof createProviderCallOptions>[0]);
+  return token === undefined
+    ? base
+    : { ...base, promptEnvelopeTransportToken: token };
+}
+
+async function drain(
+  iterator: AsyncIterableIterator<IContent>,
+): Promise<{ chunks: IContent[]; error: unknown | undefined }> {
+  const chunks: IContent[] = [];
+  let error: unknown | undefined;
+  try {
+    for await (const chunk of iterator) chunks.push(chunk);
+  } catch (caught) {
+    error = caught;
+  }
+  return { chunks, error };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+describe('RetryOrchestrator prompt-envelope retry contract (@issue:3444)', () => {
+  it('retries with a freshly projected transport token instead of the spent one', async () => {
+    const { provider, envelopes, attempts, projectionCalls } =
+      createOneShotProjectedProvider({
+        failFirstSend: true,
+        refreshProjection: 'fresh',
+      });
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 2,
+      initialDelayMs: 0,
+    });
+
+    // The caller (agent seam) mints the original projection, exactly as the
+    // production entry point does before handing options + token over.
+    const firstProjection = await provider.projectPromptEnvelope(
+      buildOptions(undefined),
+    );
+    const originalToken = firstProjection.transportToken;
+    expect(originalToken).toBe(envelopes[0].token);
+
+    const { chunks, error } = await drain(
+      orchestrator.generateChatCompletion(buildOptions(originalToken)),
+    );
+
+    expect(error).toBeUndefined();
+    expect(chunks).toHaveLength(1);
+    // First attempt keeps the caller's original token; the retry must carry
+    // a different token minted by a second projection call.
+    expect(attempts).toHaveLength(2);
+    expect(attempts[0].token).toBe(originalToken);
+    expect(attempts[1].token).toBeDefined();
+    expect(attempts[1].token).not.toBe(originalToken);
+    expect(attempts[1].succeeded).toBe(true);
+    // Caller projection + orchestrator refresh projection.
+    expect(projectionCalls()).toBe(2);
+    // No attempt ever observed the release error.
+    for (const attempt of attempts) {
+      expect(attempt.error).not.toMatchObject({
+        message: 'Cannot consume media request contents after release',
+      });
+    }
+  });
+
+  it('releases every minted envelope exactly once across the retry cycle', async () => {
+    const { provider, envelopes } = createOneShotProjectedProvider({
+      failFirstSend: true,
+      refreshProjection: 'fresh',
+    });
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 2,
+      initialDelayMs: 0,
+    });
+
+    const firstProjection = await provider.projectPromptEnvelope(
+      buildOptions(undefined),
+    );
+    const { error } = await drain(
+      orchestrator.generateChatCompletion(
+        buildOptions(firstProjection.transportToken),
+      ),
+    );
+
+    expect(error).toBeUndefined();
+    expect(envelopes).toHaveLength(2);
+    // Both envelopes were consumed by a provider attempt, which is the sole
+    // releaser on the success path (no unsent-release double fire).
+    for (const envelope of envelopes) {
+      expect(envelope.attemptReleases).toBe(1);
+      expect(envelope.unsentReleases).toBe(0);
+      expect(envelope.released).toBe(true);
+    }
+  });
+
+  it('falls back to unprojected attempts when the provider cannot re-project on refresh', async () => {
+    const { provider, envelopes, attempts } = createOneShotProjectedProvider({
+      failFirstSend: true,
+      refreshProjection: 'undefined',
+    });
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 2,
+      initialDelayMs: 0,
+    });
+
+    const firstProjection = await provider.projectPromptEnvelope(
+      buildOptions(undefined),
+    );
+    const { chunks, error } = await drain(
+      orchestrator.generateChatCompletion(
+        buildOptions(firstProjection.transportToken),
+      ),
+    );
+
+    expect(error).toBeUndefined();
+    expect(chunks).toHaveLength(1);
+    expect(attempts).toHaveLength(2);
+    // The retry must NOT carry the spent token: it either carries a fresh
+    // one or none at all (degraded to unprojected re-resolution).
+    expect(attempts[1].token).not.toBe(envelopes[0].token);
+  });
+
+  it('surfaces a failed refresh as the attempt error instead of a release error', async () => {
+    const projectionFailure = new Error('projection backend unavailable');
+    const { provider, envelopes, attempts } = createOneShotProjectedProvider({
+      failFirstSend: true,
+      refreshProjection: { error: projectionFailure },
+    });
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 2,
+      initialDelayMs: 0,
+    });
+
+    const firstProjection = await provider.projectPromptEnvelope(
+      buildOptions(undefined),
+    );
+    const { error } = await drain(
+      orchestrator.generateChatCompletion(
+        buildOptions(firstProjection.transportToken),
+      ),
+    );
+
+    expect(error).toBeDefined();
+    // The refresh failure surfaces (or is classified terminally), never the
+    // media release error.
+    expect(errorMessage(error)).not.toContain(
+      'Cannot consume media request contents after release',
+    );
+    // Only the first physical send happened; the retry died in refresh.
+    expect(attempts).toHaveLength(1);
+    // Only the caller's projection was ever minted.
+    expect(envelopes).toHaveLength(1);
+  });
+
+  it('does not invoke projectPromptEnvelope when no token was supplied', async () => {
+    const { provider, attempts, projectionCalls } =
+      createOneShotProjectedProvider({
+        failFirstSend: true,
+        refreshProjection: 'fresh',
+      });
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 2,
+      initialDelayMs: 0,
+    });
+
+    const { chunks, error } = await drain(
+      orchestrator.generateChatCompletion(buildOptions(undefined)),
+    );
+
+    expect(error).toBeUndefined();
+    expect(chunks).toHaveLength(1);
+    expect(attempts).toHaveLength(2);
+    expect(attempts.every((attempt) => attempt.token === undefined)).toBe(
+      true,
+    );
+    expect(projectionCalls()).toBe(0);
+  });
+});

--- a/packages/providers/src/__tests__/RetryOrchestrator.promptEnvelopeRetry.issue3444.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.promptEnvelopeRetry.issue3444.test.ts
@@ -213,6 +213,52 @@ function errorMessage(error: unknown): string {
 }
 
 describe('RetryOrchestrator prompt-envelope retry contract (@issue:3444)', () => {
+  it('aborts while a refresh remains pending without waiting for its projection', async () => {
+    const { provider, attempts } = createOneShotProjectedProvider({
+      failFirstSend: true,
+      refreshProjection: 'fresh',
+    });
+    const options = buildOptions(undefined);
+    const original = await mintEnvelope(provider, options);
+    let notifyStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      notifyStarted = resolve;
+    });
+    let rejectRefresh: ((error: Error) => void) | undefined;
+    const pending = new Promise<PromptEnvelopeProjection>(
+      (_resolve, reject) => {
+        rejectRefresh = reject;
+      },
+    );
+    provider.projectPromptEnvelope = () => {
+      if (notifyStarted === undefined)
+        throw new Error('Missing start resolver');
+      notifyStarted();
+      return pending;
+    };
+    const controller = new AbortController();
+    const result = drain(
+      new RetryOrchestrator(provider, {
+        maxAttempts: 2,
+        initialDelayMs: 0,
+      }).generateChatCompletion(
+        { ...options, promptEnvelopeTransportToken: original.transportToken },
+        undefined,
+        controller.signal,
+      ),
+    );
+    await started;
+    controller.abort();
+
+    const { error, chunks } = await result;
+    expect(error instanceof Error && error.name).toBe('AbortError');
+    expect(chunks).toHaveLength(0);
+    expect(attempts).toHaveLength(1);
+    if (rejectRefresh === undefined)
+      throw new Error('Missing refresh rejecter');
+    rejectRefresh(new Error('projection failed after cancellation'));
+  });
+
   it('sends once on entry with pre-consumed shared budget when retries remain only for numbering', async () => {
     const { provider, attempts } = createOneShotProjectedProvider({
       failFirstSend: false,

--- a/packages/providers/src/__tests__/RetryOrchestrator.promptEnvelopeRetry.issue3444.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.promptEnvelopeRetry.issue3444.test.ts
@@ -213,6 +213,89 @@ function errorMessage(error: unknown): string {
 }
 
 describe('RetryOrchestrator prompt-envelope retry contract (@issue:3444)', () => {
+  it('exhausts token-less retries using pre-consumed shared budget attempts', async () => {
+    const { provider, attempts, projectionCalls } =
+      createOneShotProjectedProvider({
+        failFirstSend: true,
+        refreshProjection: 'fresh',
+      });
+    const attached = attachTransportAttemptBudget(buildOptions(undefined), 4);
+    try {
+      expect(tryConsumeTransportAttempt(attached.options)).toBe(true);
+      const { chunks, error } = await drain(
+        new RetryOrchestrator(provider, {
+          maxAttempts: 2,
+          initialDelayMs: 0,
+        }).generateChatCompletion(attached.options),
+      );
+
+      expect({
+        sends: attempts.length,
+        budgetUsed: attached.budget.used,
+        outcome: errorMessage(error),
+        chunks: chunks.length,
+      }).toStrictEqual({
+        sends: 1,
+        budgetUsed: 2,
+        outcome: expect.stringContaining(
+          'retries exhausted after 2 transport attempts',
+        ),
+        chunks: 0,
+      });
+      expect(projectionCalls()).toBe(0);
+    } finally {
+      attached.release();
+    }
+  });
+
+  it('refreshes a spent token with pre-consumed shared budget when a retry remains', async () => {
+    const { provider, attempts, envelopes } = createOneShotProjectedProvider({
+      failFirstSend: true,
+      refreshProjection: 'fresh',
+    });
+    const base = buildOptions(undefined);
+    const original = await mintEnvelope(provider, base);
+    const attached = attachTransportAttemptBudget(
+      {
+        ...base,
+        invocation:
+          base.invocation === undefined
+            ? undefined
+            : {
+                ...base.invocation,
+                ephemerals: { retries: 3, retrywait: 0 },
+              },
+        promptEnvelopeTransportToken: original.transportToken,
+      },
+      4,
+    );
+    try {
+      expect(tryConsumeTransportAttempt(attached.options)).toBe(true);
+      const { chunks, error } = await drain(
+        new RetryOrchestrator(provider, {
+          maxAttempts: 3,
+          initialDelayMs: 0,
+        }).generateChatCompletion(attached.options),
+      );
+
+      expect(error).toBeUndefined();
+      expect(chunks).toHaveLength(1);
+      expect(attempts).toHaveLength(2);
+      expect(attached.budget.used).toBe(3);
+      expect(attempts[0].token).toBe(original.transportToken);
+      expect(attempts[1].token).toBeDefined();
+      expect(attempts[1].token).not.toBe(original.transportToken);
+      expect(attempts[1].succeeded).toBe(true);
+      expect(envelopes).toHaveLength(2);
+      for (const envelope of envelopes) {
+        expect(envelope.attemptDisposals).toBe(1);
+        expect(envelope.unsentDisposals).toBe(0);
+      }
+    } finally {
+      attached.release();
+    }
+  });
+
   it.each([
     'preflight rejection',
     'returned before starting',

--- a/packages/providers/src/__tests__/RetryOrchestrator.promptEnvelopeRetry.issue3444.test.ts
+++ b/packages/providers/src/__tests__/RetryOrchestrator.promptEnvelopeRetry.issue3444.test.ts
@@ -213,6 +213,38 @@ function errorMessage(error: unknown): string {
 }
 
 describe('RetryOrchestrator prompt-envelope retry contract (@issue:3444)', () => {
+  it('sends once on entry with pre-consumed shared budget when retries remain only for numbering', async () => {
+    const { provider, attempts } = createOneShotProjectedProvider({
+      failFirstSend: false,
+      refreshProjection: 'fresh',
+    });
+    const attached = attachTransportAttemptBudget(buildOptions(undefined), 4);
+    try {
+      expect(tryConsumeTransportAttempt(attached.options)).toBe(true);
+      expect(tryConsumeTransportAttempt(attached.options)).toBe(true);
+      const { chunks, error } = await drain(
+        new RetryOrchestrator(provider, {
+          maxAttempts: 2,
+          initialDelayMs: 0,
+        }).generateChatCompletion(attached.options),
+      );
+
+      expect({
+        sends: attempts.length,
+        chunks,
+        error,
+        used: attached.budget.used,
+      }).toStrictEqual({
+        sends: 1,
+        chunks: [{ speaker: 'ai', blocks: [{ type: 'text', text: 'ok' }] }],
+        error: undefined,
+        used: 3,
+      });
+    } finally {
+      attached.release();
+    }
+  });
+
   it('exhausts token-less retries using pre-consumed shared budget attempts', async () => {
     const { provider, attempts, projectionCalls } =
       createOneShotProjectedProvider({

--- a/packages/providers/src/anthropic/AnthropicProvider.promptEnvelopeRetry.issue3444.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.promptEnvelopeRetry.issue3444.test.ts
@@ -93,14 +93,6 @@ void vi.mock(
   }),
 );
 
-// Proven imageRecovery harness piece: keep the provider's INTERNAL retry
-// loop out of the picture so both 429s propagate to the RetryOrchestrator,
-// which is the layer under test.
-void vi.mock('@vybestack/llxprt-code-core/utils/retry.js', () => ({
-  getErrorStatus: vi.fn(() => undefined),
-  isNetworkTransientError: vi.fn(() => false),
-}));
-
 const createMockStream = (text: string) => ({
   async *[Symbol.asyncIterator]() {
     yield {
@@ -112,14 +104,14 @@ const createMockStream = (text: string) => ({
   },
 });
 
-function make429RateLimitError(): Error {
+function make429RateLimitError(message = 'Rate limit exceeded'): Error {
   return APIError.generate(
     429,
     {
       type: 'error',
       error: {
         type: 'rate_limit_error',
-        message: 'Rate limit exceeded',
+        message,
       },
     },
     undefined,
@@ -225,7 +217,6 @@ describe('AnthropicProvider prompt-envelope retry (@issue:3444)', () => {
     });
 
     const chunks: string[] = [];
-    let threw = false;
     let error: unknown;
     try {
       const gen = orchestrator.generateChatCompletion({
@@ -237,11 +228,10 @@ describe('AnthropicProvider prompt-envelope retry (@issue:3444)', () => {
         if (text !== undefined) chunks.push(text.text);
       }
     } catch (e) {
-      threw = true;
       error = e;
     }
 
-    expect(threw).toBe(false);
+    expect(error).toBeUndefined();
     expect(chunks.join('')).toContain('recovered');
     // Attempt 1 (429) + attempt 2 (recovered): both reached the transport.
     expect(mockMessagesCreate).toHaveBeenCalledTimes(2);
@@ -250,9 +240,7 @@ describe('AnthropicProvider prompt-envelope retry (@issue:3444)', () => {
     for (const call of mockMessagesCreate.mock.calls) {
       expect(JSON.stringify(call[0].messages)).toContain('base64');
     }
-    if (error !== undefined) {
-      expect(errorMessage(error)).not.toContain(RELEASE_ERROR);
-    }
+    expect(errorMessage(error)).not.toContain(RELEASE_ERROR);
   });
 
   it('surfaces the terminal transport error, never the media-release error, when retries exhaust', async () => {
@@ -262,9 +250,11 @@ describe('AnthropicProvider prompt-envelope retry (@issue:3444)', () => {
     mockMessagesCreate.mockReset();
     const png = await pngBase64(64, 64);
     const { provider, runtimeContext, settingsService } = setupProvider();
+    const firstError = make429RateLimitError('first SDK rate limit');
+    const finalError = make429RateLimitError('final SDK rate limit');
     mockMessagesCreate
-      .mockRejectedValueOnce(make429RateLimitError())
-      .mockRejectedValueOnce(make429RateLimitError());
+      .mockRejectedValueOnce(firstError)
+      .mockRejectedValueOnce(finalError);
 
     const callOptions = createProviderCallOptions({
       providerName: provider.name,
@@ -297,7 +287,8 @@ describe('AnthropicProvider prompt-envelope retry (@issue:3444)', () => {
 
     expect(caught).toBeDefined();
     // The real transport failure (rate limit) is what the consumer sees.
-    expect(errorMessage(caught)).toContain('Rate limit');
+    expect(errorMessage(caught)).toContain('final SDK rate limit');
+    expect(errorMessage(caught)).not.toContain('first SDK rate limit');
     expect(errorMessage(caught)).not.toContain(RELEASE_ERROR);
     // Both physical attempts reached the SDK; neither died in preparation.
     expect(mockMessagesCreate).toHaveBeenCalledTimes(2);

--- a/packages/providers/src/anthropic/AnthropicProvider.promptEnvelopeRetry.issue3444.test.ts
+++ b/packages/providers/src/anthropic/AnthropicProvider.promptEnvelopeRetry.issue3444.test.ts
@@ -1,0 +1,305 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @plan PLAN-20260909-ISSUE3444
+ *
+ * Issue #3444 — a RetryOrchestrator retry must not replay a spent
+ * promptEnvelopeTransportToken through AnthropicProvider. The token maps to a
+ * prepared media request that the attempt which consumed it releases in its
+ * finally; a retry that replays the token fails at media consumption
+ * (`Cannot consume media request contents after release`) and masks the real
+ * transport error. Only the SDK transport is mocked; the provider, projection,
+ * and RetryOrchestrator under test are real.
+ */
+
+import { vi, describe, it, expect, afterEach } from 'bun:test';
+import { APIError } from '@anthropic-ai/sdk';
+import { AnthropicProvider } from './AnthropicProvider.js';
+import { RetryOrchestrator } from '../RetryOrchestrator.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { TEST_PROVIDER_CONFIG } from '../test-utils/providerTestConfig.js';
+import {
+  createProviderWithRuntime,
+  createRuntimeConfigStub,
+} from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
+import type { ProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import type { SettingsService } from '@vybestack/llxprt-code-settings';
+import {
+  clearActiveProviderRuntimeContext,
+  setActiveProviderRuntimeContext,
+} from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import sharp from 'sharp';
+import { createAnthropicRawPostTestAdapter } from '../test-utils/rawPostTestAdapters.js';
+
+const RELEASE_ERROR = 'Cannot consume media request contents after release';
+
+async function pngBase64(width: number, height: number): Promise<string> {
+  const buffer = await sharp({
+    create: {
+      width,
+      height,
+      channels: 4,
+      background: { r: 12, g: 34, b: 56, alpha: 1 },
+    },
+  })
+    .png()
+    .toBuffer();
+  return buffer.toString('base64');
+}
+
+const mockMessagesCreate = vi.fn();
+
+void vi.mock('@anthropic-ai/sdk', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    ...createAnthropicRawPostTestAdapter(mockMessagesCreate),
+    messages: {
+      create: mockMessagesCreate,
+    },
+    beta: {
+      models: {
+        list: vi.fn().mockReturnValue({
+          async *[Symbol.asyncIterator]() {
+            yield {
+              id: 'claude-opus-5',
+              display_name: 'Claude Opus 5',
+            };
+          },
+        }),
+      },
+    },
+  })),
+}));
+
+void vi.mock('@vybestack/llxprt-code-tools/ToolFormatter.js', () => ({
+  ToolFormatter: vi.fn().mockImplementation(() => ({
+    toProviderFormat: vi.fn(() => []),
+    fromProviderFormat: vi.fn(() => []),
+  })),
+}));
+
+void vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
+  getCoreSystemPromptAsync: vi.fn().mockResolvedValue('System prompt'),
+}));
+
+void vi.mock(
+  '@vybestack/llxprt-code-core/prompt-config/subagent-delegation.js',
+  () => ({
+    shouldIncludeSubagentDelegation: vi.fn().mockReturnValue(false),
+  }),
+);
+
+// Proven imageRecovery harness piece: keep the provider's INTERNAL retry
+// loop out of the picture so both 429s propagate to the RetryOrchestrator,
+// which is the layer under test.
+void vi.mock('@vybestack/llxprt-code-core/utils/retry.js', () => ({
+  getErrorStatus: vi.fn(() => undefined),
+  isNetworkTransientError: vi.fn(() => false),
+}));
+
+const createMockStream = (text: string) => ({
+  async *[Symbol.asyncIterator]() {
+    yield {
+      type: 'content_block_delta',
+      delta: { type: 'text_delta', text },
+    };
+
+    yield { type: 'message_stop' };
+  },
+});
+
+function make429RateLimitError(): Error {
+  return APIError.generate(
+    429,
+    {
+      type: 'error',
+      error: {
+        type: 'rate_limit_error',
+        message: 'Rate limit exceeded',
+      },
+    },
+    undefined,
+    new Headers({ 'request-id': 'req_429', 'retry-after': '0' }),
+  );
+}
+
+function setupProvider(): {
+  provider: AnthropicProvider;
+  runtimeContext: ProviderRuntimeContext;
+  settingsService: SettingsService;
+} {
+  const result = createProviderWithRuntime<AnthropicProvider>(
+    ({ settingsService: svc }) => {
+      svc.set('auth-key', 'test-api-key');
+      svc.set('activeProvider', 'anthropic');
+      svc.setProviderSetting('anthropic', 'streaming', 'disabled');
+      svc.setProviderSetting('anthropic', 'prompt-caching', 'off');
+      return new AnthropicProvider(
+        'test-api-key',
+        undefined,
+        TEST_PROVIDER_CONFIG,
+      );
+    },
+    {
+      runtimeId: 'anthropic.promptEnvelopeRetry.test',
+      metadata: {
+        source: 'AnthropicProvider.promptEnvelopeRetry.issue3444.test.ts',
+      },
+    },
+  );
+  const { provider, runtime, settingsService: svc } = result;
+  runtime.config ??= createRuntimeConfigStub(svc);
+  const ephemeralSettings: Record<string, unknown> = {
+    ...svc.getAllGlobalSettings(),
+    ...svc.getProviderSettings(provider.name),
+  };
+  runtime.config.getEphemeralSettings = () => ({ ...ephemeralSettings });
+  runtime.config.getEphemeralSetting = (key: string) => {
+    const providerValue = svc.getProviderSettings(provider.name)[key];
+    if (providerValue !== undefined) return providerValue;
+    return svc.get(key);
+  };
+
+  setActiveProviderRuntimeContext(runtime);
+  return { provider, runtimeContext: runtime, settingsService: svc };
+}
+
+function mediaMessages(png: string): IContent[] {
+  return [
+    {
+      speaker: 'human',
+      blocks: [
+        {
+          type: 'media',
+          mimeType: 'image/png',
+          data: png,
+          encoding: 'base64' as const,
+        },
+        { type: 'text', text: 'describe this image' },
+      ],
+    },
+  ];
+}
+
+function errorMessage(error: unknown): string {
+  return String(error instanceof Error ? error.message : error);
+}
+
+describe('AnthropicProvider prompt-envelope retry (@issue:3444)', () => {
+  afterEach(() => {
+    clearActiveProviderRuntimeContext();
+  });
+
+  it('retries a projected media turn with a fresh envelope instead of the spent token', async () => {
+    vi.clearAllMocks();
+    // Leftover mock*Once queue entries leak across tests (a failed prep
+    // never consumes its queued response); flush them explicitly.
+    mockMessagesCreate.mockReset();
+    const png = await pngBase64(64, 64);
+    const { provider, runtimeContext, settingsService } = setupProvider();
+    mockMessagesCreate
+      .mockRejectedValueOnce(make429RateLimitError())
+      .mockResolvedValueOnce(createMockStream('recovered'));
+
+    const callOptions = createProviderCallOptions({
+      providerName: provider.name,
+      contents: mediaMessages(png),
+      settings: settingsService,
+      runtime: runtimeContext,
+      config: runtimeContext.config,
+      ephemerals: { retries: 2, retrywait: 0 },
+    } as Parameters<typeof createProviderCallOptions>[0]);
+
+    // The agent seam mints the projection and hands the token to the
+    // orchestrator-wrapped provider, exactly as the production entry does.
+    const projection = await provider.projectPromptEnvelope(callOptions);
+    expect(projection.transportToken).toBeDefined();
+
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 2,
+      initialDelayMs: 0,
+    });
+
+    const chunks: string[] = [];
+    let threw = false;
+    let error: unknown;
+    try {
+      const gen = orchestrator.generateChatCompletion({
+        ...callOptions,
+        promptEnvelopeTransportToken: projection.transportToken,
+      });
+      for await (const chunk of gen) {
+        const text = chunk.blocks.find((b) => b.type === 'text');
+        if (text !== undefined) chunks.push(text.text);
+      }
+    } catch (e) {
+      threw = true;
+      error = e;
+    }
+
+    expect(threw).toBe(false);
+    expect(chunks.join('')).toContain('recovered');
+    // Attempt 1 (429) + attempt 2 (recovered): both reached the transport.
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(2);
+    // Both attempts carried the full media payload — the image survives the
+    // retry instead of being silently dropped with it.
+    for (const call of mockMessagesCreate.mock.calls) {
+      expect(JSON.stringify(call[0].messages)).toContain('base64');
+    }
+    if (error !== undefined) {
+      expect(errorMessage(error)).not.toContain(RELEASE_ERROR);
+    }
+  });
+
+  it('surfaces the terminal transport error, never the media-release error, when retries exhaust', async () => {
+    vi.clearAllMocks();
+    // Leftover mock*Once queue entries leak across tests (a failed prep
+    // never consumes its queued response); flush them explicitly.
+    mockMessagesCreate.mockReset();
+    const png = await pngBase64(64, 64);
+    const { provider, runtimeContext, settingsService } = setupProvider();
+    mockMessagesCreate
+      .mockRejectedValueOnce(make429RateLimitError())
+      .mockRejectedValueOnce(make429RateLimitError());
+
+    const callOptions = createProviderCallOptions({
+      providerName: provider.name,
+      contents: mediaMessages(png),
+      settings: settingsService,
+      runtime: runtimeContext,
+      config: runtimeContext.config,
+      ephemerals: { retries: 2, retrywait: 0 },
+    } as Parameters<typeof createProviderCallOptions>[0]);
+
+    const projection = await provider.projectPromptEnvelope(callOptions);
+
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 2,
+      initialDelayMs: 0,
+    });
+
+    let caught: unknown;
+    try {
+      const gen = orchestrator.generateChatCompletion({
+        ...callOptions,
+        promptEnvelopeTransportToken: projection.transportToken,
+      });
+      for await (const _chunk of gen) {
+        // The exhaust case yields nothing on the final failed attempt.
+      }
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeDefined();
+    // The real transport failure (rate limit) is what the consumer sees.
+    expect(errorMessage(caught)).toContain('Rate limit');
+    expect(errorMessage(caught)).not.toContain(RELEASE_ERROR);
+    // Both physical attempts reached the SDK; neither died in preparation.
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.promptEnvelopeRetry.issue3444.test.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.promptEnvelopeRetry.issue3444.test.ts
@@ -1,0 +1,179 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @plan PLAN-20260909-ISSUE3444
+ *
+ * Issue #3444 — a RetryOrchestrator retry must not replay a spent
+ * promptEnvelopeTransportToken through the OpenAI Responses path. Releasing
+ * the prepared envelope's media request clears `request.input` (the splice
+ * cleanup registered at prepare time), so a retry that replays the token
+ * silently sends an EMPTY input payload and corrupts the turn. The provider,
+ * projection, executor, and RetryOrchestrator under test are real; only the
+ * transport fetch and the SSE body parser are mocked.
+ *
+ * Scenario wiring: the invocation omits the `retries` ephemeral, so the
+ * executor's internal streaming-retry cap falls back to its default (6)
+ * while the orchestrator cap comes from its config (7). Six 429 responses
+ * exhaust the executor's internal loop with one budget slot left; the
+ * orchestrator then drives an OUTER retry, which must carry a freshly
+ * projected envelope. This mirrors the production path where a failover
+ * stack grants more physical attempts than one backend's internal loop.
+ */
+
+import { restoreGlobals, setGlobal } from '@vybestack/llxprt-code-test-utils';
+import { describe, it, beforeEach, afterEach, expect, vi } from 'bun:test';
+import { OpenAIResponsesProvider } from './OpenAIResponsesProvider.js';
+import { RetryOrchestrator } from '../RetryOrchestrator.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
+
+const realLlxprtCodeSettingsModule = {
+  ...(await import('@vybestack/llxprt-code-settings')),
+};
+
+const mockSettingsService = {
+  set: vi.fn(),
+  get: vi.fn(),
+  setProviderSetting: vi.fn(),
+  getProviderSettings: vi.fn().mockReturnValue({}),
+  getSettings: vi.fn(),
+  updateSettings: vi.fn(),
+  getAllGlobalSettings: vi.fn().mockReturnValue({}),
+};
+
+const parseResponsesStreamMock = vi.fn(async function* () {
+  yield {
+    role: 'assistant',
+    content: [{ type: 'output_text', text: 'recovered' }],
+  };
+});
+
+const fetchMock = vi.fn();
+const requestBodies: string[] = [];
+
+void vi.mock('@vybestack/llxprt-code-settings', () => ({
+  ...realLlxprtCodeSettingsModule,
+  getSettingsService: () => mockSettingsService,
+  SETTINGS_REGISTRY: [],
+}));
+
+void vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
+  getCoreSystemPromptAsync: vi.fn().mockResolvedValue('system prompt'),
+}));
+
+void vi.mock('../openai/parseResponsesStream.js', () => ({
+  parseResponsesStream: parseResponsesStreamMock,
+}));
+
+function rateLimitResponse(): Response {
+  return new Response('rate limited', {
+    status: 429,
+    headers: { 'retry-after': '0' },
+  });
+}
+
+function successResponse(): { ok: true; body: ReadableStream } {
+  return {
+    ok: true,
+    body: new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    }),
+  };
+}
+
+describe('OpenAIResponsesProvider prompt-envelope retry (@issue:3444)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSettingsService.getSettings.mockResolvedValue({});
+    requestBodies.length = 0;
+    setGlobal('fetch', fetchMock);
+
+    // Capture each attempt's serialized request body so the test can prove
+    // the retried attempt still carries the full projected input (the RED
+    // failure mode is a silently emptied `input`, not a thrown error).
+    fetchMock.mockImplementation(async (_url: unknown, init: RequestInit) => {
+      const body = init.body as ReadableStream | null;
+      requestBodies.push(
+        body === null || body === undefined
+          ? ''
+          : await new Response(body).text(),
+      );
+      if (requestBodies.length <= 6) return rateLimitResponse();
+      return successResponse();
+    });
+  });
+
+  afterEach(() => {
+    restoreGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('an orchestrator outer retry sends a freshly projected envelope, not the spent one', async () => {
+    const provider = new OpenAIResponsesProvider('test-key', undefined, {
+      getEphemeralSettings: () => ({}),
+    });
+
+    const callOptions = createProviderCallOptions({
+      providerName: provider.name,
+      contents: [
+        {
+          speaker: 'human',
+          blocks: [{ type: 'text', text: 'hello-retry-payload' }],
+        },
+      ] as IContent[],
+      ephemerals: {
+        retrywait: 0,
+      },
+      resolved: { model: 'gpt-5' },
+    });
+
+    const projection = await provider.projectPromptEnvelope(callOptions);
+    expect(projection.transportToken).toBeDefined();
+
+    // Orchestrator cap (7) exceeds the executor's internal streaming-retry
+    // cap (6): the outer retry gets the seventh and final budget slot.
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 7,
+      initialDelayMs: 0,
+    });
+
+    const chunks: string[] = [];
+    let threw = false;
+    let error: unknown;
+    try {
+      const gen = orchestrator.generateChatCompletion({
+        ...callOptions,
+        promptEnvelopeTransportToken: projection.transportToken,
+      });
+      for await (const chunk of gen) {
+        chunks.push(JSON.stringify(chunk));
+      }
+    } catch (e) {
+      threw = true;
+      error = e;
+    }
+
+    // Six internal 429s + the orchestrator's outer retry: seven physical
+    // sends, and the seventh succeeded.
+    expect(threw).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(7);
+    expect(chunks.join('')).toContain('recovered');
+
+    // The original send carried the projected input...
+    expect(requestBodies[0]).toContain('hello-retry-payload');
+    // ...and so did the outer retry. Replaying the spent token would have
+    // spliced `input` to an empty array and silently dropped the payload.
+    expect(requestBodies[6]).toContain('hello-retry-payload');
+    if (error !== undefined) {
+      expect(String(error)).not.toContain(
+        'Cannot consume media request contents after release',
+      );
+    }
+  });
+});

--- a/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.promptEnvelopeRetry.issue3444.test.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.promptEnvelopeRetry.issue3444.test.ts
@@ -191,6 +191,42 @@ describe('OpenAIResponsesProvider prompt-envelope retry (@issue:3444)', () => {
     );
   });
 
+  it('surfaces a refresh projection failure without consuming the released media again', async () => {
+    const provider = new OpenAIResponsesProvider('test-key', undefined, {
+      getEphemeralSettings: () => ({}),
+    });
+    const options = createProviderCallOptions({
+      providerName: provider.name,
+      contents: mediaMessages(),
+      ephemerals: { retrywait: 0 },
+      resolved: { model: 'gpt-5' },
+    });
+    const projection = await provider.projectPromptEnvelope(options);
+    const failure = new Error('responses refresh projection unavailable');
+    provider.projectPromptEnvelope = async () => {
+      throw failure;
+    };
+    const chunks: IContent[] = [];
+    let caught: unknown;
+    try {
+      for await (const chunk of new RetryOrchestrator(provider, {
+        maxAttempts: 7,
+        initialDelayMs: 0,
+      }).generateChatCompletion({
+        ...options,
+        promptEnvelopeTransportToken: projection.transportToken,
+      }))
+        chunks.push(chunk);
+    } catch (error) {
+      caught = error;
+    }
+    expect(chunks).toHaveLength(0);
+    expect(caught).toBe(failure);
+    expect(String(caught)).not.toContain(
+      'Cannot consume media request contents after release',
+    );
+  });
+
   it('preserves the last transport failure when the outer retry exhausts', async () => {
     let sends = 0;
     fetchMock.mockImplementation(() => {

--- a/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.promptEnvelopeRetry.issue3444.test.ts
+++ b/packages/providers/src/openai-responses/OpenAIResponsesProviderCore.promptEnvelopeRetry.issue3444.test.ts
@@ -13,7 +13,7 @@
  * cleanup registered at prepare time), so a retry that replays the token
  * silently sends an EMPTY input payload and corrupts the turn. The provider,
  * projection, executor, and RetryOrchestrator under test are real; only the
- * transport fetch and the SSE body parser are mocked.
+ * transport fetch is mocked. The SSE parser processes real wire events.
  *
  * Scenario wiring: the invocation omits the `retries` ephemeral, so the
  * executor's internal streaming-retry cap falls back to its default (6)
@@ -45,13 +45,6 @@ const mockSettingsService = {
   getAllGlobalSettings: vi.fn().mockReturnValue({}),
 };
 
-const parseResponsesStreamMock = vi.fn(async function* () {
-  yield {
-    role: 'assistant',
-    content: [{ type: 'output_text', text: 'recovered' }],
-  };
-});
-
 const fetchMock = vi.fn();
 const requestBodies: string[] = [];
 
@@ -65,10 +58,6 @@ void vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
   getCoreSystemPromptAsync: vi.fn().mockResolvedValue('system prompt'),
 }));
 
-void vi.mock('../openai/parseResponsesStream.js', () => ({
-  parseResponsesStream: parseResponsesStreamMock,
-}));
-
 function rateLimitResponse(): Response {
   return new Response('rate limited', {
     status: 429,
@@ -76,15 +65,43 @@ function rateLimitResponse(): Response {
   });
 }
 
-function successResponse(): { ok: true; body: ReadableStream } {
-  return {
-    ok: true,
-    body: new ReadableStream({
-      start(controller) {
-        controller.close();
-      },
-    }),
-  };
+function successResponse(): Response {
+  const events = [
+    {
+      type: 'response.output_text.delta',
+      delta: 'recovered',
+      item_id: 'msg_1',
+      output_index: 0,
+      content_index: 0,
+    },
+    {
+      type: 'response.completed',
+      response: { id: 'resp_1', status: 'completed' },
+    },
+  ];
+  return new Response(
+    events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(''),
+    {
+      headers: { 'content-type': 'text/event-stream' },
+    },
+  );
+}
+
+function mediaMessages(): IContent[] {
+  return [
+    {
+      speaker: 'human',
+      blocks: [
+        { type: 'text', text: 'hello-retry-payload' },
+        {
+          type: 'media',
+          mimeType: 'image/png',
+          data: 'aValidBase64Chunk==',
+          encoding: 'base64',
+        },
+      ],
+    },
+  ];
 }
 
 describe('OpenAIResponsesProvider prompt-envelope retry (@issue:3444)', () => {
@@ -98,7 +115,7 @@ describe('OpenAIResponsesProvider prompt-envelope retry (@issue:3444)', () => {
     // the retried attempt still carries the full projected input (the RED
     // failure mode is a silently emptied `input`, not a thrown error).
     fetchMock.mockImplementation(async (_url: unknown, init: RequestInit) => {
-      const body = init.body as ReadableStream | null;
+      const body = init.body;
       requestBodies.push(
         body === null || body === undefined
           ? ''
@@ -121,12 +138,7 @@ describe('OpenAIResponsesProvider prompt-envelope retry (@issue:3444)', () => {
 
     const callOptions = createProviderCallOptions({
       providerName: provider.name,
-      contents: [
-        {
-          speaker: 'human',
-          blocks: [{ type: 'text', text: 'hello-retry-payload' }],
-        },
-      ] as IContent[],
+      contents: mediaMessages(),
       ephemerals: {
         retrywait: 0,
       },
@@ -170,10 +182,57 @@ describe('OpenAIResponsesProvider prompt-envelope retry (@issue:3444)', () => {
     // ...and so did the outer retry. Replaying the spent token would have
     // spliced `input` to an empty array and silently dropped the payload.
     expect(requestBodies[6]).toContain('hello-retry-payload');
-    if (error !== undefined) {
-      expect(String(error)).not.toContain(
-        'Cannot consume media request contents after release',
-      );
+    expect(requestBodies[6]).toContain('input_image');
+    expect(requestBodies[6]).toContain(
+      'data:image/png;base64,aValidBase64Chunk==',
+    );
+    expect(String(error)).not.toContain(
+      'Cannot consume media request contents after release',
+    );
+  });
+
+  it('preserves the last transport failure when the outer retry exhausts', async () => {
+    let sends = 0;
+    fetchMock.mockImplementation(() => {
+      sends += 1;
+      return new Response(`rate limit on physical send ${sends}`, {
+        status: 429,
+        headers: { 'retry-after': '0' },
+      });
+    });
+    const provider = new OpenAIResponsesProvider('test-key', undefined, {
+      getEphemeralSettings: () => ({}),
+    });
+    const options = createProviderCallOptions({
+      providerName: provider.name,
+      contents: mediaMessages(),
+      ephemerals: { retrywait: 0 },
+      resolved: { model: 'gpt-5' },
+    });
+    const projection = await provider.projectPromptEnvelope(options);
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 7,
+      initialDelayMs: 0,
+    });
+    let caught: unknown;
+    const chunks: IContent[] = [];
+    try {
+      for await (const chunk of orchestrator.generateChatCompletion({
+        ...options,
+        promptEnvelopeTransportToken: projection.transportToken,
+      }))
+        chunks.push(chunk);
+    } catch (error) {
+      caught = error;
     }
+    expect(chunks).toHaveLength(0);
+    expect(sends).toBe(7);
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught instanceof Error ? caught.message : '').toContain(
+      'rate limit on physical send 7',
+    );
+    expect(String(caught)).not.toContain(
+      'Cannot consume media request contents after release',
+    );
   });
 });

--- a/packages/providers/src/openai/OpenAIProvider.promptEnvelopeRetry.issue3444.test.ts
+++ b/packages/providers/src/openai/OpenAIProvider.promptEnvelopeRetry.issue3444.test.ts
@@ -158,6 +158,40 @@ describe('OpenAIProvider prompt-envelope retry (@issue:3444)', () => {
     expect(errorMessage(error)).not.toContain(RELEASE_ERROR);
   });
 
+  it('surfaces a refresh projection failure without consuming the released media again', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    mockChatCompletionsCreate.mockRejectedValueOnce(make429RateLimitError());
+    const provider = new OpenAIProvider('test-key');
+    const options = createProviderCallOptions({
+      providerName: provider.name,
+      contents: mediaMessages(),
+      ephemerals: { retries: 2, retrywait: 0 },
+      resolved: { model: 'gpt-4o' },
+    });
+    const projection = await provider.projectPromptEnvelope(options);
+    const failure = new Error('chat refresh projection unavailable');
+    provider.projectPromptEnvelope = async () => {
+      throw failure;
+    };
+    const chunks: IContent[] = [];
+    let caught: unknown;
+    try {
+      for await (const chunk of new RetryOrchestrator(provider, {
+        maxAttempts: 2,
+        initialDelayMs: 0,
+      }).generateChatCompletion({
+        ...options,
+        promptEnvelopeTransportToken: projection.transportToken,
+      }))
+        chunks.push(chunk);
+    } catch (error) {
+      caught = error;
+    }
+    expect(chunks).toHaveLength(0);
+    expect(caught).toBe(failure);
+    expect(errorMessage(caught)).not.toContain(RELEASE_ERROR);
+  });
+
   it('preserves the last transport failure when projected media retries exhaust', async () => {
     process.env.OPENAI_API_KEY = 'test-key';
     const lastFailure = Object.assign(

--- a/packages/providers/src/openai/OpenAIProvider.promptEnvelopeRetry.issue3444.test.ts
+++ b/packages/providers/src/openai/OpenAIProvider.promptEnvelopeRetry.issue3444.test.ts
@@ -1,0 +1,162 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @plan PLAN-20260909-ISSUE3444
+ *
+ * Issue #3444 — a RetryOrchestrator retry must not replay a spent
+ * promptEnvelopeTransportToken through OpenAIProvider's chat path. The token
+ * maps to a prepared media request released by the attempt that consumed it;
+ * replaying it fails at media consumption (`Cannot consume media request
+ * contents after release`) and masks the real transport error. Only the SDK
+ * transport is mocked; the provider, projection, and RetryOrchestrator are
+ * real.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'bun:test';
+import { OpenAIProvider } from './OpenAIProvider.js';
+import { RetryOrchestrator } from '../RetryOrchestrator.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { createProviderCallOptions } from '@vybestack/llxprt-code-core/test-utils/providerCallOptions.js';
+import { createOpenAIRawPostTestAdapter } from '../test-utils/rawPostTestAdapters.js';
+
+const RELEASE_ERROR = 'Cannot consume media request contents after release';
+
+const realLlxprtCodeSettingsModule = {
+  ...(await import('@vybestack/llxprt-code-settings')),
+};
+
+const mockChatCompletionsCreate = vi.fn();
+
+const mockOpenAIConstructor = vi.fn().mockImplementation(() => ({
+  ...createOpenAIRawPostTestAdapter(mockChatCompletionsCreate),
+  chat: {
+    completions: {
+      create: mockChatCompletionsCreate,
+    },
+  },
+}));
+
+void vi.mock('openai', () => ({
+  default: mockOpenAIConstructor,
+}));
+
+void vi.mock('@vybestack/llxprt-code-core/core/prompts.js', () => ({
+  getCoreSystemPromptAsync: vi.fn().mockResolvedValue('system prompt'),
+}));
+
+const mockSettingsService = {
+  set: vi.fn(),
+  get: vi.fn(),
+  getProviderSettings: vi.fn().mockReturnValue({}),
+  updateSettings: vi.fn(),
+  getAllGlobalSettings: vi.fn().mockReturnValue({}),
+};
+
+void vi.mock('@vybestack/llxprt-code-settings', () => ({
+  ...realLlxprtCodeSettingsModule,
+  getSettingsService: vi.fn(() => mockSettingsService),
+  SETTINGS_REGISTRY: [],
+}));
+
+function make429RateLimitError(): Error {
+  const error = new Error('Rate limit exceeded') as Error & {
+    status?: number;
+  };
+  error.status = 429;
+  return error;
+}
+
+function createMockChatStream(text: string) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield {
+        choices: [{ delta: { content: text } }],
+      };
+    },
+  };
+}
+
+function mediaMessages(): IContent[] {
+  return [
+    {
+      speaker: 'human',
+      blocks: [
+        { type: 'text', text: 'What is in this image?' },
+        {
+          type: 'media',
+          mimeType: 'image/png',
+          data: 'aValidBase64Chunk==',
+          encoding: 'base64' as const,
+        },
+      ],
+    },
+  ];
+}
+
+function errorMessage(error: unknown): string {
+  return String(error instanceof Error ? error.message : error);
+}
+
+describe('OpenAIProvider prompt-envelope retry (@issue:3444)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockChatCompletionsCreate.mockReset();
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it('retries a projected media turn with a fresh envelope instead of the spent token', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    mockChatCompletionsCreate
+      .mockRejectedValueOnce(make429RateLimitError())
+      .mockResolvedValueOnce(createMockChatStream('recovered'));
+
+    const provider = new OpenAIProvider('test-key');
+
+    const callOptions = createProviderCallOptions({
+      providerName: provider.name,
+      contents: mediaMessages(),
+      ephemerals: { retries: 2, retrywait: 0 },
+      resolved: { model: 'gpt-4o' },
+    } as Parameters<typeof createProviderCallOptions>[0]);
+
+    const projection = await provider.projectPromptEnvelope(callOptions);
+    expect(projection.transportToken).toBeDefined();
+
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 2,
+      initialDelayMs: 0,
+    });
+
+    const chunks: string[] = [];
+    let threw = false;
+    let error: unknown;
+    try {
+      const gen = orchestrator.generateChatCompletion({
+        ...callOptions,
+        promptEnvelopeTransportToken: projection.transportToken,
+      });
+      for await (const chunk of gen) {
+        const text = chunk.blocks.find((b) => b.type === 'text');
+        if (text !== undefined) chunks.push(text.text);
+      }
+    } catch (e) {
+      threw = true;
+      error = e;
+    }
+
+    expect(threw).toBe(false);
+    expect(chunks.join('')).toContain('recovered');
+    // Attempt 1 (429) + attempt 2 (recovered): both reached the transport.
+    expect(mockChatCompletionsCreate).toHaveBeenCalledTimes(2);
+    // The retried request still carries the image payload.
+    const retryArgs = mockChatCompletionsCreate.mock.calls[1][0];
+    expect(JSON.stringify(retryArgs.messages)).toContain('image_url');
+    if (error !== undefined) {
+      expect(errorMessage(error)).not.toContain(RELEASE_ERROR);
+    }
+  });
+});

--- a/packages/providers/src/openai/OpenAIProvider.promptEnvelopeRetry.issue3444.test.ts
+++ b/packages/providers/src/openai/OpenAIProvider.promptEnvelopeRetry.issue3444.test.ts
@@ -155,8 +155,44 @@ describe('OpenAIProvider prompt-envelope retry (@issue:3444)', () => {
     // The retried request still carries the image payload.
     const retryArgs = mockChatCompletionsCreate.mock.calls[1][0];
     expect(JSON.stringify(retryArgs.messages)).toContain('image_url');
-    if (error !== undefined) {
-      expect(errorMessage(error)).not.toContain(RELEASE_ERROR);
+    expect(errorMessage(error)).not.toContain(RELEASE_ERROR);
+  });
+
+  it('preserves the last transport failure when projected media retries exhaust', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    const lastFailure = Object.assign(
+      new Error('Rate limit on final chat send'),
+      { status: 429 },
+    );
+    mockChatCompletionsCreate
+      .mockRejectedValueOnce(make429RateLimitError())
+      .mockRejectedValueOnce(lastFailure);
+    const provider = new OpenAIProvider('test-key');
+    const options = createProviderCallOptions({
+      providerName: provider.name,
+      contents: mediaMessages(),
+      ephemerals: { retries: 2, retrywait: 0 },
+      resolved: { model: 'gpt-4o' },
+    });
+    const projection = await provider.projectPromptEnvelope(options);
+    const orchestrator = new RetryOrchestrator(provider, {
+      maxAttempts: 2,
+      initialDelayMs: 0,
+    });
+    let caught: unknown;
+    const chunks: IContent[] = [];
+    try {
+      for await (const chunk of orchestrator.generateChatCompletion({
+        ...options,
+        promptEnvelopeTransportToken: projection.transportToken,
+      }))
+        chunks.push(chunk);
+    } catch (error) {
+      caught = error;
     }
+    expect(chunks).toHaveLength(0);
+    expect(mockChatCompletionsCreate.mock.calls).toHaveLength(2);
+    expect(errorMessage(caught)).toContain(lastFailure.message);
+    expect(errorMessage(caught)).not.toContain(RELEASE_ERROR);
   });
 });

--- a/packages/providers/src/retryPromptEnvelopeRefresh.ts
+++ b/packages/providers/src/retryPromptEnvelopeRefresh.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { GenerateChatOptions, IProvider } from './IProvider.js';
+import type { TransportAttemptBudget } from './transportAttemptBudget.js';
+import { withRequestSignal } from './utils/abortSignal.js';
+import { createAbortError } from '@vybestack/llxprt-code-core/utils/delay.js';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+
+/**
+ * #3444: providers release a prepared prompt envelope when the attempt that
+ * consumed it settles, so a retry must never replay the spent transport
+ * token. Strip that token before minting a fresh retry projection:
+ *   - provider cannot re-project → keep it stripped and degrade to
+ *     unprojected re-resolution (the projection seam's own fallback);
+ *   - projection throws → the error propagates into the surrounding
+ *     attempt try/catch and is classified like any attempt failure;
+ *   - a fresh token is minted → retain its idempotent `releaseIfUnsent`
+ *     through adapter preparation and release on failure, even if the
+ *     provider already released it. Successful attempts remain provider-owned.
+ */
+async function refreshPromptEnvelopeForRetry(
+  provider: IProvider,
+  options: GenerateChatOptions,
+): Promise<{
+  options: GenerateChatOptions;
+  releaseIfUnsent: (() => Promise<void>) | undefined;
+}> {
+  if (options.promptEnvelopeTransportToken === undefined) {
+    return { options, releaseIfUnsent: undefined };
+  }
+  const { promptEnvelopeTransportToken: _spentToken, ...unprojected } = options;
+  const projection = await provider.projectPromptEnvelope?.(unprojected);
+  if (projection === undefined) {
+    return { options: unprojected, releaseIfUnsent: undefined };
+  }
+  return {
+    options: {
+      ...unprojected,
+      promptEnvelopeTransportToken: projection.transportToken,
+    },
+    releaseIfUnsent: projection.releaseIfUnsent,
+  };
+}
+
+export class RetryPromptEnvelopeRefresh {
+  options: GenerateChatOptions | undefined;
+  private unsentRelease: (() => Promise<void>) | undefined;
+  private attempt = 0;
+  recoveryConsumption = 0;
+
+  canRetry(budget: TransportAttemptBudget, maxAttempts: number): boolean {
+    return budget.used < budget.limit && this.recoveryConsumption < maxAttempts;
+  }
+
+  async settle(
+    usedDelta: number,
+    succeeded: boolean,
+    error: unknown,
+  ): Promise<void> {
+    this.recoveryConsumption +=
+      usedDelta + (this.options === undefined ? 1 : 0);
+    if (!succeeded) await this.releaseUnsent(error);
+  }
+
+  async prepare(
+    provider: IProvider,
+    options: GenerateChatOptions,
+    signal: AbortSignal,
+  ): Promise<GenerateChatOptions> {
+    this.options = undefined;
+    this.unsentRelease = undefined;
+    this.attempt += 1;
+    // #3444: the first attempt sends the options exactly as received;
+    // every retry replaces the spent prompt-envelope transport token
+    // with a freshly projected one before linking the attempt signal.
+    const sendOptions =
+      this.attempt === 1
+        ? { options, releaseIfUnsent: undefined }
+        : await refreshPromptEnvelopeForRetry(provider, options);
+    this.unsentRelease = sendOptions.releaseIfUnsent;
+    if (signal.aborted) throw createAbortError(signal.reason);
+    this.options = withRequestSignal(sendOptions.options, signal);
+    return this.options;
+  }
+
+  async releaseUnsent(attemptError: unknown): Promise<void> {
+    const release = this.unsentRelease;
+    this.unsentRelease = undefined;
+    if (release === undefined) return;
+    try {
+      await release();
+    } catch (cleanupError) {
+      if (attemptError === undefined) throw cleanupError;
+      new DebugLogger('llxprt:retry:orchestrator').debug(
+        () =>
+          `Releasing unsent prompt envelope failed: ${String(cleanupError)}`,
+      );
+    }
+  }
+}

--- a/packages/providers/src/retryPromptEnvelopeRefresh.ts
+++ b/packages/providers/src/retryPromptEnvelopeRefresh.ts
@@ -50,7 +50,7 @@ export class RetryPromptEnvelopeRefresh {
   options: GenerateChatOptions | undefined;
   private unsentRelease: (() => Promise<void>) | undefined;
   private attempt = 0;
-  recoveryConsumption = 0;
+  constructor(public recoveryConsumption: number) {}
 
   canRetry(budget: TransportAttemptBudget, maxAttempts: number): boolean {
     return budget.used < budget.limit && this.recoveryConsumption < maxAttempts;

--- a/packages/providers/src/retryPromptEnvelopeRefresh.ts
+++ b/packages/providers/src/retryPromptEnvelopeRefresh.ts
@@ -6,7 +6,7 @@
 
 import type { GenerateChatOptions, IProvider } from './IProvider.js';
 import type { TransportAttemptBudget } from './transportAttemptBudget.js';
-import { withRequestSignal } from './utils/abortSignal.js';
+import { raceWithAbort, withRequestSignal } from './utils/abortSignal.js';
 import { createAbortError } from '@vybestack/llxprt-code-core/utils/delay.js';
 import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
 
@@ -80,11 +80,29 @@ export class RetryPromptEnvelopeRefresh {
     const sendOptions =
       this.attempt === 1
         ? { options, releaseIfUnsent: undefined }
-        : await refreshPromptEnvelopeForRetry(provider, options);
+        : await this.refresh(provider, options, signal);
     this.unsentRelease = sendOptions.releaseIfUnsent;
     if (signal.aborted) throw createAbortError(signal.reason);
     this.options = withRequestSignal(sendOptions.options, signal);
     return this.options;
+  }
+
+  private async refresh(
+    provider: IProvider,
+    options: GenerateChatOptions,
+    signal: AbortSignal,
+  ): ReturnType<typeof refreshPromptEnvelopeForRetry> {
+    const pending = refreshPromptEnvelopeForRetry(provider, options);
+    try {
+      return await raceWithAbort(pending, signal);
+    } catch (error) {
+      // Cancellation can abandon a projection that later mints an envelope.
+      // Release that unsent envelope without delaying or replacing the abort.
+      void pending
+        .then((projection) => projection.releaseIfUnsent?.())
+        .catch(() => undefined);
+      throw error;
+    }
   }
 
   async releaseUnsent(attemptError: unknown): Promise<void> {
@@ -95,6 +113,8 @@ export class RetryPromptEnvelopeRefresh {
       await release();
     } catch (cleanupError) {
       if (attemptError === undefined) throw cleanupError;
+      // Cleanup diagnostics are debug-gated by design: DebugLogger also gates
+      // warn/error, and the attempt error must remain the surfaced failure.
       new DebugLogger('llxprt:retry:orchestrator').debug(
         () =>
           `Releasing unsent prompt envelope failed: ${String(cleanupError)}`,

--- a/packages/providers/src/retryPromptEnvelopeRefresh.ts
+++ b/packages/providers/src/retryPromptEnvelopeRefresh.ts
@@ -52,8 +52,8 @@ export class RetryPromptEnvelopeRefresh {
   private attempt = 0;
   constructor(public recoveryConsumption: number) {}
 
-  canRetry(budget: TransportAttemptBudget, maxAttempts: number): boolean {
-    return budget.used < budget.limit && this.recoveryConsumption < maxAttempts;
+  canRetry(budget: TransportAttemptBudget): boolean {
+    return budget.used < budget.limit;
   }
 
   async settle(

--- a/project-plans/20260909issue3444/PLAN.md
+++ b/project-plans/20260909issue3444/PLAN.md
@@ -227,3 +227,28 @@ executor's default internal cap, and the seventh send exercises the orchestrator
 fresh-envelope outer retry. Invocation settings omit `retries`; the orchestrator
 limit is seven. Both success and exhaustion cases retain payload assertions,
 and exhaustion identifies the error from send seven.
+
+## Verification record and dispositions
+
+The full-suite run in `tmp/verify3444/final3-full-test.log` ended with
+`EXIT=1`, with exactly two failures outside the changed files:
+
+1. `packages/cli`'s `startup-fatal-log.test.ts` encountered a `/var` versus
+   `/private/var` cwd mismatch caused by macOS symlink resolution. This is
+   pre-existing on main and macOS-only; CI runs Linux.
+2. `packages/core`'s `shellBoundedAcquisition` test, `preserves exit code`,
+   flaked under concurrent sibling-checkout suites and passed in isolation.
+
+Both affected files were rerun in isolation with zero failures. The remaining
+verification completed with `EXIT=0`: providers (643/643, including all
+issue3444 tests), lint (19/19), typecheck, format, build, and the `stepfun-37`
+smoke test. These dispositions do not make the full-suite run green.
+
+The boundary-f remediation seeds retry recovery consumption with entry-time
+shared `budget.used`. The token-less differential (limit 4, one prior send,
+retries 2, then a 429) reproduced two new sends and success on the unfixed
+branch, versus one new send and exhaustion on main. The regression requires
+main's result, including final budget usage 2. A projected-request regression
+uses retries 3 with one prior send and verifies that the remaining retry
+receives a fresh token. Failed refreshes still count toward recovery without
+consuming physical transport budget.

--- a/project-plans/20260909issue3444/PLAN.md
+++ b/project-plans/20260909issue3444/PLAN.md
@@ -252,3 +252,33 @@ main's result, including final budget usage 2. A projected-request regression
 uses retries 3 with one prior send and verifies that the remaining retry
 receives a fresh token. Failed refreshes still count toward recovery without
 consuming physical transport budget.
+
+Round-2 review found a remaining boundary-f entry-gate mismatch: when shared
+`budget.used >= maxAttempts` but `budget.used < budget.limit`, the additional
+recovery-consumption gate blocked entry while main allowed a send. The final
+remediation restores main's exact loop gate, `budget.used < budget.limit`,
+with `maxAttempts` enforced solely in the retry-decision path. Entry-time
+`budget.used` still seeds recovery consumption, and failed refreshes still
+increment it without consuming physical transport budget.
+
+The pre-edit differential with token-less entry used 2, limit 4, and maxAttempts
+2 produced zero sends, zero chunks, and exhaustion on HEAD b053d8b15; main
+produced one send, one `ok` chunk, and success with final budget usage 3. The
+added entry-parity regression failed with that HEAD result before the fix and
+passes with main's result afterward. The existing used-1 exhaustion regression
+and all existing refresh-bound tests remain unchanged and pass.
+
+Refresh exceptions reach `attemptError`; `settle()` adds one recovery attempt
+because preparation left `options` undefined. `handleRetryError` assigns that
+consumption to `state.attempt`. Auth refresh and bucket failover cannot continue
+at the cap, and `decideRetryOrThrow` returns exhaustion at `maxAttempts` for
+retryable errors (nonretryable errors throw immediately). The existing
+`bounds retryable refresh failures at %s attempts and preserves the last
+projection error` cases stop after one send plus limit-minus-one failed
+refreshes for limits 2 and 3. The provider-owned two-send/one-refresh case
+also passes, preserving physical budget usage 2.
+
+Final targeted verification: orchestrator issue3444 file 16 passed, full
+RetryOrchestrator suite 128 passed across 16 files, three provider issue3444
+files 6 passed, all with zero failures. Providers workspace typecheck and lint
+both exited 0.

--- a/project-plans/20260909issue3444/PLAN.md
+++ b/project-plans/20260909issue3444/PLAN.md
@@ -1,0 +1,229 @@
+# Plan: Retries must not replay a released media request (issue #3444)
+
+Plan ID: PLAN-20260909-ISSUE3444
+Generated: 2026-09-09
+Issue: vybestack/llxprt-code#3444
+Total Phases: 2 (RED tests, then GREEN fix)
+Requirements: REQ-3444-01 .. REQ-3444-06
+
+## Problem summary
+
+`RetryOrchestrator` builds every physical attempt from the same
+`requestOptions`, so a projected turn's `promptEnvelopeTransportToken` is
+replayed on retry attempts. Providers treat the token as a one-shot prepared
+envelope and release its media request in a per-attempt `finally`
+(`finishMediaRequest`). Attempt 2 therefore calls `withContents` on a released
+request and throws `Cannot consume media request contents after release`,
+masking the original retryable transport error (429/5xx/network) and breaking
+configured retry/failover for projected media turns on Anthropic Chat, OpenAI
+Chat, and OpenAI Responses.
+
+## Design decision (issue offered two options; this picks option 1)
+
+**Each retry attempt gets a fresh projection and transport token, minted by the
+orchestrator through the existing `projectPromptEnvelope` seam.**
+
+Rationale:
+
+- The codebase already established exactly this convention at the two other
+  retry loops that carry tokens:
+  - `LoadBalancingProvider` "uses a new matched projection token for each
+    failover retry" (`LoadBalancingProvider.tokenAccounting.test.ts`) — it
+    re-estimates (re-projects) per failover attempt and sends the new token.
+  - The agent seam `sendWithFreshPromptEnvelopeRetries`
+    (`packages/agents/src/core/promptEnvelopeSendSeam.ts`) re-projects via
+    `prepareAtSendSeam` on every retry attempt.
+  `RetryOrchestrator` is the only token-carrying retry loop that replays.
+- It fixes all three providers (and any future one) at the single point that
+  replays tokens; no per-provider rebuild logic, no provider code changes.
+- Provider-side per-attempt release semantics stay exactly as merged: the
+  attempt that consumes a token releases its media request. No ownership move
+  across packages, no new public abstraction (`projectPromptEnvelope` and
+  `releaseIfUnsent` already exist on the provider seam).
+- Re-projection re-resolves media and auth per retry, matching what an
+  unprojected turn's retry already does (fresh `resolveRequestMedia` +
+  fresh request preparation per attempt).
+
+Option 2 (hoist release ownership above the orchestrator) was rejected: the
+LoadBalancingProvider drops `releaseIfUnsent` when threading sub-provider
+tokens, so a "caller above owns release" contract would leak there and would
+require changes in `agents`, `LoadBalancingProvider`, and all three providers.
+
+## Acceptance criteria
+
+### REQ-3444-01: First attempt keeps the caller's token
+
+- GIVEN: options carrying `promptEnvelopeTransportToken` from a successful
+  projection
+- WHEN: the orchestrator executes its FIRST physical attempt
+- THEN: that attempt is sent with the caller's original, unmodified token
+  (the estimate==transport invariant for the estimated send is preserved)
+
+### REQ-3444-02: Retry attempts use a fresh token, never the spent one
+
+- GIVEN: options carrying `promptEnvelopeTransportToken`
+- WHEN: a retryable pre-output failure (e.g. 429) causes the orchestrator to
+  build physical attempt N+1 (N >= 1)
+- THEN: the orchestrator calls `wrappedProvider.projectPromptEnvelope` with
+  that attempt's options and sends the attempt with the returned fresh
+  `transportToken`; the spent token is never re-sent
+
+Boundary cases:
+
+a. Wrapped provider has no `projectPromptEnvelope`, or it returns `undefined`
+   at refresh time: the retry attempt is sent with `promptEnvelopeTransportToken`
+   removed (unprojected re-resolution), never with the spent token. This mirrors
+   the seam's own `projection === undefined -> { estimate: null, options }`
+   degradation.
+b. Refresh projection throws: the error becomes that attempt's error and flows
+   through the normal retry classification/telemetry pipeline (no swallow, no
+   special-casing, no masking of itself as a release error).
+c. A refreshed projection that is minted but never consumed by a provider call
+   is released via its `releaseIfUnsent` (no media-request leak). Once the
+   provider call with the fresh token starts, the provider's existing
+   per-attempt `finally` owns release (guardStream's finally closes the provider
+   iterator on every exit path).
+d. `metadata.loadBalancerDelegate === true` bypass: unchanged (single
+   delegated attempt, no orchestrator retry loop).
+e. Transport budget accounting: unchanged — each physical attempt consumes the
+   shared budget exactly as before (provider-owned-attempt accounting included).
+f. Options without a token: behavior byte-identical to today (no projection
+   calls added).
+
+### REQ-3444-03: Anthropic projected media turn survives a retry
+
+- GIVEN: a real `AnthropicProvider` (mocked SDK transport only), a projected
+  envelope via `projectPromptEnvelope`, options sent with the token, media in
+  contents
+- WHEN: the first physical attempt fails with 429 and the second succeeds
+- THEN: the turn completes successfully; no
+  `Cannot consume media request contents after release` error; exactly two
+  physical SDK calls
+
+### REQ-3444-04: OpenAI Chat projected media turn survives a retry
+
+Same shape as REQ-3444-03 through `OpenAIProvider` chat transport.
+
+### REQ-3444-05: OpenAI Responses projected media turn survives a retry
+
+Same shape as REQ-3444-03 through the OpenAI Responses path (prepared request
+context from `projectPromptEnvelope` consumed by the executor).
+
+### REQ-3444-06: Original transport error is not masked
+
+- GIVEN: a projected media turn whose retries are exhausted
+- WHEN: the final error surfaces
+- THEN: it is the transport error (or the retries-exhausted wrapper around the
+  last transport error), never
+  `Cannot consume media request contents after release`
+
+## Out of scope (explicitly)
+
+- No provider-side rebuild/retry logic; providers stay as merged.
+- No change to `promptEnvelopeSendSeam`, `LoadBalancingProvider`, or the
+  `PromptEnvelopeProjection` contract.
+- No new IProvider surface (uses the existing optional
+  `projectPromptEnvelope`).
+- No refactor of retry classification/backoff.
+
+## Test plan (RED first, all bun:test)
+
+### New files
+
+1. `packages/providers/src/__tests__/RetryOrchestrator.promptEnvelopeRetry.issue3444.test.ts`
+   - Fake provider implementing the token contract with real one-shot release
+     semantics (a `released` flag mirroring `ResolvedMediaRequest`), real
+     `RetryOrchestrator`. Tests:
+     - attempt 1 receives the caller's original token; attempt 2 receives a
+       different token minted by a second `projectPromptEnvelope` call (tokens
+       observed via sends); send fails if a spent token is replayed (this is
+       the RED assertion).
+     - both attempts' media released exactly once (release counters).
+     - degradation: provider returns `undefined` projection on refresh ->
+       attempt 2 sent with no token and succeeds.
+     - refresh throw: provider's second projection rejects -> that error
+       surfaces (and is not a release error).
+2. `packages/providers/src/anthropic/AnthropicProvider.promptEnvelopeRetry.issue3444.test.ts`
+   - Mirrors the `AnthropicProvider.imageRecovery.issue3216.test.ts` harness
+     (mocked `@anthropic-ai/sdk` messages.create, real provider, real
+     orchestrator, inline base64 image contents). Project -> send with token ->
+     first attempt 429 -> second attempt succeeds. Asserts text output,
+     exactly 2 SDK calls, and no release error (RED today).
+3. `packages/providers/src/openai/OpenAIProvider.promptEnvelopeRetry.issue3444.test.ts`
+   - Mirrors the `OpenAIProvider.mediaBlock.test.ts` harness (mocked `openai`
+     SDK chat.completions.create). Same scenario and assertions.
+4. `packages/providers/src/openai-responses/OpenAIResponsesProviderCore.promptEnvelopeRetry.issue3444.test.ts`
+   - Real `OpenAIResponsesProviderCore` (or its test provider harness from
+     `openAIResponsesExecutor.streamIntegrity.test.ts` with fetch mocking);
+     project -> token -> 429 -> success. Same assertions.
+
+### Existing suites that must stay green (no edits expected)
+
+- `packages/providers/src/__tests__/LoadBalancingProvider.tokenAccounting.test.ts`
+- `packages/providers/src/__tests__/promptEnvelopeWrapperChain.test.ts`
+- `packages/agents/src/core/promptEnvelopeSendSeam.test.ts`
+- `packages/providers/src/anthropic/AnthropicProvider.imageRecovery.issue3216.test.ts`
+- `packages/providers/src/openai-responses/openAIResponsesExecutor.streamIntegrity.test.ts`
+- full `npm run test`
+
+## Implementation sketch (GREEN phase)
+
+Modify only `packages/providers/src/RetryOrchestrator.ts` (plus a small helper
+if the file's size/complexity budget demands extraction — prefer a sibling
+helper module following `retryTransportOwnership.ts` style):
+
+- Track the physical attempt index in `runRetryRequest`'s loop (local counter;
+  do not rely on `budget.used`).
+- For attempts after the first, when
+  `requestOptions.promptEnvelopeTransportToken !== undefined`, refresh:
+  - call `this.wrappedProvider.projectPromptEnvelope(attemptOptions)`;
+  - on a projection: replace the token on the attempt options with
+    `projection.transportToken`; hold `projection.releaseIfUnsent`;
+  - on `undefined`/missing method: strip the token;
+  - a throw propagates as the attempt's error into the existing
+    catch/classify path.
+- Release a held `releaseIfUnsent` only when the refreshed projection was
+  never consumed by a provider call (documented ownership comment; after the
+  provider call starts, the provider's per-attempt finally owns release).
+- No behavior change when no token is present.
+
+## Verification
+
+- `npm run test`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run format`
+- `npm run build`
+- `bun scripts/start.ts --profile-load stepfun-37 "write me a haiku and nothing else"`
+- Test-audit scanner on touched files: no new MOCK_MIRROR / SELF_CONFIRMING
+  findings vs main baseline.
+
+## Review gates
+
+- deepthinker compliance review (max 2 rounds).
+- OCR with zai profile, glm-5.3 (max 2 rounds), before push.
+- PR must reference `fixes #3444`; CI green; CodeRabbit findings triaged as
+  Blocker-Fix / In-scope-Fix / Reject / Defer.
+
+## Review remediation log
+
+2026-09-11: Option 1 remains unchanged: the orchestrator re-projects each retry.
+Boundary c is amended: retain each minted retry envelope's cleanup handle until
+the attempt settles, then release on failure or cancellation, including adapter
+preparation failures before the provider generator starts. Release is idempotent
+in `request-media-resolution.ts` and `request-media-resolver.ts`, so a provider
+that already released the request causes no second disposal. Successful attempts
+remain provider-owned. Regressions cover rejected preparation, a returned but
+unstarted body, and cancellation during preparation, using disposal counters.
+
+The recovery cap now combines this loop's transport-budget deltas with failed
+pre-send refresh attempts. Physical-send accounting and telemetry are unchanged.
+Two internal sends followed by one failed refresh exhaust a three-action cap.
+The Anthropic harness uses the real retry classifier with SDK 429 errors and
+checks that a distinct final failure survives exhaustion.
+
+The Responses regression uses seven physical sends: six 429s exhaust the real
+executor's default internal cap, and the seventh send exercises the orchestrator's
+fresh-envelope outer retry. Invocation settings omit `retries`; the orchestrator
+limit is seven. Both success and exhaustion cases retain payload assertions,
+and exhaustion identifies the error from send seven.


### PR DESCRIPTION
## TLDR

`RetryOrchestrator` built every physical attempt from the same `requestOptions`, so a retry replayed the spent `promptEnvelopeTransportToken`. Providers release the prepared media request in a per-attempt `finally`, so attempt 2 called `withContents` on a released request and died with `Cannot consume media request contents after release`, masking the original retryable transport error (429/5xx/network) for projected media turns on Anthropic Chat, OpenAI Chat, and OpenAI Responses.

The fix is orchestrator-only (option 1 from the issue): the first attempt keeps the caller's token; every retry strips the spent token and re-projects a fresh envelope through the provider's existing `projectPromptEnvelope` seam. No provider-side changes, no new IProvider surface, no changes to `promptEnvelopeSendSeam`, `LoadBalancingProvider`, or the projection contract.

Fixes #3444

## Dive Deeper

### Design

- `packages/providers/src/retryPromptEnvelopeRefresh.ts` (new): `refreshPromptEnvelopeForRetry` strips `promptEnvelopeTransportToken` before re-projecting, plus a small `RetryPromptEnvelopeRefresh` state holder.
- `packages/providers/src/RetryOrchestrator.ts`: a physical-attempt counter drives the refresh (attempt 1 sends options exactly as received, per REQ-3444-01); an `onProviderCallStarted` callback transfers release ownership once the provider call starts, so an unsent refreshed envelope is released only if the refresh dies before the call (no leak, no double release).
- Providers that cannot re-project degrade to unprojected retry (the projection seam's own fallback); a refresh that throws flows through the existing retry classification and telemetry path instead of surfacing as a release error.

### Parity guarantees for token-less requests

Behavior without a token is byte-identical to main, pinned by three dedicated regression tests:

- The retry loop entry gate is exactly `budget.used < budget.limit`, main's gate. `maxAttempts` never gates loop entry; it is enforced only in the retry-decision path (`handleRetryError` numbering seeded from entry-time `budget.used`).
- Failed refreshes increment recovery numbering without charging physical budget, and the termination chain (`settle` +1 → `state.attempt` → `maybeRefreshAuth` → `decideRetryOrThrow`) caps them.
- Verified by main-vs-HEAD differentials on the shared-budget scenarios deepthinker flagged: pre-remediation HEAD sent 2 where main sent 1 (b053d8b15 fixed), then 0 where main sent 1 (725485a98 restored the exact gate); after each fix the differential matches main.

### Review trail

- OCR (open-code-review, glm-5.3, full range `main..HEAD`): round 1 clean; round 2 on the final head clean. 0 findings both rounds.
- deepthinker round 1: FAIL with 2 MEDIUM findings (boundary-f shared-budget parity; a full-suite log honesty issue). Remediated in b053d8b15.
- deepthinker round 2: log-honesty finding resolved; shared-budget finding partially resolved. Final remediation 725485a98 restored main's exact loop gate with a differential before/after and an entry-parity regression test. deepthinker's two-round budget was exhausted at that point; the parity conclusion rests on the differential evidence and the pinned regressions rather than a third review pass.

## Reviewer Test Plan

- `bun test packages/providers/src/__tests__/RetryOrchestrator.promptEnvelopeRetry.issue3444.test.ts packages/providers/src/anthropic/AnthropicProvider.promptEnvelopeRetry.issue3444.test.ts packages/providers/src/openai/OpenAIProvider.promptEnvelopeRetry.issue3444.test.ts packages/providers/src/openai-responses/OpenAIResponsesProviderCore.promptEnvelopeRetry.issue3444.test.ts`
- The contract file pins: attempt 1 keeps the caller's token; retries carry a fresh token from a second projection; both envelopes released exactly once; unprojected degradation when the provider cannot re-project; refresh throws surface as attempt errors, never release errors; zero projection calls when no token was supplied; and the three shared-budget parity regressions.
- The provider files exercise real `AnthropicProvider`, `OpenAIProvider`, and the Responses executor against mocked SDK transports: project, send with token, 429 on attempt 1, assert attempt 2 succeeds with exactly two physical SDK calls and no release error; plus an exhaustion case asserting the terminal error is the transport error.

## Testing Matrix

Verified on macOS (🍏) via npm-run-based commands; other cells untested locally (CI covers Linux).

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

### Verification record

Full cycle on the final head (logs under `tmp/verify3444/final5-*.log`):

- `npm run lint`, `npm run typecheck`, `npm run format`, `npm run build`, and the `stepfun-37` smoke test: all exit 0.
- `npm run test`: providers 643/643, core 431/431, agents 402/402, CLI 747/749. All 22 `@issue:3444` tests pass. Overall exit 1 comes from exactly two CLI files, both triaged and documented in `project-plans/20260909issue3444/PLAN.md`:
  - `src/utils/startup-fatal-log.test.ts`: pre-existing macOS `/var` vs `/private/var` symlink cwd mismatch; fails on main the same way; CI runs Linux.
  - `src/launcher/bun-path-resolver.test.ts`: contention flake while sibling checkouts ran their own full suites on this machine; passes 43/43 isolated.

Test inventory: 22 issue-tagged bun:test cases across 4 new files (orchestrator contract including 3 parity regressions, plus Anthropic/OpenAI Chat/OpenAI Responses suites). Plan document: `project-plans/20260909issue3444/PLAN.md`.

## Linked issues / bugs

Fixes #3444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved retries for requests containing media so each attempt uses a fresh, valid request envelope.
  - Prevented previously released media data from causing retry failures.
  - Preserved the provider’s final transport error when all retry attempts are exhausted.
  - Improved handling of cancellation and failed retry preparation.
  - Added fallback behavior when refreshed request data cannot be generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->