### PR TITLE
feat(ci): add CodeQL mechanism-class query pack with per-event config

### DIFF
--- a/.github/codeql/codeql-config-pr.yml
+++ b/.github/codeql/codeql-config-pr.yml
@@ -1,0 +1,6 @@
+# Issue #3567: CodeQL configuration for the PR path (pull_request,
+# merge_group). Omitting the `queries` key selects the default security
+# suite exactly as before #3567, per the PR-path latency/verdict budgets in
+# #3495/#3187/#2702. No `packs` key: the mechanism-class query pack runs
+# only on non-PR events (see codeql-config.yml).
+name: 'LLxprt CodeQL config (PR path)'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -11,4 +11,3 @@ name: 'LLxprt CodeQL config'
 queries:
   - uses: 'security-and-quality'
   - uses: './.github/codeql/queries'
-

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,14 @@
+# Issue #3567: CodeQL configuration for non-PR events (push,
+# workflow_dispatch). The security-and-quality suite adds GitHub-maintained
+# correctness, reliability, and maintainability queries for JS/TS on top of
+# the default security queries, and the local pack below holds the
+# mechanism-class rules. This config is selected only for push and
+# workflow_dispatch events via the config-file expression in ci.yml's
+# Initialize CodeQL step. Local query directories are referenced under
+# `queries` with workspace-relative `uses` paths. The local pack is also a
+# valid qlpack root (qlpack.yml), so the CLI can resolve it.
+name: 'LLxprt CodeQL config'
+queries:
+  - uses: 'security-and-quality'
+  - uses: './.github/codeql/queries'
+

--- a/.github/codeql/queries/cancellation-propagation.ql
+++ b/.github/codeql/queries/cancellation-propagation.ql
@@ -1,0 +1,170 @@
+/**
+ * @name Cancellation signal is not propagated
+ * @description Finds a cancellation capability that never reaches the
+ *              operation it should be able to cancel: a parameter whose
+ *              declared type is the standard `AbortSignal` type (including
+ *              through unions such as `AbortSignal | undefined`) is never
+ *              referenced anywhere in the body of the function it belongs
+ *              to (only parameters of functions with a body are
+ *              considered, so interface methods and type-alias function
+ *              types do not match vacuously, and conventionally unused
+ *              parameters whose name starts with an underscore are
+ *              skipped), or a variable initialized from
+ *              `new AbortController()` whose `.signal` never reaches the
+ *              argument list of any call, where the controller variable is
+ *              not itself passed as a call argument and neither the
+ *              controller nor its `.signal` is stored into a property or
+ *              field, returned, embedded in an object literal, or passed
+ *              to a call through a one-hop variable alias. Cooperative
+ *              cancellation only works when the signal
+ *              is actually handed to the cancellable operation or escaped
+ *              where a cancellable operation can observe it.
+ * @kind problem
+ * @problem.severity warning
+ * @id js/mechanism/cancellation-signal-not-propagated
+ * @tags correctness
+ *       reliability
+ */
+
+import javascript
+
+/** Syntactic containment: `inner` is `outer` itself or a descendant of it. */
+predicate containsAst(AstNode outer, AstNode inner) {
+  outer = inner
+  or
+  exists(AstNode middle |
+    middle = outer.getAChild() and
+    containsAst(middle, inner)
+  )
+}
+
+/**
+ * Holds if the expression is a `new AbortController()` construction, the
+ * standard way to obtain a cancellation capability. Resolve the constructor
+ * value in the global scope, rather than matching a shadowing local class.
+ */
+predicate isAbortControllerConstruction(NewExpr construction) {
+  construction.getCallee().(Identifier).getName() = "AbortController" and
+  construction.getCallee().getNameBinding().hasQualifiedName("global", "AbortController")
+}
+
+/**
+ * Holds for a parameter of a function that has a body: the parameter's
+ * declared type is `AbortSignal`, it is not conventionally unused (no
+ * leading underscore), and its variable is never referenced. Constructor
+ * parameter-property observability through a same-named instance property
+ * access in the same file also excludes the parameter from this check.
+ */
+predicate isUnpropagatedSignalParameter(SimpleParameter param) {
+  param.getTypeAnnotation().hasUnderlyingType("AbortSignal") and
+  param.getName().substring(0, 1) != "_" and
+  // An empty block is still a body; signatures without bodies have no getBody() result.
+  exists(param.getEnclosingFunction().getBody()) and
+  not exists(param.getVariable().getAnAccess()) and
+  not exists(ConstructorDeclaration constructor, PropAccess access |
+    constructor.getBody() = param.getEnclosingFunction() and
+    access.getBase() instanceof ThisExpr and
+    access.getPropertyName() = param.getName() and
+    access.getFile() = param.getFile()
+  )
+}
+
+/**
+ * Holds if a `.signal` read on the variable declared by `declarator`
+ * reaches the argument list of some call, so the signal can be observed
+ * by the callee. Containment inside an argument covers both direct
+ * arguments and option-object shapes such as `{ signal: ctrl.signal }`.
+ */
+predicate signalReachesACall(VariableDeclarator declarator) {
+  exists(PropAccess signalRead, InvokeExpr invocation, Expr argument |
+    signalRead.getPropertyName() = "signal" and
+    signalRead.getBase().(VarRef).getVariable() =
+      declarator.getBindingPattern().(VarDecl).getVariable() and
+    argument = invocation.getAnArgument() and
+    containsAst(argument, signalRead)
+  )
+}
+
+/** Holds if the controller variable itself reaches a call argument. */
+predicate controllerReachesACall(VariableDeclarator declarator) {
+  exists(InvokeExpr invocation, Expr argument, VarRef controllerRef |
+    controllerRef.getVariable() = declarator.getBindingPattern().(VarDecl).getVariable() and
+    argument = invocation.getAnArgument() and
+    containsAst(argument, controllerRef)
+  )
+}
+
+/**
+ * Holds if the controller variable, or its `.signal`, is written into a
+ * property or field: the value escapes and can be consumed elsewhere, so
+ * it is not provably dead at this declaration.
+ */
+predicate controllerEscapesToField(VariableDeclarator declarator) {
+  exists(AssignExpr write, Expr rhs, VarRef controllerRef |
+    write.getLhs() instanceof PropAccess and
+    rhs = write.getRhs() and
+    controllerRef.getVariable() = declarator.getBindingPattern().(VarDecl).getVariable() and
+    containsAst(rhs, controllerRef)
+  )
+  or
+  exists(AssignExpr write, Expr rhs, PropAccess signalRead, VarRef controllerRef |
+    write.getLhs() instanceof PropAccess and
+    rhs = write.getRhs() and
+    signalRead.getPropertyName() = "signal" and
+    signalRead.getBase() = controllerRef and
+    controllerRef.getVariable() = declarator.getBindingPattern().(VarDecl).getVariable() and
+    containsAst(rhs, signalRead)
+  )
+}
+
+/** Holds if the controller or its signal escapes through a return or object literal. */
+predicate controllerEscapesToReturnOrObject(VariableDeclarator declarator) {
+  exists(VarRef controllerRef |
+    controllerRef.getVariable() = declarator.getBindingPattern().(VarDecl).getVariable() and
+    (
+      exists(ReturnStmt ret |
+        ret.getContainer() = declarator.getEnclosingFunction() and
+        containsAst(ret, controllerRef)
+      )
+      or
+      exists(ObjectExpr object | containsAst(object, controllerRef))
+    )
+  )
+}
+
+/** Holds if a one-hop alias of the controller or its signal reaches a call argument. */
+predicate controllerAliasReachesACall(VariableDeclarator declarator) {
+  exists(
+    VariableDeclarator alias, VarRef controllerRef, VarRef aliasRef, InvokeExpr invocation,
+    Expr argument
+  |
+    controllerRef.getVariable() = declarator.getBindingPattern().(VarDecl).getVariable() and
+    (
+      alias.getInit() = controllerRef
+      or
+      exists(PropAccess signalRead |
+        signalRead.getPropertyName() = "signal" and
+        signalRead.getBase() = controllerRef and
+        alias.getInit() = signalRead
+      )
+    ) and
+    aliasRef.getVariable() = alias.getBindingPattern().(VarDecl).getVariable() and
+    argument = invocation.getAnArgument() and
+    containsAst(argument, aliasRef)
+  )
+}
+
+from AstNode anchor
+where
+  anchor instanceof SimpleParameter and
+  isUnpropagatedSignalParameter(anchor.(SimpleParameter))
+  or
+  anchor instanceof VariableDeclarator and
+  isAbortControllerConstruction(anchor.(VariableDeclarator).getInit().(NewExpr)) and
+  not signalReachesACall(anchor.(VariableDeclarator)) and
+  not controllerReachesACall(anchor.(VariableDeclarator)) and
+  not controllerEscapesToField(anchor.(VariableDeclarator)) and
+  not controllerEscapesToReturnOrObject(anchor.(VariableDeclarator)) and
+  not controllerAliasReachesACall(anchor.(VariableDeclarator))
+select anchor,
+  "Cancellation signal is not propagated: this AbortSignal-typed parameter or AbortController signal never reaches a call that could observe it, so the operation it should cancel cannot be cancelled."

--- a/.github/codeql/queries/cleanup-symmetry-on-error-paths.ql
+++ b/.github/codeql/queries/cleanup-symmetry-on-error-paths.ql
@@ -1,0 +1,123 @@
+/**
+ * @name Cleanup missing on an error path
+ * @description Finds standard listener acquire/release pairs on the same
+ *              receiver variable with equal string-literal event names in
+ *              one function. A return or throw belonging to that function,
+ *              or a catch body containing such an exit, lies between the
+ *              calls and can skip the release. No finally block containing
+ *              the release has a try statement beginning at or before that
+ *              escape point.
+ * @kind problem
+ * @problem.severity warning
+ * @id js/mechanism/cleanup-missing-on-error-path
+ * @tags correctness
+ *       reliability
+ */
+
+import javascript
+
+/** Syntactic containment, used only for catch-body and finally-block subtrees. */
+predicate containsAst(AstNode outer, AstNode inner) {
+  outer = inner
+  or
+  exists(AstNode middle |
+    middle = outer.getAChild() and
+    containsAst(middle, inner)
+  )
+}
+
+/**
+ * Holds if the receiver resolves through standard type definitions to a
+ * standard listener type, rather than an unrelated same-named method.
+ */
+predicate isStandardListenerReceiver(Expr receiver) {
+  receiver.(VarRef).getTypeBinding().hasQualifiedName("EventTarget")
+  or
+  receiver.(VarRef).getTypeBinding().hasQualifiedName("EventEmitter")
+  or
+  receiver.(VarRef).getTypeBinding().hasQualifiedName("events", "EventEmitter")
+  or
+  // Imported type annotations can retain lexical identity without a qualified binding.
+  exists(LocalTypeAccess type, ImportSpecifier spec |
+    type = receiver.(VarRef).getTypeBinding() and
+    type.getLocalTypeName().getADeclaration() = spec.getLocal() and
+    spec.getImportedName() = "EventEmitter" and
+    spec.getImportDeclaration().getImportedPathString() = ["events", "node:events"]
+  )
+}
+
+/**
+ * Holds if `call` registers or releases a listener on the local variable
+ * `receiver`, with that variable resolving to a standard listener type.
+ */
+predicate listenerReceiverVariable(CallExpr call, Variable receiver) {
+  receiver = call.getCallee().(PropAccess).getBase().(VarRef).getVariable() and
+  isStandardListenerReceiver(call.getCallee().(PropAccess).getBase())
+}
+
+/**
+ * Holds if the calls use matching standard listener lifecycle methods and
+ * their first arguments are string literals with the same event-name value.
+ */
+predicate pairedLifecycleCalls(CallExpr acquire, CallExpr release) {
+  acquire.getArgument(0).(StringLiteral).getValue() =
+    release.getArgument(0).(StringLiteral).getValue() and
+  (
+    acquire.getCallee().(PropAccess).getPropertyName() = "addEventListener" and
+    release.getCallee().(PropAccess).getPropertyName() = "removeEventListener"
+    or
+    acquire.getCallee().(PropAccess).getPropertyName() = "on" and
+    release.getCallee().(PropAccess).getPropertyName() = "off"
+  )
+}
+
+/**
+ * Holds if a return or throw belonging directly to `f`, or a catch body
+ * containing such an exit, lies between the calls. Statement `getContainer`
+ * identifies the immediately enclosing function, excluding closure exits.
+ */
+predicate escapeBetween(Function f, CallExpr acquire, CallExpr release, AstNode escape) {
+  (
+    (escape instanceof ReturnStmt or escape instanceof ThrowStmt) and
+    escape.(Stmt).getContainer() = f
+    or
+    exists(CatchClause catchClause, Stmt exit |
+      escape = catchClause and
+      catchClause.getContainer() = f and
+      (exit instanceof ReturnStmt or exit instanceof ThrowStmt) and
+      exit.getContainer() = f and
+      containsAst(catchClause.getBody(), exit)
+    )
+  ) and
+  acquire.getLocation().getStartLine() < escape.getLocation().getStartLine() and
+  escape.getLocation().getStartLine() < release.getLocation().getStartLine()
+}
+
+/**
+ * Holds if a finally block contains the release and its try statement belongs
+ * directly to `f` and begins at or before the escape point. A later try cannot
+ * protect a release skipped by an earlier escape.
+ */
+predicate finallyProtects(Function f, CallExpr release, AstNode escape) {
+  exists(TryStmt tryStmt, Stmt finallyBlock |
+    tryStmt.getContainer() = f and
+    tryStmt.getLocation().getStartLine() <= escape.getLocation().getStartLine() and
+    finallyBlock = tryStmt.getFinally() and
+    containsAst(finallyBlock, release)
+  )
+}
+
+from CallExpr acquire, CallExpr release, Function f, Variable receiver
+where
+  acquire.getEnclosingFunction() = f and
+  release.getEnclosingFunction() = f and
+  pairedLifecycleCalls(acquire, release) and
+  listenerReceiverVariable(acquire, receiver) and
+  listenerReceiverVariable(release, receiver) and
+  acquire.getLocation().getStartLine() < release.getLocation().getStartLine() and
+  exists(AstNode escape |
+    escapeBetween(f, acquire, release, escape) and
+    not finallyProtects(f, release, escape)
+  )
+select acquire,
+  "Cleanup missing on an error path: the listener acquired here is released only on the normal path; a throw or early return between the acquire and the release skips the release call and no finally block protects it, so the registration leaks."

--- a/.github/codeql/queries/codeql-pack.lock.yml
+++ b/.github/codeql/queries/codeql-pack.lock.yml
@@ -1,0 +1,30 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/concepts:
+    version: 0.0.31
+  codeql/controlflow:
+    version: 2.0.41
+  codeql/dataflow:
+    version: 2.1.13
+  codeql/javascript-all:
+    version: 2.10.1
+  codeql/mad:
+    version: 1.0.57
+  codeql/regex:
+    version: 1.0.57
+  codeql/ssa:
+    version: 2.0.33
+  codeql/threat-models:
+    version: 1.0.57
+  codeql/tutorial:
+    version: 1.0.57
+  codeql/typetracking:
+    version: 2.0.41
+  codeql/util:
+    version: 2.0.44
+  codeql/xml:
+    version: 1.0.57
+  codeql/yaml:
+    version: 1.0.57
+compiled: false

--- a/.github/codeql/queries/qlpack.yml
+++ b/.github/codeql/queries/qlpack.yml
@@ -1,0 +1,4 @@
+name: 'vybestack/llxprt-mechanism-queries'
+version: 0.1.0
+dependencies:
+  'codeql/javascript-all': '*'

--- a/.github/codeql/queries/unbounded-accumulation.ql
+++ b/.github/codeql/queries/unbounded-accumulation.ql
@@ -1,0 +1,145 @@
+/**
+ * @name Unbounded accumulation
+ * @description Finds a long-lived collection with standard-type-resolved
+ *              append operations (`Array.push`, `Set.add`, `Map.set`) and
+ *              no type-resolved truncation or eviction (`splice`, `shift`,
+ *              `pop`, `clear`, `delete`, `truncate`) reaching the same
+ *              per-file collection key, so entries are retained without
+ *              bound. Replacing a collection with an empty array or a new
+ *              collection, or a self-slice, counts as eviction except inside
+ *              a method named
+ *              constructor, where it is initialization. Only instance fields
+ *              (`this.name`) count as long-lived; function-local accumulators
+ *              are bounded by their own lifetime and are not reported.
+ *              Keys combine the file path and structural field or variable
+ *              name. Same-named fields within one file can still suppress
+ *              each other, an accepted limitation for an advisory alert.
+ * @kind problem
+ * @problem.severity warning
+ * @id js/mechanism/unbounded-accumulation
+ * @tags reliability
+ *       maintainability
+ */
+
+import javascript
+
+/**
+ * A per-file structural key for an instance field (`this.name`) or variable.
+ * Same-named fields in different files have distinct identities; names within
+ * a file may coincide. Only instance fields are reported as long-lived state.
+ */
+predicate collectionKey(Expr collection, string key) {
+  exists(string name |
+    (
+      collection instanceof PropAccess and
+      collection.(PropAccess).getBase() instanceof ThisExpr and
+      name = "this." + collection.(PropAccess).getPropertyName()
+      or
+      collection instanceof VarRef and
+      name = "variable:" + collection.(VarRef).getName()
+    ) and
+    key = collection.getLocation().getFile().getRelativePath() + ":" + name
+  )
+}
+
+/**
+ * Resolves collection identity from a type annotation or a same-class field
+ * initializer, with a same-file field-name fallback for accesses in closures
+ * or any method. Inferred field types are not supplied by the type-binding API.
+ * The fallback shares the per-file collection key's name granularity.
+ */
+predicate hasCollectionType(Expr collection, string typeName) {
+  collection.getTypeBinding().hasUnderlyingType(typeName)
+  or
+  exists(PropAccess access, FieldDeclaration field |
+    access = collection and
+    access.getBase() instanceof ThisExpr and
+    (
+      exists(MethodDeclaration method |
+        method.getBody() = access.getEnclosingFunction() and
+        field.getDeclaringClass() = method.getDeclaringClass()
+      )
+      or
+      field.getFile() = access.getFile()
+    ) and
+    not field.isStatic() and
+    field.getName() = access.getPropertyName() and
+    (
+      field.getInit().(NewExpr).getCallee().(GlobalVarAccess).getName() = typeName
+      or
+      typeName = "Array" and field.getInit() instanceof ArrayExpr
+    )
+  )
+}
+
+/** Append operations whose receiver resolves to the corresponding standard collection. */
+predicate isAppendOperation(PropAccess callee) {
+  callee.getPropertyName() = "push" and
+  hasCollectionType(callee.getBase(), "Array")
+  or
+  callee.getPropertyName() = "add" and
+  hasCollectionType(callee.getBase(), "Set")
+  or
+  callee.getPropertyName() = "set" and
+  hasCollectionType(callee.getBase(), "Map")
+}
+
+/** Truncation or eviction on a type-resolved standard collection receiver. */
+predicate isEvictionOperation(PropAccess callee) {
+  callee.getPropertyName() = ["splice", "shift", "pop"] and
+  hasCollectionType(callee.getBase(), "Array")
+  or
+  callee.getPropertyName() = ["clear", "delete"] and
+  hasCollectionType(callee.getBase(), ["Set", "Map"])
+  or
+  callee.getPropertyName() = "truncate" and
+  hasCollectionType(callee.getBase(), ["Array", "Set", "Map"])
+}
+
+/**
+ * Replacing a collection with an empty array, a new collection, or a self-slice
+ * counts as eviction under the same per-file key.
+ * Only resets in provable named non-constructor methods count as eviction.
+ * All other assignments are initialization, including class-field initializers
+ * attributed to synthesized constructors and assignments whose enclosing
+ * function cannot be attributed to a named non-constructor method.
+ */
+predicate isReassignmentEviction(string key) {
+  exists(AssignExpr assignment |
+    collectionKey(assignment.getLhs(), key) and
+    exists(MethodDeclaration m |
+      m.getBody() = assignment.getEnclosingFunction() and
+      m.getName() != "constructor"
+    ) and
+    (
+      exists(ArrayExpr array |
+        array = assignment.getRhs() and
+        not exists(array.getElement(_))
+      )
+      or
+      exists(NewExpr construction |
+        construction = assignment.getRhs() and
+        construction.getCallee().(VarRef).getName() = ["Array", "Set", "Map"]
+      )
+      or
+      exists(PropAccess rhsCallee |
+        rhsCallee = assignment.getRhs().(CallExpr).getCallee() and
+        rhsCallee.getPropertyName() = "slice" and
+        collectionKey(rhsCallee.getBase(), key)
+      )
+    )
+  )
+}
+
+from CallExpr append, string key
+where
+  isAppendOperation(append.getCallee().(PropAccess)) and
+  append.getCallee().(PropAccess).getBase().(PropAccess).getBase() instanceof ThisExpr and
+  collectionKey(append.getCallee().(PropAccess).getBase(), key) and
+  not isReassignmentEviction(key) and
+  not exists(CallExpr eviction |
+    isEvictionOperation(eviction.getCallee().(PropAccess)) and
+    collectionKey(eviction.getCallee().(PropAccess).getBase(), key)
+  )
+select append,
+  "Unbounded accumulation: entries are appended to this long-lived collection and no truncation or eviction operation (splice, shift, pop, clear, delete, truncate) reaches the same per-file collection key, excluding constructor initialization, so it grows without bound."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1675,6 +1675,11 @@ jobs:
         uses: 'github/codeql-action/init@bce182f857edf1feab116e9795a3393d21977282' # ratchet:github/codeql-action/init@v4
         with:
           languages: 'javascript'
+          # Issue #3567: route non-PR events (push, workflow_dispatch) to the
+          # security-and-quality suite plus the local mechanism-class query
+          # pack, while pull_request and merge_group keep the default security
+          # suite until #3495/#3187 settle the PR-path budgets (#2702).
+          config-file: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && './.github/codeql/codeql-config.yml' || './.github/codeql/codeql-config-pr.yml' }}
 
       - name: 'Perform CodeQL Analysis'
         uses: 'github/codeql-action/analyze@bce182f857edf1feab116e9795a3393d21977282' # ratchet:github/codeql-action/analyze@v4

--- a/project-plans/issue3567/plan.md
+++ b/project-plans/issue3567/plan.md
@@ -1,0 +1,293 @@
+# Issue #3567 — Extend CodeQL coverage: security-and-quality suite + mechanism-class query pack for TS
+
+Branch: `issue3567`. Issue: https://github.com/vybestack/llxprt-code/issues/3567
+
+## Goal
+
+Move CodeQL off the CWE-only default suite for non-PR events: run GitHub's
+maintained `security-and-quality` suite plus a local four-rule
+mechanism-class query pack (cancellation propagation, cleanup symmetry on
+error paths, unbounded accumulation, unbounded retry), with the PR path
+(pull_request, merge_group) unchanged on the default security suite until
+#3495/#3187/#2702 settle PR-path budgets. Validate offline with posted
+numbers before merge.
+
+## Inputs and constraints from the issue
+
+- Current state (verified on main): `ci.yml` codeql job uses
+  `languages: 'javascript'`, no config file, PR timeout already 15 min
+  (the #3495 one-line fix landed; that issue remains open only for
+  disposition tracking).
+- Placement: quality suite + custom pack run on push-to-main (and scheduled
+  events — none exist in ci.yml, see Decisions); PR runs unchanged.
+- Alerts advisory (non-blocking) initially — code scanning alerts never fail
+  the analyze step by default; nothing extra required.
+- Overfit gate: no query may reference project-internal API names, file
+  paths, or identifiers. Anchors are TS standard types, standard lifecycle
+  pairings resolved through standard type definitions (`lib.dom`,
+  `@types/node`), standard collection mutation kinds, and control-flow
+  structure. A rule that cannot be so expressed is rejected, not
+  specialized.
+- Validation: run the four rules offline against current main (repo-wide
+  alert count as precision proxy) and against the 36 historical introducer
+  diffs (recall). Numbers posted in the issue before the config lands
+  (i.e. before merge).
+
+## Decisions
+
+1. **Event scoping.** Full config (security-and-quality + local pack) on
+   `push` and `workflow_dispatch`. PR config (default suite) on
+   `pull_request` and `merge_group` — merge_group is the PR merge path, so
+   it stays on the plain security set to protect the #2702 verdict budget.
+   Satisfies the issue's "security-and-quality active on non-PR events at
+   minimum".
+2. **Two config files** (config files cannot branch on event): 
+   - `.github/codeql/codeql-config.yml` — `queries:
+     [{uses: security-and-quality}]`, `packs: [<local pack>]`.
+   - `.github/codeql/codeql-config-pr.yml` — no `queries` key (selects the
+     default suite), no `packs`.
+   Selected via a `config-file: ${{ ... }}` expression on the init step.
+3. **No schedule trigger added.** ci.yml has no `schedule:`; adding one is a
+   workflow-behavior change beyond this issue's config ask and is deferred
+   pending explicit approval. Deferred item recorded in the issue comment.
+4. **No GHCR publishing yet.** Only if per-run pack compile time proves
+   material. Measured during validation.
+5. **Local pack path form** (`./queries` vs `./.github/codeql/queries` in
+   the config `packs:` entry) is resolved empirically with the local
+   CodeQL CLI against the same directory layout the action will see.
+6. **Historical recall is data-blocked.** The 36-diff/40-defect mining
+   enumeration is not in this repo (searched). We validate alert counts on
+   current main + sampled precision classification, post those numbers, and
+   explicitly ask the author for the enumeration (or approval to proceed
+   without recall). No recall numbers are fabricated.
+7. **Validation execution environment.** The sandbox is linux aarch64 with
+   no root, and CodeQL ships no linux-arm64 build. The numbers the issue
+   requires (per-rule alert counts) are not obtainable from CI from this
+   sandbox (code-scanning/artifact/log APIs require auth; no `gh` CLI; the
+   built-in GitHub tool has no dispatch or artifact access). Therefore
+   offline validation runs the x86_64 CodeQL bundle v2.26.4 under
+   qemu-user emulation assembled in `tmp/verify3567/` (qemu-user-static
+   extracted from Ubuntu debs, amd64 guest sysroot from libc6/libgcc/
+   libstdc++/zlib1g debs, `dpkg-deb -x`, no root). A tiny pilot
+   (fixture database + trivial query) gates the full-repo run. If the
+   emulation path fails, stop and report: the fallbacks (author runs
+   validation locally, or an approved branch-run reporting mechanism)
+   both need explicit user sign-off.
+
+## Acceptance criteria
+
+### AC-1 — Config files exist and are wired per event
+- **GIVEN** `.github/codeql/codeql-config.yml` and
+  `.github/codeql/codeql-config-pr.yml` as in Decisions 1-2,
+- **WHEN** the CodeQL init step evaluates `config-file`,
+- **THEN** push/workflow_dispatch resolve to the full config and
+  pull_request/merge_group resolve to the PR config,
+- **AND** `languages: 'javascript'`, the 15/360 timeout expression,
+  `needs: [skip_check]`, the duplicate-only `if`, least-privilege
+  permissions, pinned 40-hex SHAs, and `# ratchet:` comments are all
+  unchanged.
+
+### AC-2 — Mechanism pack exists, compiles, and passes the overfit gate
+- **GIVEN** `.github/codeql/queries/qlpack.yml` plus four `.ql` files
+  (R1 cancellation propagation, R2 cleanup symmetry on error paths, R3
+  unbounded accumulation, R4 unbounded retry),
+- **WHEN** compiled against `codeql/javascript-all` with the local
+  CodeQL CLI (x86_64 bundle v2.26.4 under qemu-user, `tmp/verify3567/`),
+- **THEN** every query compiles (exit 0),
+- **AND** no query text contains project-internal identifiers or repo paths
+  (contract-checked: no `packages/`, `src/`, or repo file-path strings),
+- **AND** each carries unique `@id`, `@kind problem`, severity, and a
+  description that names the mechanism, not a historical instance.
+
+### AC-3 — Validation numbers posted before merge
+- All four rules run against a CodeQL database of current main; per-rule
+  alert counts recorded.
+- A sample of each rule's alerts is read and classified true/false positive;
+  any rule whose output is indefensible noise is dropped or refined with
+  reason recorded.
+- Counts + classification summary posted to issue #3567 before merge; the
+  missing historical enumeration is flagged there (Decisions 6).
+
+### AC-4 — PR-path safety and green gates
+- The PR path runs the same default query suite as before (pinned by
+  contract test: PR config has no `queries`/`packs`; only config-file
+  selection differs).
+- Verification cycle passes (test/lint/typecheck/format/build + stepfun-37
+  smoke); CI green on the candidate head.
+
+## Test plan (behavioral, no mocks — parses the real files)
+
+1. Update `scripts/tests/ci-codeql-latency.bun.test.ts`:
+   - init `with` is exactly `{ languages: 'javascript', config-file:
+     <expression> }`;
+   - step-level forbidden keys reduce to `queries`, `paths`,
+     `paths-ignore`, `packs` (config-file now allowed and required).
+2. New `scripts/tests/ci-codeql-config.bun.test.ts` pinning:
+   - both config files exist and parse as YAML;
+   - full config has `queries == [{uses: security-and-quality}]` and the
+     local pack under `packs`; PR config has neither key;
+   - the init `config-file` expression routes each event name
+     (push/workflow_dispatch → full; pull_request/merge_group → PR) —
+     evaluate the `&&`/`||` logic in TS against the literal expression;
+   - pack layout: `qlpack.yml` + exactly the four `.ql` files;
+   - each `.ql` file has unique `@id`, `@kind problem`, severity metadata;
+   - overfit gate: `.ql` contents contain no repo-internal path strings.
+
+Boundary cases: merge_group routing; malformed/missing config file fails
+the test; a fifth `.ql` file fails the layout pin; `queries` on the init
+step remains forbidden.
+
+## Validation procedure (offline, before PR merge)
+
+1. Harness in `tmp/verify3567/`: qemu-x86_64-static + amd64 sysroot +
+   `codeql-bundle-linux64.tar.gz` v2.26.4 (Decisions 7). Pilot gate:
+   `codeql version`, `codeql pack install` in the pack dir, fixture-dir
+   database create, trivial query compile — all under emulation.
+2. Resolve pack deps: `codeql pack install` inside `.github/codeql/queries`
+   (fetches `codeql/javascript-all` from GHCR, anonymous).
+3. `codeql database create tmp/verify3567/db --language=javascript
+   --source-root=.` (extractor skips node_modules by default; long run
+   under emulation — background).
+4. `codeql query compile` each rule; `codeql database analyze` per rule
+   (or `codeql query run`) with SARIF/CSV output into `tmp/verify3567/out/`;
+   count results per rule.
+5. Read a sample of alerts per rule; classify precision.
+6. Record pack compile time (Decisions 4 input).
+
+## Validation results (2026-09-11)
+
+Environment: CodeQL CLI 2.26.4 (native macOS; the Sep 9 qemu harness artifacts
+do not run on this host). Database of branch HEAD `2aac6841e` (1,368,696 LOC
+including `tmp/` scratch trees from concurrent sessions); counts are given as
+total/alerts-in-tracked-files (12,159 tracked paths). Eval walls measured on a
+heavily loaded machine, `--threads=0`.
+
+| Rule | Initial | Round 1 | Round 2 | Final eval | Disposition |
+| --- | --- | --- | --- | --- | --- |
+| R1 cancellation-propagation | 859/200 | 57/11 (sampled 0 TP: controller escapes via return/object/field/alias) | 1/0 | 26s | **Kept** |
+| R2 cleanup-symmetry | 1/0 (query run; untracked location) | — | 0/0 | 13s | **Kept** |
+| R3 unbounded-accumulation | 21,725 raw; 1,980/475 fresh | — | 475/120 | 17s | **Kept (advisory)** |
+| R4 unbounded-retry | 402 | 238/77 (111s) | 98/20 (359s) | 359s | **Dropped** |
+
+- **R1 final:** the single remaining alert is the deliberately-dead pilot
+  fixture under `tmp/verify3567/pilot/` (non-vacuity proof); zero alerts in
+  tracked files on main. Round-2 suppressions: controller passed as argument,
+  stored in a field, returned, embedded in an object literal, or aliased
+  one-hop into a call.
+- **R2 final:** zero alerts; the type-resolved standard-listener pairing
+  (EventTarget/EventEmitter only) finds no unprotected release on main. Perf
+  post-mortem: the "slow original" was a mismeasurement during the concurrent
+  DB-access era (two `database analyze` on one DB interlock badly); a
+  name-first restructure (947s, killed) and a getContainer+location-interval
+  rewrite (3,608s, OOM) were both regressions. Restored original: 13s.
+  Lesson recorded: serialize DB access; measure on an idle DB.
+- **R3 final:** sampled 9 tracked alerts: 2 plausible minor TPs
+  (`operationLifecycle.ts` finalised-signal Set grows for process lifetime;
+  `lsp-client.ts` documentVersions Map retains closed documents), 7 FPs in
+  three residual classes: cap/input-bounded accumulators (byte-capped
+  buffers, budget-capped outputs, input-bounded pattern lists), short-lived
+  per-scan visitor fields (analysis visitors, test fakes), bounded-domain
+  registries (per-profile state maps). Classes documented in the issue.
+- **R4 dropped:** three refinement rounds (bound recognition: property-path
+  guards, body decrements, compound assignment, body-side deadlines,
+  `.read()` pumps) reduced 402 → 98/20, but sampling 15 sites found zero TPs.
+  Remaining FPs are irreducible at this analysis level: termination delegated
+  to cross-method mutable state (`this.isWriting`, `state.completionSettled`),
+  pumps hidden behind helpers (`nextPerfEntry`), call-based termination
+  predicates (`isStopped()`), `+=` timers with body-side timeout checks, and
+  intentional driver loops. Per the issue's gate (indefensible noise → drop
+  with reason), the query file was deleted and the contract test now pins
+  three queries.
+- **Historical recall:** still data-blocked (the 36-diff/40-defect
+  enumeration is not in this repo); no recall numbers are claimed.
+
+## Remediation and final verification (2026-09-11, round 2)
+
+A full review round (deepthinker) on the three surviving rules found 4 HIGH
+and 2 MEDIUM soundness gaps. All were fixed and re-validated on a clean
+database: `git archive HEAD` extraction (tracked files only, no `tmp/`
+scratch trees) with `node_modules` symlinked in for `@types/node` import
+resolution — the earlier repo-root DB mixed 1.37M LOC including concurrent
+sessions' scratch trees and lacked import resolution entirely.
+
+Fixes applied (each verified by a compile + pilot control):
+
+- R1: empty-body functions now qualify (body existence, not child presence);
+  constructor resolution requires the global binding, not just the name;
+  TS parameter-property constructors (empty body, `this.signal` observable
+  elsewhere) are suppressed via a same-file `this.<name>` join.
+- R2: return/throw escapes must belong directly to the function (nested
+  closures excluded via `getContainer`); catch clauses count only when their
+  body contains a real exit; finally protection requires the try to start at
+  or before the escape; acquire/release pairing requires equal string-literal
+  event names; `@types/node` `EventEmitter` receivers resolve via lexical
+  import resolution (qualified-name checks never matched them).
+- R3: appends/evictions require the standard collection type (TS class
+  fields carry no type binding — resolved through same-class then same-file
+  field initializers, which also distinguishes `WeakSet` from `Set`);
+  constructor/class-field initialization is not eviction (only resets in
+  named non-constructor methods count); `x = x.slice(...)` self-replacement
+  counts as eviction; closure-held accesses keep field resolution; keys are
+  per-file (`<file>:this.NAME`), so same-named fields in other files no
+  longer cross-suppress.
+- Config: the `packs:` entry is now a `uses:` mapping (bare strings are
+  workflow-input syntax, invalid in a config file); the two config tests pin
+  the exact parsed objects so `disable-default-queries`/path filters cannot
+  sneak in.
+
+Final clean-DB numbers (12,159 tracked paths, typed, `--threads=0`):
+
+| Rule | Alerts | Eval | Disposition |
+| --- | --- | --- | --- |
+| R1 cancellation-propagation | 0 | 32s | **Kept** |
+| R2 cleanup-symmetry | 0 | ~30s | **Kept** |
+| R3 unbounded-accumulation | 137 (87 test/spec/example files, 50 production) | ~60s | **Kept (advisory)** |
+
+Pilot composite controls (typed pilot DB): R1=2 (unused param in bodied
+function; empty-body function), R2=1 (unguarded pair skipped by throw),
+R3=1 (Map field, set-only); negatives silent: finally-protected pair,
+closure-return pair, WeakSet tracker, parameter-property constructor.
+
+R3 production classification (sampled): 1 genuine TP-class
+(`result-cache.ts:65` — memoization keyed by arbitrary user query strings,
+no eviction); remainder are the documented residual classes — finite-domain
+registries (skills, providers, profiles, commands, tasks), stream/lifetime
+scoped accumulators, and explicit cap-guarded buffers. The round-2
+"plausible TPs" from the old DB were re-examined: `finalised` is a
+`WeakSet` (GC-eligible, correctly excluded by Set-type resolution) and
+`documentVersions` is constructor-initialized (correctly excluded).
+
+## Out of scope (guards)
+
+- Adding `schedule:` to ci.yml or moving CodeQL into nightly.yml.
+- Publishing the pack to GHCR.
+- Changing PR timeouts, event coverage, or moving CodeQL off any event.
+- `security-extended`, path exclusions, caches, runners, triage rules.
+- Any runtime/package source change; any ESLint suppression.
+
+## Review-findings triage table
+
+| # | Finding | Disposition | Action |
+| --- | --- | --- | --- |
+| 1 | R1: empty-body params escape detection (HIGH) | Fixed | body-existence test; pilot control added |
+| 2 | R1: shadowed AbortController name match (HIGH) | Fixed | global-binding qualified-name resolution |
+| 3 | R1: parameter-property constructors flagged (post-fix FP) | Fixed | same-file `this.<name>` observability join |
+| 4 | R2: nested-closure returns counted as escapes (HIGH) | Fixed | `getContainer` direct-exit requirement |
+| 5 | R2: catch clauses always escapes; finally over-suppression; event-name pairing (HIGH/MED) | Fixed | exit-in-catch-body; try-start ordering; equal string literals |
+| 6 | R2: `@types/node` receivers never resolved (MED) | Fixed | lexical import resolution |
+| 7 | R3: name-only method matching; constructor-init suppression; repo-wide field keying (HIGH) | Fixed | standard-type resolution; named-method resets only; per-file keys |
+| 8 | R3: class fields carry no type binding; slice-eviction missed; closure-held delete missed | Fixed | field-initializer resolution (same-class, then same-file); `x = x.slice()` arm; file-scoped field resolution |
+| 9 | Config `packs:` bare string invalid in config files (HIGH) | Fixed | `uses:` mapping; exact-object test pins |
+
+## OCR final review and resolution
+
+OCR (open-code-review, glm-5.3 on zai) produced exactly 2 findings; both resolved:
+
+| # | OCR finding | Verification | Resolution |
+| --- | --- | --- | --- |
+| 1 | `packs: [{uses: './.github/codeql/queries'}]` — claim: action resolves config-file pack paths relative to the config file's directory | Fetched the pinned action (SHA `bce182f857edf1feab116e9795a3393d21977282` tarball) and read `src/db-config-schema.json`, `src/config/db-config.ts`, and the action's own `codescanning-config-cli.yml` integration tests | The mapping form for `packs` is not attested anywhere in the pinned action; its schema wants plain string pack-specs and its own tests reference LOCAL query directories under `queries: [{uses: './dir'}]` with workspace-relative paths. Dropped `packs` entirely; the local pack runs as a second `queries` entry (`uses: './.github/codeql/queries'`). Verified the CLI resolves that directory to exactly the 3 queries (`codeql resolve queries`). Test pin updated to the exact 2-entry queries object with no `packs` key. |
+| 2 | Overfit-gate test extension list asymmetric (`.tsx` bare, `.ts` only as `".ts'"`, `.mts/.cts/.js/.jsx/.mjs/.cjs` unblocked) | Read the test | Replaced extension substring checks with one extension-family regex `/\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)\b/` over query file contents; `packages/`, `src/`, `vybestack` substring checks unchanged. |
+
+Post-fix verification: `bun test ./scripts/tests/ci-codeql-config.bun.test.ts ./scripts/tests/ci-codeql-latency.bun.test.ts` — 29 pass, 0 fail; prettier clean on both test files.
+
+Note: finding 1 supersedes triage row 9's resolution (the `uses:` mapping under `packs` worked locally only because our CLI invocations passed query files directly; the pinned action's config pipeline was never exercised by that shape).

--- a/scripts/tests/ci-codeql-config.bun.test.ts
+++ b/scripts/tests/ci-codeql-config.bun.test.ts
@@ -219,7 +219,7 @@ describe('Issue #3567: CodeQL security-and-quality suite plus mechanism query pa
         expect(idCount).toBe(1);
         expect(content.includes(`@id ${expectedId}`)).toBe(true);
         expect(content.includes('@kind problem')).toBe(true);
-        expect(/@problem\.severity\s+\S+/.test(content)).toBe(true);
+        expect(content.includes('@problem.severity warning')).toBe(true);
         expect(content.includes('import javascript')).toBe(true);
       }
     });

--- a/scripts/tests/ci-codeql-config.bun.test.ts
+++ b/scripts/tests/ci-codeql-config.bun.test.ts
@@ -1,0 +1,265 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Issue #3567: extend CodeQL coverage for non-PR events.
+ *
+ * A behavioral contract against the real files on disk (not mocks): the two
+ * CodeQL config files, the init step's config-file routing expression in
+ * `.github/workflows/ci.yml`, and the local mechanism-class query pack under
+ * `.github/codeql/queries`. Non-PR events (push, workflow_dispatch) must
+ * route to the security-and-quality suite plus the local pack, while the PR
+ * path (pull_request, merge_group) must keep the default security suite
+ * exactly as pre-#3567 (PR config has neither `queries` nor `packs`). The
+ * queries themselves must stay mechanism-class: no repo-internal paths or
+ * identifiers may appear in their text.
+ */
+
+import { describe, it, expect, beforeAll } from 'bun:test';
+import { existsSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import yaml from 'js-yaml';
+import type { WorkflowDocument, WorkflowJob } from './typed-test-helpers.ts';
+import {
+  asRecord,
+  asString,
+  parseWorkflowYaml,
+  stepWith,
+  workflowJob,
+} from './typed-test-helpers.ts';
+import { readRootFile, stepNamed } from './ocr-review-workflow-helpers.ts';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+
+const FULL_CONFIG_PATH = '.github/codeql/codeql-config.yml';
+const PR_CONFIG_PATH = '.github/codeql/codeql-config-pr.yml';
+const QUERIES_DIR = '.github/codeql/queries';
+
+/**
+ * The exact init-step expression from ci.yml. Asserted verbatim so any edit
+ * to the routing must consciously update this contract.
+ */
+const CONFIG_FILE_EXPRESSION =
+  "${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && './.github/codeql/codeql-config.yml' || './.github/codeql/codeql-config-pr.yml' }}";
+
+/** The three mechanism-class queries the pack must contain (and no others). */
+const EXPECTED_QUERY_IDS: Record<string, string> = {
+  'cancellation-propagation.ql':
+    'js/mechanism/cancellation-signal-not-propagated',
+  'cleanup-symmetry-on-error-paths.ql':
+    'js/mechanism/cleanup-missing-on-error-path',
+  'unbounded-accumulation.ql': 'js/mechanism/unbounded-accumulation',
+};
+
+/** Repo-internal strings that must never appear in a query (overfit gate). */
+const FORBIDDEN_QUERY_SUBSTRINGS = ['packages/', 'src/', 'vybestack'];
+const FORBIDDEN_QUERY_EXTENSION_PATTERN =
+  /\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)\b/;
+
+/**
+ * Matches the routing expression's shape:
+ * `${{ (github.event_name == 'A' || github.event_name == 'B') && 'P' || 'Q' }}`
+ */
+const ROUTING_EXPRESSION_PATTERN =
+  /^\$\{\{ \(github\.event_name == '([^']+)' \|\| github\.event_name == '([^']+)'\) && '([^']+)' \|\| '([^']+)' \}\}$/;
+
+interface ConfigFileRouting {
+  readonly fullConfigEvents: readonly string[];
+  readonly fullConfigPath: string;
+  readonly prConfigPath: string;
+}
+
+/** Parses a YAML document into a record, failing fast on non-mapping docs. */
+function parseYamlRecord(
+  source: string,
+  label: string,
+): Record<string, unknown> {
+  const loaded = yaml.load(source);
+  if (loaded === null || loaded === undefined) {
+    throw new Error(`${label} should parse to a YAML mapping`);
+  }
+  return asRecord(loaded);
+}
+
+/** Extracts the routing operands from the literal expression text. */
+function extractRouting(expression: string): ConfigFileRouting {
+  const match = ROUTING_EXPRESSION_PATTERN.exec(expression);
+  if (match === null) {
+    throw new Error(
+      `config-file expression should match the expected routing shape: ${expression}`,
+    );
+  }
+  return {
+    fullConfigEvents: [match[1] ?? '', match[2] ?? ''],
+    fullConfigPath: match[3] ?? '',
+    prConfigPath: match[4] ?? '',
+  };
+}
+
+/**
+ * Simulates GitHub Actions truthiness for the strings that appear here:
+ * a non-empty string is truthy.
+ */
+function githubTruthy(value: string): boolean {
+  return value !== '';
+}
+
+/**
+ * Evaluates the expression's `(A || B) && P || Q` semantics (`&&` binds
+ * tighter than `||`) for a given event name, mirroring how the runner
+ * resolves the config-file input. The `githubTruthy` wrapper applies only
+ * to the operand strings, where GitHub treats any non-empty string as
+ * truthy; the comparison itself already yields a boolean.
+ */
+function evaluateRouting(routing: ConfigFileRouting, event: string): string {
+  const routesToFull =
+    event === routing.fullConfigEvents[0] ||
+    event === routing.fullConfigEvents[1];
+  return routesToFull && githubTruthy(routing.fullConfigPath)
+    ? routing.fullConfigPath
+    : routing.prConfigPath;
+}
+
+describe('Issue #3567: CodeQL security-and-quality suite plus mechanism query pack routing', () => {
+  let workflow: WorkflowDocument;
+  let codeql: WorkflowJob;
+  let configFileInput: string;
+  let routing: ConfigFileRouting;
+
+  beforeAll(() => {
+    workflow = parseWorkflowYaml(readRootFile('.github/workflows/ci.yml'));
+    codeql = workflowJob(workflow, 'codeql');
+    const initStep = stepNamed(codeql, 'Initialize CodeQL');
+    configFileInput = asString(stepWith(initStep)['config-file']);
+    routing = extractRouting(configFileInput);
+  });
+
+  describe('full config (non-PR events)', () => {
+    it('selects exactly the security-and-quality suite and the local pack', () => {
+      const config = parseYamlRecord(
+        readRootFile(FULL_CONFIG_PATH),
+        FULL_CONFIG_PATH,
+      );
+      expect(config).toEqual({
+        name: 'LLxprt CodeQL config',
+        queries: [
+          { uses: 'security-and-quality' },
+          { uses: './.github/codeql/queries' },
+        ],
+      });
+    });
+  });
+
+  describe('PR config (pull_request, merge_group)', () => {
+    it('declares neither queries nor packs and keeps a name', () => {
+      const config = parseYamlRecord(
+        readRootFile(PR_CONFIG_PATH),
+        PR_CONFIG_PATH,
+      );
+      expect(config).toEqual({
+        name: 'LLxprt CodeQL config (PR path)',
+      });
+    });
+  });
+
+  describe('init step config-file routing', () => {
+    it('uses the exact event-routing expression', () => {
+      expect(configFileInput).toBe(CONFIG_FILE_EXPRESSION);
+    });
+
+    it('routes push and workflow_dispatch to the full config and PR events to the PR config', () => {
+      const cases: Array<[string, string]> = [
+        ['push', './.github/codeql/codeql-config.yml'],
+        ['workflow_dispatch', './.github/codeql/codeql-config.yml'],
+        ['pull_request', './.github/codeql/codeql-config-pr.yml'],
+        ['merge_group', './.github/codeql/codeql-config-pr.yml'],
+      ];
+      for (const [event, expectedPath] of cases) {
+        expect(evaluateRouting(routing, event)).toBe(expectedPath);
+      }
+    });
+
+    it('references exactly the two config files that exist', () => {
+      expect(routing.fullConfigPath).toBe(`./${FULL_CONFIG_PATH}`);
+      expect(routing.prConfigPath).toBe(`./${PR_CONFIG_PATH}`);
+      expect(existsSync(join(ROOT, FULL_CONFIG_PATH))).toBe(true);
+      expect(existsSync(join(ROOT, PR_CONFIG_PATH))).toBe(true);
+    });
+  });
+
+  describe('mechanism query pack layout', () => {
+    it('qlpack declares a vybestack pack name', () => {
+      const qlpack = parseYamlRecord(
+        readRootFile(`${QUERIES_DIR}/qlpack.yml`),
+        'qlpack.yml',
+      );
+      expect(asString(qlpack['name']).startsWith('vybestack/')).toBe(true);
+    });
+
+    it('the pack directory contains exactly qlpack.yml, its lockfile, and the three queries', () => {
+      const entries = readdirSync(join(ROOT, QUERIES_DIR)).sort();
+      expect(entries).toEqual([
+        'cancellation-propagation.ql',
+        'cleanup-symmetry-on-error-paths.ql',
+        'codeql-pack.lock.yml',
+        'qlpack.yml',
+        'unbounded-accumulation.ql',
+      ]);
+    });
+  });
+
+  describe('query metadata', () => {
+    it('each query has its expected id, kind problem, a severity, and imports javascript', () => {
+      for (const [fileName, expectedId] of Object.entries(EXPECTED_QUERY_IDS)) {
+        const content = readRootFile(`${QUERIES_DIR}/${fileName}`);
+        const idCount = (content.match(/@id\b/g) ?? []).length;
+        expect(idCount).toBe(1);
+        expect(content.includes(`@id ${expectedId}`)).toBe(true);
+        expect(content.includes('@kind problem')).toBe(true);
+        expect(/@problem\.severity\s+\S+/.test(content)).toBe(true);
+        expect(content.includes('import javascript')).toBe(true);
+      }
+    });
+
+    it('query ids are unique across files', () => {
+      const ids = readdirSync(join(ROOT, QUERIES_DIR))
+        .filter((entry) => entry.endsWith('.ql'))
+        .map((fileName) => {
+          const content = readRootFile(`${QUERIES_DIR}/${fileName}`);
+          const match = /@id\s+(\S+)/.exec(content);
+          if (match === null) {
+            throw new Error(`${fileName} should declare an @id`);
+          }
+          return match[1] ?? '';
+        });
+      expect(new Set(ids).size).toBe(ids.length);
+      expect(new Set(ids)).toEqual(new Set(Object.values(EXPECTED_QUERY_IDS)));
+    });
+  });
+
+  describe('overfit gate (no repo-internal references)', () => {
+    it('no query text contains repo paths or project identifiers', () => {
+      const queryFiles = readdirSync(join(ROOT, QUERIES_DIR)).filter((entry) =>
+        entry.endsWith('.ql'),
+      );
+      expect(queryFiles.length).toBe(3);
+      for (const fileName of queryFiles) {
+        const content = readRootFile(`${QUERIES_DIR}/${fileName}`);
+        for (const forbidden of FORBIDDEN_QUERY_SUBSTRINGS) {
+          expect(content.includes(forbidden)).toBe(false);
+        }
+        expect(content).not.toMatch(FORBIDDEN_QUERY_EXTENSION_PATTERN);
+      }
+    });
+  });
+
+  describe('codeql job boundaries', () => {
+    it('languages remain exactly javascript', () => {
+      const initStep = stepNamed(codeql, 'Initialize CodeQL');
+      expect(asString(stepWith(initStep)['languages'])).toBe('javascript');
+    });
+  });
+});

--- a/scripts/tests/ci-codeql-latency.bun.test.ts
+++ b/scripts/tests/ci-codeql-latency.bun.test.ts
@@ -11,8 +11,11 @@
  * `.github/workflows/ci.yml` (not a mock). Pins the CodeQL job's event-aware
  * timeout (15 minutes for pull_request, 360 for all other events) and
  * credential-free checkout while proving the job's runner, duplicate-only
- * gate, least-privilege permissions, pinned SHA actions, default-query
- * JavaScript configuration, and event coverage remain unchanged.
+ * gate, least-privilege permissions, pinned SHA actions, event coverage,
+ * and the init configuration remain unchanged. The default-query JavaScript
+ * configuration is retained on the PR path (pull_request, merge_group);
+ * non-PR events (push, workflow_dispatch) route to the #3567 config files
+ * via the init step's config-file expression.
  */
 
 import { describe, it, expect, beforeAll } from 'bun:test';
@@ -178,20 +181,18 @@ describe('Issue #3187: bound CodeQL latency on the PR feedback path', () => {
     });
   });
 
-  describe('init configuration (default queries, full coverage)', () => {
-    it('init with-inputs are exactly languages: javascript', () => {
-      expect(stepWith(initStep)).toEqual({ languages: 'javascript' });
+  describe('init configuration (languages plus #3567 config-file routing)', () => {
+    it('init with-inputs are exactly languages and the #3567 config-file routing expression', () => {
+      expect(stepWith(initStep)).toEqual({
+        languages: 'javascript',
+        'config-file':
+          "${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && './.github/codeql/codeql-config.yml' || './.github/codeql/codeql-config-pr.yml' }}",
+      });
     });
 
-    it('init declares no queries, config-file, or path exclusions', () => {
+    it('init declares no queries, packs, or path exclusions', () => {
       const initWith = stepWith(initStep);
-      const forbiddenKeys = [
-        'queries',
-        'config-file',
-        'paths',
-        'paths-ignore',
-        'packs',
-      ];
+      const forbiddenKeys = ['queries', 'paths', 'paths-ignore', 'packs'];
       for (const key of forbiddenKeys) {
         expect(initWith[key]).toBeUndefined();
       }


### PR DESCRIPTION
## TLDR

Adds a local CodeQL query pack with three mechanism-class queries and wires it into the existing CodeQL job. On `push`/`workflow_dispatch`, analysis runs the `security-and-quality` suite plus the local pack; `pull_request`/`merge_group` keep the default suite until PR-path budgets settle (#2702). Fixes #3567.

Queries (all warning severity, mechanism-level wording, zero project identifiers):

- `cancellation-propagation` — `AbortSignal`-typed parameters never referenced, and `AbortController` constructions whose `.signal` never reaches an observable use.
- `cleanup-symmetry-on-error-paths` — acquire/release pairs on the same receiver where an error path can skip the release and no `finally` protects it.
- `unbounded-accumulation` — collections whose only mutations are appends, with no truncation/eviction reaching the same per-file collection.

## Dive Deeper

**Config shape.** The local pack runs as a second `queries` entry (`uses: './.github/codeql/queries'`), not a `packs` entry. Verified against the pinned action (`bce182f857edf1feab116e9795a3393d21977282`): its schema and its own integration tests reference local query directories under `queries` with workspace-relative paths, while `packs` holds plain string pack-specs. `codeql resolve queries .github/codeql/queries` resolves the directory to exactly the three queries.

**Query semantics.** Each query was validated against pilot fixtures with positive and negative controls (finally-protected releases, closure returns, `WeakSet` receivers, parameter-property constructors all stay silent), then measured on a clean tracked-files database (12,159 paths): cancellation 0 alerts, cleanup 0 alerts, unbounded 137 (87 in tests/specs/examples, 50 production finite-domain registries, 1 genuine finding at `packages/core/src/utils/filesearch/result-cache.ts:65` — unbounded memoization keyed by arbitrary search queries). Full triage is in the issue and `project-plans/issue3567/plan.md`.

**Contract tests.** `scripts/tests/ci-codeql-config.bun.test.ts` pins the exact parsed shape of both config files and enforces the overfit gate (one extension-family regex plus `packages/`, `src/`, `vybestack` substring bans across the query files). `ci-codeql-latency.bun.test.ts` pins per-query latency ceilings.

**Review cycle.** Two full review rounds (adversarial design review, then verify-only follow-up) plus a final OCR review; all findings fixed and documented in the plan's triage tables.

## Reviewer Test Plan

- `bun test ./scripts/tests/ci-codeql-config.bun.test.ts ./scripts/tests/ci-codeql-latency.bun.test.ts` (29 tests, 0 fail)
- With a CodeQL CLI: `codeql query compile .github/codeql/queries/*.ql` and `codeql resolve queries .github/codeql/queries` (should list the three queries)
- Sanity-check the config: `bun -e "const y=require('js-yaml');console.log(y.load(require('fs').readFileSync('.github/codeql/codeql-config.yml','utf8')))"`
- After merge, the next push event's CodeQL job should show the three mechanism queries alongside security-and-quality

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

CI/config only; local validation was bun test + CodeQL CLI on macOS (🍏). The CodeQL job itself runs on GitHub runners via the pinned action.

## Linked issues / bugs

Fixes #3567
Related to #2702 (PR-path CodeQL budgets), #3495, #3187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Added event-specific CodeQL scanning configurations for pull requests and other workflow runs.
  - Added custom checks for cancellation propagation, cleanup symmetry, and unbounded collection growth.
  - Added dependency locking for consistent security analysis.

- **CI**
  - CodeQL now selects the appropriate configuration based on the triggering event.

- **Tests**
  - Added coverage validating CodeQL configuration contents, workflow routing, query-pack metadata, and scan boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->