### PR TITLE
feat(profiles): transactional ProfileController with scheduler-safe commits

### DIFF
--- a/packages/agents/src/core/profile/__tests__/activeProfileRuntime.test.ts
+++ b/packages/agents/src/core/profile/__tests__/activeProfileRuntime.test.ts
@@ -1,0 +1,429 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import type {
+  ProfileState,
+  ProfileRuntimeBinding,
+  EffectiveToolPolicy,
+  PolicyCeiling,
+} from '@vybestack/llxprt-code-core';
+import { ActiveProfileRuntime } from '../activeProfileRuntime.js';
+import {
+  configuredState as requireConfigured,
+  type ConfiguredProfileState,
+} from './controllerTestFakes.js';
+
+const permissivePolicy: EffectiveToolPolicy = {
+  allowedTools: [],
+  disabledTools: [],
+  shellMode: 'all',
+  approvalCeiling: 'yolo',
+};
+
+const configuredState = (): ConfiguredProfileState => ({
+  status: 'configured',
+  revision: 3,
+  identity: {
+    kind: 'saved',
+    name: 'work',
+    source: { kind: 'stat', mtimeMs: 1234, size: 512 },
+  },
+  document: {
+    version: 1,
+    type: 'standard',
+    provider: 'anthropic',
+    model: 'claude-3-7-sonnet',
+    modelParams: { temperature: 0.2 },
+    ephemeralSettings: {},
+  },
+});
+
+/**
+ * Controllable fake binding whose dispose never settles until released.
+ */
+function deferredBinding(): {
+  binding: ProfileRuntimeBinding;
+  release: () => void;
+  disposeCount: () => number;
+} {
+  let disposeCalls = 0;
+  let release: () => void = () => {};
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const binding: ProfileRuntimeBinding = {
+    bindingId: 'binding-fake-1',
+    configFingerprint: 'fp-1',
+    [Symbol.asyncDispose]: (): Promise<void> => {
+      disposeCalls += 1;
+      return promise;
+    },
+  };
+  return {
+    binding,
+    release,
+    disposeCount: () => disposeCalls,
+  };
+}
+
+describe('ActiveProfileRuntime', () => {
+  it('exposes the construction state and a healthy default', () => {
+    const runtime = new ActiveProfileRuntime(
+      configuredState,
+      undefined,
+      permissivePolicy,
+    );
+    expect(runtime.getState()).toStrictEqual(configuredState());
+    expect(runtime.getHealth()).toStrictEqual({
+      status: 'ok',
+      degradedAspects: [],
+    });
+  });
+
+  describe('ActiveProfileRuntime policy and role views', () => {
+    const declarations = [
+      { name: 'read', description: 'Read a file' },
+      { name: 'edit', description: 'Edit a file' },
+      { name: 'shell', description: 'Run a command' },
+    ];
+
+    it('filters from an immutable construction policy without changing declarations', () => {
+      const policy: EffectiveToolPolicy = {
+        allowedTools: ['read', 'edit'],
+        disabledTools: ['edit'],
+        shellMode: 'allowlist',
+        approvalCeiling: 'standard',
+      };
+      const runtime = new ActiveProfileRuntime(configuredState, 5000, policy);
+      policy.allowedTools = ['shell'];
+      policy.disabledTools = [];
+      const filtered = runtime.getFilteredToolDeclarations(declarations);
+      expect(filtered).toStrictEqual([declarations[0]]);
+      expect(Object.isFrozen(filtered)).toStrictEqual(true);
+      expect(Object.isFrozen(filtered[0])).toStrictEqual(true);
+      expect(Object.isFrozen(declarations[0])).toStrictEqual(false);
+      expect(Object.isFrozen(runtime.getPolicy())).toStrictEqual(true);
+      expect(Object.isFrozen(runtime.getPolicy().allowedTools)).toStrictEqual(
+        true,
+      );
+    });
+
+    it('keeps all declarations with an unrestricted allowlist, except disabled tools', () => {
+      const runtime = new ActiveProfileRuntime(
+        configuredState,
+        undefined,
+        permissivePolicy,
+      );
+      expect(runtime.getFilteredToolDeclarations(declarations)).toStrictEqual(
+        declarations,
+      );
+      const restricted = new ActiveProfileRuntime(configuredState, 5000, {
+        ...runtime.getPolicy(),
+        disabledTools: ['shell'],
+      });
+      expect(
+        restricted.getFilteredToolDeclarations(declarations),
+      ).toStrictEqual(declarations.slice(0, 2));
+    });
+
+    it('captures the role document and parent revision while sharing the binding', async () => {
+      const parent = new ActiveProfileRuntime(configuredState, 5000, {
+        allowedTools: ['read', 'edit'],
+        disabledTools: ['shell'],
+        shellMode: 'allowlist',
+        approvalCeiling: 'standard',
+      });
+      const fake = deferredBinding();
+      parent.attach(fake.binding);
+      const document = {
+        ...configuredState().document,
+        modelParams: { temperature: 0.2 },
+      };
+      const captured = structuredClone(document);
+      const rolePolicy: PolicyCeiling = {
+        allowedTools: ['read'],
+        approvalCeiling: 'strict',
+      };
+      expect(parent.snapshot().roleRuntimeCount).toStrictEqual(0);
+      const child = parent.createRoleRuntime(
+        { name: 'reviewer', document },
+        rolePolicy,
+      );
+      document.model = 'changed';
+      document.modelParams['temperature'] = 0.9;
+      rolePolicy.allowedTools = ['shell'];
+      parent.resupplyState(() => ({ ...configuredState(), revision: 4 }));
+      expect(requireConfigured(child.getState()).document).toStrictEqual(
+        captured,
+      );
+      expect(child.snapshot().revision).toStrictEqual(3);
+      expect(
+        Object.isFrozen(
+          requireConfigured(child.getState()).document.modelParams,
+        ),
+      ).toStrictEqual(true);
+      expect(child.getBindingId()).toStrictEqual(parent.getBindingId());
+      expect(child.getPolicy()).toStrictEqual({
+        allowedTools: ['read'],
+        disabledTools: ['shell'],
+        shellMode: 'allowlist',
+        approvalCeiling: 'strict',
+      });
+      expect(child.getFilteredToolDeclarations(declarations)).toStrictEqual([
+        declarations[0],
+      ]);
+      expect(parent.snapshot().roleRuntimeCount).toStrictEqual(1);
+      expect(JSON.stringify(parent.snapshot())).not.toContain('reviewer');
+      await child[Symbol.asyncDispose]();
+      expect(fake.disposeCount()).toStrictEqual(0);
+      fake.release();
+      await parent[Symbol.asyncDispose]();
+      await child[Symbol.asyncDispose]();
+      expect(fake.disposeCount()).toStrictEqual(1);
+    });
+
+    it('does not widen tools for disjoint role allowlists or omitted ceilings', () => {
+      const parent = new ActiveProfileRuntime(configuredState, 5000, {
+        allowedTools: ['read'],
+        disabledTools: [],
+        shellMode: 'none',
+        approvalCeiling: 'strict',
+      });
+      const roleRef = { name: 'role', document: configuredState().document };
+      const unrestricted = parent.createRoleRuntime(roleRef);
+      expect(unrestricted.getPolicy()).toStrictEqual(parent.getPolicy());
+      const disjoint = parent.createRoleRuntime(roleRef, {
+        allowedTools: ['edit'],
+      });
+      expect(disjoint.getFilteredToolDeclarations(declarations)).toStrictEqual(
+        [],
+      );
+      const descendant = disjoint.createRoleRuntime(roleRef);
+      expect(
+        descendant.getFilteredToolDeclarations(declarations),
+      ).toStrictEqual([]);
+    });
+
+    it('narrows an unrestricted parent to the role allowlist', () => {
+      const parent = new ActiveProfileRuntime(
+        configuredState,
+        undefined,
+        permissivePolicy,
+      );
+      const child = parent.createRoleRuntime(
+        { name: 'reader', document: configuredState().document },
+        { allowedTools: ['read'] },
+      );
+      expect(child.getPolicy().allowedTools).toStrictEqual(['read']);
+      expect(child.getFilteredToolDeclarations(declarations)).toStrictEqual([
+        declarations[0],
+      ]);
+    });
+  });
+
+  it('snapshot follows a re-supplied state and keeps health untouched', () => {
+    const savedState = (): ConfiguredProfileState => ({
+      status: 'configured',
+      revision: 1,
+      identity: {
+        kind: 'saved',
+        name: 'work',
+        source: { kind: 'stat', mtimeMs: 7, size: 9 },
+      },
+      document: {
+        version: 1,
+        type: 'standard',
+        provider: 'prov-a',
+        model: 'm1',
+        modelParams: {},
+        ephemeralSettings: {},
+      },
+    });
+    let current = savedState();
+    const runtime = new ActiveProfileRuntime(
+      () => current,
+      undefined,
+      permissivePolicy,
+    );
+    runtime.attach(deferredBinding().binding);
+    runtime.reportDegradation(['slow']);
+
+    current = {
+      ...savedState(),
+      revision: 2,
+      identity: {
+        kind: 'draft',
+        derivedFrom: {
+          name: 'work',
+          source: { kind: 'stat', mtimeMs: 7, size: 9 },
+        },
+      },
+    };
+    runtime.resupplyState(() => current);
+
+    const snapshot = runtime.snapshot();
+    expect(snapshot.revision).toBe(2);
+    expect(snapshot.identity).toStrictEqual(current.identity);
+    expect(snapshot.identityKind).toBe('draft');
+    expect(runtime.getHealth()).toStrictEqual({
+      status: 'degraded',
+      degradedAspects: ['slow'],
+    });
+  });
+
+  it('attach rebinds and keeps current health', () => {
+    const runtime = new ActiveProfileRuntime(
+      configuredState,
+      undefined,
+      permissivePolicy,
+    );
+    const { binding } = deferredBinding();
+    runtime.attach(binding);
+    runtime.reportDegradation(['slow']);
+    expect(runtime.getHealth().status).toBe('degraded');
+    runtime.attach(binding);
+    expect(runtime.getHealth()).toStrictEqual({
+      status: 'degraded',
+      degradedAspects: ['slow'],
+    });
+    expect(runtime.getBinding()).toBe(binding);
+    expect(runtime.getBindingId()).toBe('binding-fake-1');
+  });
+
+  it('inheritHealthFrom carries a prior runtime health across a binding reuse', () => {
+    const prior = new ActiveProfileRuntime(
+      configuredState,
+      undefined,
+      permissivePolicy,
+    );
+    const { binding } = deferredBinding();
+    prior.attach(binding);
+    prior.reportDegradation(['lb-member-down']);
+
+    const next = new ActiveProfileRuntime(
+      configuredState,
+      undefined,
+      permissivePolicy,
+    );
+    next.attach(binding);
+    expect(next.getHealth()).toStrictEqual({
+      status: 'ok',
+      degradedAspects: [],
+    });
+    next.inheritHealthFrom(prior);
+    expect(next.getHealth()).toStrictEqual({
+      status: 'degraded',
+      degradedAspects: ['lb-member-down'],
+    });
+  });
+
+  it('degradation does not change identity, revision, or document', () => {
+    const runtime = new ActiveProfileRuntime(
+      configuredState,
+      undefined,
+      permissivePolicy,
+    );
+    const before = structuredClone(runtime.getState());
+    runtime.attach(deferredBinding().binding);
+    runtime.reportDegradation(['slow', 'stale']);
+    expect(runtime.getState()).toStrictEqual(before);
+    expect(runtime.getHealth().status).toBe('degraded');
+    expect([...runtime.getHealth().degradedAspects].sort()).toStrictEqual([
+      'slow',
+      'stale',
+    ]);
+    const state = requireConfigured(runtime.getState());
+    expect(state.revision).toBe(3);
+    expect(state.identity.kind).toBe('saved');
+    expect(state.document).toStrictEqual(configuredState().document);
+  });
+
+  it('recovery removes aspects and returns to ok when none remain', () => {
+    const runtime = new ActiveProfileRuntime(
+      configuredState,
+      undefined,
+      permissivePolicy,
+    );
+    runtime.attach(deferredBinding().binding);
+    runtime.reportDegradation(['a', 'b']);
+    runtime.reportRecovery(['a']);
+    expect(runtime.getHealth()).toStrictEqual({
+      status: 'degraded',
+      degradedAspects: ['b'],
+    });
+    runtime.reportRecovery(['b']);
+    expect(runtime.getHealth()).toStrictEqual({
+      status: 'ok',
+      degradedAspects: [],
+    });
+  });
+
+  it('asyncDispose disposes the binding exactly once even when it hangs', async () => {
+    const fake = deferredBinding();
+    const runtime = new ActiveProfileRuntime(
+      configuredState,
+      100,
+      permissivePolicy,
+    );
+    runtime.attach(fake.binding);
+    await runtime[Symbol.asyncDispose]();
+    expect(fake.disposeCount()).toBe(1);
+    expect(runtime.getHealth().status).toBe('degraded');
+    fake.release();
+  });
+
+  it('asyncDispose swallows a failing dispose and records a degraded aspect', async () => {
+    const failingBinding: ProfileRuntimeBinding = {
+      bindingId: 'binding-fake-2',
+      configFingerprint: 'fp-2',
+      [Symbol.asyncDispose]: async () => {
+        throw new Error('dispose boom');
+      },
+    };
+    const runtime = new ActiveProfileRuntime(
+      configuredState,
+      undefined,
+      permissivePolicy,
+    );
+    runtime.attach(failingBinding);
+    await expect(runtime[Symbol.asyncDispose]()).resolves.toBeUndefined();
+    expect(runtime.getHealth().status).toBe('degraded');
+    expect(runtime.getHealth().degradedAspects[0]).toContain('dispose-failed');
+  });
+
+  it('snapshot exposes no secret keys', () => {
+    const state: ProfileState = {
+      status: 'configured',
+      revision: 2,
+      identity: {
+        kind: 'draft',
+        derivedFrom: {
+          name: 'work',
+          source: { kind: 'stat', mtimeMs: 1, size: 2 },
+        },
+      },
+      document: {
+        version: 1,
+        provider: 'openai',
+        model: 'gpt-4o',
+        modelParams: {},
+        ephemeralSettings: {
+          'auth-key': 'sk-super-secret',
+          'auth-key-name': 'creds',
+        },
+      },
+    };
+    const runtime = new ActiveProfileRuntime(
+      () => state,
+      undefined,
+      permissivePolicy,
+    );
+    const snapshot = runtime.snapshot();
+    expect(JSON.stringify(snapshot)).not.toContain('sk-super-secret');
+    expect(JSON.stringify(snapshot)).not.toContain('auth-key');
+  });
+});

--- a/packages/agents/src/core/profile/__tests__/activeProfileRuntime.test.ts
+++ b/packages/agents/src/core/profile/__tests__/activeProfileRuntime.test.ts
@@ -11,7 +11,10 @@ import type {
   EffectiveToolPolicy,
   PolicyCeiling,
 } from '@vybestack/llxprt-code-core';
-import { ActiveProfileRuntime } from '../activeProfileRuntime.js';
+import {
+  ActiveProfileRuntime,
+  ProfileRuntimeDisposedError,
+} from '../activeProfileRuntime.js';
 import {
   configuredState as requireConfigured,
   type ConfiguredProfileState,
@@ -273,6 +276,52 @@ describe('ActiveProfileRuntime', () => {
       status: 'degraded',
       degradedAspects: ['slow'],
     });
+  });
+
+  it('invalidates role operations on reattachment without widening binding ownership', async () => {
+    const runtime = new ActiveProfileRuntime(
+      configuredState,
+      100,
+      permissivePolicy,
+    );
+    const first = deferredBinding();
+    const second = deferredBinding();
+    runtime.attach(first.binding);
+    const role = { name: 'reader', document: configuredState().document };
+    const child = runtime.createRoleRuntime(role);
+    const descendant = child.createRoleRuntime(role);
+    runtime.attach(first.binding);
+    expect(child.getBinding()).toStrictEqual(first.binding);
+    runtime.attach(second.binding);
+    const operations = [
+      () => child.getState(),
+      () => child.getPolicy(),
+      () => child.getFilteredToolDeclarations([]),
+      () => child.getHealth(),
+      () => child.getBinding(),
+      () => child.getBindingId(),
+      () => child.snapshot(),
+      () => child.attach(second.binding),
+      () => child.createRoleRuntime(role),
+      () => child.reportDegradation(['stale']),
+      () => child.reportRecovery(['stale']),
+      () => child.resupplyState(configuredState),
+      () => child.releaseOwnership(),
+      () => child.inheritHealthFrom(runtime),
+      () => child.retainRoleRuntimesFrom(runtime),
+      () => descendant.getBinding(),
+    ];
+    for (const operation of operations)
+      expect(operation).toThrow(ProfileRuntimeDisposedError);
+    await child[Symbol.asyncDispose]();
+    expect(first.disposeCount()).toStrictEqual(0);
+    const fresh = runtime.createRoleRuntime(role);
+    expect(fresh.getBinding()).toStrictEqual(second.binding);
+    const disposing = runtime[Symbol.asyncDispose]();
+    expect(() => fresh.getBinding()).toThrow(ProfileRuntimeDisposedError);
+    expect(second.disposeCount()).toStrictEqual(1);
+    second.release();
+    await disposing;
   });
 
   it('attach rebinds and keeps current health', () => {

--- a/packages/agents/src/core/profile/__tests__/controller-commit.test.ts
+++ b/packages/agents/src/core/profile/__tests__/controller-commit.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it, spyOn } from 'bun:test';
 import { commitCandidate } from '../controllerCommit.js';
 import { ProfileController } from '../profileController.js';
+import { ProfileRuntimeDisposedError } from '../activeProfileRuntime.js';
 import {
   FakeBinding,
   makeDeps,
@@ -16,6 +17,61 @@ import {
 } from './controllerTestFakes.js';
 
 describe('profile commit ownership', () => {
+  it.each([false, true])(
+    'invalidates retained roles on binding replacement after reuse=%s',
+    async (reuse) => {
+      const harness = makeDeps();
+      harness.repo.seed('first');
+      harness.repo.seed('second', standardProvADocument('m2'));
+      const controller = new ProfileController(harness.deps);
+      await releaseAndAwait(
+        harness,
+        controller.execute({
+          kind: 'startup',
+          profileName: 'first',
+          expectedRevision: 0,
+        }),
+      );
+      const prior = controller.getRuntime();
+      if (prior === undefined) throw new Error('expected runtime');
+      const binding = prior.getBinding();
+      if (!(binding instanceof FakeBinding))
+        throw new Error('expected binding');
+      const roleRef = { name: 'reader', document: standardProvADocument('m1') };
+      const child = prior.createRoleRuntime(roleRef);
+      if (reuse) {
+        await releaseAndAwait(
+          harness,
+          controller.execute({
+            kind: 'load',
+            name: 'first',
+            expectedRevision: 1,
+          }),
+        );
+      }
+      expect(child.getBinding()).toStrictEqual(binding);
+      const result = await releaseAndAwait(
+        harness,
+        controller.execute({
+          kind: 'load',
+          name: 'second',
+          expectedRevision: reuse ? 2 : 1,
+        }),
+      );
+      expect(result.kind).toStrictEqual('committed');
+      expect(binding.disposeCount).toStrictEqual(1);
+      expect(() => child.getBinding()).toThrow(ProfileRuntimeDisposedError);
+      expect(() => child.getState()).toThrow(ProfileRuntimeDisposedError);
+      const current = controller.getRuntime();
+      if (current === undefined) throw new Error('expected replacement');
+      const fresh = current.createRoleRuntime(roleRef);
+      expect(fresh.getBinding()).toStrictEqual(current.getBinding());
+      expect(fresh.getBindingId()).not.toStrictEqual(binding.bindingId);
+      await controller.dispose();
+      expect(() => fresh.getBinding()).toThrow(ProfileRuntimeDisposedError);
+    },
+  );
+
   it('preserves the cancelled outcome when candidate disposal throws synchronously', async () => {
     const harness = makeDeps();
     const abort = new AbortController();

--- a/packages/agents/src/core/profile/__tests__/controller-commit.test.ts
+++ b/packages/agents/src/core/profile/__tests__/controller-commit.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, spyOn } from 'bun:test';
+import { commitCandidate } from '../controllerCommit.js';
+import { ProfileController } from '../profileController.js';
+import {
+  FakeBinding,
+  makeDeps,
+  releaseAndAwait,
+  seedMyLb,
+  standardProvADocument,
+} from './controllerTestFakes.js';
+
+describe('profile commit ownership', () => {
+  it('preserves the cancelled outcome when candidate disposal throws synchronously', async () => {
+    const harness = makeDeps();
+    const abort = new AbortController();
+    let disposals = 0;
+    harness.deps.boundary = {
+      withSafeBoundary: async (fn) => ({
+        status: 'committed',
+        value: await fn(),
+      }),
+    };
+    harness.deps.runtimeFactory = {
+      build: async () => {
+        abort.abort();
+        return {
+          bindingId: 'throwing-dispose',
+          configFingerprint: 'candidate',
+          [Symbol.asyncDispose](): Promise<void> {
+            disposals += 1;
+            throw new Error('synchronous cleanup failure');
+          },
+        };
+      },
+    };
+    const outcome = await commitCandidate(
+      { status: 'unconfigured' },
+      {
+        document: standardProvADocument('m1'),
+        identity: { kind: 'draft' },
+        commandKind: 'startup',
+        baseRevision: 0,
+        nextRevision: 1,
+      },
+      { kind: 'startup', provider: 'prov-a', expectedRevision: 0 },
+      harness.deps,
+      undefined,
+      () => false,
+      () => {},
+      abort.signal,
+    );
+    expect(outcome.result).toStrictEqual({
+      kind: 'cancelled',
+      reason: 'execute cancelled',
+      revision: 0,
+    });
+    expect(disposals).toStrictEqual(1);
+  });
+
+  it('leaves the prior runtime owning a reused binding when health transfer fails', async () => {
+    const harness = makeDeps();
+    seedMyLb(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    await releaseAndAwait(
+      harness,
+      controller.execute({
+        kind: 'startup',
+        profileName: 'mylb',
+        expectedRevision: 0,
+      }),
+    );
+    const prior = controller.getRuntime();
+    if (prior === undefined) throw new Error('expected prior runtime');
+    const binding = prior.getBinding();
+    if (!(binding instanceof FakeBinding))
+      throw new Error('expected fake binding');
+    const health = spyOn(prior, 'getHealth').mockImplementation(() => {
+      throw new Error('health unavailable');
+    });
+    try {
+      expect(
+        await releaseAndAwait(
+          harness,
+          controller.execute({
+            kind: 'load',
+            name: 'mylb',
+            expectedRevision: 1,
+          }),
+        ),
+      ).toStrictEqual({
+        kind: 'failed',
+        error: 'runtime swap failed',
+        revision: 1,
+      });
+      expect(binding.disposeCount).toStrictEqual(0);
+      await controller.dispose();
+      expect(binding.disposeCount).toStrictEqual(1);
+    } finally {
+      health.mockRestore();
+    }
+  });
+});

--- a/packages/agents/src/core/profile/__tests__/controllerTestFakes.ts
+++ b/packages/agents/src/core/profile/__tests__/controllerTestFakes.ts
@@ -1,0 +1,629 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Deterministic infrastructure fakes for the profile controller tests.
+ *
+ * Each fake implements one core port the agents controller consumes: an in-memory
+ * repository with content-hash fingerprints, a scheduler boundary that resolves only
+ * when a test releases it, a counting runtime factory whose fingerprint is derived
+ * from document content, a static provider catalog, and a permissive trust ceiling.
+ */
+
+import {
+  fingerprintsMatch,
+  ProfileRepositoryConflictError,
+  type ProfileDocument,
+  type ProfileState,
+  type ProfileCommandResult,
+  type WorkingProfileIdentity,
+  type ProfileRepositoryPort,
+  type ProfileRuntimeBinding,
+  type ProfileRuntimeFactoryPort,
+  type ProviderModelCatalogPort,
+  type ResolvedProfileSpec,
+  type SafeBoundaryOutcome,
+  type SchedulerBoundaryPort,
+  type SourceFingerprint,
+  type StandardProfileDocument,
+  type TrustToolEnvironmentPort,
+} from '@vybestack/llxprt-code-core';
+import type { ProfileController } from '../profileController.js';
+import type { ActiveProfileRuntime } from '../activeProfileRuntime.js';
+import type { ProfileControllerDeps } from '../controllerTypes.js';
+
+/**
+ * Build a standard `prov-a` document for the given model.
+ */
+export function standardProvADocument(model: string): StandardProfileDocument {
+  return {
+    version: 1,
+    type: 'standard',
+    provider: 'prov-a',
+    model,
+    modelParams: {},
+    ephemeralSettings: {},
+  };
+}
+
+/**
+ * Content-derived fingerprint: identical documents always carry identical
+ * fingerprints, and the value is stable across repeated stat calls.
+ */
+function contentFingerprint(document: ProfileDocument): SourceFingerprint {
+  return { kind: 'hash', hash: `content:${JSON.stringify(document)}` };
+}
+
+interface RepositoryEntry {
+  document: ProfileDocument;
+  fingerprint: SourceFingerprint;
+}
+
+/**
+ * Map-backed repository fake. Fingerprints are content hashes, so a save with an
+ * expected fingerprint only conflicts when the stored entry was tampered with or
+ * holds different content. Loading a missing profile throws; saving with an
+ * expected fingerprint against a missing or mismatched entry raises
+ * {@link ProfileRepositoryConflictError} exactly like the real adapter.
+ */
+export class InMemoryRepository implements ProfileRepositoryPort {
+  private readonly entries = new Map<string, RepositoryEntry>();
+  private readFailureArmed = false;
+
+  async load(
+    name: string,
+  ): Promise<{ document: ProfileDocument; fingerprint: SourceFingerprint }> {
+    this.maybeFailRead();
+    const entry = this.entries.get(name);
+    if (entry === undefined) {
+      throw new Error(`Profile '${name}' not found`);
+    }
+    return { document: entry.document, fingerprint: entry.fingerprint };
+  }
+
+  async save(
+    name: string,
+    document: ProfileDocument,
+    expected?: SourceFingerprint,
+    opts?: { mustCreate?: boolean },
+  ): Promise<SourceFingerprint> {
+    if (opts?.mustCreate === true && this.entries.has(name)) {
+      throw new ProfileRepositoryConflictError(
+        `Profile '${name}' already exists`,
+      );
+    }
+    if (expected !== undefined) {
+      const current = this.entries.get(name);
+      if (
+        current === undefined ||
+        !fingerprintsMatch(current.fingerprint, expected)
+      ) {
+        throw new ProfileRepositoryConflictError(
+          `Profile '${name}' changed on disk`,
+        );
+      }
+    }
+    const fingerprint = contentFingerprint(document);
+    this.entries.set(name, { document, fingerprint });
+    return fingerprint;
+  }
+
+  async list(): Promise<ReadonlyArray<{ name: string }>> {
+    return [...this.entries.keys()].map((name) => ({ name }));
+  }
+
+  async delete(name: string): Promise<void> {
+    this.entries.delete(name);
+  }
+
+  async stat(name: string): Promise<SourceFingerprint | null> {
+    this.maybeFailRead();
+    return this.entries.get(name)?.fingerprint ?? null;
+  }
+
+  /**
+   * Make the next repository read (load or stat) throw once, simulating an I/O
+   * failure underneath the port. Either read can fail so a failure can be injected at
+   * any point of a command's repository interaction.
+   */
+  failNextRead(): void {
+    this.readFailureArmed = true;
+  }
+
+  private maybeFailRead(): void {
+    if (this.readFailureArmed) {
+      this.readFailureArmed = false;
+      throw new Error('repository I/O failed');
+    }
+  }
+
+  /**
+   * Seed a profile under `name`, defaulting to the standard `prov-a`/`m1` document.
+   */
+  seed(
+    name: string,
+    document: ProfileDocument = standardProvADocument('m1'),
+  ): void {
+    this.entries.set(name, {
+      document,
+      fingerprint: contentFingerprint(document),
+    });
+  }
+
+  /**
+   * Simulate an external edit by replacing the stored fingerprint with a different
+   * value: either the explicit fingerprint a test supplies, or a derived variant of
+   * the current one. The document content is left alone; only the fingerprint moves.
+   */
+  tamperFingerprint(name: string, fingerprint?: SourceFingerprint): void {
+    const entry = this.entries.get(name);
+    if (entry === undefined) {
+      throw new Error(`cannot tamper fingerprint of unknown profile '${name}'`);
+    }
+    entry.fingerprint =
+      fingerprint ??
+      (entry.fingerprint.kind === 'hash'
+        ? { kind: 'hash', hash: `${entry.fingerprint.hash}:tampered` }
+        : {
+            kind: 'stat',
+            mtimeMs: entry.fingerprint.mtimeMs + 1,
+            size: entry.fingerprint.size,
+          });
+  }
+}
+
+/**
+ * Scheduler boundary fake that never opens its window on its own: every caller is
+ * parked until a test releases it. `release('safe')` runs the parked work inside the
+ * held window and settles the caller with the committed value; `release('cancelled')`
+ * settles the caller as cancelled without ever running the parked work.
+ */
+export class DeferredBoundary implements SchedulerBoundaryPort {
+  private readonly parked: Array<{
+    commit: () => void;
+    cancel: () => void;
+  }> = [];
+
+  withSafeBoundary<T>(
+    fn: (signal?: AbortSignal) => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<SafeBoundaryOutcome<T>> {
+    return new Promise<SafeBoundaryOutcome<T>>((resolve, reject) => {
+      this.parked.push({
+        commit: () => {
+          fn(signal).then(
+            (value) => {
+              resolve({ status: 'committed', value });
+            },
+            (error: unknown) => {
+              reject(error);
+            },
+          );
+        },
+        cancel: () => {
+          resolve({ status: 'cancelled' });
+        },
+      });
+    });
+  }
+
+  /**
+   * Release the oldest parked caller with the given result.
+   */
+  release(result: 'safe' | 'cancelled'): void {
+    const next = this.parked.shift();
+    if (next === undefined) {
+      return;
+    }
+    if (result === 'safe') {
+      next.commit();
+    } else {
+      next.cancel();
+    }
+  }
+
+  /**
+   * Number of callers parked at the boundary; a commit route in flight shows up
+   * here as exactly one.
+   */
+  pendingCount(): number {
+    return this.parked.length;
+  }
+}
+
+/**
+ * Runtime binding fake that counts disposals.
+ */
+export class FakeBinding implements ProfileRuntimeBinding {
+  readonly bindingId: string;
+  readonly configFingerprint: string;
+  disposeCount = 0;
+  disposed = false;
+
+  constructor(bindingId: string, configFingerprint: string) {
+    this.bindingId = bindingId;
+    this.configFingerprint = configFingerprint;
+  }
+
+  [Symbol.asyncDispose](): Promise<void> {
+    this.disposeCount += 1;
+    this.disposed = true;
+    return Promise.resolve();
+  }
+}
+
+/**
+ * Runtime factory fake. The config fingerprint is derived from the document
+ * content, so identical documents produce identical fingerprints and the factory
+ * returns the prior binding unchanged on the reuse path. `failNextBuild`
+ * makes exactly one build call throw; `holdNextBuild` parks exactly one build
+ * inside the factory until a test releases it, so tests can inject failures or
+ * cancellations mid-build.
+ */
+export class CountingFactory implements ProfileRuntimeFactoryPort {
+  private builds = 0;
+  private failOnce = false;
+  private failMessage: string | undefined;
+  private heldBuilds = 0;
+  private releaseBuild: (() => void) | undefined;
+  lastBinding: FakeBinding | undefined;
+  /** The most recent spec handed to build; lets tests inspect what construction received. */
+  lastSpec: ResolvedProfileSpec | undefined;
+
+  /**
+   * Number of build calls that constructed a fresh binding; reuse returns the
+   * prior binding without touching this count.
+   */
+  get built(): number {
+    return this.builds;
+  }
+
+  async build(
+    spec: ResolvedProfileSpec,
+    prior?: ProfileRuntimeBinding,
+  ): Promise<ProfileRuntimeBinding> {
+    this.lastSpec = spec;
+    if (this.failOnce) {
+      this.failOnce = false;
+      throw new Error(this.failMessage ?? 'runtime factory build failed');
+    }
+    const configFingerprint = `config:${JSON.stringify(spec.document)}`;
+    if (prior !== undefined && prior.configFingerprint === configFingerprint) {
+      return prior;
+    }
+    this.builds += 1;
+    if (this.heldBuilds > 0) {
+      this.heldBuilds -= 1;
+      await new Promise<void>((resolve) => {
+        this.releaseBuild = resolve;
+      });
+    }
+    const binding = new FakeBinding(
+      `binding-${this.builds}`,
+      configFingerprint,
+    );
+    this.lastBinding = binding;
+    return binding;
+  }
+
+  /**
+   * Make the next build call throw once, optionally with a caller-supplied message.
+   */
+  failNextBuild(message?: string): void {
+    this.failOnce = true;
+    this.failMessage = message;
+  }
+
+  /**
+   * Park the next fresh build inside the factory until released.
+   */
+  holdNextBuild(): void {
+    this.heldBuilds += 1;
+  }
+
+  /**
+   * Release a build parked by {@link holdNextBuild}.
+   */
+  releaseHeldBuild(): void {
+    this.releaseBuild?.();
+    this.releaseBuild = undefined;
+  }
+}
+
+/**
+ * Static catalog fake for `prov-a`: default model `def-model`, models `m1`/`m2`,
+ * `valid` support for exactly those models — rejecting the unknown `bogus-param`
+ * model parameter — and the restricted blank template for the provider. Every other
+ * provider or model is `unknown` and carries no template.
+ */
+export class FakeCatalog implements ProviderModelCatalogPort {
+  async getDefaultModel(provider: string): Promise<string | undefined> {
+    return provider === 'prov-a' ? 'def-model' : undefined;
+  }
+
+  async listModels(provider: string): Promise<readonly string[]> {
+    return provider === 'prov-a' ? ['m1', 'm2'] : [];
+  }
+
+  async validateModelSupport(
+    provider: string,
+    model: string,
+    params?: Readonly<Record<string, unknown>>,
+  ): Promise<
+    | { status: 'valid' }
+    | { status: 'invalid'; reason: string }
+    | { status: 'unknown' }
+  > {
+    if (provider === 'prov-a' && (model === 'm1' || model === 'm2')) {
+      if (params !== undefined && 'bogus-param' in params) {
+        return {
+          status: 'invalid',
+          reason: `unknown model parameter 'bogus-param' for ${provider}/${model}`,
+        };
+      }
+      return { status: 'valid' };
+    }
+    return { status: 'unknown' };
+  }
+
+  async getProviderTemplate(
+    provider: string,
+  ): Promise<StandardProfileDocument | undefined> {
+    // Materialized fresh per call: the committed workspace adopts the template
+    // object, so a shared instance would be frozen by the first adoption.
+    if (provider !== 'prov-a') {
+      return undefined;
+    }
+    return {
+      version: 1,
+      type: 'standard',
+      provider: 'prov-a',
+      model: 'm2',
+      modelParams: { temperature: 0.25 },
+      ephemeralSettings: { 'base-url': 'https://restricted.example.com' },
+    };
+  }
+}
+
+/**
+ * Permissive trust ceiling: `shell`/`edit`/`read` allowed, nothing disabled, every
+ * tool available, `allowlist` shell mode, `standard` approval ceiling.
+ */
+export class FakeTrust implements TrustToolEnvironmentPort {
+  getToolCeiling(): {
+    allowedTools: readonly string[];
+    disabledTools: readonly string[];
+  } {
+    return { allowedTools: ['shell', 'edit', 'read'], disabledTools: [] };
+  }
+
+  isToolAvailable(_toolId: string): boolean {
+    return true;
+  }
+
+  getShellCeiling(): 'allowlist' | 'all' | 'none' {
+    return 'allowlist';
+  }
+
+  getApprovalCeiling(): 'yolo' | 'standard' | 'strict' {
+    return 'standard';
+  }
+}
+
+/**
+ * Everything a controller test needs: the assembled deps plus the concrete fakes
+ * behind them so tests can seed, release, and inspect.
+ */
+export interface ControllerTestHarness {
+  deps: ProfileControllerDeps;
+  repo: InMemoryRepository;
+  factory: CountingFactory;
+  boundary: DeferredBoundary;
+}
+
+/**
+ * Assemble {@link ProfileControllerDeps} over the fakes, optionally sharing a
+ * caller-provided repository between harnesses. The session ceiling is permissive
+ * (`{}`), and only `ui.theme` counts as an application-owned key.
+ */
+export function makeDeps(
+  repository?: InMemoryRepository,
+): ControllerTestHarness {
+  const repo = repository ?? new InMemoryRepository();
+  const factory = new CountingFactory();
+  const boundary = new DeferredBoundary();
+  const deps: ProfileControllerDeps = {
+    agentId: 'test-agent',
+    repository: repo,
+    runtimeFactory: factory,
+    boundary,
+    catalog: new FakeCatalog(),
+    trust: new FakeTrust(),
+    session: {},
+    isApplicationOwnedKey: (key: string) => key === 'ui.theme',
+  };
+  return { deps, repo, factory, boundary };
+}
+
+/**
+ * Seed the standard `alpha` profile (`prov-a`/`m1`).
+ */
+export function seedAlpha(repo: InMemoryRepository): void {
+  repo.seed('alpha', standardProvADocument('m1'));
+}
+
+/**
+ * Seed the `mylb` load balancer with members `m1p` and `m2p`, both on `prov-a`.
+ */
+export function seedMyLb(repo: InMemoryRepository): void {
+  repo.seed('m1p', standardProvADocument('m1'));
+  repo.seed('m2p', standardProvADocument('m2'));
+  repo.seed('mylb', {
+    version: 1,
+    type: 'loadbalancer',
+    policy: 'roundrobin',
+    profiles: ['m1p', 'm2p'],
+    provider: 'prov-a',
+    model: 'm1',
+    modelParams: {},
+    ephemeralSettings: {},
+  });
+}
+
+/**
+ * Seed a v1-style `blanklb` load balancer parent whose provider and model fields are
+ * blank, exactly as v1 repository documents carried them. Members `m1p` and `m2p` are
+ * standard `prov-a` profiles.
+ */
+export function seedBlankLb(repo: InMemoryRepository): void {
+  repo.seed('m1p', standardProvADocument('m1'));
+  repo.seed('m2p', standardProvADocument('m2'));
+  repo.seed('blanklb', {
+    version: 1,
+    type: 'loadbalancer',
+    policy: 'roundrobin',
+    profiles: ['m1p', 'm2p'],
+    provider: '',
+    model: '',
+    modelParams: {},
+    ephemeralSettings: {},
+  });
+}
+
+export type ConfiguredProfileState = Extract<
+  ProfileState,
+  { status: 'configured' }
+>;
+export type CommittedResult = Extract<
+  ProfileCommandResult,
+  { kind: 'committed' }
+>;
+
+/**
+ * Poll until the predicate holds, failing after a bounded deadline instead of
+ * hanging the suite on an async drain that never lands.
+ */
+export async function settle(
+  predicate: () => boolean,
+  timeoutMs = 2000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error('settle timed out before the condition was met');
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 1);
+    });
+  }
+}
+
+export function configuredState(state: ProfileState): ConfiguredProfileState {
+  if (state.status !== 'configured') {
+    throw new Error('expected a configured workspace state');
+  }
+  return state;
+}
+
+export function committed(result: ProfileCommandResult): CommittedResult {
+  if (result.kind !== 'committed') {
+    throw new Error(`expected a committed result, received ${result.kind}`);
+  }
+  return result;
+}
+
+/**
+ * Await a command that parks at the scheduler boundary, release it as safe, and
+ * return its settled result.
+ */
+export async function releaseAndAwait(
+  harness: ControllerTestHarness,
+  pending: Promise<ProfileCommandResult>,
+): Promise<ProfileCommandResult> {
+  await settle(() => harness.boundary.pendingCount() === 1);
+  harness.boundary.release('safe');
+  return pending;
+}
+
+export function committedSnapshot(
+  identity: WorkingProfileIdentity,
+  revision: number,
+  model: string,
+): ReturnType<ActiveProfileRuntime['snapshot']> {
+  return {
+    identity,
+    revision,
+    provider: 'prov-a',
+    model,
+    isLoadBalancer: false,
+    identityKind: identity.kind,
+    providerOrLbSummary: `prov-a/${model}`,
+    health: { status: 'ok', degradedAspects: [] },
+    roleRuntimeCount: 0,
+  };
+}
+
+export async function alphaFingerprint(
+  harness: ControllerTestHarness,
+): Promise<SourceFingerprint> {
+  const fingerprint = await harness.repo.stat('alpha');
+  if (fingerprint === null) {
+    throw new Error('alpha fingerprint missing from the repository');
+  }
+  return fingerprint;
+}
+
+/**
+ * Bring the seeded alpha profile up through the controller, releasing the boundary
+ * the commit route waits on. A named-profile startup is the unconfigured
+ * workspace's load path; a bare load requires an already configured workspace.
+ */
+export async function loadAlpha(
+  harness: ControllerTestHarness,
+  controller: ProfileController,
+): Promise<ProfileCommandResult> {
+  const pending = controller.execute({
+    kind: 'startup',
+    profileName: 'alpha',
+    expectedRevision: 0,
+  });
+  return releaseAndAwait(harness, pending);
+}
+
+export async function setupSavedAlpha(
+  harness: ControllerTestHarness,
+  controller: ProfileController,
+): Promise<SourceFingerprint> {
+  const result = await loadAlpha(harness, controller);
+  if (result.kind !== 'committed') {
+    throw new Error(`alpha load did not commit, received ${result.kind}`);
+  }
+  return alphaFingerprint(harness);
+}
+
+/**
+ * Move the workspace to an unsaved draft at revision 2 by switching the model.
+ */
+export async function setupDraftAtRevision2(
+  harness: ControllerTestHarness,
+  controller: ProfileController,
+): Promise<SourceFingerprint> {
+  const fingerprint = await setupSavedAlpha(harness, controller);
+  const model = controller.execute({
+    kind: 'model',
+    model: 'm2',
+    expectedRevision: 1,
+  });
+  await settle(() => harness.boundary.pendingCount() === 1);
+  harness.boundary.release('safe');
+  const modelResult = await model;
+  if (modelResult.kind !== 'committed') {
+    throw new Error(
+      `model change did not commit, received ${modelResult.kind}`,
+    );
+  }
+  return fingerprint;
+}

--- a/packages/agents/src/core/profile/__tests__/profileController.lifecycle.test.ts
+++ b/packages/agents/src/core/profile/__tests__/profileController.lifecycle.test.ts
@@ -1,0 +1,858 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Lifecycle behavior tests for the profile controller.
+ *
+ * Every case drives the real ProfileController through its public execute surface with
+ * deterministic infrastructure fakes: invalid-input atomicity, listener isolation,
+ * unverified candidates, boundary cancellation, external-change draft promotion,
+ * load-balancer binding reuse, per-agent independence over a shared repository, failed
+ * builds, and the immutability of previously captured state objects.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type {
+  ProfileEvent,
+  ProfileCommand,
+  ProfileState,
+  StandardProfileDocument,
+} from '@vybestack/llxprt-code-core';
+import { ProfileController } from '../profileController.js';
+import { buildReductionEnvironment } from '../controllerEnv.js';
+import {
+  FakeBinding,
+  FakeCatalog,
+  InMemoryRepository,
+  makeDeps,
+  configuredState,
+  committed,
+  settle,
+  releaseAndAwait,
+  committedSnapshot,
+  type CommittedResult,
+  seedAlpha,
+  seedBlankLb,
+  seedMyLb,
+  standardProvADocument,
+  type ControllerTestHarness,
+} from './controllerTestFakes.js';
+
+class TemplateCatalog extends FakeCatalog {
+  constructor(private readonly template: StandardProfileDocument | undefined) {
+    super();
+  }
+
+  override async getProviderTemplate(): Promise<
+    StandardProfileDocument | undefined
+  > {
+    return this.template;
+  }
+
+  override async getDefaultModel(): Promise<string | undefined> {
+    return 'm1';
+  }
+}
+
+function requireBinding(controller: ProfileController): FakeBinding {
+  const binding = controller.getRuntime()?.getBinding();
+  if (binding === undefined || !(binding instanceof FakeBinding)) {
+    throw new Error('expected a live runtime with a bound binding');
+  }
+  return binding;
+}
+
+/**
+ * Bring a named profile up from the unconfigured workspace through the controller's
+ * startup path, releasing the boundary the commit route waits on.
+ */
+async function startupNamed(
+  harness: ControllerTestHarness,
+  controller: ProfileController,
+  name: string,
+): Promise<CommittedResult> {
+  const pending = controller.execute({
+    kind: 'startup',
+    profileName: name,
+    expectedRevision: 0,
+  });
+  return committed(await releaseAndAwait(harness, pending));
+}
+
+/**
+ * Bring the seeded alpha profile up to revision 1 and return the live binding.
+ */
+async function bringUpAlpha(
+  harness: ControllerTestHarness,
+  controller: ProfileController,
+): Promise<FakeBinding> {
+  await startupNamed(harness, controller, 'alpha');
+  return requireBinding(controller);
+}
+
+describe('ProfileController lifecycle', () => {
+  it('transfers reused binding ownership away from the prior runtime', async () => {
+    const harness = makeDeps();
+    seedMyLb(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    await startupNamed(harness, controller, 'mylb');
+    const prior = controller.getRuntime();
+    if (prior === undefined) {
+      throw new Error('expected prior runtime');
+    }
+    const binding = requireBinding(controller);
+    await releaseAndAwait(
+      harness,
+      controller.execute({ kind: 'load', name: 'mylb', expectedRevision: 1 }),
+    );
+    await prior[Symbol.asyncDispose]();
+    expect(binding.disposeCount).toStrictEqual(0);
+    await controller.dispose();
+    expect(binding.disposeCount).toStrictEqual(1);
+  });
+
+  it('keeps member menu outages unverified instead of failing commands', async () => {
+    const harness = makeDeps();
+    seedMyLb(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    await startupNamed(harness, controller, 'mylb');
+    class UnavailableCatalog extends FakeCatalog {
+      override async listModels(provider: string): Promise<readonly string[]> {
+        if (provider === 'prov-a') {
+          throw new Error('catalog offline');
+        }
+        return super.listModels(provider);
+      }
+    }
+    harness.deps.catalog = new UnavailableCatalog();
+    const before = structuredClone(controller.getState());
+    const command = {
+      kind: 'model',
+      member: 'm2p',
+      model: 'm1',
+      expectedRevision: 1,
+    } satisfies ProfileCommand;
+    const env = await buildReductionEnvironment(before, command, harness.deps);
+    expect(env.memberCaptures['m2p'].models).toStrictEqual([]);
+    expect(await controller.execute(command)).toStrictEqual({
+      kind: 'unverified',
+      constraints: ['model menu unavailable for provider prov-a'],
+      revision: 1,
+    });
+    expect(controller.getState()).toStrictEqual(before);
+  });
+
+  it('exposes the resolved policy on the committed runtime', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    harness.deps.getPolicyIntent = () => ({
+      allowedTools: ['read', 'edit'],
+      disabledTools: ['edit'],
+    });
+    const controller = new ProfileController(harness.deps);
+    await bringUpAlpha(harness, controller);
+    expect(controller.getRuntime()?.getPolicy()).toStrictEqual({
+      allowedTools: ['read'],
+      disabledTools: ['edit'],
+      shellMode: 'allowlist',
+      approvalCeiling: 'standard',
+    });
+    expect(
+      controller.getRuntime()?.getFilteredToolDeclarations([
+        { name: 'read', description: 'Read' },
+        { name: 'edit', description: 'Edit' },
+      ]),
+    ).toStrictEqual([{ name: 'read', description: 'Read' }]);
+  });
+
+  it('rejects unsupported model params before entering the boundary', async () => {
+    const harness = makeDeps();
+    harness.repo.seed('bad', {
+      ...standardProvADocument('m1'),
+      modelParams: { 'bogus-param': true },
+    });
+    const controller = new ProfileController(harness.deps);
+    const result = await controller.execute({
+      kind: 'startup',
+      profileName: 'bad',
+      expectedRevision: 0,
+    });
+    expect(result).toStrictEqual({
+      kind: 'invalid',
+      errors: [
+        "unknown model parameter 'bogus-param' for prov-a/m1",
+        'model m1 is not supported by provider prov-a',
+      ],
+      revision: 0,
+    });
+    expect(controller.getState()).toStrictEqual({ status: 'unconfigured' });
+    expect(harness.boundary.pendingCount()).toStrictEqual(0);
+  });
+
+  it('uses catalog template fields instead of fabricating provider defaults', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const template: StandardProfileDocument = {
+      ...standardProvADocument('m2'),
+      modelParams: { temperature: 0.25 },
+      ephemeralSettings: { 'base-url': 'https://restricted.example.com' },
+      auth: { type: 'oauth', buckets: ['restricted'] },
+    };
+    harness.deps.catalog = new TemplateCatalog(template);
+    const controller = new ProfileController(harness.deps);
+    await bringUpAlpha(harness, controller);
+    const result = await releaseAndAwait(
+      harness,
+      controller.execute({
+        kind: 'provider',
+        provider: 'prov-a',
+        expectedRevision: 1,
+      }),
+    );
+    expect(result.kind).toStrictEqual('committed');
+    expect(configuredState(controller.getState()).document).toStrictEqual(
+      template,
+    );
+  });
+
+  it('uses the default model only when no catalog template is available', async () => {
+    const harness = makeDeps();
+    harness.deps.catalog = new TemplateCatalog(undefined);
+    const controller = new ProfileController(harness.deps);
+    const result = await releaseAndAwait(
+      harness,
+      controller.execute({
+        kind: 'startup',
+        provider: 'prov-a',
+        expectedRevision: 0,
+      }),
+    );
+    expect(result.kind).toStrictEqual('committed');
+    expect(configuredState(controller.getState()).document).toStrictEqual(
+      standardProvADocument('m1'),
+    );
+  });
+
+  it('holds the safe window until the controller has adopted the new state and binding', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    let held = false;
+    const statesAtRelease: ProfileState[] = [];
+    const bindingIdsAtRelease: Array<string | undefined> = [];
+    harness.deps.boundary = {
+      withSafeBoundary: (fn, signal) =>
+        harness.boundary.withSafeBoundary(async (boundarySignal) => {
+          held = true;
+          try {
+            const value = await fn(boundarySignal);
+            statesAtRelease.push(controller.getState());
+            bindingIdsAtRelease.push(controller.getRuntime()?.getBindingId());
+            return value;
+          } finally {
+            held = false;
+          }
+        }, signal),
+    };
+    const controller = new ProfileController(harness.deps);
+    harness.factory.holdNextBuild();
+    const pending = controller.execute({
+      kind: 'startup',
+      profileName: 'alpha',
+      expectedRevision: 0,
+    });
+    await settle(() => harness.boundary.pendingCount() === 1);
+    harness.boundary.release('safe');
+    await settle(() => harness.factory.built === 1);
+    expect(held).toStrictEqual(true);
+    expect(controller.getState()).toStrictEqual({ status: 'unconfigured' });
+    harness.factory.releaseHeldBuild();
+    expect((await pending).kind).toStrictEqual('committed');
+    expect(held).toStrictEqual(false);
+    expect(statesAtRelease).toStrictEqual([controller.getState()]);
+    expect(bindingIdsAtRelease).toStrictEqual([
+      controller.getRuntime()?.getBindingId(),
+    ]);
+  });
+
+  it('rejects an unknown provider as invalid and leaves state and runtime intact', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    const binding = await bringUpAlpha(harness, controller);
+
+    const result = await controller.execute({
+      kind: 'provider',
+      provider: 'nope',
+      expectedRevision: 1,
+    });
+
+    expect(result).toStrictEqual({
+      kind: 'invalid',
+      errors: ['unknown provider template'],
+      revision: 1,
+    });
+    expect(configuredState(controller.getState()).revision).toBe(1);
+    expect(controller.getRuntime()?.getBinding()).toBe(binding);
+  });
+
+  it('isolates a throwing listener so the other listeners still fire and the command commits', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const events: ProfileEvent[] = [];
+    harness.deps.listeners = [
+      () => {
+        throw new Error('boom');
+      },
+      (event) => {
+        events.push(event);
+      },
+    ];
+    const controller = new ProfileController(harness.deps);
+
+    const result = await startupNamed(harness, controller, 'alpha');
+
+    expect(result.revision).toBe(1);
+    expect(events.length).toBeGreaterThanOrEqual(2);
+    expect(events.some((event) => event.type === 'committed')).toBe(true);
+  });
+
+  it('reports an unknown model as unverified without committing', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    const binding = await bringUpAlpha(harness, controller);
+
+    const result = await controller.execute({
+      kind: 'model',
+      model: 'm-unknown',
+      expectedRevision: 1,
+    });
+
+    expect(result).toStrictEqual({
+      kind: 'unverified',
+      constraints: ['model support unknown for provider prov-a'],
+      revision: 1,
+    });
+    expect(configuredState(controller.getState()).revision).toBe(1);
+    expect(controller.getRuntime()?.getBinding()).toBe(binding);
+  });
+
+  it('cancels at the boundary and keeps the prior runtime bound and undisposed', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    const binding = await bringUpAlpha(harness, controller);
+
+    const pending = controller.execute({
+      kind: 'model',
+      model: 'm2',
+      expectedRevision: 1,
+    });
+    await settle(() => harness.boundary.pendingCount() === 1);
+    harness.boundary.release('cancelled');
+
+    expect(await pending).toStrictEqual({
+      kind: 'cancelled',
+      reason: 'boundary cancelled',
+      revision: 1,
+    });
+    expect(controller.getRuntime()?.getBinding()).toBe(binding);
+    expect(binding.disposeCount).toBe(0);
+  });
+
+  it('promotes a saved identity to a stale draft when the source changed before the boundary released', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    const binding = await bringUpAlpha(harness, controller);
+
+    const pending = controller.execute({
+      kind: 'model',
+      model: 'm2',
+      expectedRevision: 1,
+    });
+    await settle(() => harness.boundary.pendingCount() === 1);
+    harness.repo.tamperFingerprint('alpha', {
+      kind: 'stat',
+      mtimeMs: 999,
+      size: 999,
+    });
+    harness.boundary.release('safe');
+
+    expect(await pending).toStrictEqual({
+      kind: 'stale',
+      expectedRevision: 1,
+      currentRevision: 2,
+      revision: 1,
+    });
+    const state = configuredState(controller.getState());
+    expect(state.revision).toBe(2);
+    if (state.identity.kind !== 'draft') {
+      throw new Error('expected the identity to be promoted to a draft');
+    }
+    expect(state.identity.derivedFrom?.name).toBe('alpha');
+    expect(state.document).toStrictEqual(standardProvADocument('m1'));
+    expect(controller.getRuntime()?.getBinding()).toBe(binding);
+  });
+
+  it('reuses the live binding when an unchanged load balancer is reapplied without building a duplicate', async () => {
+    const harness = makeDeps();
+    seedMyLb(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    await startupNamed(harness, controller, 'mylb');
+    const bindingA = requireBinding(controller);
+    expect(harness.factory.built).toBe(1);
+
+    const pending = controller.execute({
+      kind: 'load',
+      name: 'mylb',
+      expectedRevision: 1,
+    });
+    const result = committed(await releaseAndAwait(harness, pending));
+
+    expect(result.revision).toBe(2);
+    expect(controller.getRuntime()?.getBinding()).toBe(bindingA);
+    expect(harness.factory.built).toBe(1);
+    expect(bindingA.disposeCount).toBe(0);
+  });
+
+  it('commits a v1 blank load-balancer parent with a live binding instead of half-applied state', async () => {
+    const harness = makeDeps();
+    seedBlankLb(harness.repo);
+    const controller = new ProfileController(harness.deps);
+
+    const result = await startupNamed(harness, controller, 'blanklb');
+
+    expect(result.revision).toBe(1);
+    const binding = requireBinding(controller);
+    expect(harness.factory.built).toBe(1);
+    expect(binding.disposeCount).toBe(0);
+  });
+
+  it('builds a fresh binding and disposes the old one when the config genuinely changes', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    const bindingA = await bringUpAlpha(harness, controller);
+    expect(harness.factory.built).toBe(1);
+
+    const pending = controller.execute({
+      kind: 'model',
+      model: 'm2',
+      expectedRevision: 1,
+    });
+    const result = committed(await releaseAndAwait(harness, pending));
+
+    expect(result.revision).toBe(2);
+    expect(harness.factory.built).toBe(2);
+    const bindingB = requireBinding(controller);
+    expect(bindingB).not.toBe(bindingA);
+    expect(bindingA.disposeCount).toBe(1);
+    expect(bindingB.disposeCount).toBe(0);
+  });
+
+  it('carries degraded health across a load-balancer binding reuse', async () => {
+    const harness = makeDeps();
+    seedMyLb(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    await startupNamed(harness, controller, 'mylb');
+    controller.getRuntime()?.reportDegradation(['lb-member-down']);
+
+    const pending = controller.execute({
+      kind: 'load',
+      name: 'mylb',
+      expectedRevision: 1,
+    });
+    const result = committed(await releaseAndAwait(harness, pending));
+
+    expect(result.revision).toBe(2);
+    const runtime = controller.getRuntime();
+    if (runtime === undefined) {
+      throw new Error('expected a live runtime after the reuse commit');
+    }
+    expect(runtime.getHealth()).toStrictEqual({
+      status: 'degraded',
+      degradedAspects: ['lb-member-down'],
+    });
+  });
+
+  it('cancels a commit whose build was aborted and disposes the candidate binding', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    const bindingA = await bringUpAlpha(harness, controller);
+    const abort = new AbortController();
+    harness.factory.holdNextBuild();
+
+    const pending = controller.execute(
+      { kind: 'model', model: 'm2', expectedRevision: 1 },
+      { signal: abort.signal },
+    );
+    await settle(() => harness.boundary.pendingCount() === 1);
+    harness.boundary.release('safe');
+    await settle(() => harness.factory.built === 2);
+    abort.abort();
+    harness.factory.releaseHeldBuild();
+
+    expect(await pending).toStrictEqual({
+      kind: 'cancelled',
+      reason: 'execute cancelled',
+      revision: 1,
+    });
+    expect(controller.getRuntime()?.getBinding()).toBe(bindingA);
+    expect(bindingA.disposeCount).toBe(0);
+    expect(configuredState(controller.getState()).revision).toBe(1);
+    expect(harness.factory.lastBinding?.disposed).toBe(true);
+  });
+
+  it('honors execute cancellation when the held boundary supplies its own signal', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const boundaryAbort = new AbortController();
+    harness.deps.boundary = {
+      withSafeBoundary: (fn, signal) =>
+        harness.boundary.withSafeBoundary(
+          () => fn(boundaryAbort.signal),
+          signal,
+        ),
+    };
+    const controller = new ProfileController(harness.deps);
+    const binding = await bringUpAlpha(harness, controller);
+    const abort = new AbortController();
+    harness.factory.holdNextBuild();
+    const pending = controller.execute(
+      { kind: 'model', model: 'm2', expectedRevision: 1 },
+      { signal: abort.signal },
+    );
+    await settle(() => harness.boundary.pendingCount() === 1);
+    harness.boundary.release('safe');
+    await settle(() => harness.factory.built === 2);
+    abort.abort();
+    harness.factory.releaseHeldBuild();
+    expect(await pending).toStrictEqual({
+      kind: 'cancelled',
+      reason: 'execute cancelled',
+      revision: 1,
+    });
+    expect(controller.getRuntime()?.getBinding()).toBe(binding);
+    expect(harness.factory.lastBinding?.disposed).toStrictEqual(true);
+  });
+
+  it('fails a commit when the controller is disposed mid-build and leaves no leak', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    await bringUpAlpha(harness, controller);
+    harness.factory.holdNextBuild();
+
+    const pending = controller.execute({
+      kind: 'model',
+      model: 'm2',
+      expectedRevision: 1,
+    });
+    await settle(() => harness.boundary.pendingCount() === 1);
+    harness.boundary.release('safe');
+    await settle(() => harness.factory.built === 2);
+    await controller.dispose();
+    harness.factory.releaseHeldBuild();
+
+    expect(await pending).toStrictEqual({
+      kind: 'failed',
+      error: 'controller disposed',
+      revision: 1,
+    });
+    expect(controller.getRuntime()).toBeUndefined();
+    expect(configuredState(controller.getState()).revision).toBe(1);
+    expect(harness.factory.lastBinding?.disposed).toBe(true);
+  });
+
+  it('keeps two controllers over one repository independent', async () => {
+    const repo = new InMemoryRepository();
+    seedAlpha(repo);
+    const harness1 = makeDeps(repo);
+    const harness2 = makeDeps(repo);
+    const controller1 = new ProfileController(harness1.deps);
+    const controller2 = new ProfileController(harness2.deps);
+    await startupNamed(harness1, controller1, 'alpha');
+    await startupNamed(harness2, controller2, 'alpha');
+    const binding2 = requireBinding(controller2);
+
+    const setPending = controller1.execute({
+      kind: 'set',
+      patch: { temperature: 0.2 },
+      expectedRevision: 1,
+    });
+    const setResult = committed(await releaseAndAwait(harness1, setPending));
+    expect(setResult.revision).toBe(2);
+
+    const state2 = configuredState(controller2.getState());
+    expect(state2.revision).toBe(1);
+    if (state2.identity.kind !== 'saved') {
+      throw new Error('expected controller2 to keep its saved identity');
+    }
+    expect(state2.identity.name).toBe('alpha');
+    expect(state2.document.ephemeralSettings).toStrictEqual({});
+
+    const binding1 = requireBinding(controller1);
+    expect(binding1).not.toBe(binding2);
+
+    await controller1.dispose();
+    expect(controller2.getRuntime()?.getBinding()).toBe(binding2);
+    expect(binding2.disposeCount).toBe(0);
+  });
+
+  it('reports a failed build and keeps the prior runtime bound', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    const binding = await bringUpAlpha(harness, controller);
+    harness.factory.failNextBuild();
+
+    const pending = controller.execute({
+      kind: 'model',
+      model: 'm2',
+      expectedRevision: 1,
+    });
+
+    expect(await releaseAndAwait(harness, pending)).toStrictEqual({
+      kind: 'failed',
+      error: 'Error: runtime factory build failed',
+      revision: 1,
+    });
+    expect(controller.getRuntime()?.getBinding()).toBe(binding);
+    expect(configuredState(controller.getState()).revision).toBe(1);
+  });
+
+  it('never mutates a previously captured state object when later commits land', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    await bringUpAlpha(harness, controller);
+
+    const captured = controller.getState();
+    const before = structuredClone(captured);
+
+    const setPending = controller.execute({
+      kind: 'set',
+      patch: { temperature: 0.3 },
+      expectedRevision: 1,
+    });
+    expect(committed(await releaseAndAwait(harness, setPending)).revision).toBe(
+      2,
+    );
+
+    expect(captured).toStrictEqual(before);
+    expect(configuredState(controller.getState()).revision).toBe(2);
+  });
+
+  it('reports the promoted draft identity in the runtime snapshot after an external change', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    const binding = await bringUpAlpha(harness, controller);
+    const sourceFingerprint = await harness.repo.stat('alpha');
+    if (sourceFingerprint === null) {
+      throw new Error('alpha fingerprint missing from the repository');
+    }
+
+    const pending = controller.execute({
+      kind: 'model',
+      model: 'm2',
+      expectedRevision: 1,
+    });
+    await settle(() => harness.boundary.pendingCount() === 1);
+    harness.repo.tamperFingerprint('alpha', {
+      kind: 'stat',
+      mtimeMs: 999,
+      size: 999,
+    });
+    harness.boundary.release('safe');
+
+    expect(await pending).toStrictEqual({
+      kind: 'stale',
+      expectedRevision: 1,
+      currentRevision: 2,
+      revision: 1,
+    });
+    const runtime = controller.getRuntime();
+    expect(controller.getRuntime()?.getBinding()).toBe(binding);
+    if (runtime === undefined) {
+      throw new Error('expected the runtime to survive the promotion');
+    }
+    expect(runtime.snapshot()).toStrictEqual(
+      committedSnapshot(
+        {
+          kind: 'draft',
+          derivedFrom: { name: 'alpha', source: sourceFingerprint },
+        },
+        2,
+        'm1',
+      ),
+    );
+  });
+
+  it('rejects a load whose candidate source changed on disk before the boundary released', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+
+    const pending = controller.execute({
+      kind: 'startup',
+      profileName: 'alpha',
+      expectedRevision: 0,
+    });
+    await settle(() => harness.boundary.pendingCount() === 1);
+    harness.repo.tamperFingerprint('alpha', {
+      kind: 'stat',
+      mtimeMs: 999,
+      size: 999,
+    });
+    harness.boundary.release('safe');
+
+    expect(await pending).toStrictEqual({
+      kind: 'stale',
+      expectedRevision: 0,
+      currentRevision: 0,
+      revision: 0,
+    });
+    expect(controller.getState()).toStrictEqual({ status: 'unconfigured' });
+    expect(controller.getRuntime()).toBeUndefined();
+  });
+
+  it('promotes a deleted source to a draft before a no-op model command runs', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    await bringUpAlpha(harness, controller);
+    const sourceFingerprint = await harness.repo.stat('alpha');
+    if (sourceFingerprint === null) {
+      throw new Error('alpha fingerprint missing from the repository');
+    }
+
+    await harness.repo.delete('alpha');
+    const firstAttempt = await controller.execute({
+      kind: 'model',
+      model: 'm1',
+      expectedRevision: 1,
+    });
+    expect(firstAttempt).toStrictEqual({
+      kind: 'stale',
+      expectedRevision: 1,
+      currentRevision: 2,
+      revision: 2,
+    });
+    const promoted = configuredState(controller.getState());
+    expect(promoted.revision).toBe(2);
+    expect(promoted.identity).toStrictEqual({
+      kind: 'draft',
+      derivedFrom: { name: 'alpha', source: sourceFingerprint },
+    });
+    expect(promoted.document).toStrictEqual(standardProvADocument('m1'));
+
+    // The resubmission runs against the promoted draft: no-op detection sees the
+    // same model on the preserved document and commits nothing.
+    const result = await controller.execute({
+      kind: 'model',
+      model: 'm1',
+      expectedRevision: 2,
+    });
+    expect(result).toStrictEqual({
+      kind: 'no-op',
+      reason: 'model unchanged',
+      revision: 2,
+    });
+    const state = configuredState(controller.getState());
+    expect(state.revision).toBe(2);
+    expect(state.identity).toStrictEqual({
+      kind: 'draft',
+      derivedFrom: { name: 'alpha', source: sourceFingerprint },
+    });
+    expect(state.document).toStrictEqual(standardProvADocument('m1'));
+  });
+
+  it('forks an explicit member from the captured source instead of rereading the edited file', async () => {
+    const harness = makeDeps();
+    const capturedMember = (): StandardProfileDocument => ({
+      ...standardProvADocument('m1'),
+      modelParams: { temperature: 0.1 },
+      ephemeralSettings: { 'base-url': 'https://old.example.com' },
+    });
+    harness.repo.seed('m1p', capturedMember());
+    harness.repo.seed('m2p', standardProvADocument('m2'));
+    harness.repo.seed('mylb', {
+      version: 1,
+      type: 'loadbalancer',
+      policy: 'roundrobin',
+      profiles: ['m1p', 'm2p'],
+      provider: 'prov-a',
+      model: 'm1',
+      modelParams: {},
+      ephemeralSettings: {},
+    });
+    const controller = new ProfileController(harness.deps);
+    await startupNamed(harness, controller, 'mylb');
+
+    harness.repo.seed('m1p', {
+      ...standardProvADocument('m1'),
+      modelParams: { temperature: 0.9 },
+      ephemeralSettings: { 'base-url': 'https://new.example.com' },
+    });
+
+    const pending = controller.execute({
+      kind: 'model',
+      model: 'm2',
+      member: 'm1p',
+      expectedRevision: 1,
+    });
+    const result = committed(await releaseAndAwait(harness, pending));
+
+    expect(result.revision).toBe(2);
+    const state = configuredState(controller.getState());
+    expect(state.document).toStrictEqual({
+      ...capturedMember(),
+      model: 'm2',
+    });
+  });
+
+  it('carries the resolved member documents to the factory on a load-balancer commit', async () => {
+    const harness = makeDeps();
+    seedMyLb(harness.repo);
+    const controller = new ProfileController(harness.deps);
+
+    await startupNamed(harness, controller, 'mylb');
+
+    const spec = harness.factory.lastSpec;
+    if (spec === undefined) {
+      throw new Error('expected the load-balancer commit to reach the factory');
+    }
+    expect(spec.memberDocuments).toStrictEqual({
+      m1p: standardProvADocument('m1'),
+      m2p: standardProvADocument('m2'),
+    });
+  });
+
+  it('redacts secret material in a failed build error', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    const binding = await bringUpAlpha(harness, controller);
+    harness.factory.failNextBuild('build failed with auth-key: sk-123 in env');
+
+    const pending = controller.execute({
+      kind: 'model',
+      model: 'm2',
+      expectedRevision: 1,
+    });
+
+    expect(await releaseAndAwait(harness, pending)).toStrictEqual({
+      kind: 'failed',
+      error: 'Error: build failed with auth-key: [redacted]',
+      revision: 1,
+    });
+    expect(controller.getRuntime()?.getBinding()).toBe(binding);
+    expect(configuredState(controller.getState()).document.model).toBe('m1');
+  });
+});

--- a/packages/agents/src/core/profile/__tests__/profileController.persistence.test.ts
+++ b/packages/agents/src/core/profile/__tests__/profileController.persistence.test.ts
@@ -1,0 +1,270 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type {
+  ProfileDocument,
+  ProfileRepositoryPort,
+  ProfileEvent,
+  SourceFingerprint,
+} from '@vybestack/llxprt-code-core';
+import { ProfileController } from '../profileController.js';
+import {
+  InMemoryRepository,
+  makeDeps,
+  seedAlpha,
+  standardProvADocument,
+  settle,
+  setupSavedAlpha,
+  setupDraftAtRevision2,
+} from './controllerTestFakes.js';
+
+describe('ProfileController persistence', () => {
+  for (const stage of ['stat', 'save']) {
+    for (const stop of ['abort', 'dispose']) {
+      it(`reconciles persisted state after ${stop} during save ${stage}`, async () => {
+        let release: () => void = () => {};
+        const held = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        let entered = false;
+        let armed = false;
+        let writes = 0;
+        class HeldRepository extends InMemoryRepository {
+          override async stat(name: string): Promise<SourceFingerprint | null> {
+            if (armed && stage === 'stat') {
+              entered = true;
+              await held;
+            }
+            return super.stat(name);
+          }
+          override async save(
+            name: string,
+            document: ProfileDocument,
+            expected?: SourceFingerprint,
+            opts?: Parameters<ProfileRepositoryPort['save']>[3],
+          ): Promise<SourceFingerprint> {
+            if (armed && stage === 'save') {
+              entered = true;
+              await held;
+            }
+            writes += 1;
+            return super.save(name, document, expected, opts);
+          }
+        }
+        const harness = makeDeps(new HeldRepository());
+        seedAlpha(harness.repo);
+        const events: ProfileEvent[] = [];
+        harness.deps.listeners = [
+          (event) => {
+            events.push(event);
+          },
+        ];
+        const controller = new ProfileController(harness.deps);
+        await setupDraftAtRevision2(harness, controller);
+        const before = structuredClone(controller.getState());
+        if (before.status !== 'configured')
+          throw new Error('expected configured state');
+        const abort = new AbortController();
+        armed = true;
+        const pending = controller.execute(
+          { kind: 'save', name: 'beta', expectedRevision: 2 },
+          { signal: abort.signal },
+        );
+        await settle(() => entered);
+        const eventsBefore = [...events];
+        if (stop === 'abort') {
+          abort.abort();
+        } else {
+          await controller.dispose();
+        }
+        release();
+        expect(await pending).toStrictEqual(
+          stop === 'abort'
+            ? { kind: 'cancelled', reason: 'execute cancelled', revision: 2 }
+            : { kind: 'failed', error: 'controller disposed', revision: 2 },
+        );
+        const source = await harness.repo.stat('beta');
+        expect(controller.getState()).toStrictEqual(
+          source === null
+            ? before
+            : {
+                ...before,
+                identity: { kind: 'saved', name: 'beta', source },
+              },
+        );
+        expect(
+          events.filter((event) => event.type === 'committed'),
+        ).toStrictEqual(
+          eventsBefore.filter((event) => event.type === 'committed'),
+        );
+        expect(writes).toStrictEqual(stage === 'stat' ? 0 : 1);
+      });
+    }
+  }
+
+  it('retains the persisted fingerprint when an anchored save aborts after writing', async () => {
+    const abort = new AbortController();
+    class AbortingRepository extends InMemoryRepository {
+      override async save(
+        ...args: Parameters<ProfileRepositoryPort['save']>
+      ): Promise<SourceFingerprint> {
+        await super.save(...args);
+        this.tamperFingerprint(args[0]);
+        const fingerprint = await super.stat(args[0]);
+        if (fingerprint === null) throw new Error('expected persisted profile');
+        abort.abort();
+        return fingerprint;
+      }
+    }
+    const harness = makeDeps(new AbortingRepository());
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    await setupDraftAtRevision2(harness, controller);
+    expect(
+      await controller.execute(
+        { kind: 'save', name: 'alpha', expectedRevision: 2 },
+        { signal: abort.signal },
+      ),
+    ).toStrictEqual({
+      kind: 'cancelled',
+      reason: 'execute cancelled',
+      revision: 2,
+    });
+    expect(
+      await controller.execute({
+        kind: 'model',
+        model: 'm2',
+        expectedRevision: 2,
+      }),
+    ).toStrictEqual({ kind: 'no-op', reason: 'model unchanged', revision: 2 });
+    const source = await harness.repo.stat('alpha');
+    if (source === null) throw new Error('expected persisted source');
+    expect(controller.getState()).toStrictEqual({
+      status: 'configured',
+      revision: 2,
+      document: standardProvADocument('m2'),
+      identity: { kind: 'saved', name: 'alpha', source },
+    });
+  });
+
+  it('rejects commands after disposal without repository interaction', async () => {
+    let reads = 0;
+    class ObservedRepository extends InMemoryRepository {
+      override async stat(name: string): Promise<SourceFingerprint | null> {
+        reads += 1;
+        return super.stat(name);
+      }
+      override async load(
+        name: string,
+      ): ReturnType<ProfileRepositoryPort['load']> {
+        reads += 1;
+        return super.load(name);
+      }
+    }
+    const harness = makeDeps(new ObservedRepository());
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    await setupSavedAlpha(harness, controller);
+    await controller.dispose();
+    const before = reads;
+    expect(
+      await controller.execute({
+        kind: 'load',
+        name: 'alpha',
+        expectedRevision: 1,
+      }),
+    ).toStrictEqual({
+      kind: 'failed',
+      error: 'controller disposed',
+      revision: 1,
+    });
+    expect(reads - before).toStrictEqual(0);
+  });
+
+  it('saves a modified draft over its unchanged source', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    await setupDraftAtRevision2(harness, controller);
+    const result = await controller.execute({
+      kind: 'save',
+      name: 'alpha',
+      expectedRevision: 2,
+    });
+    expect(result.kind).toStrictEqual('committed');
+    expect((await harness.repo.load('alpha')).document.model).toStrictEqual(
+      'm2',
+    );
+    const source = await harness.repo.stat('alpha');
+    if (source === null) {
+      throw new Error('expected saved source');
+    }
+    expect(controller.getState()).toStrictEqual({
+      status: 'configured',
+      revision: 2,
+      document: standardProvADocument('m2'),
+      identity: { kind: 'saved', name: 'alpha', source },
+    });
+  });
+
+  it('anchors a promoted draft save to its original source fingerprint', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    await setupSavedAlpha(harness, controller);
+    harness.repo.seed('alpha', standardProvADocument('m2'));
+    await controller.execute({
+      kind: 'save',
+      name: 'alpha',
+      expectedRevision: 1,
+    });
+    const before = structuredClone(controller.getState());
+    expect(
+      await controller.execute({
+        kind: 'save',
+        name: 'alpha',
+        expectedRevision: 2,
+      }),
+    ).toStrictEqual({ kind: 'conflict', cause: 'source-changed', revision: 2 });
+    expect(controller.getState()).toStrictEqual(before);
+    expect((await harness.repo.load('alpha')).document.model).toStrictEqual(
+      'm2',
+    );
+  });
+
+  it('refuses a save-as destination created between stat and save', async () => {
+    class RacingRepository extends InMemoryRepository {
+      override async stat(name: string): Promise<SourceFingerprint | null> {
+        const found = await super.stat(name);
+        if (name === 'beta' && found === null) {
+          this.seed(name, standardProvADocument('m2'));
+        }
+        return found;
+      }
+    }
+    const harness = makeDeps(new RacingRepository());
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    await setupSavedAlpha(harness, controller);
+    const before = structuredClone(controller.getState());
+    expect(
+      await controller.execute({
+        kind: 'save',
+        name: 'beta',
+        expectedRevision: 1,
+      }),
+    ).toStrictEqual({
+      kind: 'conflict',
+      cause: 'destination-exists',
+      revision: 1,
+    });
+    expect(controller.getState()).toStrictEqual(before);
+    expect((await harness.repo.load('beta')).document.model).toStrictEqual(
+      'm2',
+    );
+  });
+});

--- a/packages/agents/src/core/profile/__tests__/profileController.serialization.test.ts
+++ b/packages/agents/src/core/profile/__tests__/profileController.serialization.test.ts
@@ -1,0 +1,820 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Serialization behavior tests for the profile controller.
+ *
+ * Every case drives the real ProfileController through its public execute surface
+ * with deterministic infrastructure fakes: queued commands, busy rejections, discard
+ * confirmations, optimistic-concurrency conflicts, and no-op detection are verified
+ * against observable results, committed state, events, and live runtime identity.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type {
+  PendingConfirmation,
+  ProfileCommand,
+  ProfileCommandResult,
+  ProfileEvent,
+  SourceFingerprint,
+} from '@vybestack/llxprt-code-core';
+import { ProfileController } from '../profileController.js';
+import {
+  makeDeps,
+  alphaFingerprint,
+  loadAlpha,
+  setupSavedAlpha,
+  setupDraftAtRevision2,
+  configuredState,
+  settle,
+  releaseAndAwait,
+  committedSnapshot,
+  seedAlpha,
+  standardProvADocument,
+  type ControllerTestHarness,
+} from './controllerTestFakes.js';
+
+async function setupLoadOverUnsavedDraft(
+  harness: ControllerTestHarness,
+  controller: ProfileController,
+): Promise<{ pending: PendingConfirmation; fingerprint: SourceFingerprint }> {
+  const fingerprint = await setupDraftAtRevision2(harness, controller);
+  const load = await controller.execute({
+    kind: 'load',
+    name: 'alpha',
+    expectedRevision: 2,
+  });
+  if (load.kind !== 'confirmation-required') {
+    throw new Error(`expected confirmation-required, received ${load.kind}`);
+  }
+  return { pending: load.pending, fingerprint };
+}
+
+function committedModelResult(
+  fingerprint: SourceFingerprint,
+): ProfileCommandResult {
+  return {
+    kind: 'committed',
+    revision: 2,
+    snapshot: committedSnapshot(
+      {
+        kind: 'draft',
+        derivedFrom: { name: 'alpha', source: fingerprint },
+      },
+      2,
+      'm2',
+    ),
+  };
+}
+
+describe('ProfileController serialization', () => {
+  it.each(['provider', 'startup-provider'])(
+    'confirms %s replacement before resetting a draft',
+    async (kind) => {
+      const harness = makeDeps();
+      seedAlpha(harness.repo);
+      const controller = new ProfileController(harness.deps);
+      const fingerprint = await setupDraftAtRevision2(harness, controller);
+      const command: ProfileCommand =
+        kind === 'provider'
+          ? { kind: 'provider', provider: 'prov-a', expectedRevision: 2 }
+          : { kind: 'startup', provider: 'prov-a', expectedRevision: 2 };
+      let settled = false;
+      const request = controller.execute(command).then((result) => {
+        settled = true;
+        return result;
+      });
+      await settle(() => settled || harness.boundary.pendingCount() === 1);
+      if (harness.boundary.pendingCount() === 1) {
+        harness.boundary.release('safe');
+      }
+      const result = await request;
+      expect(result.kind).toStrictEqual('confirmation-required');
+      if (result.kind !== 'confirmation-required') {
+        throw new Error(`expected confirmation, got ${result.kind}`);
+      }
+      expect(controller.getState()).toStrictEqual({
+        status: 'configured',
+        revision: 2,
+        identity: {
+          kind: 'draft',
+          derivedFrom: { name: 'alpha', source: fingerprint },
+        },
+        document: standardProvADocument('m2'),
+      });
+      const confirm = controller.execute({
+        kind: 'confirm-discard',
+        pending: result.pending,
+        expectedRevision: 2,
+      });
+      expect((await releaseAndAwait(harness, confirm)).kind).toStrictEqual(
+        'committed',
+      );
+      const state = configuredState(controller.getState());
+      expect({
+        identity: state.identity,
+        revision: state.revision,
+        document: state.document,
+      }).toStrictEqual({
+        identity: { kind: 'draft' },
+        revision: 3,
+        document: {
+          ...standardProvADocument('m2'),
+          modelParams: { temperature: 0.25 },
+          ephemeralSettings: { 'base-url': 'https://restricted.example.com' },
+        },
+      });
+      expect(controller.getPendingConfirmations()).toStrictEqual([]);
+    },
+  );
+
+  it('rejects a valid token presented with a mismatched command kind without consuming it', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    const { pending, fingerprint } = await setupLoadOverUnsavedDraft(
+      harness,
+      controller,
+    );
+    let settled = false;
+    const confirm = controller
+      .execute({
+        kind: 'confirm-discard',
+        pending: { ...pending, commandKind: 'setup' },
+        expectedRevision: 2,
+      })
+      .then((result) => {
+        settled = true;
+        return result;
+      });
+    await settle(() => settled || harness.boundary.pendingCount() === 1);
+    if (harness.boundary.pendingCount() === 1) {
+      harness.boundary.release('safe');
+    }
+    expect(await confirm).toStrictEqual({
+      kind: 'invalid',
+      errors: ['confirmation command kind mismatch'],
+      revision: 2,
+    });
+    expect(controller.getState()).toStrictEqual({
+      status: 'configured',
+      revision: 2,
+      identity: {
+        kind: 'draft',
+        derivedFrom: { name: 'alpha', source: fingerprint },
+      },
+      document: standardProvADocument('m2'),
+    });
+    expect(controller.getPendingConfirmations()).toStrictEqual([pending.token]);
+    const validConfirm = controller.execute({
+      kind: 'confirm-discard',
+      pending,
+      expectedRevision: 2,
+    });
+    expect((await releaseAndAwait(harness, validConfirm)).kind).toStrictEqual(
+      'committed',
+    );
+    expect(controller.getPendingConfirmations()).toStrictEqual([]);
+  });
+
+  for (const kind of ['startup', 'setup']) {
+    it(`replays ${kind} after discard confirmation and commits`, async () => {
+      const harness = makeDeps();
+      seedAlpha(harness.repo);
+      const controller = new ProfileController(harness.deps);
+      await setupDraftAtRevision2(harness, controller);
+      const command: ProfileCommand =
+        kind === 'startup'
+          ? { kind: 'startup', profileName: 'alpha', expectedRevision: 2 }
+          : { kind: 'setup', expectedRevision: 2 };
+      const result = await controller.execute(command);
+      if (result.kind !== 'confirmation-required') {
+        throw new Error(`expected confirmation, got ${result.kind}`);
+      }
+      const confirm = controller.execute({
+        kind: 'confirm-discard',
+        pending: result.pending,
+        expectedRevision: 2,
+      });
+      expect((await releaseAndAwait(harness, confirm)).kind).toStrictEqual(
+        'committed',
+      );
+      expect(configuredState(controller.getState()).revision).toStrictEqual(3);
+      expect(
+        configuredState(controller.getState()).document.model,
+      ).toStrictEqual(kind === 'startup' ? 'm1' : '');
+      expect(controller.getPendingConfirmations()).toStrictEqual([]);
+    });
+  }
+
+  it('runs a queued command after the boundary release and the queued command sees the committed result', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const events: ProfileEvent[] = [];
+    harness.deps.listeners = [
+      (event) => {
+        events.push(event);
+      },
+    ];
+    const controller = new ProfileController(harness.deps);
+    await loadAlpha(harness, controller);
+
+    const first = controller.execute({
+      kind: 'model',
+      model: 'm2',
+      expectedRevision: 1,
+    });
+    await settle(() => harness.boundary.pendingCount() === 1);
+    const second = controller.execute({
+      kind: 'model',
+      model: 'm2',
+      expectedRevision: 2,
+    });
+    await expect(second).resolves.toStrictEqual({
+      kind: 'queued',
+      baseRevision: 1,
+      revision: 1,
+    });
+
+    harness.boundary.release('safe');
+    expect(await first).toStrictEqual(
+      committedModelResult(await alphaFingerprint(harness)),
+    );
+
+    const state = configuredState(controller.getState());
+    expect(state.revision).toBe(2);
+    expect(state.document).toStrictEqual({
+      version: 1,
+      type: 'standard',
+      provider: 'prov-a',
+      model: 'm2',
+      modelParams: {},
+      ephemeralSettings: {},
+    });
+    expect(
+      events.some(
+        (event) =>
+          event.type === 'command-no-op' &&
+          event.commandKind === 'model' &&
+          event.revision === 2,
+      ),
+    ).toBe(true);
+  });
+
+  it('never rebases a queued stale command and rejects it after the boundary cancels', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const events: ProfileEvent[] = [];
+    harness.deps.listeners = [
+      (event) => {
+        events.push(event);
+      },
+    ];
+    const controller = new ProfileController(harness.deps);
+    const fingerprint = await setupSavedAlpha(harness, controller);
+
+    const first = controller.execute({
+      kind: 'model',
+      model: 'm2',
+      expectedRevision: 1,
+    });
+    await settle(() => harness.boundary.pendingCount() === 1);
+    const second = controller.execute({
+      kind: 'model',
+      model: 'm2',
+      expectedRevision: 2,
+    });
+    await expect(second).resolves.toStrictEqual({
+      kind: 'queued',
+      baseRevision: 1,
+      revision: 1,
+    });
+
+    harness.boundary.release('cancelled');
+    await expect(first).resolves.toStrictEqual({
+      kind: 'cancelled',
+      reason: 'boundary cancelled',
+      revision: 1,
+    });
+
+    expect(
+      events.some(
+        (event) =>
+          event.type === 'command-rejected' &&
+          event.commandKind === 'model' &&
+          event.revision === 1,
+      ),
+    ).toBe(true);
+
+    const state = configuredState(controller.getState());
+    expect(state.revision).toBe(1);
+    expect(state.identity).toStrictEqual({
+      kind: 'saved',
+      name: 'alpha',
+      source: fingerprint,
+    });
+    expect(state.document).toStrictEqual(standardProvADocument('m1'));
+  });
+
+  it('answers a non-queueing caller with busy while a command is in flight', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    await setupSavedAlpha(harness, controller);
+
+    const first = controller.execute({
+      kind: 'model',
+      model: 'm2',
+      expectedRevision: 1,
+    });
+    await settle(() => harness.boundary.pendingCount() === 1);
+    const busy = await controller.execute(
+      { kind: 'model', model: 'm2', expectedRevision: 2 },
+      { queue: false },
+    );
+    expect(busy).toStrictEqual({
+      kind: 'busy',
+      activeCommandKind: 'model',
+      revision: 1,
+    });
+
+    harness.boundary.release('safe');
+    expect(await first).toStrictEqual(
+      committedModelResult(await alphaFingerprint(harness)),
+    );
+    expect(configuredState(controller.getState()).revision).toBe(2);
+  });
+
+  it('requires confirmation when a load targets an unsaved draft', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    const { pending } = await setupLoadOverUnsavedDraft(harness, controller);
+
+    expect(pending.commandKind).toBe('load');
+    expect(controller.getPendingConfirmations()).toStrictEqual([pending.token]);
+    expect(configuredState(controller.getState()).revision).toBe(2);
+  });
+
+  it('replays the original load after confirm-discard and commits the saved identity', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    const { pending, fingerprint } = await setupLoadOverUnsavedDraft(
+      harness,
+      controller,
+    );
+
+    const confirm = controller.execute({
+      kind: 'confirm-discard',
+      pending,
+      expectedRevision: 2,
+    });
+    await settle(() => harness.boundary.pendingCount() === 1);
+    harness.boundary.release('safe');
+
+    expect(await confirm).toStrictEqual({
+      kind: 'committed',
+      revision: 3,
+      snapshot: committedSnapshot(
+        { kind: 'saved', name: 'alpha', source: fingerprint },
+        3,
+        'm1',
+      ),
+    });
+    expect(configuredState(controller.getState()).identity).toStrictEqual({
+      kind: 'saved',
+      name: 'alpha',
+      source: fingerprint,
+    });
+    expect(controller.getPendingConfirmations()).toStrictEqual([]);
+  });
+
+  it('rejects a confirm-discard with an unknown token as invalid', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    const fingerprint = await setupSavedAlpha(harness, controller);
+
+    const result = await controller.execute({
+      kind: 'confirm-discard',
+      pending: {
+        token: 'discard:never-issued',
+        commandKind: 'load',
+        description: 'no such confirmation',
+      },
+      expectedRevision: 1,
+    });
+
+    expect(result).toStrictEqual({
+      kind: 'invalid',
+      errors: ['unknown confirmation token'],
+      revision: 1,
+    });
+    expect(controller.getPendingConfirmations()).toStrictEqual([]);
+    const state = configuredState(controller.getState());
+    expect(state.revision).toBe(1);
+    expect(state.identity).toStrictEqual({
+      kind: 'saved',
+      name: 'alpha',
+      source: fingerprint,
+    });
+  });
+
+  it('refuses a save-as onto an existing profile with a destination-exists conflict', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    const fingerprint = await setupSavedAlpha(harness, controller);
+
+    harness.repo.seed('bravo', standardProvADocument('m1'));
+
+    const result = await controller.execute({
+      kind: 'save',
+      name: 'bravo',
+      expectedRevision: 1,
+    });
+
+    expect(result).toStrictEqual({
+      kind: 'conflict',
+      cause: 'destination-exists',
+      revision: 1,
+    });
+    const state = configuredState(controller.getState());
+    expect(state.revision).toBe(1);
+    expect(state.identity).toStrictEqual({
+      kind: 'saved',
+      name: 'alpha',
+      source: fingerprint,
+    });
+    expect(state.document).toStrictEqual(standardProvADocument('m1'));
+    const bravo = await harness.repo.stat('bravo');
+    expect(bravo).not.toBeNull();
+  });
+
+  it('refuses a draft save over an existing unrelated name with a destination-exists conflict', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    await setupDraftAtRevision2(harness, controller);
+
+    harness.repo.seed('bravo', standardProvADocument('m1'));
+    const result = await controller.execute({
+      kind: 'save',
+      name: 'bravo',
+      expectedRevision: 2,
+    });
+
+    expect(result).toStrictEqual({
+      kind: 'conflict',
+      cause: 'destination-exists',
+      revision: 2,
+    });
+    const state = configuredState(controller.getState());
+    expect(state.revision).toBe(2);
+    if (state.identity.kind !== 'draft') {
+      throw new Error('expected the workspace to stay an unsaved draft');
+    }
+    expect(state.document).toStrictEqual(standardProvADocument('m2'));
+  });
+
+  it('commits a save-as to a fresh name and leaves the source profile intact', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    await setupSavedAlpha(harness, controller);
+
+    const result = await controller.execute({
+      kind: 'save',
+      name: 'beta',
+      expectedRevision: 1,
+    });
+
+    expect(result.kind).toBe('committed');
+    const betaFingerprint = await harness.repo.stat('beta');
+    if (betaFingerprint === null) {
+      throw new Error('beta fingerprint missing from the repository');
+    }
+    const state = configuredState(controller.getState());
+    expect(state.identity).toStrictEqual({
+      kind: 'saved',
+      name: 'beta',
+      source: betaFingerprint,
+    });
+    expect(state.document).toStrictEqual(standardProvADocument('m1'));
+    const alpha = await harness.repo.load('alpha');
+    expect(alpha.document).toStrictEqual(standardProvADocument('m1'));
+  });
+
+  it('keeps the revision and the live runtime identity across a successful save', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    const fingerprint = await setupSavedAlpha(harness, controller);
+    const runtime = controller.getRuntime();
+    const binding = runtime?.getBinding();
+    if (runtime === undefined || binding === undefined) {
+      throw new Error('expected a live runtime after the alpha load');
+    }
+
+    const result = await controller.execute({
+      kind: 'save',
+      name: 'charlie',
+      expectedRevision: 1,
+    });
+
+    expect(result).toStrictEqual({
+      kind: 'committed',
+      revision: 1,
+      snapshot: {
+        identity: { kind: 'saved', name: 'charlie', source: fingerprint },
+        revision: 1,
+        provider: 'prov-a',
+        model: 'm1',
+        isLoadBalancer: false,
+      },
+    });
+    const state = configuredState(controller.getState());
+    expect(state.revision).toBe(1);
+    expect(state.identity).toStrictEqual({
+      kind: 'saved',
+      name: 'charlie',
+      source: fingerprint,
+    });
+    expect(controller.getRuntime()).toBe(runtime);
+    expect(controller.getRuntime()?.getBinding()).toBe(binding);
+  });
+
+  it('treats a same-model /model command as a no-op', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    await setupSavedAlpha(harness, controller);
+
+    const result = await controller.execute({
+      kind: 'model',
+      model: 'm1',
+      expectedRevision: 1,
+    });
+
+    expect(result).toStrictEqual({
+      kind: 'no-op',
+      reason: 'model unchanged',
+      revision: 1,
+    });
+    const state = configuredState(controller.getState());
+    expect(state.revision).toBe(1);
+    expect(state.document).toStrictEqual(standardProvADocument('m1'));
+  });
+
+  it('keeps serialization healthy when a queued command throws inside the drain', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const events: ProfileEvent[] = [];
+    harness.deps.listeners = [
+      (event) => {
+        events.push(event);
+      },
+    ];
+    const controller = new ProfileController(harness.deps);
+    await loadAlpha(harness, controller);
+
+    const first = controller.execute({
+      kind: 'model',
+      model: 'm2',
+      expectedRevision: 1,
+    });
+    await settle(() => harness.boundary.pendingCount() === 1);
+    harness.factory.holdNextBuild();
+    harness.boundary.release('safe');
+    await settle(() => harness.factory.built === 2);
+
+    const second = controller.execute({
+      kind: 'save',
+      name: 'beta',
+      expectedRevision: 2,
+    });
+    await expect(second).resolves.toStrictEqual({
+      kind: 'queued',
+      baseRevision: 1,
+      revision: 1,
+    });
+
+    harness.repo.failNextRead();
+    harness.factory.releaseHeldBuild();
+
+    // The first command's promise must still resolve committed even though the
+    // queued save-as threw on its destination stat inside the shared drain.
+    expect(await first).toStrictEqual(
+      committedModelResult(await alphaFingerprint(harness)),
+    );
+
+    expect(
+      events.some(
+        (event) =>
+          event.type === 'command-rejected' &&
+          event.commandKind === 'save' &&
+          event.revision === 2,
+      ),
+    ).toBe(true);
+    expect(configuredState(controller.getState()).revision).toBe(2);
+    expect(await harness.repo.stat('beta')).toBeNull();
+
+    const third = controller.execute({
+      kind: 'model',
+      model: 'm2',
+      expectedRevision: 2,
+    });
+    expect(await third).toStrictEqual({
+      kind: 'no-op',
+      reason: 'model unchanged',
+      revision: 2,
+    });
+  });
+
+  it('emits the committed event only after the new state and runtime are adopted', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const revisionsAtCommit: number[] = [];
+    const kindsAtCommit: Array<string | null> = [];
+    harness.deps.listeners = [
+      (event) => {
+        if (event.type === 'committed') {
+          const state = controller.getState();
+          revisionsAtCommit.push(
+            state.status === 'configured' ? state.revision : 0,
+          );
+          kindsAtCommit.push(event.commandKind);
+        }
+      },
+    ];
+    const controller = new ProfileController(harness.deps);
+
+    await loadAlpha(harness, controller);
+    const pending = controller.execute({
+      kind: 'model',
+      model: 'm2',
+      expectedRevision: 1,
+    });
+    await settle(() => harness.boundary.pendingCount() === 1);
+    harness.boundary.release('safe');
+    expect((await pending).kind).toBe('committed');
+
+    expect(revisionsAtCommit).toStrictEqual([1, 2]);
+    expect(kindsAtCommit).toStrictEqual(['startup', 'model']);
+  });
+
+  it('announces a save conflict as a rejection instead of a commit', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const events: ProfileEvent[] = [];
+    harness.deps.listeners = [
+      (event) => {
+        events.push(event);
+      },
+    ];
+    const controller = new ProfileController(harness.deps);
+    await setupSavedAlpha(harness, controller);
+    harness.repo.seed('bravo', standardProvADocument('m1'));
+    const commitsBefore = events.filter(
+      (event) => event.type === 'committed',
+    ).length;
+
+    const result = await controller.execute({
+      kind: 'save',
+      name: 'bravo',
+      expectedRevision: 1,
+    });
+
+    expect(result).toStrictEqual({
+      kind: 'conflict',
+      cause: 'destination-exists',
+      revision: 1,
+    });
+    expect(
+      events.some(
+        (event) =>
+          event.type === 'command-rejected' &&
+          event.commandKind === 'save' &&
+          event.revision === 1,
+      ),
+    ).toBe(true);
+    expect(events.filter((event) => event.type === 'committed').length).toBe(
+      commitsBefore,
+    );
+  });
+
+  it('dispatches deep-frozen events that listeners cannot mutate', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const frozenFlags: boolean[] = [];
+    harness.deps.listeners = [
+      (event) => {
+        frozenFlags.push(Object.isFrozen(event));
+      },
+    ];
+    const controller = new ProfileController(harness.deps);
+
+    await loadAlpha(harness, controller);
+
+    expect(frozenFlags.length).toBeGreaterThan(0);
+    expect(frozenFlags.every((flag) => flag)).toBe(true);
+  });
+
+  it('hands out a committed state graph frozen against mutation', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    await loadAlpha(harness, controller);
+
+    const state = configuredState(controller.getState());
+    expect(Object.isFrozen(state)).toBe(true);
+    expect(Object.isFrozen(state.document)).toBe(true);
+    expect(Object.isFrozen(state.document.modelParams)).toBe(true);
+    expect(Object.isFrozen(state.document.ephemeralSettings)).toBe(true);
+    expect(() => {
+      state.document.model = 'mutated';
+    }).toThrow(TypeError);
+    expect(configuredState(controller.getState()).document.model).toBe('m1');
+  });
+
+  it('executes a queued command from an immutable copy, not the caller object', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    await loadAlpha(harness, controller);
+
+    const first = controller.execute({
+      kind: 'model',
+      model: 'm2',
+      expectedRevision: 1,
+    });
+    await settle(() => harness.boundary.pendingCount() === 1);
+
+    const queuedCommand: ProfileCommand = {
+      kind: 'model',
+      model: 'm1',
+      expectedRevision: 2,
+    };
+    const second = controller.execute(queuedCommand);
+    await expect(second).resolves.toStrictEqual({
+      kind: 'queued',
+      baseRevision: 1,
+      revision: 1,
+    });
+
+    // Tampering toward the no-op model must not reach the queue: the protected
+    // copy still carries 'm1', so the drain forks back to m1 at revision 3. A
+    // leaked reference would run 'm2' and no-op, leaving m2 committed at 2.
+    queuedCommand.model = 'm2';
+
+    harness.boundary.release('safe');
+    await settle(() => harness.boundary.pendingCount() === 1);
+    harness.boundary.release('safe');
+    expect(await first).toStrictEqual(
+      committedModelResult(await alphaFingerprint(harness)),
+    );
+    const state = configuredState(controller.getState());
+    expect(state.revision).toBe(3);
+    expect(state.document).toStrictEqual(standardProvADocument('m1'));
+  });
+
+  it('reflects a save in the live runtime snapshot at the new fingerprint', async () => {
+    const harness = makeDeps();
+    seedAlpha(harness.repo);
+    const controller = new ProfileController(harness.deps);
+    const runtime = await setupSavedAlpha(harness, controller).then(() =>
+      controller.getRuntime(),
+    );
+    if (runtime === undefined) {
+      throw new Error('expected a live runtime after the alpha load');
+    }
+
+    const result = await controller.execute({
+      kind: 'save',
+      name: 'charlie',
+      expectedRevision: 1,
+    });
+    expect(result.kind).toBe('committed');
+
+    const charlieFingerprint = await harness.repo.stat('charlie');
+    if (charlieFingerprint === null) {
+      throw new Error('charlie fingerprint missing from the repository');
+    }
+    expect(controller.getRuntime()).toBe(runtime);
+    expect(runtime.snapshot()).toStrictEqual(
+      committedSnapshot(
+        {
+          kind: 'saved',
+          name: 'charlie',
+          source: charlieFingerprint,
+        },
+        1,
+        'm1',
+      ),
+    );
+  });
+});

--- a/packages/agents/src/core/profile/__tests__/profileRepositoryAdapter.test.ts
+++ b/packages/agents/src/core/profile/__tests__/profileRepositoryAdapter.test.ts
@@ -89,6 +89,88 @@ describe('ProfileManagerProfileRepository', () => {
     tempDirs.length = 0;
   });
 
+  describe.each(['overwrite', 'create', 'expected'])(
+    'load-balancer %s validation',
+    (mode) => {
+      async function prepare(): Promise<SourceFingerprint | undefined> {
+        await setupRepository();
+        await repository.save('member-a', standardDocument());
+        await repository.save('member-b', standardDocument());
+        return mode === 'expected'
+          ? repository.save('lb', loadBalancerDocument())
+          : undefined;
+      }
+
+      it.each(['unknown', 'nested', 'self'])(
+        'rejects %s references before writing',
+        async (reference) => {
+          const expected = await prepare();
+          await repository.save('nested', loadBalancerDocument());
+          const profiles = reference === 'self' ? ['lb'] : [reference];
+          await expect(
+            repository.save(
+              'lb',
+              { ...loadBalancerDocument(), profiles },
+              expected,
+              { mustCreate: mode === 'create' },
+            ),
+          ).rejects.toThrow(/LoadBalancer profile/);
+          expect(await repository.stat('lb')).toStrictEqual(expected ?? null);
+        },
+      );
+
+      it('saves valid members', async () => {
+        const expected = await prepare();
+        const document = { ...loadBalancerDocument(), contextLimit: 64000 };
+        await repository.save('lb', document, expected, {
+          mustCreate: mode === 'create',
+        });
+        expect((await repository.load('lb')).document).toStrictEqual(document);
+      });
+    },
+  );
+
+  it.each([false, true])(
+    'rejects self-reference when replacing a standard profile with expected=%s',
+    async (anchored) => {
+      await setupRepository();
+      const expected = await repository.save('self', standardDocument());
+      await expect(
+        repository.save(
+          'self',
+          { ...loadBalancerDocument(), profiles: ['self'] },
+          anchored ? expected : undefined,
+        ),
+      ).rejects.toThrow(/cannot reference itself/);
+      expect(await repository.stat('self')).toStrictEqual(expected);
+    },
+  );
+
+  it('preserves load-balancer create conflicts and optimistic concurrency', async () => {
+    await setupRepository();
+    await repository.save('member-a', standardDocument());
+    await repository.save('member-b', standardDocument());
+    const document = loadBalancerDocument();
+    const expected = await repository.save('lb', document, undefined, {
+      mustCreate: true,
+    });
+    await expect(
+      repository.save('lb', document, undefined, { mustCreate: true }),
+    ).rejects.toBeInstanceOf(ProfileRepositoryConflictError);
+    await repository.save(
+      'lb',
+      { ...document, profiles: ['member-a'] },
+      expected,
+    );
+    await expect(
+      repository.save('lb', document, expected),
+    ).rejects.toBeInstanceOf(ProfileRepositoryConflictError);
+    expect((await repository.load('lb')).document).toStrictEqual({
+      ...document,
+      profiles: ['member-a'],
+    });
+  });
+
   it('checks the overwrite anchor after acquiring a contended profiles lock', async () => {
     await setupRepository();
     const expected = await repository.save('contended', standardDocument());

--- a/packages/agents/src/core/profile/__tests__/profileRepositoryAdapter.test.ts
+++ b/packages/agents/src/core/profile/__tests__/profileRepositoryAdapter.test.ts
@@ -1,0 +1,528 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Behavior tests for the agents-side profile repository adapter.
+ *
+ * Real temp filesystem + the real ProfileManager: save/load round-trips and
+ * optimistic-concurrency behavior are verified against actual JSON files, not stubs.
+ */
+
+import { describe, it, expect, afterEach, spyOn } from 'bun:test';
+import * as fs from 'node:fs/promises';
+import { channel } from 'node:diagnostics_channel';
+import {
+  withProfilesLock,
+  LOCK_CONTENTION_CHANNEL,
+} from '../../../../../settings/src/profiles/profileStore.js';
+import os from 'node:os';
+import path from 'node:path';
+import { ProfileManager, type Profile } from '@vybestack/llxprt-code-settings';
+import {
+  ProfileRepositoryConflictError,
+  isStandardProfileDocument,
+  type LoadBalancerProfileDocument,
+  type ProfileDocument,
+  type SourceFingerprint,
+} from '@vybestack/llxprt-code-core';
+import {
+  ProfileManagerProfileRepository,
+  toProfileDocument,
+  toSettingsProfile,
+} from '../profileRepositoryAdapter.js';
+import { ProfileController } from '../profileController.js';
+import { makeDeps, releaseAndAwait } from './controllerTestFakes.js';
+
+function makeTempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'llxprt-agent-profile-'));
+}
+
+const standardDocument = (): ProfileDocument => ({
+  version: 1,
+  type: 'standard',
+  provider: 'openai',
+  model: 'gpt-4o',
+  modelParams: { temperature: 0.2 },
+  ephemeralSettings: {
+    'auth-key': 'sk-test',
+    'base-url': 'https://example.com',
+  },
+});
+
+const loadBalancerDocument = (): LoadBalancerProfileDocument => ({
+  version: 1,
+  type: 'loadbalancer',
+  policy: 'roundrobin',
+  profiles: ['member-a', 'member-b'],
+  contextLimit: 128000,
+  provider: '',
+  model: '',
+  modelParams: {},
+  ephemeralSettings: { 'context-limit': 128000 },
+});
+
+function uniqueName(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+describe('ProfileManagerProfileRepository', () => {
+  let repository: ProfileManagerProfileRepository;
+
+  const tempDirs: string[] = [];
+
+  async function setupRepository(
+    manager: (dir: string) => ProfileManager = (dir) => new ProfileManager(dir),
+  ): Promise<void> {
+    const dir = await makeTempDir();
+    tempDirs.push(dir);
+    const profileManager = manager(dir);
+    repository = new ProfileManagerProfileRepository(profileManager, dir);
+  }
+
+  afterEach(async () => {
+    for (const dir of tempDirs) {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+    tempDirs.length = 0;
+  });
+
+  it('checks the overwrite anchor after acquiring a contended profiles lock', async () => {
+    await setupRepository();
+    const expected = await repository.save('contended', standardDocument());
+    const contention = channel(LOCK_CONTENTION_CHANNEL);
+    let observed: () => void = () => {};
+    const waiting = new Promise<void>((resolve) => {
+      observed = resolve;
+    });
+    const onContention = (): void => observed();
+    contention.subscribe(onContention);
+    let saving: Promise<SourceFingerprint> | undefined;
+    try {
+      await withProfilesLock(repository.profilesDir, async () => {
+        saving = repository.save(
+          'contended',
+          { ...standardDocument(), model: 'loser' },
+          expected,
+        );
+        await waiting;
+        await fs.writeFile(
+          path.join(repository.profilesDir, 'contended.json'),
+          JSON.stringify({ ...standardDocument(), model: 'external-winner' }),
+        );
+      });
+      await expect(saving).rejects.toBeInstanceOf(
+        ProfileRepositoryConflictError,
+      );
+      expect((await repository.load('contended')).document.model).toStrictEqual(
+        'external-winner',
+      );
+    } finally {
+      contention.unsubscribe(onContention);
+    }
+  });
+
+  it.each(['EACCES', 'EMFILE'])(
+    'propagates %s from stat through load and anchored save',
+    async (code) => {
+      await setupRepository();
+      const expected = await repository.save('unreadable', standardDocument());
+      const failure = Object.assign(new Error('filesystem unavailable'), {
+        code,
+      });
+      const stat = spyOn(fs, 'stat').mockRejectedValue(failure);
+      try {
+        await expect(repository.stat('unreadable')).rejects.toBe(failure);
+        await expect(repository.load('unreadable')).rejects.toBe(failure);
+        await expect(
+          repository.save('unreadable', standardDocument(), expected),
+        ).rejects.toBe(failure);
+      } finally {
+        stat.mockRestore();
+      }
+    },
+  );
+
+  it.each(['ENOENT', 'ENOTDIR'])(
+    'treats %s as a missing source',
+    async (code) => {
+      await setupRepository();
+      const stat = spyOn(fs, 'stat').mockRejectedValue(
+        Object.assign(new Error('missing'), { code }),
+      );
+      try {
+        expect(await repository.stat('missing')).toStrictEqual(null);
+      } finally {
+        stat.mockRestore();
+      }
+    },
+  );
+
+  it('isolates nested values in both document conversion directions', () => {
+    const original: Profile = {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: { extra: { nested: ['original'] } },
+      ephemeralSettings: {
+        'custom-headers': { header: 'original' },
+        'disabled-tools': ['shell'],
+        'tools.allowed': ['read'],
+      },
+    };
+    const untouched = structuredClone(original);
+    const document = toProfileDocument(original);
+    const settings = toSettingsProfile(document);
+    for (const value of [
+      settings.ephemeralSettings,
+      document.ephemeralSettings,
+    ]) {
+      const headers = value['custom-headers'];
+      if (typeof headers !== 'object' || headers === null)
+        throw new Error('expected headers');
+      Object.assign(headers, { header: 'changed' });
+      const tools = value['disabled-tools'];
+      if (!Array.isArray(tools)) throw new Error('expected tools');
+      tools.push('edit');
+    }
+    expect(original).toStrictEqual(untouched);
+    expect(document.ephemeralSettings['disabled-tools']).toStrictEqual([
+      'shell',
+      'edit',
+    ]);
+    const nested = settings.modelParams.extra;
+    if (typeof nested !== 'object' || nested === null)
+      throw new Error('expected nested model params');
+    Object.assign(nested, { nested: ['changed'] });
+    expect(document.modelParams).toStrictEqual(untouched.modelParams);
+  });
+
+  it('skips binding construction for an untagged blank returned by the manager', async () => {
+    class CoreDocumentManager extends ProfileManager {
+      constructor(private readonly directory: string) {
+        super(directory);
+      }
+      override async loadProfile(name: string): Promise<Profile> {
+        const raw: unknown = JSON.parse(
+          await fs.readFile(path.join(this.directory, `${name}.json`), 'utf8'),
+        );
+        if (!isStandardProfileDocument(raw)) {
+          throw new Error('expected a standard document');
+        }
+        return toSettingsProfile(raw);
+      }
+    }
+    await setupRepository((dir) => new CoreDocumentManager(dir));
+    const harness = makeDeps();
+    harness.deps.repository = repository;
+    const writer = new ProfileController(harness.deps);
+    expect(
+      (
+        await releaseAndAwait(
+          harness,
+          writer.execute({ kind: 'setup', expectedRevision: 0 }),
+        )
+      ).kind,
+    ).toStrictEqual('committed');
+    expect(
+      (
+        await writer.execute({
+          kind: 'save',
+          name: 'blank',
+          expectedRevision: 1,
+        })
+      ).kind,
+    ).toStrictEqual('committed');
+    expect((await repository.load('blank')).document.type).toBeUndefined();
+    const reader = new ProfileController(harness.deps);
+    expect(
+      (
+        await releaseAndAwait(
+          harness,
+          reader.execute({
+            kind: 'startup',
+            profileName: 'blank',
+            expectedRevision: 0,
+          }),
+        )
+      ).kind,
+    ).toStrictEqual('committed');
+    expect(harness.factory.built).toStrictEqual(0);
+    expect(reader.getRuntime()?.getBinding()).toBeUndefined();
+  });
+
+  async function setupRacingRepository(
+    keepRacing: boolean,
+  ): Promise<() => number> {
+    let loads = 0;
+    class RacingManager extends ProfileManager {
+      override async loadProfile(name: string): Promise<Profile> {
+        const loaded = await super.loadProfile(name);
+        loads += 1;
+        if (keepRacing || loads === 1) {
+          await this.saveProfile(name, {
+            ...loaded,
+            model: `${loaded.model}-changed`,
+          });
+        }
+        return loaded;
+      }
+    }
+    await setupRepository((dir) => new RacingManager(dir));
+    await repository.save('racing', standardDocument());
+    return () => loads;
+  }
+
+  it('throws a typed conflict after two unstable reads and maps it to controller failure', async () => {
+    const loads = await setupRacingRepository(true);
+    await expect(repository.load('racing')).rejects.toBeInstanceOf(
+      ProfileRepositoryConflictError,
+    );
+    expect(loads()).toStrictEqual(2);
+    const harness = makeDeps();
+    harness.deps.repository = repository;
+    const controller = new ProfileController(harness.deps);
+    expect(
+      await controller.execute({
+        kind: 'startup',
+        profileName: 'racing',
+        expectedRevision: 0,
+      }),
+    ).toStrictEqual({
+      kind: 'failed',
+      error: "Profile 'racing' changed while loading",
+      revision: 0,
+    });
+  });
+
+  it('retries a racing read and returns a coherent document and fingerprint', async () => {
+    const loads = await setupRacingRepository(false);
+    const loaded = await repository.load('racing');
+    expect(loaded.document.model).toStrictEqual('gpt-4o-changed');
+    expect(await repository.stat('racing')).toStrictEqual(loaded.fingerprint);
+    expect(loads()).toStrictEqual(2);
+  });
+
+  it.each(['', '.', '..', 'a/../b', '/etc/passwd', 'a\\b', 'bad\u0000name'])(
+    'rejects invalid name %j before filesystem or manager access',
+    async (name) => {
+      let calls = 0;
+      class ObservedManager extends ProfileManager {
+        override async loadProfile(): Promise<Profile> {
+          calls += 1;
+          return toSettingsProfile(standardDocument());
+        }
+        override async saveProfile(): Promise<void> {
+          calls += 1;
+        }
+        override async deleteProfile(): Promise<void> {
+          calls += 1;
+        }
+      }
+      await setupRepository((dir) => new ObservedManager(dir));
+      const statSpy = spyOn(fs, 'stat');
+      try {
+        await expect(repository.load(name)).rejects.toBeInstanceOf(RangeError);
+        await expect(
+          repository.save(name, standardDocument()),
+        ).rejects.toBeInstanceOf(RangeError);
+        await expect(repository.stat(name)).rejects.toBeInstanceOf(RangeError);
+        await expect(repository.delete(name)).rejects.toBeInstanceOf(
+          RangeError,
+        );
+        expect(calls).toStrictEqual(0);
+        expect(statSpy.mock.calls.length).toStrictEqual(0);
+      } finally {
+        statSpy.mockRestore();
+      }
+    },
+  );
+
+  it('rejects invalid names returned by the manager listing', async () => {
+    class InvalidListingManager extends ProfileManager {
+      override async listProfiles(): Promise<string[]> {
+        return ['ok', '../escape'];
+      }
+    }
+    await setupRepository((dir) => new InvalidListingManager(dir));
+    await expect(repository.list()).rejects.toBeInstanceOf(RangeError);
+  });
+
+  it('atomically refuses concurrent create-only saves without overwriting the winner', async () => {
+    await setupRepository();
+    const documents = [
+      standardDocument(),
+      { ...standardDocument(), model: 'gpt-4o-mini' },
+    ];
+    const results = await Promise.allSettled(
+      documents.map((document) =>
+        repository.save('exclusive', document, undefined, { mustCreate: true }),
+      ),
+    );
+    expect(
+      results.filter((result) => result.status === 'fulfilled').length,
+    ).toStrictEqual(1);
+    const loser = results.find((result) => result.status === 'rejected');
+    if (loser === undefined) {
+      throw new Error('expected one conflict');
+    }
+    expect(loser.reason).toBeInstanceOf(ProfileRepositoryConflictError);
+    const winnerIndex = results.findIndex(
+      (result) => result.status === 'fulfilled',
+    );
+    expect((await repository.load('exclusive')).document.model).toStrictEqual(
+      documents[winnerIndex].model,
+    );
+  });
+
+  it('round-trips a standard document through save and load', async () => {
+    await setupRepository();
+    const name = uniqueName('std');
+    await repository.save(name, standardDocument());
+    const loaded = await repository.load(name);
+    // The settings parser drops the optional `type` on a standard profile, so
+    // the persisted document is the standard shape without an explicit type field.
+    const { type: _type, ...expected } = standardDocument();
+    expect(loaded.document).toStrictEqual(expected);
+    expect(loaded.fingerprint.kind).toBe('stat');
+    const fingerprint: SourceFingerprint = loaded.fingerprint;
+    if (fingerprint.kind !== 'stat') {
+      throw new Error('expected a stat fingerprint');
+    }
+    expect(fingerprint.size).toBeGreaterThan(0);
+  });
+
+  it('round-trips a load balancer document through save and load', async () => {
+    await setupRepository();
+    const memberName = uniqueName('member-a');
+    const memberB = uniqueName('member-b');
+    const memberDoc: ProfileDocument = {
+      version: 1,
+      provider: 'anthropic',
+      model: 'claude-3-7-sonnet',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+    await repository.save(memberName, memberDoc);
+    await repository.save(memberB, memberDoc);
+    const lbName = uniqueName('lb');
+    const lbDoc = loadBalancerDocument();
+    const lbWithNames: ProfileDocument = {
+      ...lbDoc,
+      type: 'loadbalancer',
+      profiles: [memberName, memberB],
+    };
+    await repository.save(lbName, lbWithNames);
+    const loaded = await repository.load(lbName);
+    expect(loaded.document).toStrictEqual(lbWithNames);
+  });
+
+  it('stat returns a fingerprint that changes after re-save', async () => {
+    await setupRepository();
+    const name = uniqueName('stat');
+    await repository.save(name, standardDocument());
+    const first = await repository.stat(name);
+    expect(first).not.toBeNull();
+    // Re-save with different content so mtime/size can change.
+    await repository.save(name, {
+      ...standardDocument(),
+      model: 'gpt-4o-mini',
+    });
+    const second = await repository.stat(name);
+    expect(second).not.toBeNull();
+    if (
+      first === null ||
+      second === null ||
+      first.kind !== 'stat' ||
+      second.kind !== 'stat'
+    ) {
+      throw new Error('expected stat fingerprints for both saves');
+    }
+    expect(second).not.toStrictEqual(first);
+    expect(second.size).toBeGreaterThan(first.size);
+  });
+
+  it('save with the matching expected fingerprint succeeds', async () => {
+    await setupRepository();
+    const name = uniqueName('match');
+    await repository.save(name, standardDocument());
+    const expected = await repository.stat(name);
+    if (expected === null) {
+      throw new Error('expected persisted fingerprint');
+    }
+    const updated = { ...standardDocument(), model: 'gpt-4o-mini' };
+    const fingerprint = await repository.save(name, updated, expected);
+    expect(fingerprint.kind).toBe('stat');
+    const loaded = await repository.load(name);
+    expect(loaded.document.model).toBe('gpt-4o-mini');
+  });
+
+  it('save with a stale expected fingerprint throws and leaves the file untouched', async () => {
+    await setupRepository();
+    const name = uniqueName('stale');
+    await repository.save(name, standardDocument());
+    const stale: SourceFingerprint = {
+      kind: 'stat',
+      mtimeMs: 1,
+      size: 1,
+    };
+    await expect(
+      repository.save(
+        name,
+        { ...standardDocument(), model: 'gpt-4o-mini' },
+        stale,
+      ),
+    ).rejects.toBeInstanceOf(ProfileRepositoryConflictError);
+    const loaded = await repository.load(name);
+    // The save was refused, so the file still holds the original document. The
+    // settings parser drops the optional `type` field on standard profiles.
+    const { type: _type, ...untouched } = standardDocument();
+    expect(loaded.document).toStrictEqual(untouched);
+  });
+
+  it('list returns saved profile names without extensions', async () => {
+    await setupRepository();
+    const nameA = uniqueName('list-a');
+    const nameB = uniqueName('list-b');
+    await repository.save(nameA, standardDocument());
+    await repository.save(nameB, standardDocument());
+    const names = (await repository.list()).map((entry) => entry.name);
+    expect(names).toContain(nameA);
+    expect(names).toContain(nameB);
+  });
+
+  it('delete removes the file so stat returns null', async () => {
+    await setupRepository();
+    const name = uniqueName('del');
+    await repository.save(name, standardDocument());
+    const before = await repository.stat(name);
+    expect(before).not.toBeNull();
+    await repository.delete(name);
+    const after = await repository.stat(name);
+    expect(after).toBeNull();
+  });
+
+  it('converts a settings profile to a core document without shared records', () => {
+    const settings: Profile = {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: { temperature: 0.2 },
+      ephemeralSettings: { 'auth-key': 'sk-test' },
+    };
+    const doc = toProfileDocument(settings);
+    expect(doc.modelParams).not.toBe(settings.modelParams);
+    expect(doc.ephemeralSettings).not.toBe(settings.ephemeralSettings);
+  });
+
+  it('converts a core document into a structurally compatible profile', () => {
+    const { type: _type, ...document } = standardDocument();
+    const settingsDoc = toSettingsProfile(document);
+    expect(settingsDoc.version).toBe(1);
+    expect(settingsDoc.provider).toBe('openai');
+    expect(settingsDoc.model).toBe('gpt-4o');
+    expect(settingsDoc.ephemeralSettings['auth-key']).toBe('sk-test');
+  });
+});

--- a/packages/agents/src/core/profile/activeProfileRuntime.ts
+++ b/packages/agents/src/core/profile/activeProfileRuntime.ts
@@ -54,6 +54,13 @@ function snapshotSummary(state: ProfileState): {
   return { revision: state.revision, identityKind, providerOrLbSummary };
 }
 
+export class ProfileRuntimeDisposedError extends Error {
+  constructor() {
+    super('Profile role runtime is no longer valid');
+    this.name = 'ProfileRuntimeDisposedError';
+  }
+}
+
 /**
  * Wrapper that owns a profile runtime binding and its observed health.
  *
@@ -64,6 +71,8 @@ function snapshotSummary(state: ProfileState): {
  * bound stay construction-time facts. Health is mutable and separate from state.
  */
 export class ActiveProfileRuntime {
+  private invalidated = false;
+  private roleRuntimes = new Set<WeakRef<ActiveProfileRuntime>>();
   private stateSupplier: () => ProfileState;
   private readonly disposeTimeoutMs: number;
   private binding: ProfileRuntimeBinding | undefined;
@@ -87,12 +96,14 @@ export class ActiveProfileRuntime {
   }
 
   getPolicy(): Readonly<EffectiveToolPolicy> {
+    this.ensureValid();
     return this.policy;
   }
 
   getFilteredToolDeclarations(
     declarations: ReadonlyArray<{ name: string; description: string }>,
   ): ReadonlyArray<Readonly<{ name: string; description: string }>> {
+    this.ensureValid();
     return Object.freeze(
       declarations
         .filter(
@@ -140,6 +151,7 @@ export class ActiveProfileRuntime {
       this.restrictedAllowlist || rolePolicy?.allowedTools !== undefined;
     child.binding = this.binding;
     child.ownsBinding = false;
+    this.roleRuntimes.add(new WeakRef(child));
     this.roleRuntimeCount += 1;
     return child;
   }
@@ -148,6 +160,7 @@ export class ActiveProfileRuntime {
    * The workspace state the runtime currently describes, read through the supplier.
    */
   getState(): ProfileState {
+    this.ensureValid();
     return this.stateSupplier();
   }
 
@@ -158,11 +171,13 @@ export class ActiveProfileRuntime {
    * behind the committed workspace, even when the runtime object itself was reused.
    */
   resupplyState(currentState: () => ProfileState): void {
+    this.ensureValid();
     this.stateSupplier = currentState;
   }
 
   /** Current health of the bound runtime. */
   getHealth(): ProfileHealth {
+    this.ensureValid();
     return {
       status: this.health.status,
       degradedAspects: [...this.health.degradedAspects],
@@ -171,15 +186,18 @@ export class ActiveProfileRuntime {
 
   /** The bound runtime, if any. */
   getBinding(): ProfileRuntimeBinding | undefined {
+    this.ensureValid();
     return this.binding;
   }
 
   releaseOwnership(): void {
+    this.ensureValid();
     this.ownsBinding = false;
   }
 
   /** Identifier of the bound runtime. */
   getBindingId(): string | undefined {
+    this.ensureValid();
     return this.binding?.bindingId;
   }
 
@@ -191,6 +209,8 @@ export class ActiveProfileRuntime {
    * attaching never resets health to ok.
    */
   attach(binding: ProfileRuntimeBinding): void {
+    this.ensureValid();
+    if (this.binding !== binding) this.invalidateRoleRuntimes();
     this.binding = binding;
   }
 
@@ -202,6 +222,7 @@ export class ActiveProfileRuntime {
    * survive the wrapper swap.
    */
   inheritHealthFrom(prior: ActiveProfileRuntime): void {
+    this.ensureValid();
     this.health = prior.getHealth();
   }
 
@@ -210,6 +231,7 @@ export class ActiveProfileRuntime {
    * and revision are never touched.
    */
   reportDegradation(aspects: readonly string[]): void {
+    this.ensureValid();
     const merged = new Set(this.health.degradedAspects);
     for (const aspect of aspects) {
       merged.add(aspect);
@@ -224,6 +246,7 @@ export class ActiveProfileRuntime {
    * Clear degraded aspects. Health returns to `'ok'` when none remain.
    */
   reportRecovery(aspects: readonly string[]): void {
+    this.ensureValid();
     const remaining = [...this.health.degradedAspects].filter(
       (aspect) => !aspects.includes(aspect),
     );
@@ -244,6 +267,7 @@ export class ActiveProfileRuntime {
     health: ProfileHealth;
     roleRuntimeCount: number;
   } {
+    this.ensureValid();
     const state = this.stateSupplier();
     // The unconfigured workspace has no source to derive from, so it presents as
     // an underived draft; the committed-result contract requires an identity.
@@ -274,12 +298,16 @@ export class ActiveProfileRuntime {
    * degraded aspect and never rethrown.
    */
   async [Symbol.asyncDispose](): Promise<void> {
-    if (this.disposed || !this.ownsBinding || this.binding === undefined) {
-      this.disposed = true;
-      return;
-    }
+    if (this.disposed) return;
     const binding = this.binding;
     this.disposed = true;
+    this.binding = undefined;
+    this.invalidateRoleRuntimes();
+    if (!this.ownsBinding) {
+      this.invalidated = true;
+      return;
+    }
+    if (binding === undefined) return;
     const disposeResult = binding[Symbol.asyncDispose]();
     try {
       await this.boundedRace(disposeResult);
@@ -288,6 +316,32 @@ export class ActiveProfileRuntime {
         `dispose-failed:${error instanceof Error ? error.message : String(error)}`,
       ]);
     }
+  }
+
+  retainRoleRuntimesFrom(prior: ActiveProfileRuntime): void {
+    this.ensureValid();
+    // Keep child invalidation reachable even if the prior wrapper is collected.
+    this.roleRuntimes = prior.roleRuntimes;
+    this.roleRuntimes.add(new WeakRef(prior));
+  }
+
+  private ensureValid(): void {
+    if (this.invalidated) throw new ProfileRuntimeDisposedError();
+  }
+
+  private invalidateRoleRuntimes(): void {
+    const references = [...this.roleRuntimes];
+    this.roleRuntimes.clear();
+    for (const reference of references) {
+      reference.deref()?.invalidate();
+    }
+  }
+
+  private invalidate(): void {
+    this.invalidated = true;
+    this.disposed = true;
+    this.binding = undefined;
+    this.invalidateRoleRuntimes();
   }
 
   private async boundedRace(dispose: PromiseLike<void>): Promise<void> {

--- a/packages/agents/src/core/profile/activeProfileRuntime.ts
+++ b/packages/agents/src/core/profile/activeProfileRuntime.ts
@@ -1,0 +1,312 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Agents-owned wrapper around a live profile runtime binding.
+ *
+ * The active runtime owns the health of the binding in use. The profile state is read
+ * through a supplier the controller re-supplies on every adoption, so identity and
+ * revision always track the committed workspace; health reporting only merges degraded
+ * aspects and never touches state, identity, or revision. Disposal is best-effort
+ * and bounded so a hanging binding cannot stall teardown.
+ */
+
+import type {
+  ProfileRuntimeBinding,
+  ProfileState,
+  ProfileHealth,
+  RedactedProfileSnapshot,
+  EffectiveToolPolicy,
+  PolicyCeiling,
+  ProfileDocument,
+} from '@vybestack/llxprt-code-core';
+import {
+  buildRedactedSnapshot,
+  deepFreeze,
+  intersectPolicy,
+} from '@vybestack/llxprt-code-core';
+
+/**
+ * Build a redacted view of the active profile.
+ */
+function snapshotSummary(state: ProfileState): {
+  revision: number;
+  identityKind: string | null;
+  providerOrLbSummary: string | null;
+} {
+  if (state.status !== 'configured') {
+    return {
+      revision: 0,
+      identityKind: null,
+      providerOrLbSummary: null,
+    };
+  }
+  const identityKind = state.identity.kind === 'saved' ? 'saved' : 'draft';
+  let providerOrLbSummary: string | null;
+  if (state.document.type === 'loadbalancer') {
+    providerOrLbSummary = `loadbalancer:${state.document.policy}:${state.document.profiles.length}`;
+  } else {
+    providerOrLbSummary = `${state.document.provider}/${state.document.model}`;
+  }
+  return { revision: state.revision, identityKind, providerOrLbSummary };
+}
+
+/**
+ * Wrapper that owns a profile runtime binding and its observed health.
+ *
+ * Identity, revision, and document are read through the state supplier on every
+ * access, so the runtime always describes the workspace the controller has
+ * committed — including transitions that reuse the runtime (a save or an
+ * external-change promotion) and never rebuilt it. The binding and the disposal
+ * bound stay construction-time facts. Health is mutable and separate from state.
+ */
+export class ActiveProfileRuntime {
+  private stateSupplier: () => ProfileState;
+  private readonly disposeTimeoutMs: number;
+  private binding: ProfileRuntimeBinding | undefined;
+  private health: ProfileHealth;
+  private disposed = false;
+  private ownsBinding = true;
+  private roleRuntimeCount = 0;
+  private readonly policy: Readonly<EffectiveToolPolicy>;
+  private restrictedAllowlist: boolean;
+
+  constructor(
+    currentState: () => ProfileState,
+    disposeTimeoutMs = 5000,
+    policy: EffectiveToolPolicy,
+  ) {
+    this.stateSupplier = currentState;
+    this.disposeTimeoutMs = disposeTimeoutMs;
+    this.health = { status: 'ok', degradedAspects: [] };
+    this.policy = deepFreeze(structuredClone(policy));
+    this.restrictedAllowlist = policy.allowedTools.length > 0;
+  }
+
+  getPolicy(): Readonly<EffectiveToolPolicy> {
+    return this.policy;
+  }
+
+  getFilteredToolDeclarations(
+    declarations: ReadonlyArray<{ name: string; description: string }>,
+  ): ReadonlyArray<Readonly<{ name: string; description: string }>> {
+    return Object.freeze(
+      declarations
+        .filter(
+          ({ name }) =>
+            !this.policy.disabledTools.includes(name) &&
+            (!this.restrictedAllowlist ||
+              this.policy.allowedTools.includes(name)),
+        )
+        .map((declaration) => Object.freeze({ ...declaration })),
+    );
+  }
+
+  createRoleRuntime(
+    roleRef: { name: string; document: ProfileDocument },
+    rolePolicy?: PolicyCeiling,
+  ): ActiveProfileRuntime {
+    const parentState = this.getState();
+    if (parentState.status !== 'configured') {
+      throw new Error('role runtime requires a configured parent');
+    }
+    const state: ProfileState = deepFreeze({
+      status: 'configured',
+      revision: parentState.revision,
+      identity: { kind: 'draft' },
+      document: structuredClone(roleRef.document),
+    });
+    const policy = intersectPolicy(
+      {
+        ...this.policy,
+        allowedTools: this.restrictedAllowlist
+          ? this.policy.allowedTools
+          : (rolePolicy?.allowedTools ?? []),
+      },
+      {},
+      {},
+      rolePolicy,
+    ).policy;
+    const child = new ActiveProfileRuntime(
+      () => state,
+      this.disposeTimeoutMs,
+      policy,
+    );
+    // An empty intersection must not reopen an explicitly restricted allowlist.
+    child.restrictedAllowlist =
+      this.restrictedAllowlist || rolePolicy?.allowedTools !== undefined;
+    child.binding = this.binding;
+    child.ownsBinding = false;
+    this.roleRuntimeCount += 1;
+    return child;
+  }
+
+  /**
+   * The workspace state the runtime currently describes, read through the supplier.
+   */
+  getState(): ProfileState {
+    return this.stateSupplier();
+  }
+
+  /**
+   * Point the runtime's state view at a new supplier.
+   *
+   * The controller calls this on every state adoption so snapshot reads never lag
+   * behind the committed workspace, even when the runtime object itself was reused.
+   */
+  resupplyState(currentState: () => ProfileState): void {
+    this.stateSupplier = currentState;
+  }
+
+  /** Current health of the bound runtime. */
+  getHealth(): ProfileHealth {
+    return {
+      status: this.health.status,
+      degradedAspects: [...this.health.degradedAspects],
+    };
+  }
+
+  /** The bound runtime, if any. */
+  getBinding(): ProfileRuntimeBinding | undefined {
+    return this.binding;
+  }
+
+  releaseOwnership(): void {
+    this.ownsBinding = false;
+  }
+
+  /** Identifier of the bound runtime. */
+  getBindingId(): string | undefined {
+    return this.binding?.bindingId;
+  }
+
+  /**
+   * Attach a runtime binding.
+   *
+   * Replaces any prior binding. Health is preserved: observed degradation belongs to
+   * the workspace's runtime history, and a fresh runtime starts healthy anyway, so
+   * attaching never resets health to ok.
+   */
+  attach(binding: ProfileRuntimeBinding): void {
+    this.binding = binding;
+  }
+
+  /**
+   * Carry a prior runtime's observed health into this runtime.
+   *
+   * Used when the prior binding is reused across a state transition: the binding's
+   * operational history, including degraded aspects, belongs to the binding and must
+   * survive the wrapper swap.
+   */
+  inheritHealthFrom(prior: ActiveProfileRuntime): void {
+    this.health = prior.getHealth();
+  }
+
+  /**
+   * Record degraded aspects. Health becomes `'degraded'`; state, identity,
+   * and revision are never touched.
+   */
+  reportDegradation(aspects: readonly string[]): void {
+    const merged = new Set(this.health.degradedAspects);
+    for (const aspect of aspects) {
+      merged.add(aspect);
+    }
+    this.health = {
+      status: 'degraded',
+      degradedAspects: [...merged],
+    };
+  }
+
+  /**
+   * Clear degraded aspects. Health returns to `'ok'` when none remain.
+   */
+  reportRecovery(aspects: readonly string[]): void {
+    const remaining = [...this.health.degradedAspects].filter(
+      (aspect) => !aspects.includes(aspect),
+    );
+    this.health = {
+      status: remaining.length > 0 ? 'degraded' : 'ok',
+      degradedAspects: remaining,
+    };
+  }
+
+  /**
+   * Redacted snapshot of the active profile plus health.
+   *
+   * Only safe fields are exposed: no secret values, no document body. Identity and
+   * revision are derived from the current state at call time, so a save or an
+   * external-change promotion that reused this runtime is reflected immediately.
+   */
+  snapshot(): RedactedProfileSnapshot & {
+    health: ProfileHealth;
+    roleRuntimeCount: number;
+  } {
+    const state = this.stateSupplier();
+    // The unconfigured workspace has no source to derive from, so it presents as
+    // an underived draft; the committed-result contract requires an identity.
+    const base: RedactedProfileSnapshot =
+      state.status === 'configured'
+        ? buildRedactedSnapshot(state)
+        : {
+            identity: { kind: 'draft' },
+            revision: 0,
+            provider: '',
+            model: '',
+            isLoadBalancer: false,
+          };
+    const summary = snapshotSummary(state);
+    return {
+      ...base,
+      ...summary,
+      health: this.getHealth(),
+      roleRuntimeCount: this.roleRuntimeCount,
+    };
+  }
+
+  /**
+   * Best-effort bounded disposal of the bound binding.
+   *
+   * A binding whose dispose hangs is abandoned after a bounded race; the losing
+   * promise never becomes an unhandled rejection. A failed disposal is recorded as a
+   * degraded aspect and never rethrown.
+   */
+  async [Symbol.asyncDispose](): Promise<void> {
+    if (this.disposed || !this.ownsBinding || this.binding === undefined) {
+      this.disposed = true;
+      return;
+    }
+    const binding = this.binding;
+    this.disposed = true;
+    const disposeResult = binding[Symbol.asyncDispose]();
+    try {
+      await this.boundedRace(disposeResult);
+    } catch (error) {
+      this.reportDegradation([
+        `dispose-failed:${error instanceof Error ? error.message : String(error)}`,
+      ]);
+    }
+  }
+
+  private async boundedRace(dispose: PromiseLike<void>): Promise<void> {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => {
+        const error = new Error(
+          `runtime binding dispose timed out after ${this.disposeTimeoutMs}ms`,
+        );
+        dispose.then(undefined, () => {});
+        reject(error);
+      }, this.disposeTimeoutMs);
+    });
+    try {
+      await Promise.race([dispose, timeoutPromise]);
+    } finally {
+      if (timeout !== undefined) {
+        clearTimeout(timeout);
+      }
+    }
+  }
+}

--- a/packages/agents/src/core/profile/controllerCommit.ts
+++ b/packages/agents/src/core/profile/controllerCommit.ts
@@ -1,0 +1,669 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Commit route for the agents-side profile controller.
+ *
+ * Turns a reduction candidate into a live runtime. The candidate is first resolved into
+ * a buildable spec (credential bindings and effective policy), then the scheduler
+ * boundary holds a safe window across everything that follows: the state and on-disk
+ * sources are rechecked against the command's expected revision inside the held window,
+ * a binding is built or the prior one reused when the factory sees an effectively
+ * unchanged spec, and the swap is committed by attaching the chosen binding to a new
+ * {@link ActiveProfileRuntime} — all before the window closes, so no new work can
+ * start between the recheck and the swap. The caller owns disposing the prior runtime
+ * after the swap.
+ *
+ * Cancellation and controller disposal are rechecked after every await: an aborted or
+ * disposed commit never lands, and every candidate binding built along the way is
+ * disposed through a bounded ownership scope. Events are not emitted here; the
+ * controller emits after it adopts the outcome.
+ */
+
+import {
+  fingerprintsMatch,
+  redactSecrets,
+  resolveProfileCandidate,
+  type CapturedStandardSource,
+  type EffectiveToolPolicy,
+  type ProfileCommand,
+  type ProfileCommandKind,
+  type ProfileCommandResult,
+  type ProfileDocument,
+  type ProfilePolicyIntent,
+  type ProfileState,
+  type ProfileRuntimeBinding,
+  type WorkingProfileIdentity,
+} from '@vybestack/llxprt-code-core';
+import type { ProfileCandidateResolution } from '@vybestack/llxprt-code-core';
+import type { ProfileControllerDeps } from './controllerTypes.js';
+import { DEFAULT_DISPOSE_TIMEOUT_MS } from './controllerTypes.js';
+import { ActiveProfileRuntime } from './activeProfileRuntime.js';
+
+/**
+ * Revision of a workspace state; the unconfigured workspace has revision zero.
+ *
+ * The reducer's revision gate treats an unconfigured state as revision zero, so every
+ * stale check and result revision in the commit route must read revisions through this
+ * helper instead of off the state directly.
+ */
+function revisionOf(state: ProfileState): number {
+  return state.status === 'configured' ? state.revision : 0;
+}
+
+/**
+ * Empty policy intent: resolves the candidate under the pure environment and session
+ * ceilings, requesting no tools, shell mode, or approval narrowing of its own.
+ */
+const EMPTY_POLICY_INTENT: ProfilePolicyIntent = {};
+
+/**
+ * Proposed profile transition: the document, identity, and optional load-balancer member
+ * capture to commit at the given revision range, plus the kind of the command that
+ * produced the candidate (threaded into every outcome for event emission).
+ */
+export interface CommitCandidateInput {
+  document: ProfileDocument;
+  identity: WorkingProfileIdentity;
+  activeMember?: CapturedStandardSource;
+  commandKind: ProfileCommandKind;
+  baseRevision: number;
+  nextRevision: number;
+}
+
+/**
+ * Outcome of the commit route: the command result, the state the workspace moves to,
+ * the runtime swapped in, and the kind of the command that produced it (threaded so the
+ * controller can emit the terminal event with the real command kind after adoption).
+ * `newRuntime === undefined` keeps whatever runtime the caller already holds.
+ */
+export interface CommitRouteOutcome {
+  result: ProfileCommandResult;
+  commandKind: ProfileCommandKind;
+  newState: ProfileState;
+  newRuntime: ActiveProfileRuntime | undefined;
+}
+
+/**
+ * A binding choice from the build/reuse step: either the binding to attach, or a
+ * terminal failed result.
+ */
+type BindingChoice =
+  | { chosen?: ProfileRuntimeBinding }
+  | { outcome: CommitRouteOutcome };
+
+/**
+ * Result of a runtime swap: the fresh runtime, or a terminal failed result.
+ */
+type SwapResult =
+  | { ok: true; newRuntime: ActiveProfileRuntime }
+  | { ok: false; outcome: CommitRouteOutcome };
+
+/**
+ * Surface a resolution rejection as a terminal outcome, or proceed when valid.
+ */
+function resolutionFailure(
+  state: ProfileState,
+  commandKind: ProfileCommandKind,
+  resolved: ProfileCandidateResolution,
+): CommitRouteOutcome | undefined {
+  if (resolved.status === 'invalid') {
+    return {
+      result: {
+        kind: 'invalid',
+        errors: [...resolved.errors],
+        revision: revisionOf(state),
+      },
+      commandKind,
+      newState: state,
+      newRuntime: undefined,
+    };
+  }
+  if (resolved.status === 'unverified') {
+    return {
+      result: {
+        kind: 'unverified',
+        constraints: [...resolved.unverifiedConstraints],
+        revision: revisionOf(state),
+      },
+      commandKind,
+      newState: state,
+      newRuntime: undefined,
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Terminal outcome for an aborted or disposed commit, or undefined when the commit may
+ * proceed. Checked after every await so a cancellation or controller disposal that lands
+ * mid-route stops the commit before anything is attached or adopted.
+ */
+function guardOutcome(
+  state: ProfileState,
+  commandKind: ProfileCommandKind,
+  signal?: AbortSignal,
+  isClosed?: () => boolean,
+): CommitRouteOutcome | undefined {
+  if (signal?.aborted === true) {
+    return {
+      result: {
+        kind: 'cancelled',
+        reason: 'execute cancelled',
+        revision: revisionOf(state),
+      },
+      commandKind,
+      newState: state,
+      newRuntime: undefined,
+    };
+  }
+  if (isClosed?.() === true) {
+    return {
+      result: {
+        kind: 'failed',
+        error: 'controller disposed',
+        revision: revisionOf(state),
+      },
+      commandKind,
+      newState: state,
+      newRuntime: undefined,
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Dispose one resource with a bounded race: a binding whose dispose hangs is abandoned
+ * after `timeoutMs` instead of stalling the exit path, and the losing promise never
+ * becomes an unhandled rejection. Dispose failures are swallowed; disposal is
+ * best-effort by contract.
+ */
+async function boundedDispose(
+  disposable: AsyncDisposable,
+  timeoutMs: number,
+): Promise<void> {
+  const dispose = disposable[Symbol.asyncDispose]();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      dispose.then(undefined, () => {});
+      reject(new Error(`dispose timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+  try {
+    await Promise.race([dispose, timeoutPromise]);
+  } catch {
+    // bounded best-effort disposal: a hanging or failing dispose must not surface
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+/**
+ * Ownership scope for resources created while committing a candidate.
+ *
+ * Every candidate binding built inside the commit route is tracked here. Success calls
+ * {@link release} to hand ownership to the runtime; every other exit path calls
+ * {@link disposeAll}, which disposes each tracked resource with a bounded race.
+ */
+class CandidateScope {
+  private readonly tracked: AsyncDisposable[] = [];
+
+  constructor(private readonly disposeTimeoutMs: number) {}
+
+  track(disposable: AsyncDisposable): void {
+    this.tracked.push(disposable);
+  }
+
+  /**
+   * Success path: tracked resources now belong to the adopted runtime.
+   */
+  release(): void {
+    this.tracked.length = 0;
+  }
+
+  /**
+   * Failure/cancellation path: dispose every tracked resource.
+   */
+  async disposeAll(): Promise<void> {
+    const pending = [...this.tracked];
+    this.tracked.length = 0;
+    for (const disposable of pending) {
+      try {
+        await boundedDispose(disposable, this.disposeTimeoutMs);
+      } catch {
+        // A synchronous dispose failure must not skip remaining resources.
+      }
+    }
+  }
+}
+
+/**
+ * Resolve a candidate into a buildable spec under the controller's ceilings.
+ */
+async function resolveCandidate(
+  candidate: CommitCandidateInput,
+  deps: ProfileControllerDeps,
+): Promise<ProfileCandidateResolution> {
+  return resolveProfileCandidate(
+    {
+      document: candidate.document,
+      policyIntent:
+        deps.getPolicyIntent?.(candidate.document) ?? EMPTY_POLICY_INTENT,
+    },
+    {
+      catalog: deps.catalog,
+      trust: deps.trust,
+      session: deps.session,
+      role: deps.role,
+      repository: deps.repository,
+    },
+  );
+}
+
+/**
+ * Recheck the workspace after the boundary gate: reject a stale command, detach a
+ * saved identity to a draft when its source changed on disk, and reject the commit
+ * when the candidate's own saved source (a load or startup target) changed between
+ * the environment build and the boundary release. The controller emits the terminal
+ * event for the returned outcome after it adopts the (possibly promoted) state.
+ */
+async function recheckForStale(
+  state: ProfileState,
+  candidate: CommitCandidateInput,
+  command: ProfileCommand,
+  deps: ProfileControllerDeps,
+): Promise<CommitRouteOutcome | undefined> {
+  if (revisionOf(state) !== command.expectedRevision) {
+    return staleOutcome(state, command);
+  }
+  if (state.status === 'configured' && state.identity.kind === 'saved') {
+    const now = await deps.repository.stat(state.identity.name);
+    if (now === null || !fingerprintsMatch(now, state.identity.source)) {
+      const externalNewState: ProfileState = {
+        ...state,
+        revision: state.revision + 1,
+        identity: {
+          kind: 'draft',
+          derivedFrom: {
+            name: state.identity.name,
+            source: state.identity.source,
+          },
+        },
+      };
+      return {
+        result: staleResult(
+          command.expectedRevision,
+          externalNewState.revision,
+          state.revision,
+        ),
+        commandKind: candidate.commandKind,
+        newState: externalNewState,
+        newRuntime: undefined,
+      };
+    }
+  }
+  // The candidate's own source was loaded before the boundary was awaited; a file
+  // that moved underneath it since must not commit as if it were fresh.
+  if (candidate.identity.kind === 'saved') {
+    const candidateNow = await deps.repository.stat(candidate.identity.name);
+    if (
+      candidateNow === null ||
+      !fingerprintsMatch(candidateNow, candidate.identity.source)
+    ) {
+      return {
+        result: staleResult(
+          command.expectedRevision,
+          revisionOf(state),
+          revisionOf(state),
+        ),
+        commandKind: candidate.commandKind,
+        newState: state,
+        newRuntime: undefined,
+      };
+    }
+  }
+  return undefined;
+}
+
+function staleOutcome(
+  state: ProfileState,
+  command: ProfileCommand,
+): CommitRouteOutcome {
+  return {
+    result: staleResult(
+      command.expectedRevision,
+      revisionOf(state),
+      revisionOf(state),
+    ),
+    commandKind: command.kind,
+    newState: state,
+    newRuntime: undefined,
+  };
+}
+
+function staleResult(
+  expectedRevision: number,
+  currentRevision: number,
+  revision: number,
+): ProfileCommandResult {
+  return { kind: 'stale', expectedRevision, currentRevision, revision };
+}
+
+/**
+ * Build or reuse the binding for a resolved candidate.
+ *
+ * A blank setup draft (empty provider and model) commits with no binding; the shortcut
+ * applies to standard documents only, because v1 load-balancer parent documents carry
+ * those same blank values and must always resolve through the runtime factory.
+ * Otherwise the factory builds one, receiving the prior binding so the factory itself
+ * can return it unchanged when the resolved spec is effectively unchanged — the
+ * controller never constructs a duplicate just to throw it away.
+ */
+async function chooseBinding(
+  state: ProfileState,
+  candidate: CommitCandidateInput,
+  resolved: ProfileCandidateResolution,
+  deps: ProfileControllerDeps,
+  priorRuntime: ActiveProfileRuntime | undefined,
+  scope: CandidateScope,
+): Promise<BindingChoice> {
+  if (
+    candidate.document.type !== 'loadbalancer' &&
+    candidate.document.provider === '' &&
+    candidate.document.model === ''
+  ) {
+    return {};
+  }
+  const priorBinding = priorRuntime?.getBinding();
+  let binding: ProfileRuntimeBinding;
+  try {
+    binding = await deps.runtimeFactory.build(resolved.resolved, priorBinding);
+  } catch (error) {
+    return {
+      outcome: {
+        result: {
+          kind: 'failed',
+          error: redactSecrets(String(error)),
+          revision: revisionOf(state),
+        },
+        commandKind: candidate.commandKind,
+        newState: state,
+        newRuntime: undefined,
+      },
+    };
+  }
+  if (binding !== priorBinding) {
+    // A freshly built binding is a candidate resource until the swap lands: the scope
+    // disposes it on any later failure, cancellation, or disposal exit path.
+    scope.track(binding);
+  }
+  return { chosen: binding };
+}
+
+/**
+ * Attach the chosen binding to a runtime for the next state.
+ *
+ * When the chosen binding is the prior runtime's binding (the factory reused it), the
+ * new runtime inherits the prior runtime's health so degraded aspects survive the
+ * wrapper swap. On failure the outcome is returned and the candidate scope — not this
+ * function — disposes any fresh binding.
+ */
+function swapRuntime(
+  state: ProfileState,
+  commandKind: ProfileCommandKind,
+  nextState: ProfileState,
+  chosen: ProfileRuntimeBinding | undefined,
+  priorRuntime: ActiveProfileRuntime | undefined,
+  disposeTimeoutMs: number,
+  policy: EffectiveToolPolicy,
+): SwapResult {
+  const newRuntime = new ActiveProfileRuntime(
+    () => nextState,
+    disposeTimeoutMs,
+    policy,
+  );
+  try {
+    if (chosen !== undefined) {
+      const reusing =
+        priorRuntime !== undefined && priorRuntime.getBinding() === chosen;
+      if (reusing) {
+        newRuntime.inheritHealthFrom(priorRuntime);
+      }
+      newRuntime.attach(chosen);
+      if (reusing) {
+        priorRuntime.releaseOwnership();
+      }
+    }
+  } catch {
+    return {
+      ok: false,
+      outcome: {
+        result: {
+          kind: 'failed',
+          error: 'runtime swap failed',
+          revision: revisionOf(state),
+        },
+        commandKind,
+        newState: state,
+        newRuntime: undefined,
+      },
+    };
+  }
+  return { ok: true, newRuntime };
+}
+
+/**
+ * Result of the resolve/boundary/recheck preamble: either a terminal outcome that stops
+ * the commit, or the resolved spec the commit may proceed with.
+ */
+type GateResult =
+  | { kind: 'stop'; outcome: CommitRouteOutcome }
+  | { kind: 'proceed'; resolved: ProfileCandidateResolution };
+
+/**
+ * Resolve the candidate and reject it before any boundary waiting.
+ *
+ * Resolution precedes the safe window so invalid or unverifiable candidates are
+ * rejected without gating on the scheduler. The execute signal and the controller's
+ * closed flag are rechecked after the await.
+ */
+async function resolveCandidateGate(
+  state: ProfileState,
+  candidate: CommitCandidateInput,
+  deps: ProfileControllerDeps,
+  isClosed: () => boolean,
+  signal?: AbortSignal,
+): Promise<GateResult> {
+  const commandKind = candidate.commandKind;
+  const resolved = await resolveCandidate(candidate, deps);
+  const afterResolve = guardOutcome(state, commandKind, signal, isClosed);
+  if (afterResolve !== undefined) {
+    return { kind: 'stop', outcome: afterResolve };
+  }
+  const rejected = resolutionFailure(state, commandKind, resolved);
+  if (rejected !== undefined) {
+    return { kind: 'stop', outcome: rejected };
+  }
+  return { kind: 'proceed', resolved };
+}
+
+interface SafeWindowInput {
+  state: ProfileState;
+  candidate: CommitCandidateInput;
+  command: ProfileCommand;
+  resolved: ProfileCandidateResolution;
+  deps: ProfileControllerDeps;
+  priorRuntime: ActiveProfileRuntime | undefined;
+  scope: CandidateScope;
+  isClosed: () => boolean;
+  signal: AbortSignal | undefined;
+  disposeTimeoutMs: number;
+  adopt: (outcome: CommitRouteOutcome) => void;
+}
+
+/**
+ * Recheck, build, and swap inside a held safe window.
+ *
+ * Everything between the window opening and the swap landing runs here: the
+ * stale/external-change recheck protects the commit from a workspace that moved or a
+ * saved source that changed on disk, the binding is built or reused, and the swap is
+ * prepared. Because the boundary holds the window across this whole function, no new
+ * work can start between the recheck and the swap. The execute signal (or the
+ * boundary's own signal) and the controller's closed flag are rechecked after every
+ * await.
+ */
+async function commitUnderSafeWindow(
+  input: SafeWindowInput,
+): Promise<CommitRouteOutcome> {
+  const { state, candidate, command, resolved, deps, priorRuntime, scope } =
+    input;
+  const { isClosed, signal, disposeTimeoutMs } = input;
+  const commandKind = candidate.commandKind;
+
+  const afterWindow = guardOutcome(state, commandKind, signal, isClosed);
+  if (afterWindow !== undefined) {
+    return afterWindow;
+  }
+  const rechecked = await recheckForStale(state, candidate, command, deps);
+  const afterRecheck = guardOutcome(state, commandKind, signal, isClosed);
+  if (afterRecheck !== undefined) {
+    return afterRecheck;
+  }
+  if (rechecked !== undefined) {
+    input.adopt(rechecked);
+    return rechecked;
+  }
+
+  const choice = await chooseBinding(
+    state,
+    candidate,
+    resolved,
+    deps,
+    priorRuntime,
+    scope,
+  );
+  if ('outcome' in choice) {
+    await scope.disposeAll();
+    return choice.outcome;
+  }
+  const afterBuild = guardOutcome(state, commandKind, signal, isClosed);
+  if (afterBuild !== undefined) {
+    await scope.disposeAll();
+    return afterBuild;
+  }
+
+  const nextState: ProfileState = {
+    status: 'configured',
+    revision: candidate.nextRevision,
+    identity: candidate.identity,
+    document: candidate.document,
+    ...(candidate.activeMember === undefined
+      ? {}
+      : { activeMember: candidate.activeMember }),
+  };
+
+  const swap = swapRuntime(
+    state,
+    commandKind,
+    nextState,
+    choice.chosen,
+    priorRuntime,
+    disposeTimeoutMs,
+    resolved.resolved.policy,
+  );
+  if (!swap.ok) {
+    await scope.disposeAll();
+    return swap.outcome;
+  }
+
+  const outcome: CommitRouteOutcome = {
+    result: {
+      kind: 'committed',
+      revision: candidate.nextRevision,
+      snapshot: swap.newRuntime.snapshot(),
+    },
+    commandKind,
+    newState: nextState,
+    newRuntime: swap.newRuntime,
+  };
+  input.adopt(outcome);
+  scope.release();
+  return outcome;
+}
+
+/**
+ * Commit a resolved candidate into a live runtime.
+ *
+ * The candidate is resolved first, outside the safe window, so invalid or
+ * unverifiable candidates never gate on the scheduler. The boundary then holds a safe
+ * window across the whole recheck/build/swap sequence: no new work can start between
+ * the recheck and the swap. After every await the route rechecks the execute signal
+ * and the controller's closed flag: an aborted or disposed commit returns a typed
+ * terminal outcome and the candidate scope disposes anything built so far. The caller
+ * disposes the prior runtime after the swap; this route never does.
+ */
+export async function commitCandidate(
+  state: ProfileState,
+  candidate: CommitCandidateInput,
+  command: ProfileCommand,
+  deps: ProfileControllerDeps,
+  priorRuntime: ActiveProfileRuntime | undefined,
+  isClosed: () => boolean,
+  adopt: (outcome: CommitRouteOutcome) => void,
+  signal?: AbortSignal,
+): Promise<CommitRouteOutcome> {
+  const commandKind = candidate.commandKind;
+  const disposeTimeoutMs = deps.disposeTimeoutMs ?? DEFAULT_DISPOSE_TIMEOUT_MS;
+  const scope = new CandidateScope(disposeTimeoutMs);
+
+  const gate = await resolveCandidateGate(
+    state,
+    candidate,
+    deps,
+    isClosed,
+    signal,
+  );
+  if (gate.kind === 'stop') {
+    return gate.outcome;
+  }
+
+  const boundaryOutcome = await deps.boundary.withSafeBoundary(
+    (boundarySignal) =>
+      commitUnderSafeWindow({
+        state,
+        candidate,
+        command,
+        resolved: gate.resolved,
+        deps,
+        priorRuntime,
+        scope,
+        isClosed,
+        signal:
+          boundarySignal !== undefined && signal !== undefined
+            ? AbortSignal.any([boundarySignal, signal])
+            : (boundarySignal ?? signal),
+        disposeTimeoutMs,
+        adopt,
+      }),
+    signal,
+  );
+  if (boundaryOutcome.status === 'cancelled') {
+    return {
+      result: {
+        kind: 'cancelled',
+        reason: 'boundary cancelled',
+        revision: revisionOf(state),
+      },
+      commandKind,
+      newState: state,
+      newRuntime: undefined,
+    };
+  }
+  return boundaryOutcome.value;
+}

--- a/packages/agents/src/core/profile/controllerEnv.ts
+++ b/packages/agents/src/core/profile/controllerEnv.ts
@@ -1,0 +1,241 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Builds the {@link ProfileReductionEnvironment} the pure reducer runs against.
+ *
+ * All async port access happens here, before reduction: provider templates are
+ * materialized from the catalog, load/save targets and load-balancer members are
+ * loaded from the repository, and member captures carry each standard member's
+ * model menu. Records are built as plain local objects; nothing here mutates state,
+ * documents, or any caller-owned record.
+ */
+
+import {
+  isStandardProfileDocument,
+  ProfileRepositoryConflictError,
+  type CapturedStandardSource,
+  type ProfileCommand,
+  type ProfileDocument,
+  type ProfileReductionEnvironment,
+  type ProfileState,
+  type SourceFingerprint,
+  type StandardProfileDocument,
+} from '@vybestack/llxprt-code-core';
+import type { ProfileControllerDeps } from './controllerTypes.js';
+
+/**
+ * The provider a command targets, when the command materializes a provider template:
+ * a `/provider` command, or a provider-only startup.
+ */
+function commandProvider(command: ProfileCommand): string | undefined {
+  if (command.kind === 'provider') {
+    return command.provider;
+  }
+  if (
+    command.kind === 'startup' &&
+    command.provider !== undefined &&
+    command.profileName === undefined
+  ) {
+    return command.provider;
+  }
+  return undefined;
+}
+
+/**
+ * Materialize the reduction environment for a command.
+ *
+ * A provider command (or a provider-only startup) prefers the catalog's restricted
+ * template for the provider, falling back to a template fabricated from the provider
+ * default model only when the catalog supplies none; a provider with neither is left
+ * without a template so the reducer invalids it. A load command (or a profile-named
+ * startup) loads the repository document and keeps the fingerprint the load returned.
+ * Members of any load-balancer document in the current state or in a just-loaded
+ * repository document are captured with their model menus, except the active state's
+ * first member, whose committed capture is reused so an explicit fork never rereads
+ * the file.
+ */
+export async function buildReductionEnvironment(
+  state: ProfileState,
+  command: ProfileCommand,
+  deps: ProfileControllerDeps,
+): Promise<ProfileReductionEnvironment> {
+  // The environment surfaces are readonly for the reducer, so the builder
+  // accumulates into plain local records and hands ownership over at return.
+  const providerTemplates: Record<string, StandardProfileDocument> = {};
+  const providerModelMenus: Record<string, readonly string[]> = {};
+  const repository: Record<
+    string,
+    { document: ProfileDocument; fingerprint: SourceFingerprint }
+  > = {};
+  const memberCaptures: Record<string, CapturedStandardSource> = {};
+
+  const provider = commandProvider(command);
+  if (provider !== undefined) {
+    const template = await deps.catalog.getProviderTemplate(provider);
+    if (template !== undefined) {
+      providerTemplates[provider] = template;
+    } else {
+      const model = await deps.catalog.getDefaultModel(provider);
+      // settings-backed adapter materializes restricted connection defaults at cutover #2640
+      if (model !== undefined) {
+        providerTemplates[provider] = {
+          version: 1,
+          type: 'standard',
+          provider,
+          model,
+          modelParams: {},
+          ephemeralSettings: {},
+        };
+      }
+    }
+    if (provider in providerTemplates) {
+      const menu = await catalogModelMenu(provider, deps);
+      if (menu !== undefined) {
+        providerModelMenus[provider] = menu;
+      }
+    }
+  }
+
+  let loadedName: string | undefined;
+  if (command.kind === 'load') {
+    loadedName = command.name;
+  } else if (command.kind === 'startup' && command.profileName !== undefined) {
+    loadedName = command.profileName;
+  }
+
+  const loadedDocuments: ReadonlyArray<{
+    name: string;
+    document: ProfileDocument;
+  }> =
+    loadedName === undefined
+      ? []
+      : await loadRepositoryEntry(loadedName, repository, deps);
+
+  await captureMembers(state, loadedDocuments, memberCaptures, deps);
+
+  return {
+    providerTemplates,
+    providerModelMenus,
+    repository,
+    memberCaptures,
+    isApplicationOwnedKey: deps.isApplicationOwnedKey,
+  };
+}
+
+/**
+ * Capture a provider's model menu before reduction runs. A catalog that offers no menu
+ * leaves no entry: the reducer then treats a chosen model as unverified instead of
+ * invalid, matching the environment contract.
+ */
+async function catalogModelMenu(
+  provider: string,
+  deps: ProfileControllerDeps,
+): Promise<readonly string[] | undefined> {
+  try {
+    return await deps.catalog.listModels(provider);
+  } catch {
+    return undefined;
+  }
+}
+
+async function loadRepositoryEntry(
+  name: string,
+  repository: Record<
+    string,
+    { document: ProfileDocument; fingerprint: SourceFingerprint }
+  >,
+  deps: ProfileControllerDeps,
+): Promise<ReadonlyArray<{ name: string; document: ProfileDocument }>> {
+  let entry: {
+    document: ProfileDocument;
+    fingerprint: SourceFingerprint;
+  };
+  try {
+    entry = await deps.repository.load(name);
+  } catch (error) {
+    if (error instanceof ProfileRepositoryConflictError) {
+      throw error;
+    }
+    return [];
+  }
+  // The fingerprint paired with the document is the one the load itself returned:
+  // a separate stat afterwards could observe a newer file and pair it with the
+  // older document, so identity and captures always share the load's pairing.
+  repository[name] = {
+    document: entry.document,
+    fingerprint: entry.fingerprint,
+  };
+  return [{ name, document: entry.document }];
+}
+
+async function captureMembers(
+  state: ProfileState,
+  loadedDocuments: ReadonlyArray<{ name: string; document: ProfileDocument }>,
+  memberCaptures: Record<string, CapturedStandardSource>,
+  deps: ProfileControllerDeps,
+): Promise<void> {
+  const memberNames: string[] = [];
+  const seen = new Set<string>();
+  const add = (name: string): void => {
+    if (!seen.has(name)) {
+      seen.add(name);
+      memberNames.push(name);
+    }
+  };
+
+  const stateDocument =
+    state.status === 'configured' ? state.document : undefined;
+  if (stateDocument !== undefined && stateDocument.type === 'loadbalancer') {
+    for (const member of stateDocument.profiles) {
+      add(member);
+    }
+    // The live load-balancer state already holds the immutable capture of its
+    // first member: an explicit-member fork of that member must fork the capture
+    // the workspace committed with, never a fresh reread of the file.
+    if (state.status === 'configured' && state.activeMember !== undefined) {
+      memberCaptures[stateDocument.profiles[0]] = state.activeMember;
+    }
+  }
+  for (const entry of loadedDocuments) {
+    if (entry.document.type === 'loadbalancer') {
+      for (const member of entry.document.profiles) {
+        add(member);
+      }
+    }
+  }
+
+  for (const member of memberNames) {
+    if (Object.prototype.hasOwnProperty.call(memberCaptures, member) === true) {
+      continue;
+    }
+    await captureMember(member, memberCaptures, deps);
+  }
+}
+
+async function captureMember(
+  member: string,
+  memberCaptures: Record<string, CapturedStandardSource>,
+  deps: ProfileControllerDeps,
+): Promise<void> {
+  let document: ProfileDocument;
+  try {
+    const entry = await deps.repository.load(member);
+    document = entry.document;
+  } catch {
+    return;
+  }
+  if (!isStandardProfileDocument(document)) {
+    return;
+  }
+  const models = (await catalogModelMenu(document.provider, deps)) ?? [];
+  memberCaptures[member] = {
+    revision: 0,
+    provider: document.provider,
+    sourceDocument: document,
+    models,
+  };
+}

--- a/packages/agents/src/core/profile/controllerSave.ts
+++ b/packages/agents/src/core/profile/controllerSave.ts
@@ -1,0 +1,169 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Save route for the agents-side profile controller.
+ *
+ * Persists the working document under `name` through the repository port. When the save
+ * targets the identity's own saved name, the route hands the repository the source
+ * fingerprint as the optimistic-concurrency anchor so an outside edit to the underlying
+ * file surfaces as a conflict instead of being silently overwritten. Any other save is a
+ * save-as: the route stats the destination first and refuses — with a typed
+ * `destination-exists` conflict, workspace untouched — rather than overwriting an
+ * existing profile. On success the state stays configured at the same revision and
+ * document, now bound to the freshly saved fingerprint.
+ */
+
+import {
+  buildRedactedSnapshot,
+  ProfileRepositoryConflictError,
+  type ProfileCommandResult,
+  type ProfileDocument,
+  type ProfileState,
+  type SourceFingerprint,
+} from '@vybestack/llxprt-code-core';
+import type { ProfileControllerDeps } from './controllerTypes.js';
+
+/**
+ * Outcome of the save route: the command result plus the state the workspace moves to.
+ */
+export interface SaveRouteOutcome {
+  result: ProfileCommandResult;
+  newState: ProfileState;
+}
+
+/**
+ * The fingerprint to anchor the write with, when the save targets the identity's own
+ * saved name. A save-as never anchors on the source: the source fingerprint belongs to
+ * a different file.
+ */
+function expectedFingerprint(
+  state: ProfileState,
+  name: string,
+): SourceFingerprint | undefined {
+  if (state.status !== 'configured') {
+    return undefined;
+  }
+  const source =
+    state.identity.kind === 'saved'
+      ? state.identity
+      : state.identity.derivedFrom;
+  return source?.name === name ? source.source : undefined;
+}
+
+function saveGuard(
+  state: ProfileState,
+  revision: number,
+  isClosed: () => boolean,
+  signal?: AbortSignal,
+): SaveRouteOutcome | undefined {
+  if (signal?.aborted === true) {
+    return {
+      result: { kind: 'cancelled', reason: 'execute cancelled', revision },
+      newState: state,
+    };
+  }
+  if (isClosed()) {
+    return {
+      result: { kind: 'failed', error: 'controller disposed', revision },
+      newState: state,
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Execute a save of the working document.
+ *
+ * Saving over the identity's own name anchors the write with its source fingerprint; any
+ * other save (a rename, or a draft's first save) is a create: the destination is statted
+ * first, and an existing destination yields a `destination-exists` conflict without
+ * touching the workspace. When the repository detects the persisted file changed under
+ * the expected fingerprint it throws a conflict error, which becomes a `source-changed`
+ * conflict result.
+ */
+export async function executeSaveRoute(
+  state: ProfileState,
+  name: string,
+  document: ProfileDocument,
+  revision: number,
+  deps: ProfileControllerDeps,
+  isClosed: () => boolean,
+  signal?: AbortSignal,
+): Promise<SaveRouteOutcome> {
+  const guard = (): SaveRouteOutcome | undefined =>
+    saveGuard(state, revision, isClosed, signal);
+  const beforeSave = guard();
+  if (beforeSave !== undefined) {
+    return beforeSave;
+  }
+  const expectedFp = expectedFingerprint(state, name);
+
+  if (expectedFp === undefined) {
+    const existing = await deps.repository.stat(name);
+    const afterStat = guard();
+    if (afterStat !== undefined) {
+      return afterStat;
+    }
+    if (existing !== null) {
+      return {
+        result: { kind: 'conflict', cause: 'destination-exists', revision },
+        newState: state,
+      };
+    }
+  }
+
+  let newFp: SourceFingerprint;
+  try {
+    newFp = await deps.repository.save(name, document, expectedFp, {
+      mustCreate: expectedFp === undefined,
+    });
+  } catch (error) {
+    const stopped = guard();
+    if (stopped !== undefined) {
+      return stopped;
+    }
+    if (error instanceof ProfileRepositoryConflictError) {
+      return {
+        result: {
+          kind: 'conflict',
+          cause:
+            expectedFp === undefined ? 'destination-exists' : 'source-changed',
+          revision,
+        },
+        newState: state,
+      };
+    }
+    throw error;
+  }
+  const persisted = await deps.repository.stat(name);
+  const newState: ProfileState = {
+    status: 'configured',
+    revision,
+    identity:
+      persisted === null
+        ? { kind: 'draft', derivedFrom: { name, source: newFp } }
+        : { kind: 'saved', name, source: persisted },
+    document,
+    ...(state.status === 'configured' && state.activeMember !== undefined
+      ? { activeMember: state.activeMember }
+      : {}),
+  };
+
+  const afterSave = saveGuard(newState, revision, isClosed, signal);
+  if (afterSave !== undefined) {
+    return afterSave;
+  }
+
+  return {
+    result: {
+      kind: 'committed',
+      revision,
+      snapshot: buildRedactedSnapshot(newState),
+    },
+    newState,
+  };
+}

--- a/packages/agents/src/core/profile/controllerTypes.ts
+++ b/packages/agents/src/core/profile/controllerTypes.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Agents-side types for the profile controller.
+ *
+ * The controller wires the pure core reduction tree to agents-owned ports: a
+ * repository, a runtime factory, a scheduler boundary, a model catalog, and the
+ * trust/session/role policy ceilings. `getPolicyIntent` and `listeners` are
+ * optional extensions; `isApplicationOwnedKey` classifies which document keys
+ * the controller may rewrite.
+ */
+
+import type {
+  PolicyCeiling,
+  ProfileCommand,
+  ProfileDocument,
+  ProfileEvent,
+  ProfilePolicyIntent,
+  ProfileRepositoryPort,
+  ProfileRuntimeFactoryPort,
+  ProviderModelCatalogPort,
+  SchedulerBoundaryPort,
+  TrustToolEnvironmentPort,
+} from '@vybestack/llxprt-code-core';
+
+/**
+ * Everything the profile controller needs to reduce commands and build runtimes.
+ */
+export interface ProfileControllerDeps {
+  agentId: string;
+  repository: ProfileRepositoryPort;
+  runtimeFactory: ProfileRuntimeFactoryPort;
+  boundary: SchedulerBoundaryPort;
+  catalog: ProviderModelCatalogPort;
+  trust: TrustToolEnvironmentPort;
+  session: PolicyCeiling;
+  role?: PolicyCeiling;
+  isApplicationOwnedKey: (key: string) => boolean;
+  getPolicyIntent?: (document: ProfileDocument) => ProfilePolicyIntent;
+  listeners?: ReadonlyArray<(event: ProfileEvent) => void>;
+  /**
+   * Bound, in milliseconds, for best-effort disposal of candidate bindings. Defaults
+   * to {@link DEFAULT_DISPOSE_TIMEOUT_MS}; a hanging binding dispose is abandoned
+   * after this bound instead of stalling the commit route.
+   */
+  disposeTimeoutMs?: number;
+}
+
+/**
+ * Default bound for best-effort disposal, matching the ActiveProfileRuntime default.
+ */
+export const DEFAULT_DISPOSE_TIMEOUT_MS = 5000;
+
+/**
+ * Options for executing a command against the profile controller.
+ */
+export interface ControllerExecuteOptions {
+  signal?: AbortSignal;
+  queue?: boolean;
+}
+
+/**
+ * A command held for later execution, with its own cancellation signal.
+ */
+export interface QueuedProfileCommand {
+  command: ProfileCommand;
+  signal?: AbortSignal;
+}

--- a/packages/agents/src/core/profile/profileController.ts
+++ b/packages/agents/src/core/profile/profileController.ts
@@ -522,6 +522,8 @@ export class ProfileController {
         // The reuse path carries the prior binding into the new runtime; disposing
         // the prior runtime here would dispose the binding that is still live.
         void prior[Symbol.asyncDispose]().catch(() => {});
+      } else if (prior !== undefined) {
+        committed.newRuntime.retainRoleRuntimesFrom(prior);
       }
     } else if (
       committed.newState !== this.state &&

--- a/packages/agents/src/core/profile/profileController.ts
+++ b/packages/agents/src/core/profile/profileController.ts
@@ -1,0 +1,635 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Serialized executor for profile commands.
+ *
+ * The controller serializes command execution over the pure core reduction tree,
+ * carrying its own committed state, live runtime, pending-destroy confirmations, and
+ * a FIFO queue with per-command cancellation. Commands land as `busy` or `queued`
+ * while another command is in flight; the queue drains reactively. Commit and save
+ * routes attach new runtimes and persist documents through the agents-owned ports; the
+ * caller never touches core's pure surface directly.
+ */
+
+import {
+  deepFreeze,
+  fingerprintsMatch,
+  reduceProfileCommand,
+} from '@vybestack/llxprt-code-core';
+import type {
+  ProfileCommand,
+  ProfileCommandKind,
+  ProfileCommandResult,
+  ProfileEvent,
+  ProfileReductionOutcome,
+  ProfileState,
+} from '@vybestack/llxprt-code-core';
+import type {
+  ControllerExecuteOptions,
+  ProfileControllerDeps,
+  QueuedProfileCommand,
+} from './controllerTypes.js';
+import type {
+  CommitCandidateInput,
+  CommitRouteOutcome,
+} from './controllerCommit.js';
+import { commitCandidate } from './controllerCommit.js';
+import { executeSaveRoute } from './controllerSave.js';
+import type { SaveRouteOutcome } from './controllerSave.js';
+import { buildReductionEnvironment } from './controllerEnv.js';
+import type { ActiveProfileRuntime } from './activeProfileRuntime.js';
+
+/**
+ * Revision of a workspace state; the unconfigured workspace has revision zero.
+ */
+function revisionOf(state: ProfileState): number {
+  return state.status === 'configured' ? state.revision : 0;
+}
+
+/**
+ * Redact an unexpected failure to the plain message a typed `failed` result carries:
+ * no stack, no wrapper prefixes, nothing but the message itself.
+ */
+function redactError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * The maximum number of reduction passes per command. The rewrite pass for a confirmed
+ * discard bumps the count from zero to one; a second discard-authorized outcome would
+ * mean the rewrite was ineffective, so the guard aborts instead of looping forever.
+ */
+const MAX_REDUCTION_PASSES = 2;
+
+/**
+ * Copy a queued command so later caller-side mutation cannot change what runs.
+ *
+ * Command fields are primitives except the `set` patch and the `confirm-discard`
+ * pending payload; both are structured-cloned. The copy is deep-frozen before it
+ * enters the queue so a queued command is immutable from submission to drain.
+ */
+function freezeQueuedCommand(command: ProfileCommand): ProfileCommand {
+  const copy: ProfileCommand = { ...command };
+  if (copy.kind === 'set') {
+    return deepFreeze({ ...copy, patch: structuredClone(copy.patch) });
+  }
+  if (copy.kind === 'confirm-discard') {
+    return deepFreeze({ ...copy, pending: structuredClone(copy.pending) });
+  }
+  return deepFreeze(copy);
+}
+
+/**
+ * Serialized profile controller.
+ *
+ * `state` is the committed workspace: `{ status: 'unconfigured' }` until the
+ * first commit or save lands. `runtime` is the live runtime for the committed
+ * state, swapped when a new state commits. `pendingConfirmations` holds the original
+ * command behind each outstanding discard token so a confirmed discard can be replayed
+ * with destructive intent.
+ */
+export class ProfileController {
+  private state: ProfileState = deepFreeze({ status: 'unconfigured' });
+  private runtime: ActiveProfileRuntime | undefined;
+  private queue: QueuedProfileCommand[] = [];
+  private inFlight = false;
+  private activeKind: ProfileCommandKind | undefined;
+  private closed = false;
+  private readonly pendingConfirmations = new Map<string, ProfileCommand>();
+  private readonly deps: ProfileControllerDeps;
+
+  constructor(deps: ProfileControllerDeps) {
+    this.deps = deps;
+  }
+
+  /**
+   * Adopt a new committed workspace state.
+   *
+   * The state graph is deep-frozen before it is stored — `ProfileState` carries no
+   * functions, so freezing is safe — which means getState hands out a committed
+   * document no caller can mutate. The live runtime's state view is re-supplied so
+   * its snapshot always describes the adopted workspace, including transitions that
+   * reuse the runtime (a save or an external-change promotion).
+   */
+  private adoptState(state: ProfileState): void {
+    this.state = deepFreeze(state);
+    this.runtime?.resupplyState(() => this.state);
+  }
+
+  private executionGuard(
+    signal?: AbortSignal,
+  ): ProfileCommandResult | undefined {
+    const revision = revisionOf(this.state);
+    if (signal?.aborted === true) {
+      return { kind: 'cancelled', reason: 'execute cancelled', revision };
+    }
+    if (this.closed) {
+      return { kind: 'failed', error: 'controller disposed', revision };
+    }
+    return undefined;
+  }
+
+  /**
+   * Reconcile the active saved identity with its on-disk source before reduction.
+   *
+   * A source that disappeared or changed outside the controller detaches the
+   * workspace to a draft (revision + 1, document and runtime preserved) so every
+   * later step of the command — including no-op detection — runs against the
+   * promoted state instead of a saved identity whose file no longer backs it.
+   */
+  private async reconcileSavedSource(signal?: AbortSignal): Promise<void> {
+    if (
+      this.state.status !== 'configured' ||
+      this.state.identity.kind !== 'saved'
+    ) {
+      return;
+    }
+    const now = await this.deps.repository.stat(this.state.identity.name);
+    if (this.executionGuard(signal) !== undefined) {
+      return;
+    }
+    if (now !== null && fingerprintsMatch(now, this.state.identity.source)) {
+      return;
+    }
+    this.adoptState({
+      ...this.state,
+      revision: this.state.revision + 1,
+      identity: {
+        kind: 'draft',
+        derivedFrom: {
+          name: this.state.identity.name,
+          source: this.state.identity.source,
+        },
+      },
+    });
+  }
+
+  /**
+   * The committed workspace state, frozen against mutation.
+   */
+  getState(): ProfileState {
+    return this.state;
+  }
+
+  /**
+   * The live runtime bound to the committed state, if any.
+   */
+  getRuntime(): ActiveProfileRuntime | undefined {
+    return this.runtime;
+  }
+
+  /**
+   * Confirmation tokens awaiting a `confirm-discard` command.
+   */
+  getPendingConfirmations(): readonly string[] {
+    return [...this.pendingConfirmations.keys()];
+  }
+
+  /**
+   * Execute a command.
+   *
+   * While a command is in flight: a non-queueing caller gets `busy` immediately,
+   * otherwise the command is queued with its own signal and answered `queued`. When
+   * idle, the command runs immediately and the queue drains afterwards.
+   */
+  async execute(
+    command: ProfileCommand,
+    options?: ControllerExecuteOptions,
+  ): Promise<ProfileCommandResult> {
+    const stopped = this.executionGuard(options?.signal);
+    if (stopped !== undefined) {
+      return stopped;
+    }
+    if (this.inFlight) {
+      if (options?.queue === false) {
+        return {
+          kind: 'busy',
+          activeCommandKind: this.activeKind ?? command.kind,
+          revision: revisionOf(this.state),
+        };
+      }
+      const copy = freezeQueuedCommand(command);
+      this.queue.push({ command: copy, signal: options?.signal });
+      this.emit('command-queued', command.kind, revisionOf(this.state));
+      return {
+        kind: 'queued',
+        baseRevision: revisionOf(this.state),
+        revision: revisionOf(this.state),
+      };
+    }
+
+    this.inFlight = true;
+    this.activeKind = command.kind;
+    try {
+      return await this.runCommand(command, options?.signal);
+    } finally {
+      await this.drain();
+    }
+  }
+
+  /**
+   * Dispose the controller: drop queued commands and pending confirmations, then
+   * release the live runtime best-effort. A hanging or failing disposal is isolated.
+   *
+   * Setting `closed` first lets any commit route still in flight observe the disposal
+   * at its next await boundary and bail out with a typed failure instead of landing a
+   * runtime after teardown.
+   */
+  async dispose(): Promise<void> {
+    this.closed = true;
+    this.queue = [];
+    this.pendingConfirmations.clear();
+    const runtime = this.runtime;
+    this.runtime = undefined;
+    if (runtime !== undefined) {
+      try {
+        await runtime[Symbol.asyncDispose]();
+      } catch {
+        // best-effort teardown; disposal failure must not surface to the caller
+      }
+    }
+  }
+
+  /**
+   * Run one command, translating unexpected throws into typed `failed` results.
+   *
+   * A route that throws must never reject the caller of an already-committed command
+   * (the drain shares this method, and queued callers were already answered `queued`),
+   * nor leave the serialization lock held: every failure lands as a result plus a
+   * `command-rejected` event.
+   */
+  private async runCommand(
+    command: ProfileCommand,
+    signal?: AbortSignal,
+  ): Promise<ProfileCommandResult> {
+    try {
+      return await this.process(command, signal);
+    } catch (error) {
+      const stopped = this.executionGuard(signal);
+      if (stopped !== undefined) {
+        return stopped;
+      }
+      const result: ProfileCommandResult = {
+        kind: 'failed',
+        error: redactError(error),
+        revision: revisionOf(this.state),
+      };
+      this.emit('command-rejected', command.kind, result.revision);
+      return result;
+    }
+  }
+
+  /**
+   * Run one reduction pass, applying the outcome, then continue queued commands.
+   */
+  private async process(
+    command: ProfileCommand,
+    signal?: AbortSignal,
+  ): Promise<ProfileCommandResult> {
+    const before = this.executionGuard(signal);
+    if (before !== undefined) {
+      return before;
+    }
+    await this.reconcileSavedSource(signal);
+    const afterReconcile = this.executionGuard(signal);
+    if (afterReconcile !== undefined) {
+      return afterReconcile;
+    }
+    let current = command;
+    for (let pass = 0; pass < MAX_REDUCTION_PASSES; pass += 1) {
+      this.emit('command-started', current.kind, revisionOf(this.state));
+      const env = await buildReductionEnvironment(
+        this.state,
+        current,
+        this.deps,
+      );
+      const afterEnvironment = this.executionGuard(signal);
+      if (afterEnvironment !== undefined) {
+        return afterEnvironment;
+      }
+      const outcome = reduceProfileCommand(this.state, current, env);
+      const result = await this.applyOutcome(current, outcome, signal);
+      if (result.rewritten !== undefined) {
+        current = result.rewritten;
+        continue;
+      }
+      return result.result;
+    }
+    this.emit('command-rejected', current.kind, revisionOf(this.state));
+    return {
+      kind: 'invalid',
+      errors: ['confirmation rewrite exceeded maximum passes'],
+      revision: revisionOf(this.state),
+    };
+  }
+
+  /**
+   * Apply a reduction outcome. A confirmed discard yields a rewritten command instead of
+   * a result so the discard replay can proceed on the next pass.
+   */
+  private async applyOutcome(
+    command: ProfileCommand,
+    outcome: ProfileReductionOutcome,
+    signal: AbortSignal | undefined,
+  ): Promise<
+    | { result: ProfileCommandResult; rewritten?: undefined }
+    | { result?: undefined; rewritten: ProfileCommand }
+  > {
+    switch (outcome.kind) {
+      case 'unverified':
+        this.emit('command-rejected', command.kind, revisionOf(this.state));
+        return {
+          result: {
+            kind: 'unverified',
+            constraints: [...outcome.constraints],
+            revision: revisionOf(this.state),
+          },
+        };
+      case 'stale':
+        this.emit('command-rejected', command.kind, revisionOf(this.state));
+        return {
+          result: {
+            kind: 'stale',
+            expectedRevision: outcome.expectedRevision,
+            currentRevision: outcome.currentRevision,
+            revision: revisionOf(this.state),
+          },
+        };
+      case 'invalid':
+        this.emit('command-rejected', command.kind, revisionOf(this.state));
+        return {
+          result: {
+            kind: 'invalid',
+            errors: [...outcome.errors],
+            revision: revisionOf(this.state),
+          },
+        };
+      case 'no-op':
+        this.emit('command-no-op', command.kind, revisionOf(this.state));
+        return {
+          result: {
+            kind: 'no-op',
+            reason: outcome.reason,
+            revision: revisionOf(this.state),
+          },
+        };
+      case 'confirmation-required':
+        this.pendingConfirmations.set(outcome.pending.token, command);
+        return {
+          result: {
+            kind: 'confirmation-required',
+            pending: outcome.pending,
+            revision: revisionOf(this.state),
+          },
+        };
+      case 'discard-authorized':
+        return this.authorizeDiscard(command);
+      case 'save': {
+        const saved = await this.saveRoute(outcome, signal);
+        return { result: saved.result };
+      }
+      case 'candidate': {
+        const committed = await this.commitRoute(outcome, command, signal);
+        return { result: committed.result };
+      }
+      default:
+        throw new Error('unreachable reduction outcome');
+    }
+  }
+
+  /**
+   * Turn a discard authorization into the replayed command, or reject an unexpected
+   * token.
+   */
+  private authorizeDiscard(
+    command: ProfileCommand,
+  ):
+    | { result: ProfileCommandResult; rewritten?: undefined }
+    | { result?: undefined; rewritten: ProfileCommand } {
+    if (command.kind !== 'confirm-discard') {
+      this.emit('command-rejected', command.kind, revisionOf(this.state));
+      return {
+        result: {
+          kind: 'invalid',
+          errors: ['confirm-discard required for discard authorization'],
+          revision: revisionOf(this.state),
+        },
+      };
+    }
+    const original = this.pendingConfirmations.get(command.pending.token);
+    if (original === undefined) {
+      this.emit('command-rejected', command.kind, revisionOf(this.state));
+      return {
+        result: {
+          kind: 'invalid',
+          errors: ['unknown confirmation token'],
+          revision: revisionOf(this.state),
+        },
+      };
+    }
+    if (command.pending.commandKind !== original.kind) {
+      this.emit('command-rejected', command.kind, revisionOf(this.state));
+      return {
+        result: {
+          kind: 'invalid',
+          errors: ['confirmation command kind mismatch'],
+          revision: revisionOf(this.state),
+        },
+      };
+    }
+    this.pendingConfirmations.delete(command.pending.token);
+    return { rewritten: this.withDiscardIntent(original) };
+  }
+
+  /**
+   * Persist a save outcome and move the workspace to the bound saved state.
+   *
+   * The terminal event fires only after the state is adopted, so listeners observe the
+   * committed workspace; a conflict result is announced as a rejection, not a commit.
+   */
+  private async saveRoute(
+    outcome: Extract<ProfileReductionOutcome, { kind: 'save' }>,
+    signal?: AbortSignal,
+  ): Promise<SaveRouteOutcome> {
+    const saved = await executeSaveRoute(
+      this.state,
+      outcome.name,
+      outcome.document,
+      outcome.revision,
+      this.deps,
+      () => this.closed,
+      signal,
+    );
+    this.adoptState(saved.newState);
+    const stopped = this.executionGuard(signal);
+    if (stopped !== undefined) {
+      return { result: stopped, newState: this.state };
+    }
+    this.emitResultEvent(saved.result, 'save');
+    return saved;
+  }
+
+  /**
+   * Commit a candidate: swap in the new runtime when one is produced, otherwise adopt
+   * the new state when it moves forward.
+   *
+   * The commit route never emits; the terminal event fires here, after the controller
+   * has adopted the outcome's state and runtime, so a listener reading state during the
+   * event always sees the revision the event announces.
+   */
+  private async commitRoute(
+    outcome: Extract<ProfileReductionOutcome, { kind: 'candidate' }>,
+    command: ProfileCommand,
+    signal: AbortSignal | undefined,
+  ): Promise<CommitRouteOutcome> {
+    const candidate: CommitCandidateInput = {
+      document: outcome.document,
+      identity: outcome.identity,
+      ...(outcome.activeMember === undefined
+        ? {}
+        : { activeMember: outcome.activeMember }),
+      commandKind: command.kind,
+      baseRevision: outcome.baseRevision,
+      nextRevision: outcome.nextRevision,
+    };
+    const committed = await commitCandidate(
+      this.state,
+      candidate,
+      command,
+      this.deps,
+      this.runtime,
+      () => this.closed,
+      (committed) => this.adoptCommit(committed),
+      signal,
+    );
+    this.emitResultEvent(committed.result, committed.commandKind);
+    return committed;
+  }
+
+  private adoptCommit(committed: CommitRouteOutcome): void {
+    if (committed.newRuntime !== undefined) {
+      const prior = this.runtime;
+      this.runtime = committed.newRuntime;
+      this.adoptState(committed.newState);
+      if (
+        prior !== undefined &&
+        prior.getBinding() !== committed.newRuntime.getBinding()
+      ) {
+        // The reuse path carries the prior binding into the new runtime; disposing
+        // the prior runtime here would dispose the binding that is still live.
+        void prior[Symbol.asyncDispose]().catch(() => {});
+      }
+    } else if (
+      committed.newState !== this.state &&
+      revisionOf(committed.newState) > revisionOf(this.state)
+    ) {
+      this.adoptState(committed.newState);
+    }
+  }
+
+  /**
+   * Replay a confirmed-destroy command with destructive intent.
+   *
+   * Workspace replacements replay with `discardUnsaved` set.
+   */
+  private withDiscardIntent(command: ProfileCommand): ProfileCommand {
+    if (
+      command.kind === 'load' ||
+      command.kind === 'startup' ||
+      command.kind === 'setup' ||
+      command.kind === 'provider'
+    ) {
+      return { ...command, discardUnsaved: true };
+    }
+    return command;
+  }
+
+  /**
+   * Drain the queue, then release the in-flight lock.
+   *
+   * Every queued command runs through {@link runCommand}, so a route that throws is
+   * recorded as a typed failure plus a `command-rejected` event instead of escaping the
+   * drain. The lock release sits in a finally around the whole loop: no failure path can
+   * leave the controller permanently busy.
+   */
+  private async drain(): Promise<void> {
+    try {
+      while (this.queue.length > 0) {
+        const next = this.queue.shift();
+        if (next === undefined) {
+          break;
+        }
+        this.activeKind = next.command.kind;
+        await this.runCommand(next.command, next.signal);
+      }
+    } finally {
+      this.inFlight = false;
+      this.activeKind = undefined;
+    }
+  }
+
+  /**
+   * Emit the terminal event a command result announces.
+   *
+   * Committed results announce commits; conflicts, staleness, invalidity, build
+   * failures, and cancellations all announce rejections or cancellations rather than a
+   * commit. `queued` and `busy` results have no terminal event: queued callers were
+   * answered at enqueue time and busy callers were never running.
+   */
+  private emitResultEvent(
+    result: ProfileCommandResult,
+    commandKind: ProfileCommandKind,
+  ): void {
+    switch (result.kind) {
+      case 'committed':
+        this.emit('committed', commandKind, result.revision);
+        return;
+      case 'cancelled':
+        this.emit('command-cancelled', commandKind, result.revision);
+        return;
+      case 'no-op':
+        this.emit('command-no-op', commandKind, result.revision);
+        return;
+      case 'queued':
+      case 'busy':
+      case 'confirmation-required':
+        return;
+      default:
+        this.emit('command-rejected', commandKind, result.revision);
+    }
+  }
+
+  /**
+   * Fan a controller event out to the registered listeners, isolating each one.
+   *
+   * Events are deep-frozen before dispatch: a listener can neither mutate the event for
+   * later listeners nor retain a mutable handle into controller state.
+   */
+  private emit(
+    type: ProfileEvent['type'],
+    commandKind: ProfileCommandKind | null,
+    revision: number,
+  ): void {
+    if (this.closed) {
+      return;
+    }
+    const event: ProfileEvent = deepFreeze({
+      type,
+      agentId: this.deps.agentId,
+      commandKind,
+      revision,
+      at: Date.now(),
+    });
+    for (const listener of this.deps.listeners ?? []) {
+      try {
+        listener(event);
+      } catch {
+        // a throwing listener must not break command processing
+      }
+    }
+  }
+}

--- a/packages/agents/src/core/profile/profileRepositoryAdapter.ts
+++ b/packages/agents/src/core/profile/profileRepositoryAdapter.ts
@@ -1,0 +1,261 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Agents-side implementation of {@link ProfileRepositoryPort} backed by the
+ * settings-owned {@link ProfileManager}.
+ *
+ * Documents are converted between the settings `Profile` shape and the implementation-
+ * neutral core `ProfileDocument` contract field by field. The persisted file's stat
+ * is the source fingerprint for optimistic-concurrency checks, and `delete` prefers the
+ * manager's own delete path so load-balancer reference checks still apply.
+ */
+
+import * as fs from 'node:fs/promises';
+import path from 'node:path';
+import {
+  writeProfileFile,
+  type ProfileManager,
+} from '@vybestack/llxprt-code-settings';
+import {
+  ProfileRepositoryConflictError,
+  fingerprintsMatch,
+  type ProfileAuthConfig,
+  type ProfileDocument,
+  type ProfileRepositoryPort,
+  type SourceFingerprint,
+} from '@vybestack/llxprt-code-core';
+import type {
+  AuthConfig,
+  Profile,
+  ModelParams,
+} from '@vybestack/llxprt-code-settings';
+
+/**
+ * Convert a settings profile into a core profile document.
+ *
+ * Every nested record is copied so the returned document shares no mutable state with
+ * the settings profile that produced it.
+ */
+export function toProfileDocument(profile: Profile): ProfileDocument {
+  const modelParams: ModelParams = structuredClone(profile.modelParams);
+  const ephemeralSettings: Record<string, unknown> = structuredClone({
+    ...profile.ephemeralSettings,
+  });
+  if (profile.type === 'loadbalancer') {
+    return {
+      version: 1,
+      type: 'loadbalancer',
+      policy: profile.policy,
+      profiles: [...profile.profiles],
+      provider: profile.provider,
+      model: profile.model,
+      modelParams,
+      ephemeralSettings,
+      ...(profile.contextLimit !== undefined
+        ? { contextLimit: profile.contextLimit }
+        : {}),
+    };
+  }
+  if (profile.auth !== undefined) {
+    return {
+      version: 1,
+      provider: profile.provider,
+      model: profile.model,
+      modelParams,
+      ephemeralSettings,
+      auth: copyAuthConfig(profile.auth),
+    };
+  }
+  return {
+    version: 1,
+    provider: profile.provider,
+    model: profile.model,
+    modelParams,
+    ephemeralSettings,
+  };
+}
+
+/**
+ * Copy an auth config between the settings and core document shapes.
+ *
+ * The settings {@link AuthConfig} and core {@link ProfileAuthConfig} are
+ * structurally compatible once narrowed, so a single copy serves both
+ * conversion directions. The buckets array is always freshly allocated so the
+ * result shares no state with its input.
+ */
+function copyAuthConfig(
+  auth: AuthConfig | ProfileAuthConfig,
+): { type: 'oauth'; buckets: string[] } | { type: 'apikey' } {
+  if (auth.type === 'oauth') {
+    return { type: 'oauth', buckets: auth.buckets ? [...auth.buckets] : [] };
+  }
+  return { type: 'apikey' };
+}
+
+/**
+ * Convert a core profile document into a settings profile.
+ */
+export function toSettingsProfile(document: ProfileDocument): Profile {
+  const modelParams: ModelParams = structuredClone(document.modelParams);
+  const ephemeralSettings = structuredClone(document.ephemeralSettings);
+  if (document.type === 'loadbalancer') {
+    return {
+      version: 1,
+      type: 'loadbalancer',
+      policy: document.policy,
+      profiles: [...document.profiles],
+      provider: document.provider,
+      model: document.model,
+      modelParams,
+      ephemeralSettings,
+      ...(document.contextLimit !== undefined
+        ? { contextLimit: document.contextLimit }
+        : {}),
+    };
+  }
+  return {
+    version: 1,
+    provider: document.provider,
+    model: document.model,
+    modelParams,
+    ephemeralSettings,
+    auth:
+      document.auth !== undefined ? copyAuthConfig(document.auth) : undefined,
+  };
+}
+
+/**
+ * Persistence boundary over a settings {@link ProfileManager}.
+ *
+ * The stat fingerprint is derived from the managed profiles directory (the same
+ * directory the manager writes to), so optimistic-concurrency checks observe external
+ * edits to the underlying file.
+ */
+export class ProfileManagerProfileRepository implements ProfileRepositoryPort {
+  readonly profilesDir: string;
+  private profileManager: ProfileManager;
+
+  constructor(profileManager: ProfileManager, profilesDir: string) {
+    this.profileManager = profileManager;
+    this.profilesDir = profilesDir;
+  }
+
+  private validateName(name: string): void {
+    if (
+      ['', '.', '..'].includes(name.trim()) ||
+      name.trim() !== name ||
+      /[/\\\0]/u.test(name)
+    ) {
+      throw new RangeError(`Invalid profile name: ${JSON.stringify(name)}`);
+    }
+  }
+
+  private filePath(name: string): string {
+    this.validateName(name);
+    return path.join(this.profilesDir, `${name}.json`);
+  }
+
+  private async statFingerprint(
+    name: string,
+  ): Promise<SourceFingerprint | null> {
+    const filePath = this.filePath(name);
+    try {
+      const info = await fs.stat(filePath);
+      return { kind: 'stat', mtimeMs: info.mtimeMs, size: info.size };
+    } catch (error) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        ['ENOENT', 'ENOTDIR'].includes(String(error.code))
+      ) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async load(
+    name: string,
+  ): Promise<{ document: ProfileDocument; fingerprint: SourceFingerprint }> {
+    this.validateName(name);
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const before = await this.statFingerprint(name);
+      if (before === null) {
+        throw new Error(`Profile '${name}' not found`);
+      }
+      const profile = await this.profileManager.loadProfile(name);
+      const fingerprint = await this.statFingerprint(name);
+      if (fingerprint !== null && fingerprintsMatch(before, fingerprint)) {
+        return { document: toProfileDocument(profile), fingerprint };
+      }
+    }
+    throw new ProfileRepositoryConflictError(
+      `Profile '${name}' changed while loading`,
+    );
+  }
+
+  async save(
+    name: string,
+    document: ProfileDocument,
+    expected?: SourceFingerprint,
+    opts?: { mustCreate?: boolean },
+  ): Promise<SourceFingerprint> {
+    this.validateName(name);
+    const profile = toSettingsProfile(document);
+    if (opts?.mustCreate === true) {
+      const created = await writeProfileFile(
+        this.profilesDir,
+        name,
+        JSON.stringify(profile, null, 2),
+        'create',
+      );
+      if (created.kind === 'exists') {
+        throw new ProfileRepositoryConflictError(
+          `Profile '${name}' already exists`,
+        );
+      }
+    } else if (expected !== undefined) {
+      if (
+        expected.kind !== 'stat' ||
+        !(await this.profileManager.saveProfileIfUnchanged(
+          name,
+          profile,
+          expected,
+        ))
+      ) {
+        throw new ProfileRepositoryConflictError(
+          `Profile '${name}' changed on disk`,
+        );
+      }
+    } else {
+      await this.profileManager.saveProfile(name, profile);
+    }
+    const fingerprint = await this.statFingerprint(name);
+    if (fingerprint === null) {
+      throw new Error(`Profile '${name}' was not persisted`);
+    }
+    return fingerprint;
+  }
+
+  async list(): Promise<ReadonlyArray<{ name: string }>> {
+    const names = await this.profileManager.listProfiles();
+    return names.map((name) => {
+      this.validateName(name);
+      return { name };
+    });
+  }
+
+  async delete(name: string): Promise<void> {
+    this.validateName(name);
+    await this.profileManager.deleteProfile(name);
+  }
+
+  async stat(name: string): Promise<SourceFingerprint | null> {
+    return this.statFingerprint(name);
+  }
+}

--- a/packages/agents/src/core/profile/profileRepositoryAdapter.ts
+++ b/packages/agents/src/core/profile/profileRepositoryAdapter.ts
@@ -207,6 +207,9 @@ export class ProfileManagerProfileRepository implements ProfileRepositoryPort {
   ): Promise<SourceFingerprint> {
     this.validateName(name);
     const profile = toSettingsProfile(document);
+    if (profile.type === 'loadbalancer') {
+      await this.profileManager.validateLoadBalancerProfile(name, profile);
+    }
     if (opts?.mustCreate === true) {
       const created = await writeProfileFile(
         this.profilesDir,

--- a/packages/auth/src/__tests__/auth-precedence-resolver.di.test.ts
+++ b/packages/auth/src/__tests__/auth-precedence-resolver.di.test.ts
@@ -109,6 +109,79 @@ describe('AuthPrecedenceResolver DI behavioral tests', () => {
   });
 
   describe('precedence chain resolution', () => {
+    it.each(['oauth', 'apikey', undefined])(
+      'honors member auth intent %s with ambient credentials present',
+      async (intent) => {
+        const authIntent =
+          intent === 'oauth' || intent === 'apikey' ? intent : undefined;
+        const settings = createInMemorySettingsService(
+          { authOnly: false, 'auth-key': 'global-key' },
+          { anthropic: { 'auth-key': 'provider-key' } },
+        );
+        const resolver = new AuthPrecedenceResolver(
+          {
+            providerId: 'anthropic',
+            oauthProvider: 'anthropic',
+            supportsOAuth: true,
+            isOAuthEnabled: true,
+            apiKey: 'constructor-key',
+            envKeyNames: ['TEST_LB_INTENT_KEY'],
+          },
+          {
+            settingsService: settings,
+            oauthManager: createOAuthManager('member-oauth'),
+          },
+        );
+        const prior = process.env.TEST_LB_INTENT_KEY;
+        process.env.TEST_LB_INTENT_KEY = 'environment-key';
+        try {
+          expect(
+            await resolver.resolveAuthenticationResult({
+              includeOAuth: true,
+              profileId: 'member',
+              authIntent,
+            }),
+          ).toStrictEqual({
+            token: authIntent === 'oauth' ? 'member-oauth' : 'provider-key',
+          });
+        } finally {
+          if (prior === undefined) delete process.env.TEST_LB_INTENT_KEY;
+          else process.env.TEST_LB_INTENT_KEY = prior;
+        }
+      },
+    );
+
+    it('does not fall back to ambient credentials when member OAuth is missing', async () => {
+      const resolver = new AuthPrecedenceResolver(
+        {
+          providerId: 'anthropic',
+          oauthProvider: 'anthropic',
+          supportsOAuth: true,
+          isOAuthEnabled: true,
+          apiKey: 'constructor-key',
+        },
+        {
+          settingsService: createInMemorySettingsService({ authOnly: false }),
+          oauthManager: {
+            getToken: async () => null,
+            isAuthenticated: async () => false,
+          },
+        },
+      );
+      const result = await resolver.resolveAuthenticationResult({
+        includeOAuth: true,
+        authIntent: 'oauth',
+        profileId: 'missing-member',
+      });
+      expect(result.token).toStrictEqual(null);
+      if (result.token !== null)
+        throw new Error('expected missing OAuth credential');
+      expect(result.failure.kind).toStrictEqual('credential-not-found');
+      expect(result.failure.diagnostics.attemptedMechanisms).toStrictEqual([
+        'oauth',
+      ]);
+    });
+
     it('resolves auth-key from provider-specific settings first', async () => {
       const settings = createInMemorySettingsService(
         { 'auth-key': 'global-key' },

--- a/packages/auth/src/auth-precedence-resolver.ts
+++ b/packages/auth/src/auth-precedence-resolver.ts
@@ -47,6 +47,7 @@ export interface ResolveAuthOptions {
   settingsService?: ISettingsService | null;
   includeOAuth?: boolean;
   runtimeId?: string;
+  profileId?: string;
 }
 
 interface ResolutionFailure {
@@ -225,6 +226,7 @@ export class AuthPrecedenceResolver {
         settingsService,
         providerKey,
         trace,
+        options?.profileId,
       );
       if (oauthAuth !== null) return { token: oauthAuth };
     }
@@ -377,8 +379,13 @@ export class AuthPrecedenceResolver {
     settingsService: ISettingsService,
     providerKey: string | undefined,
     trace: ResolutionTrace,
+    profileId?: string,
   ): Promise<string | null> {
-    const context = this.buildOAuthContext(settingsService, providerKey);
+    const context = this.buildOAuthContext(
+      settingsService,
+      providerKey,
+      profileId,
+    );
     if ((await this.isOAuthDisabledByManager()) === true) {
       this.invalidateDisabledOAuthEntry(context);
       return null;
@@ -403,9 +410,10 @@ export class AuthPrecedenceResolver {
   private buildOAuthContext(
     settingsService: ISettingsService,
     providerKey: string | undefined,
+    explicitProfileId?: string,
   ): OAuthResolutionContext {
     const providerId = this.resolveProviderIdentifier(providerKey);
-    const profileId = resolveProfileId(settingsService);
+    const profileId = explicitProfileId ?? resolveProfileId(settingsService);
     const runtime = this.tryGetRuntimeState(settingsService, providerId);
     return {
       settingsService,

--- a/packages/auth/src/auth-precedence-resolver.ts
+++ b/packages/auth/src/auth-precedence-resolver.ts
@@ -25,6 +25,7 @@ import {
 import { type OAuthToken } from './types.js';
 import type {
   AuthPrecedenceConfig,
+  ResolveAuthOptions,
   OAuthManager,
   OAuthTokenRequestMetadata,
   RuntimeScopedState,
@@ -43,12 +44,7 @@ import {
   storeRuntimeScopedToken,
 } from './precedence.js';
 
-export interface ResolveAuthOptions {
-  settingsService?: ISettingsService | null;
-  includeOAuth?: boolean;
-  runtimeId?: string;
-  profileId?: string;
-}
+export type { ResolveAuthOptions } from './precedence.js';
 
 interface ResolutionFailure {
   readonly kind: CredentialResolutionErrorKind;
@@ -212,7 +208,10 @@ export class AuthPrecedenceResolver {
       proxyContacted: false,
       remediation: undefined,
     };
-    if (!isAuthOnlyEnabled(settingsService.get('authOnly'))) {
+    if (
+      options?.authIntent !== 'oauth' &&
+      !isAuthOnlyEnabled(settingsService.get('authOnly'))
+    ) {
       const nonOAuthAuth = await this.resolveNonOAuthAuthentication(
         settingsService,
         providerKey,

--- a/packages/auth/src/precedence.ts
+++ b/packages/auth/src/precedence.ts
@@ -22,6 +22,14 @@ import type { ISettingsService } from './interfaces/settings-service.js';
 import type { IProviderRuntimeContext } from './interfaces/runtime-context.js';
 import type { IDebugLogger } from './interfaces/index.js';
 
+export interface ResolveAuthOptions {
+  settingsService?: ISettingsService | null;
+  includeOAuth?: boolean;
+  runtimeId?: string;
+  profileId?: string;
+  authIntent?: 'oauth' | 'apikey';
+}
+
 export interface AuthPrecedenceConfig {
   // Constructor/direct API key
   apiKey?: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -645,6 +645,9 @@ export {
   activateSettingsRuntimeContext,
 } from './runtime/settingsRuntimeAdapter.js';
 
+// Export profile contracts and ports
+export * from './profiles/index.js';
+
 export type {
   RuntimeProvider,
   RuntimeProviderManager,

--- a/packages/core/src/profiles/contracts/capabilities.ts
+++ b/packages/core/src/profiles/contracts/capabilities.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ProfileCommand } from './profileCommands.js';
+import type { ProfileCommandResult } from './profileResults.js';
+import type { RedactedProfileEvent } from './profileEvents.js';
+import type { ProfileDocument } from './profileDocument.js';
+import type { ProfileHealth, RedactedProfileSnapshot } from './profileViews.js';
+import type { ToolPolicySnapshot } from './routingContexts.js';
+
+/**
+ * Narrow read-only capability over the profile workspace. A capability exposes one
+ * focused surface and nothing else: it is never a service bag handing out credentials,
+ * the SettingsService, the ProviderManager, or a generic services object.
+ */
+export interface ProfileQueryCapability {
+  getSnapshot(): RedactedProfileSnapshot;
+  getRevision(): number;
+  getHealth(): ProfileHealth;
+  subscribe(listener: (event: RedactedProfileEvent) => void): () => void;
+}
+
+/**
+ * Query surface plus the ability to drive profile transitions by dispatching commands.
+ */
+export interface AgentProfileCapability extends ProfileQueryCapability {
+  transition(command: ProfileCommand): Promise<ProfileCommandResult>;
+}
+
+/**
+ * Direct access to the raw profile document.
+ *
+ * For repository and runtime-factory boundaries only: this capability intentionally leaks
+ * the unredacted document, so it must never be exposed to UI or API layers.
+ */
+export interface ProfileDocumentReadCapability {
+  getDocument(): ProfileDocument;
+}
+
+/**
+ * Read access to the tool policy captured at a routing decision point.
+ */
+export interface PolicySnapshotReadCapability {
+  getPolicySnapshot(): ToolPolicySnapshot;
+}

--- a/packages/core/src/profiles/contracts/index.ts
+++ b/packages/core/src/profiles/contracts/index.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Profile contract exports.
+ *
+ * These structural contracts describe the profile workspace surface core owns: the document
+ * format, state, commands, results, events, and views, plus the immutable routing
+ * contexts and the narrow capabilities built on top of them.
+ */
+
+export type { ProfileDocument } from './profileDocument.js';
+export {
+  isStandardProfileDocument,
+  isLoadBalancerProfileDocument,
+} from './profileDocument.js';
+export type {
+  ProfileAuthConfig,
+  StandardProfileDocument,
+  LoadBalancerProfileDocument,
+} from './profileDocument.js';
+export type {
+  SourceFingerprint,
+  WorkingProfileIdentity,
+  CapturedStandardSource,
+  ProfileState,
+} from './profileState.js';
+export { fingerprintsMatch } from './profileState.js';
+export type {
+  ProfileCommandKind,
+  ProfileCommand,
+  PendingConfirmation,
+} from './profileCommands.js';
+export { isProfileCommand } from './profileCommands.js';
+export type { ProfileCommandResult } from './profileResults.js';
+export { isProfileCommandResult } from './profileResults.js';
+export type { ProfileEvent, RedactedProfileEvent } from './profileEvents.js';
+export { toRedactedProfileEvent } from './profileEvents.js';
+export type {
+  RedactedProfileSnapshot,
+  RedactedProfileDiff,
+  ProfileHealth,
+} from './profileViews.js';
+export {
+  SECRET_SETTING_KEYS,
+  redactProfileDocument,
+  redactSecrets,
+  buildRedactedSnapshot,
+  diffProfileDocuments,
+} from './profileViews.js';
+export type {
+  ToolPolicySnapshot,
+  AgentRoutingTarget,
+  TurnContext,
+  ProviderCallContext,
+  ToolInvocationContext,
+} from './routingContexts.js';
+export { deepFreeze } from './routingContexts.js';
+export {
+  createTurnContext,
+  createProviderCallContext,
+  createToolInvocationContext,
+} from './routingContexts.js';
+export type {
+  ProfileQueryCapability,
+  AgentProfileCapability,
+  ProfileDocumentReadCapability,
+  PolicySnapshotReadCapability,
+} from './capabilities.js';

--- a/packages/core/src/profiles/contracts/profileCommands.test.ts
+++ b/packages/core/src/profiles/contracts/profileCommands.test.ts
@@ -1,0 +1,175 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { isProfileCommand } from './profileCommands.js';
+
+describe('isProfileCommand', () => {
+  it.each(['startup', 'setup'])(
+    'accepts explicit discard booleans for %s',
+    (kind) => {
+      for (const discardUnsaved of [true, false]) {
+        expect(
+          isProfileCommand({ kind, discardUnsaved, expectedRevision: 3 }),
+        ).toStrictEqual(true);
+      }
+    },
+  );
+
+  const valid = (
+    kind: string,
+    extra: Record<string, unknown> = {},
+  ): unknown => ({ kind, expectedRevision: 3, ...extra });
+  it.each([
+    { kind: 'model' },
+    { kind: 'model', model: 7 },
+    { kind: 'provider' },
+    { kind: 'provider', provider: null },
+    { kind: 'load' },
+    { kind: 'load', name: false },
+    { kind: 'set' },
+    { kind: 'set', patch: null },
+    { kind: 'set', patch: [] },
+    { kind: 'set', patch: 'temperature' },
+    { kind: 'set', patch: new Date() },
+    { kind: 'save', name: 7 },
+    { kind: 'startup', profileName: 7 },
+    { kind: 'startup', provider: false },
+    { kind: 'startup', model: [] },
+    { kind: 'startup', member: null },
+    { kind: 'startup', discardUnsaved: 'true' },
+    { kind: 'startup', discardUnsaved: null },
+    { kind: 'setup', discardUnsaved: 'true' },
+    { kind: 'setup', discardUnsaved: null },
+    { kind: 'confirm-discard' },
+    { kind: 'confirm-discard', pending: null },
+    { kind: 'confirm-discard', pending: [] },
+    { kind: 'confirm-discard', pending: {} },
+    {
+      kind: 'confirm-discard',
+      pending: { token: 7, commandKind: 'load', description: 'discard' },
+    },
+    {
+      kind: 'confirm-discard',
+      pending: { token: 't', commandKind: 7, description: 'discard' },
+    },
+    {
+      kind: 'confirm-discard',
+      pending: { token: 't', commandKind: 'load', description: 7 },
+    },
+    { kind: 'confirm-discard', pending: { token: 't', commandKind: 'load' } },
+  ])('rejects malformed payload %j', (payload) => {
+    expect(isProfileCommand({ expectedRevision: 3, ...payload })).toBe(false);
+  });
+
+  it.each(['save', 'startup'])(
+    'accepts omitted optional fields for %s',
+    (kind) => {
+      expect(isProfileCommand(valid(kind))).toBe(true);
+    },
+  );
+
+  it('accepts a model command', () => {
+    const cmd = valid('model', { model: 'claude-3-7-sonnet', member: 'a' });
+    expect(isProfileCommand(cmd)).toBe(true);
+  });
+
+  it('accepts a provider command', () => {
+    const cmd = valid('provider', { provider: 'openai' });
+    expect(isProfileCommand(cmd)).toBe(true);
+  });
+
+  it.each([true, false])(
+    'accepts provider discardUnsaved=%s',
+    (discardUnsaved) => {
+      expect(
+        isProfileCommand(
+          valid('provider', { provider: 'openai', discardUnsaved }),
+        ),
+      ).toStrictEqual(true);
+    },
+  );
+
+  it.each(['true', null, 1])(
+    'rejects provider discardUnsaved=%s',
+    (discardUnsaved) => {
+      expect(
+        isProfileCommand(
+          valid('provider', { provider: 'openai', discardUnsaved }),
+        ),
+      ).toStrictEqual(false);
+    },
+  );
+
+  it('accepts a load command', () => {
+    const cmd = valid('load', { name: 'work', discardUnsaved: true });
+    expect(isProfileCommand(cmd)).toBe(true);
+  });
+
+  it('accepts a setup command', () => {
+    const cmd = valid('setup');
+    expect(isProfileCommand(cmd)).toBe(true);
+  });
+
+  it('accepts a set command', () => {
+    const cmd = valid('set', { patch: { temperature: 0.2 } });
+    expect(isProfileCommand(cmd)).toBe(true);
+  });
+
+  it('accepts a save command', () => {
+    const cmd = valid('save', { name: 'saved-profile' });
+    expect(isProfileCommand(cmd)).toBe(true);
+  });
+
+  it('accepts a startup command', () => {
+    const cmd = valid('startup', {
+      profileName: 'work',
+      model: 'claude-3-7-sonnet',
+      provider: 'anthropic',
+      member: 'a',
+    });
+    expect(isProfileCommand(cmd)).toBe(true);
+  });
+
+  it('accepts a confirm-discard command with a valid pending payload', () => {
+    const cmd = valid('confirm-discard', {
+      pending: {
+        token: 'tok-1',
+        commandKind: 'load',
+        description: 'discard unsaved changes',
+      },
+    });
+    expect(isProfileCommand(cmd)).toBe(true);
+  });
+
+  it('rejects a command with a missing expectedRevision', () => {
+    const cmd: unknown = { kind: 'setup' };
+    expect(isProfileCommand(cmd)).toBe(false);
+  });
+
+  it('rejects a command with a non-number expectedRevision', () => {
+    const cmd: unknown = { kind: 'setup', expectedRevision: '3' };
+    expect(isProfileCommand(cmd)).toBe(false);
+  });
+
+  it('rejects an unknown kind string', () => {
+    const cmd = valid('list');
+    expect(isProfileCommand(cmd)).toBe(false);
+  });
+
+  it('rejects null', () => {
+    expect(isProfileCommand(null)).toBe(false);
+  });
+
+  it('rejects an array', () => {
+    expect(isProfileCommand(['setup', 3])).toBe(false);
+  });
+
+  it('rejects a confirm-discard command with a malformed pending payload', () => {
+    const cmd = valid('confirm-discard', { pending: { token: 7 } });
+    expect(isProfileCommand(cmd)).toBe(false);
+  });
+});

--- a/packages/core/src/profiles/contracts/profileCommands.test.ts
+++ b/packages/core/src/profiles/contracts/profileCommands.test.ts
@@ -8,6 +8,35 @@ import { describe, it, expect } from 'bun:test';
 import { isProfileCommand } from './profileCommands.js';
 
 describe('isProfileCommand', () => {
+  it.each([
+    { kind: 'model', model: 'gpt-4o', member: 7 },
+    { kind: 'model', model: 'gpt-4o', member: null },
+    { kind: 'load', name: 'work', discardUnsaved: 'true' },
+    { kind: 'load', name: 'work', discardUnsaved: null },
+    { kind: 'load', name: 'work', discardUnsaved: 1 },
+    { kind: 'save', name: null },
+    { kind: 'startup', profileName: null },
+    {
+      kind: 'confirm-discard',
+      pending: { token: 't', commandKind: 'unknown', description: 'discard' },
+    },
+  ])('rejects malformed optional fields %j', (payload) => {
+    expect(isProfileCommand({ expectedRevision: 3, ...payload })).toStrictEqual(
+      false,
+    );
+  });
+
+  it.each([true, false])('accepts load discardUnsaved=%s', (discardUnsaved) => {
+    expect(
+      isProfileCommand({
+        kind: 'load',
+        name: 'work',
+        discardUnsaved,
+        expectedRevision: 3,
+      }),
+    ).toStrictEqual(true);
+  });
+
   it.each(['startup', 'setup'])(
     'accepts explicit discard booleans for %s',
     (kind) => {

--- a/packages/core/src/profiles/contracts/profileCommands.ts
+++ b/packages/core/src/profiles/contracts/profileCommands.ts
@@ -69,12 +69,17 @@ function isString(value: unknown): value is string {
 }
 
 const COMMAND_VALIDATORS = {
-  model: (value): boolean => isString(value['model']),
+  model: (value): boolean =>
+    isString(value['model']) &&
+    (value['member'] === undefined || isString(value['member'])),
   provider: (value): boolean =>
     isString(value['provider']) &&
     (value['discardUnsaved'] === undefined ||
       typeof value['discardUnsaved'] === 'boolean'),
-  load: (value): boolean => isString(value['name']),
+  load: (value): boolean =>
+    isString(value['name']) &&
+    (value['discardUnsaved'] === undefined ||
+      typeof value['discardUnsaved'] === 'boolean'),
   setup: (value): boolean =>
     value['discardUnsaved'] === undefined ||
     typeof value['discardUnsaved'] === 'boolean',
@@ -101,14 +106,18 @@ const COMMAND_VALIDATORS = {
   (value: Record<string, unknown>) => boolean
 >;
 
-function isProfileCommandKind(value: unknown): value is ProfileCommandKind {
+export function isProfileCommandKind(
+  value: unknown,
+): value is ProfileCommandKind {
   return (
     isString(value) &&
     Object.prototype.hasOwnProperty.call(COMMAND_VALIDATORS, value)
   );
 }
 
-function isPendingConfirmation(value: unknown): value is PendingConfirmation {
+export function isPendingConfirmation(
+  value: unknown,
+): value is PendingConfirmation {
   if (!isRecord(value)) {
     return false;
   }

--- a/packages/core/src/profiles/contracts/profileCommands.ts
+++ b/packages/core/src/profiles/contracts/profileCommands.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Discriminant of a profile command.
+ */
+export type ProfileCommandKind = ProfileCommand['kind'];
+
+/**
+ * Pending confirmation payload used by `confirm-discard`.
+ */
+export interface PendingConfirmation {
+  token: string;
+  commandKind: ProfileCommandKind;
+  description: string;
+}
+
+/**
+ * Commands the profile controller accepts.
+ *
+ * Every member carries `kind` as its discriminant and `expectedRevision` so the
+ * controller can reject commands aimed at a stale workspace state.
+ */
+export type ProfileCommand =
+  | { kind: 'model'; model: string; member?: string; expectedRevision: number }
+  | {
+      kind: 'provider';
+      provider: string;
+      discardUnsaved?: boolean;
+      expectedRevision: number;
+    }
+  | {
+      kind: 'load';
+      name: string;
+      discardUnsaved?: boolean;
+      expectedRevision: number;
+    }
+  | { kind: 'setup'; discardUnsaved?: boolean; expectedRevision: number }
+  | {
+      kind: 'set';
+      patch: Readonly<Record<string, unknown>>;
+      expectedRevision: number;
+    }
+  | { kind: 'save'; name?: string; expectedRevision: number }
+  | {
+      kind: 'startup';
+      discardUnsaved?: boolean;
+      profileName?: string;
+      model?: string;
+      provider?: string;
+      member?: string;
+      expectedRevision: number;
+    }
+  | {
+      kind: 'confirm-discard';
+      pending: PendingConfirmation;
+      expectedRevision: number;
+    };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+const COMMAND_VALIDATORS = {
+  model: (value): boolean => isString(value['model']),
+  provider: (value): boolean =>
+    isString(value['provider']) &&
+    (value['discardUnsaved'] === undefined ||
+      typeof value['discardUnsaved'] === 'boolean'),
+  load: (value): boolean => isString(value['name']),
+  setup: (value): boolean =>
+    value['discardUnsaved'] === undefined ||
+    typeof value['discardUnsaved'] === 'boolean',
+  set: (value): boolean => {
+    const patch = value['patch'];
+    return (
+      isRecord(patch) &&
+      (Object.getPrototypeOf(patch) === Object.prototype ||
+        Object.getPrototypeOf(patch) === null)
+    );
+  },
+  save: (value): boolean =>
+    value['name'] === undefined || isString(value['name']),
+  startup: (value): boolean =>
+    (value['discardUnsaved'] === undefined ||
+      typeof value['discardUnsaved'] === 'boolean') &&
+    ['profileName', 'provider', 'model', 'member'].every(
+      (key) => value[key] === undefined || isString(value[key]),
+    ),
+  'confirm-discard': (value): boolean =>
+    isPendingConfirmation(value['pending']),
+} satisfies Record<
+  ProfileCommandKind,
+  (value: Record<string, unknown>) => boolean
+>;
+
+function isProfileCommandKind(value: unknown): value is ProfileCommandKind {
+  return (
+    isString(value) &&
+    Object.prototype.hasOwnProperty.call(COMMAND_VALIDATORS, value)
+  );
+}
+
+function isPendingConfirmation(value: unknown): value is PendingConfirmation {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    isString(value['token']) &&
+    isProfileCommandKind(value['commandKind']) &&
+    isString(value['description'])
+  );
+}
+
+/**
+ * Structural type guard for a profile command.
+ */
+export function isProfileCommand(value: unknown): value is ProfileCommand {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (
+    !isProfileCommandKind(value['kind']) ||
+    typeof value['expectedRevision'] !== 'number'
+  ) {
+    return false;
+  }
+  return COMMAND_VALIDATORS[value['kind']](value);
+}

--- a/packages/core/src/profiles/contracts/profileDocument.test.ts
+++ b/packages/core/src/profiles/contracts/profileDocument.test.ts
@@ -1,0 +1,278 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  isStandardProfileDocument,
+  isLoadBalancerProfileDocument,
+} from './profileDocument.js';
+
+describe('isStandardProfileDocument', () => {
+  it('treats undefined load balancer fields as absent', () => {
+    expect(
+      isStandardProfileDocument({
+        version: 1,
+        provider: 'openai',
+        model: 'gpt-4o',
+        modelParams: {},
+        ephemeralSettings: {},
+        type: undefined,
+        auth: undefined,
+        contextLimit: undefined,
+        policy: undefined,
+        profiles: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    { contextLimit: '128000' },
+    { policy: null },
+    { profiles: 'alpha' },
+  ])('rejects defined load balancer fields %j', (fields) => {
+    expect(
+      isStandardProfileDocument({
+        version: 1,
+        provider: 'openai',
+        model: 'gpt-4o',
+        modelParams: {},
+        ephemeralSettings: {},
+        ...fields,
+      }),
+    ).toBe(false);
+  });
+
+  it.each([
+    { type: 'oauth', buckets: 'primary' },
+    { type: 'oauth', buckets: ['primary', 7] },
+    { type: 'unknown' },
+  ])('rejects malformed auth %j', (auth) => {
+    const doc = {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {},
+      auth,
+    };
+    expect(isStandardProfileDocument(doc)).toBe(false);
+    expect(
+      isLoadBalancerProfileDocument({
+        ...doc,
+        type: 'loadbalancer',
+        policy: 'roundrobin',
+        profiles: ['alpha'],
+      }),
+    ).toBe(false);
+  });
+
+  it('accepts a standard document with oauth auth', () => {
+    const doc: unknown = {
+      version: 1,
+      type: 'standard',
+      provider: 'anthropic',
+      model: 'claude-3-7-sonnet',
+      modelParams: { temperature: 0.7 },
+      ephemeralSettings: {},
+      auth: { type: 'oauth', buckets: ['bucket-a', 'bucket-b'] },
+    };
+    expect(isStandardProfileDocument(doc)).toBe(true);
+  });
+
+  it('accepts a standard document without an explicit type field', () => {
+    const doc: unknown = {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+    expect(isStandardProfileDocument(doc)).toBe(true);
+  });
+
+  it('rejects a load balancer document', () => {
+    const doc: unknown = {
+      version: 1,
+      type: 'loadbalancer',
+      policy: 'roundrobin',
+      profiles: ['alpha', 'beta'],
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+    expect(isStandardProfileDocument(doc)).toBe(false);
+  });
+});
+
+describe('isLoadBalancerProfileDocument', () => {
+  it.each(['128000', NaN, -1, 0, Infinity, -Infinity, null])(
+    'rejects invalid contextLimit %s',
+    (contextLimit) => {
+      expect(
+        isLoadBalancerProfileDocument({
+          version: 1,
+          type: 'loadbalancer',
+          policy: 'roundrobin',
+          profiles: ['alpha'],
+          contextLimit,
+          provider: 'openai',
+          model: 'gpt-4o',
+          modelParams: {},
+          ephemeralSettings: {},
+        }),
+      ).toBe(false);
+    },
+  );
+
+  it('accepts an explicitly undefined contextLimit', () => {
+    expect(
+      isLoadBalancerProfileDocument({
+        version: 1,
+        type: 'loadbalancer',
+        policy: 'roundrobin',
+        profiles: ['alpha'],
+        contextLimit: undefined,
+        provider: 'openai',
+        model: 'gpt-4o',
+        modelParams: {},
+        ephemeralSettings: {},
+      }),
+    ).toBe(true);
+  });
+
+  it('accepts a load balancer document with roundrobin policy and two members', () => {
+    const doc: unknown = {
+      version: 1,
+      type: 'loadbalancer',
+      policy: 'roundrobin',
+      profiles: ['alpha', 'beta'],
+      contextLimit: 128000,
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+    expect(isLoadBalancerProfileDocument(doc)).toBe(true);
+  });
+
+  it('accepts a load balancer document with failover policy', () => {
+    const doc: unknown = {
+      version: 1,
+      type: 'loadbalancer',
+      policy: 'failover',
+      profiles: ['primary', 'backup'],
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+    expect(isLoadBalancerProfileDocument(doc)).toBe(true);
+  });
+
+  it('rejects a standard document', () => {
+    const doc: unknown = {
+      version: 1,
+      type: 'standard',
+      provider: 'anthropic',
+      model: 'claude-3-7-sonnet',
+      modelParams: {},
+      ephemeralSettings: {},
+      auth: { type: 'apikey' },
+    };
+    expect(isLoadBalancerProfileDocument(doc)).toBe(false);
+  });
+});
+
+describe('malformed profile documents', () => {
+  it('rejects null in both guards', () => {
+    expect(isStandardProfileDocument(null)).toBe(false);
+    expect(isLoadBalancerProfileDocument(null)).toBe(false);
+  });
+
+  it('rejects undefined in both guards', () => {
+    expect(isStandardProfileDocument(undefined)).toBe(false);
+    expect(isLoadBalancerProfileDocument(undefined)).toBe(false);
+  });
+
+  it('rejects primitive values in both guards', () => {
+    for (const primitive of ['profile', 42, true, Symbol('p')]) {
+      expect(isStandardProfileDocument(primitive)).toBe(false);
+      expect(isLoadBalancerProfileDocument(primitive)).toBe(false);
+    }
+  });
+
+  it('rejects an array in both guards', () => {
+    expect(isStandardProfileDocument([])).toBe(false);
+    expect(isLoadBalancerProfileDocument([])).toBe(false);
+  });
+
+  it('rejects a document missing provider in both guards', () => {
+    const doc: unknown = {
+      version: 1,
+      type: 'standard',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+    expect(isStandardProfileDocument(doc)).toBe(false);
+    expect(isLoadBalancerProfileDocument(doc)).toBe(false);
+  });
+
+  it('rejects a document with a non-string provider in both guards', () => {
+    const doc: unknown = {
+      version: 1,
+      provider: 7,
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+    expect(isStandardProfileDocument(doc)).toBe(false);
+    expect(isLoadBalancerProfileDocument(doc)).toBe(false);
+  });
+
+  it('rejects a document whose version is not the number 1 in both guards', () => {
+    for (const version of ['1', 2, null, undefined]) {
+      const doc: unknown = {
+        version,
+        provider: 'openai',
+        model: 'gpt-4o',
+        modelParams: {},
+        ephemeralSettings: {},
+      };
+      expect(isStandardProfileDocument(doc)).toBe(false);
+      expect(isLoadBalancerProfileDocument(doc)).toBe(false);
+    }
+  });
+
+  it('rejects a load balancer document with a non-array profiles field', () => {
+    const doc: unknown = {
+      version: 1,
+      type: 'loadbalancer',
+      policy: 'roundrobin',
+      profiles: 'alpha',
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+    expect(isLoadBalancerProfileDocument(doc)).toBe(false);
+  });
+
+  it('rejects a load balancer document with an invalid policy', () => {
+    const doc: unknown = {
+      version: 1,
+      type: 'loadbalancer',
+      policy: 'weighted',
+      profiles: ['alpha', 'beta'],
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+    expect(isLoadBalancerProfileDocument(doc)).toBe(false);
+  });
+});

--- a/packages/core/src/profiles/contracts/profileDocument.ts
+++ b/packages/core/src/profiles/contracts/profileDocument.ts
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Implementation-neutral structural mirror of the v1 profile document format.
+ *
+ * This contract describes only the persisted profile document surface that core
+ * consumes. Settings-owned profile types are structurally compatible with it without
+ * importing them, preserving the core -> providers/settings dependency direction.
+ * Type guards perform structural checks only: no assertions, no `any`.
+ */
+
+/**
+ * Authentication configuration for a standard profile document.
+ */
+export type ProfileAuthConfig =
+  | { type: 'oauth'; buckets?: readonly string[] }
+  | { type: 'apikey' };
+
+/**
+ * Standard (single model) profile document.
+ */
+export interface StandardProfileDocument {
+  version: 1;
+  type?: 'standard';
+  provider: string;
+  model: string;
+  modelParams: Readonly<Record<string, unknown>>;
+  ephemeralSettings: Readonly<Record<string, unknown>>;
+  auth?: ProfileAuthConfig;
+}
+
+/**
+ * Load balancer profile document (multiple profiles).
+ */
+export interface LoadBalancerProfileDocument {
+  version: 1;
+  type: 'loadbalancer';
+  policy: 'roundrobin' | 'failover';
+  profiles: readonly string[];
+  contextLimit?: number;
+  provider: string;
+  model: string;
+  modelParams: Readonly<Record<string, unknown>>;
+  ephemeralSettings: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Complete profile document (union type).
+ */
+export type ProfileDocument =
+  | StandardProfileDocument
+  | LoadBalancerProfileDocument;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+function isProfileAuthConfig(value: unknown): value is ProfileAuthConfig {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (value['type'] === 'oauth') {
+    if ('buckets' in value && value['buckets'] !== undefined) {
+      return (
+        Array.isArray(value['buckets']) && value['buckets'].every(isString)
+      );
+    }
+    return true;
+  }
+  return value['type'] === 'apikey';
+}
+
+function hasBaseDocumentShape(value: Record<string, unknown>): boolean {
+  if (value['version'] !== 1) {
+    return false;
+  }
+  if (!isString(value['provider']) || !isString(value['model'])) {
+    return false;
+  }
+  if (
+    !isRecord(value['modelParams']) ||
+    !isRecord(value['ephemeralSettings'])
+  ) {
+    return false;
+  }
+  if (
+    'auth' in value &&
+    value['auth'] !== undefined &&
+    !isProfileAuthConfig(value['auth'])
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Structural type guard for a standard profile document.
+ */
+export function isStandardProfileDocument(
+  value: unknown,
+): value is StandardProfileDocument {
+  if (!isRecord(value) || !hasBaseDocumentShape(value)) {
+    return false;
+  }
+  if (
+    'type' in value &&
+    value['type'] !== undefined &&
+    value['type'] !== 'standard'
+  ) {
+    return false;
+  }
+  if (
+    value['contextLimit'] !== undefined ||
+    value['policy'] !== undefined ||
+    value['profiles'] !== undefined
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Structural type guard for a load balancer profile document.
+ */
+export function isLoadBalancerProfileDocument(
+  value: unknown,
+): value is LoadBalancerProfileDocument {
+  if (!isRecord(value) || !hasBaseDocumentShape(value)) {
+    return false;
+  }
+  if (value['type'] !== 'loadbalancer') {
+    return false;
+  }
+  if (value['policy'] !== 'roundrobin' && value['policy'] !== 'failover') {
+    return false;
+  }
+  if (!Array.isArray(value['profiles']) || !value['profiles'].every(isString)) {
+    return false;
+  }
+  const contextLimit = value['contextLimit'];
+  if (
+    contextLimit !== undefined &&
+    (typeof contextLimit !== 'number' ||
+      !Number.isFinite(contextLimit) ||
+      contextLimit <= 0)
+  ) {
+    return false;
+  }
+  return true;
+}

--- a/packages/core/src/profiles/contracts/profileEvents.test.ts
+++ b/packages/core/src/profiles/contracts/profileEvents.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { toRedactedProfileEvent } from './profileEvents.js';
+
+describe('toRedactedProfileEvent', () => {
+  it('preserves all factual fields', () => {
+    const event = {
+      type: 'committed' as const,
+      agentId: 'agent-1',
+      commandKind: 'set' as const,
+      revision: 7,
+      at: 1_700_000_000_000,
+    };
+    const redacted = toRedactedProfileEvent(event);
+    expect(redacted.type).toBe('committed');
+    expect(redacted.agentId).toBe('agent-1');
+    expect(redacted.commandKind).toBe('set');
+    expect(redacted.revision).toBe(7);
+    expect(redacted.at).toBe(1_700_000_000_000);
+  });
+
+  it('preserves a null commandKind', () => {
+    const event = {
+      type: 'health-changed' as const,
+      agentId: 'agent-1',
+      commandKind: null,
+      revision: 3,
+      at: 42,
+    };
+    const redacted = toRedactedProfileEvent(event);
+    expect(redacted.commandKind).toBeNull();
+  });
+
+  it('returns a deeply frozen object', () => {
+    const event = {
+      type: 'command-queued' as const,
+      agentId: 'agent-2',
+      commandKind: 'load' as const,
+      revision: 4,
+      at: 99,
+    };
+    const redacted = toRedactedProfileEvent(event);
+    expect(Object.isFrozen(redacted)).toBe(true);
+    expect(() => {
+      (redacted as Record<string, unknown>)['agentId'] = 'changed';
+    }).toThrow(TypeError);
+  });
+});

--- a/packages/core/src/profiles/contracts/profileEvents.ts
+++ b/packages/core/src/profiles/contracts/profileEvents.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ProfileCommandKind } from './profileCommands.js';
+
+/**
+ * Event emitted by the profile controller.
+ *
+ * Events carry no document contents, secrets, or model/provider names.
+ */
+export type ProfileEvent = {
+  type:
+    | 'command-queued'
+    | 'command-started'
+    | 'command-cancelled'
+    | 'committed'
+    | 'command-no-op'
+    | 'command-rejected'
+    | 'health-changed';
+  agentId: string;
+  commandKind: ProfileCommandKind | null;
+  revision: number;
+  at: number;
+};
+
+/**
+ * Deeply-frozen readable projection of a profile event. It keeps the factual fields
+ * (including `commandKind`) and drops nothing: redaction here is about deep freezing,
+ * not eliding.
+ */
+export type RedactedProfileEvent = Readonly<{
+  type: ProfileEvent['type'];
+  agentId: string;
+  commandKind: ProfileCommandKind | null;
+  revision: number;
+  at: number;
+}>;
+
+/**
+ * Build a deep-frozen readable projection of a profile event.
+ */
+export function toRedactedProfileEvent(
+  event: ProfileEvent,
+): RedactedProfileEvent {
+  const redacted: RedactedProfileEvent = Object.freeze({
+    type: event.type,
+    agentId: event.agentId,
+    commandKind: event.commandKind,
+    revision: event.revision,
+    at: event.at,
+  });
+  return redacted;
+}

--- a/packages/core/src/profiles/contracts/profileResults.test.ts
+++ b/packages/core/src/profiles/contracts/profileResults.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { isProfileCommandResult } from './profileResults.js';
+import type { ProfileCommandResult } from './profileResults.js';
+
+const PAYLOADS = {
+  committed: { snapshot: {} },
+  'no-op': {},
+  queued: { baseRevision: 4 },
+  'confirmation-required': {
+    pending: { token: 't', commandKind: 'load', description: 'discard' },
+  },
+  cancelled: {},
+  busy: { activeCommandKind: 'load' },
+  stale: { expectedRevision: 4, currentRevision: 5 },
+  conflict: { cause: 'changed on disk' },
+  invalid: { errors: ['bad'] },
+  unverified: { constraints: ['offline'] },
+  failed: { error: 'failed to load' },
+} satisfies Record<ProfileCommandResult['kind'], Record<string, unknown>>;
+
+describe('isProfileCommandResult', () => {
+  it.each([
+    { kind: 'committed' },
+    { kind: 'committed', snapshot: undefined },
+    { kind: 'committed', snapshot: null },
+    { kind: 'confirmation-required' },
+    { kind: 'confirmation-required', pending: null },
+    { kind: 'confirmation-required', pending: [] },
+    { kind: 'confirmation-required', pending: 'token' },
+    { kind: 'busy' },
+    { kind: 'busy', activeCommandKind: 7 },
+    { kind: 'queued' },
+    { kind: 'queued', baseRevision: '4' },
+    { kind: 'stale', expectedRevision: 4 },
+    { kind: 'stale', currentRevision: 5 },
+    { kind: 'stale', expectedRevision: '4', currentRevision: 5 },
+    { kind: 'stale', expectedRevision: 4, currentRevision: '5' },
+    { kind: 'conflict' },
+    { kind: 'conflict', cause: 7 },
+    { kind: 'invalid' },
+    { kind: 'invalid', errors: 'bad' },
+    { kind: 'invalid', errors: null },
+    { kind: 'unverified' },
+    { kind: 'unverified', constraints: {} },
+    { kind: 'failed' },
+    { kind: 'failed', error: {} },
+  ])('rejects malformed payload %j', (payload) => {
+    expect(isProfileCommandResult({ revision: 5, ...payload })).toBe(false);
+  });
+
+  it('accepts each of the eleven kinds', () => {
+    for (const [kind, payload] of Object.entries(PAYLOADS)) {
+      const result: unknown = { kind, revision: 5, ...payload };
+      expect(isProfileCommandResult(result)).toBe(true);
+    }
+  });
+
+  it('accepts a committed result carrying a snapshot', () => {
+    const result: unknown = { kind: 'committed', revision: 5, snapshot: {} };
+    expect(isProfileCommandResult(result)).toBe(true);
+  });
+
+  it('accepts an invalid result carrying readonly error lines', () => {
+    const result: unknown = { kind: 'invalid', revision: 1, errors: ['bad'] };
+    expect(isProfileCommandResult(result)).toBe(true);
+  });
+
+  it('rejects a result without a revision', () => {
+    const result: unknown = { kind: 'committed' };
+    expect(isProfileCommandResult(result)).toBe(false);
+  });
+
+  it('rejects a result with a non-number revision', () => {
+    const result: unknown = { kind: 'committed', revision: '5' };
+    expect(isProfileCommandResult(result)).toBe(false);
+  });
+
+  it('rejects an unknown kind', () => {
+    const result: unknown = { kind: 'executed', revision: 5 };
+    expect(isProfileCommandResult(result)).toBe(false);
+  });
+
+  it('rejects null', () => {
+    expect(isProfileCommandResult(null)).toBe(false);
+  });
+
+  it('rejects an array', () => {
+    expect(isProfileCommandResult(['committed', 5])).toBe(false);
+  });
+
+  it('rejects a primitive string', () => {
+    expect(isProfileCommandResult('committed')).toBe(false);
+  });
+});

--- a/packages/core/src/profiles/contracts/profileResults.test.ts
+++ b/packages/core/src/profiles/contracts/profileResults.test.ts
@@ -7,15 +7,24 @@
 import { describe, it, expect } from 'bun:test';
 import { isProfileCommandResult } from './profileResults.js';
 import type { ProfileCommandResult } from './profileResults.js';
+import type { RedactedProfileSnapshot } from './profileViews.js';
+
+const snapshot: RedactedProfileSnapshot = {
+  identity: { kind: 'draft' },
+  revision: 5,
+  provider: 'openai',
+  model: 'gpt-4o',
+  isLoadBalancer: false,
+};
 
 const PAYLOADS = {
-  committed: { snapshot: {} },
-  'no-op': {},
+  committed: { snapshot },
+  'no-op': { reason: 'unchanged' },
   queued: { baseRevision: 4 },
   'confirmation-required': {
     pending: { token: 't', commandKind: 'load', description: 'discard' },
   },
-  cancelled: {},
+  cancelled: { reason: 'superseded' },
   busy: { activeCommandKind: 'load' },
   stale: { expectedRevision: 4, currentRevision: 5 },
   conflict: { cause: 'changed on disk' },
@@ -26,6 +35,43 @@ const PAYLOADS = {
 
 describe('isProfileCommandResult', () => {
   it.each([
+    { kind: 'committed', snapshot: 7 },
+    { kind: 'committed', snapshot: {} },
+    { kind: 'committed', snapshot: [] },
+    { kind: 'no-op' },
+    { kind: 'no-op', reason: 7 },
+    { kind: 'cancelled' },
+    { kind: 'cancelled', reason: null },
+    { kind: 'confirmation-required', pending: {} },
+    {
+      kind: 'confirmation-required',
+      pending: { token: 7, commandKind: 'load', description: 'discard' },
+    },
+    {
+      kind: 'confirmation-required',
+      pending: { token: 't', commandKind: 'unknown', description: 'discard' },
+    },
+    {
+      kind: 'confirmation-required',
+      pending: { token: 't', commandKind: 7, description: 'discard' },
+    },
+    {
+      kind: 'confirmation-required',
+      pending: { token: 't', commandKind: 'load', description: 7 },
+    },
+    {
+      kind: 'confirmation-required',
+      pending: { token: 't', commandKind: 'load' },
+    },
+    { kind: 'busy', activeCommandKind: 'unknown' },
+    { kind: 'busy', activeCommandKind: 'constructor' },
+    { kind: 'invalid', errors: [7] },
+    { kind: 'invalid', errors: ['bad', ''] },
+    { kind: 'invalid', errors: ['  '] },
+    { kind: 'unverified', constraints: [7] },
+    { kind: 'unverified', constraints: ['offline', ''] },
+    { kind: 'unverified', constraints: ['  '] },
+    { kind: 'failed', error: 7 },
     { kind: 'committed' },
     { kind: 'committed', snapshot: undefined },
     { kind: 'committed', snapshot: null },
@@ -54,6 +100,94 @@ describe('isProfileCommandResult', () => {
     expect(isProfileCommandResult({ revision: 5, ...payload })).toBe(false);
   });
 
+  it.each([
+    { identity: undefined },
+    { identity: null },
+    { identity: {} },
+    { identity: { kind: 'other' } },
+    {
+      identity: { kind: 'saved', name: 7, source: { kind: 'hash', hash: 'h' } },
+    },
+    { identity: { kind: 'saved', name: 'work' } },
+    { identity: { kind: 'saved', name: 'work', source: {} } },
+    {
+      identity: {
+        kind: 'saved',
+        name: 'work',
+        source: { kind: 'hash', hash: 7 },
+      },
+    },
+    {
+      identity: {
+        kind: 'saved',
+        name: 'work',
+        source: { kind: 'stat', mtimeMs: '1', size: 2 },
+      },
+    },
+    {
+      identity: {
+        kind: 'saved',
+        name: 'work',
+        source: { kind: 'stat', mtimeMs: 1, size: '2' },
+      },
+    },
+    { identity: { kind: 'draft', derivedFrom: {} } },
+    { identity: { kind: 'draft', derivedFrom: null } },
+    { revision: undefined },
+    { revision: '5' },
+    { provider: undefined },
+    { provider: 7 },
+    { model: undefined },
+    { model: 7 },
+    { isLoadBalancer: undefined },
+    { isLoadBalancer: 'false' },
+    { memberCount: '2' },
+    { identityKind: 7 },
+    { providerOrLbSummary: false },
+    { health: {} },
+    { health: { status: 'other', degradedAspects: [] } },
+    { health: { status: 'ok', degradedAspects: [7] } },
+    { roleRuntimeCount: '1' },
+  ])('rejects malformed snapshot fields %j', (fields) => {
+    expect(
+      isProfileCommandResult({
+        kind: 'committed',
+        revision: 5,
+        snapshot: { ...snapshot, ...fields },
+      }),
+    ).toStrictEqual(false);
+  });
+
+  it.each([
+    { kind: 'saved', name: 'work', source: { kind: 'hash', hash: 'h' } },
+    {
+      kind: 'saved',
+      name: 'work',
+      source: { kind: 'stat', mtimeMs: 1, size: 2 },
+    },
+    {
+      kind: 'draft',
+      derivedFrom: { name: 'work', source: { kind: 'hash', hash: 'h' } },
+    },
+  ])('accepts complete snapshot identity %j', (identity) => {
+    expect(
+      isProfileCommandResult({
+        kind: 'committed',
+        revision: 5,
+        snapshot: {
+          ...snapshot,
+          identity,
+          isLoadBalancer: true,
+          memberCount: 2,
+          identityKind: null,
+          providerOrLbSummary: null,
+          health: { status: 'degraded', degradedAspects: ['offline'] },
+          roleRuntimeCount: 1,
+        },
+      }),
+    ).toStrictEqual(true);
+  });
+
   it('accepts each of the eleven kinds', () => {
     for (const [kind, payload] of Object.entries(PAYLOADS)) {
       const result: unknown = { kind, revision: 5, ...payload };
@@ -62,7 +196,7 @@ describe('isProfileCommandResult', () => {
   });
 
   it('accepts a committed result carrying a snapshot', () => {
-    const result: unknown = { kind: 'committed', revision: 5, snapshot: {} };
+    const result: unknown = { kind: 'committed', revision: 5, snapshot };
     expect(isProfileCommandResult(result)).toBe(true);
   });
 

--- a/packages/core/src/profiles/contracts/profileResults.ts
+++ b/packages/core/src/profiles/contracts/profileResults.ts
@@ -8,7 +8,14 @@ import type {
   PendingConfirmation,
   ProfileCommandKind,
 } from './profileCommands.js';
-import type { RedactedProfileSnapshot } from './profileViews.js';
+import {
+  isPendingConfirmation,
+  isProfileCommandKind,
+} from './profileCommands.js';
+import {
+  isRedactedProfileSnapshot,
+  type RedactedProfileSnapshot,
+} from './profileViews.js';
 
 /**
  * Result of running a profile command.
@@ -39,20 +46,27 @@ export type ProfileCommandResult =
   | { kind: 'unverified'; revision: number; constraints: readonly string[] }
   | { kind: 'failed'; revision: number; error: string };
 
+function isNonEmptyStringArray(value: unknown): value is readonly string[] {
+  return (
+    Array.isArray(value) &&
+    value.every((entry: unknown) => isString(entry) && entry.trim().length > 0)
+  );
+}
+
 const RESULT_VALIDATORS = {
-  committed: (value): boolean =>
-    value['snapshot'] !== undefined && value['snapshot'] !== null,
-  'no-op': (): boolean => true,
+  committed: (value): boolean => isRedactedProfileSnapshot(value['snapshot']),
+  'no-op': (value): boolean => isString(value['reason']),
   queued: (value): boolean => typeof value['baseRevision'] === 'number',
-  'confirmation-required': (value): boolean => isRecord(value['pending']),
-  cancelled: (): boolean => true,
-  busy: (value): boolean => isString(value['activeCommandKind']),
+  'confirmation-required': (value): boolean =>
+    isPendingConfirmation(value['pending']),
+  cancelled: (value): boolean => isString(value['reason']),
+  busy: (value): boolean => isProfileCommandKind(value['activeCommandKind']),
   stale: (value): boolean =>
     typeof value['expectedRevision'] === 'number' &&
     typeof value['currentRevision'] === 'number',
   conflict: (value): boolean => isString(value['cause']),
-  invalid: (value): boolean => Array.isArray(value['errors']),
-  unverified: (value): boolean => Array.isArray(value['constraints']),
+  invalid: (value): boolean => isNonEmptyStringArray(value['errors']),
+  unverified: (value): boolean => isNonEmptyStringArray(value['constraints']),
   failed: (value): boolean => isString(value['error']),
 } satisfies Record<
   ProfileCommandResult['kind'],

--- a/packages/core/src/profiles/contracts/profileResults.ts
+++ b/packages/core/src/profiles/contracts/profileResults.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  PendingConfirmation,
+  ProfileCommandKind,
+} from './profileCommands.js';
+import type { RedactedProfileSnapshot } from './profileViews.js';
+
+/**
+ * Result of running a profile command.
+ *
+ * Every member carries `revision`, the revision the result applies to. Redacted error
+ * payloads are plain strings: callers pre-redact anything sensitive before building a
+ * result.
+ */
+export type ProfileCommandResult =
+  | { kind: 'committed'; revision: number; snapshot: RedactedProfileSnapshot }
+  | { kind: 'no-op'; revision: number; reason: string }
+  | { kind: 'queued'; revision: number; baseRevision: number }
+  | {
+      kind: 'confirmation-required';
+      revision: number;
+      pending: PendingConfirmation;
+    }
+  | { kind: 'cancelled'; revision: number; reason: string }
+  | { kind: 'busy'; revision: number; activeCommandKind: ProfileCommandKind }
+  | {
+      kind: 'stale';
+      revision: number;
+      expectedRevision: number;
+      currentRevision: number;
+    }
+  | { kind: 'conflict'; revision: number; cause: string }
+  | { kind: 'invalid'; revision: number; errors: readonly string[] }
+  | { kind: 'unverified'; revision: number; constraints: readonly string[] }
+  | { kind: 'failed'; revision: number; error: string };
+
+const RESULT_VALIDATORS = {
+  committed: (value): boolean =>
+    value['snapshot'] !== undefined && value['snapshot'] !== null,
+  'no-op': (): boolean => true,
+  queued: (value): boolean => typeof value['baseRevision'] === 'number',
+  'confirmation-required': (value): boolean => isRecord(value['pending']),
+  cancelled: (): boolean => true,
+  busy: (value): boolean => isString(value['activeCommandKind']),
+  stale: (value): boolean =>
+    typeof value['expectedRevision'] === 'number' &&
+    typeof value['currentRevision'] === 'number',
+  conflict: (value): boolean => isString(value['cause']),
+  invalid: (value): boolean => Array.isArray(value['errors']),
+  unverified: (value): boolean => Array.isArray(value['constraints']),
+  failed: (value): boolean => isString(value['error']),
+} satisfies Record<
+  ProfileCommandResult['kind'],
+  (value: Record<string, unknown>) => boolean
+>;
+
+function isProfileCommandResultKind(
+  value: unknown,
+): value is ProfileCommandResult['kind'] {
+  return (
+    isString(value) &&
+    Object.prototype.hasOwnProperty.call(RESULT_VALIDATORS, value)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+/**
+ * Structural type guard for a profile command result.
+ */
+export function isProfileCommandResult(
+  value: unknown,
+): value is ProfileCommandResult {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (typeof value['revision'] !== 'number') {
+    return false;
+  }
+  return (
+    isProfileCommandResultKind(value['kind']) &&
+    RESULT_VALIDATORS[value['kind']](value)
+  );
+}

--- a/packages/core/src/profiles/contracts/profileState.test.ts
+++ b/packages/core/src/profiles/contracts/profileState.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { fingerprintsMatch } from './profileState.js';
+import type { SourceFingerprint } from './profileState.js';
+
+describe('fingerprintsMatch', () => {
+  it('returns true for identical stat fingerprints', () => {
+    const a: SourceFingerprint = {
+      kind: 'stat',
+      mtimeMs: 1_700_000_000_000,
+      size: 1024,
+    };
+    expect(fingerprintsMatch(a, { ...a })).toBe(true);
+  });
+
+  it('returns true for identical hash fingerprints', () => {
+    const a: SourceFingerprint = {
+      kind: 'hash',
+      hash: 'abc123def456',
+    };
+    expect(fingerprintsMatch(a, { ...a })).toBe(true);
+  });
+
+  it('returns false across stat and hash kinds', () => {
+    const stat: SourceFingerprint = {
+      kind: 'stat',
+      mtimeMs: 1_700_000_000_000,
+      size: 1024,
+    };
+    const hash: SourceFingerprint = {
+      kind: 'hash',
+      hash: 'abc123def456',
+    };
+    expect(fingerprintsMatch(stat, hash)).toBe(false);
+    expect(fingerprintsMatch(hash, stat)).toBe(false);
+  });
+
+  it('returns false when mtimeMs differs', () => {
+    const a: SourceFingerprint = {
+      kind: 'stat',
+      mtimeMs: 1_700_000_000_000,
+      size: 1024,
+    };
+    const b: SourceFingerprint = {
+      kind: 'stat',
+      mtimeMs: 1_700_000_000_001,
+      size: 1024,
+    };
+    expect(fingerprintsMatch(a, b)).toBe(false);
+  });
+
+  it('returns false when size differs', () => {
+    const a: SourceFingerprint = {
+      kind: 'stat',
+      mtimeMs: 1_700_000_000_000,
+      size: 1024,
+    };
+    const b: SourceFingerprint = {
+      kind: 'stat',
+      mtimeMs: 1_700_000_000_000,
+      size: 2048,
+    };
+    expect(fingerprintsMatch(a, b)).toBe(false);
+  });
+
+  it('returns false when hash differs', () => {
+    const a: SourceFingerprint = {
+      kind: 'hash',
+      hash: 'abc123def456',
+    };
+    const b: SourceFingerprint = {
+      kind: 'hash',
+      hash: 'abc123def789',
+    };
+    expect(fingerprintsMatch(a, b)).toBe(false);
+  });
+});

--- a/packages/core/src/profiles/contracts/profileState.ts
+++ b/packages/core/src/profiles/contracts/profileState.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  ProfileDocument,
+  StandardProfileDocument,
+} from './profileDocument.js';
+
+/**
+ * Fingerprint identifying the file a saved profile was loaded from.
+ *
+ * A stat fingerprint compares mtime and size; a hash fingerprint compares a content
+ * digest. The kind is part of the identity so a fingerprint changes kind when the
+ * strategy does.
+ */
+export type SourceFingerprint =
+  | { kind: 'stat'; mtimeMs: number; size: number }
+  | { kind: 'hash'; hash: string };
+
+/**
+ * Identity of the profile being worked on: a saved profile tied to a source file,
+ * or an in-memory draft derived from one.
+ */
+export type WorkingProfileIdentity =
+  | { kind: 'saved'; name: string; source: SourceFingerprint }
+  | {
+      kind: 'draft';
+      derivedFrom?: { name: string; source: SourceFingerprint };
+    };
+
+/**
+ * Snapshot of the standard profile document a load balancer member resolves to.
+ */
+export interface CapturedStandardSource {
+  revision: number;
+  provider: string;
+  sourceDocument: StandardProfileDocument;
+  models: readonly string[];
+}
+
+/**
+ * State of the active profile workspace.
+ */
+export type ProfileState =
+  | { status: 'unconfigured' }
+  | {
+      status: 'configured';
+      revision: number;
+      identity: WorkingProfileIdentity;
+      document: ProfileDocument;
+      activeMember?: CapturedStandardSource;
+    };
+
+/**
+ * Equality for source fingerprints: only true when both have the same kind and equal
+ * values. Stat fingerprints compare mtimeMs and size, hash fingerprints compare hash.
+ */
+export function fingerprintsMatch(
+  a: SourceFingerprint,
+  b: SourceFingerprint,
+): boolean {
+  if (a.kind !== b.kind) {
+    return false;
+  }
+  if (a.kind === 'stat') {
+    return b.kind === 'stat' && a.mtimeMs === b.mtimeMs && a.size === b.size;
+  }
+  return b.kind === 'hash' && a.hash === b.hash;
+}

--- a/packages/core/src/profiles/contracts/profileViews.test.ts
+++ b/packages/core/src/profiles/contracts/profileViews.test.ts
@@ -1,0 +1,460 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  SECRET_SETTING_KEYS,
+  redactProfileDocument,
+  redactSecrets,
+  buildRedactedSnapshot,
+  diffProfileDocuments,
+} from './profileViews.js';
+import {
+  isLoadBalancerProfileDocument,
+  type ProfileDocument,
+} from './profileDocument.js';
+import type { WorkingProfileIdentity } from './profileState.js';
+
+const standardDocument = (): ProfileDocument => ({
+  version: 1,
+  type: 'standard',
+  provider: 'openai',
+  model: 'gpt-4o',
+  modelParams: { temperature: 0.2 },
+  ephemeralSettings: {
+    'auth-key': 'sk-secret-abc',
+    'auth-key-name': 'creds',
+    'base-url': 'https://api.example.com',
+    temperature: 0.7,
+  },
+});
+
+const loadBalancerDocument = (): ProfileDocument => ({
+  version: 1,
+  type: 'loadbalancer',
+  policy: 'roundrobin',
+  profiles: ['alpha', 'beta', 'gamma'],
+  contextLimit: 128000,
+  provider: 'openai',
+  model: 'gpt-4o',
+  modelParams: {},
+  ephemeralSettings: {
+    'auth-key': 'sk-lb-secret',
+    'context-limit': 128000,
+  },
+});
+
+const identity = (): WorkingProfileIdentity => ({
+  kind: 'saved',
+  name: 'work',
+  source: { kind: 'stat', mtimeMs: 1_700_000_000_000, size: 1024 },
+});
+
+describe('SECRET_SETTING_KEYS', () => {
+  it('contains the auth-key key', () => {
+    expect(SECRET_SETTING_KEYS).toContain('auth-key');
+  });
+
+  it('covers the credential-bearing value keys across the repo', () => {
+    expect(SECRET_SETTING_KEYS).toContain('api-key');
+    expect(SECRET_SETTING_KEYS).toContain('apikey');
+    expect(SECRET_SETTING_KEYS).toContain('authorization');
+    expect(SECRET_SETTING_KEYS).toContain('x-api-key');
+    expect(SECRET_SETTING_KEYS).toContain('auth-token');
+  });
+
+  it('keeps reference keys out of the secret set', () => {
+    expect(SECRET_SETTING_KEYS).not.toContain('auth-key-name');
+    expect(SECRET_SETTING_KEYS).not.toContain('auth-keyfile');
+  });
+});
+
+describe('redactSecrets', () => {
+  it('masks a key-value fragment', () => {
+    expect(redactSecrets('build failed with auth-key: sk-123 in env')).toBe(
+      'build failed with auth-key: [redacted]',
+    );
+  });
+
+  it('masks quoted JSON members', () => {
+    expect(redactSecrets('{"api-key": "sk-9", "model": "m1"}')).toBe(
+      '{"api-key": "[redacted]", "model": "m1"}',
+    );
+  });
+
+  it('masks every credential-bearing value key', () => {
+    const message = `apikey: k1
+authorization: Bearer t2
+x-api-key: k3
+auth-token: t4`;
+    const redacted = redactSecrets(message);
+    expect(redacted).not.toContain('k1');
+    expect(redacted).not.toContain('t2');
+    expect(redacted).not.toContain('k3');
+    expect(redacted).not.toContain('t4');
+    expect(redacted).toContain('apikey: [redacted]');
+    expect(redacted).toContain('authorization: [redacted]');
+    expect(redacted).toContain('x-api-key: [redacted]');
+    expect(redacted).toContain('auth-token: [redacted]');
+  });
+
+  it('leaves reference keys and non-secret text readable', () => {
+    const message =
+      'auth-key-name: creds auth-keyfile: /path/key base-url: https://x';
+    expect(redactSecrets(message)).toBe(message);
+  });
+
+  it('leaves messages without secret keys untouched', () => {
+    expect(redactSecrets('runtime factory build failed')).toBe(
+      'runtime factory build failed',
+    );
+  });
+});
+
+describe('redactProfileDocument', () => {
+  it('masks a secret setting value', () => {
+    const doc = standardDocument();
+    const redacted = redactProfileDocument(doc);
+    expect(redacted.ephemeralSettings['auth-key']).toBe('[redacted]');
+  });
+
+  it('leaves non-secret settings untouched', () => {
+    const redacted = redactProfileDocument(standardDocument());
+    expect(redacted.ephemeralSettings['auth-key-name']).toBe('creds');
+    expect(redacted.ephemeralSettings['base-url']).toBe(
+      'https://api.example.com',
+    );
+    expect(redacted.ephemeralSettings['temperature']).toBe(0.7);
+  });
+
+  it('does not mutate the input document or share nested objects', () => {
+    const modelOptions = { depth: 2 };
+    const settingOptions = { enabled: true };
+    const buckets = ['primary'];
+    const doc: ProfileDocument = {
+      ...standardDocument(),
+      type: 'standard',
+      modelParams: { options: modelOptions },
+      ephemeralSettings: {
+        'auth-key': 'sk-secret-abc',
+        options: settingOptions,
+      },
+      auth: { type: 'oauth', buckets },
+    };
+    const redacted = redactProfileDocument(doc);
+    expect(doc.ephemeralSettings['auth-key']).toBe('sk-secret-abc');
+    const clonedOptions = redacted.modelParams['options'];
+    if (
+      typeof clonedOptions !== 'object' ||
+      clonedOptions === null ||
+      !('depth' in clonedOptions)
+    ) {
+      throw new Error('expected nested model options');
+    }
+    clonedOptions.depth = 4;
+    expect(modelOptions.depth).toBe(2);
+    modelOptions.depth = 6;
+    expect(clonedOptions.depth).toBe(4);
+
+    const clonedSettings = redacted.ephemeralSettings['options'];
+    if (
+      typeof clonedSettings !== 'object' ||
+      clonedSettings === null ||
+      !('enabled' in clonedSettings)
+    ) {
+      throw new Error('expected nested setting options');
+    }
+    clonedSettings.enabled = false;
+    expect(settingOptions.enabled).toBe(true);
+    settingOptions.enabled = false;
+    clonedSettings.enabled = true;
+    expect(settingOptions.enabled).toBe(false);
+
+    if (redacted.type !== 'standard' || redacted.auth?.type !== 'oauth') {
+      throw new Error('expected oauth auth');
+    }
+    buckets.push('backup');
+    expect(redacted.auth.buckets).toStrictEqual(['primary']);
+    redacted.auth.buckets = ['replacement'];
+    expect(doc.auth).toStrictEqual({
+      type: 'oauth',
+      buckets: ['primary', 'backup'],
+    });
+  });
+
+  it('masks mixed-case secret keys in documents and text', () => {
+    const doc: ProfileDocument = {
+      ...standardDocument(),
+      ephemeralSettings: {
+        'Auth-Key': 'mixed-auth-secret',
+        'X-API-Key': 'mixed-api-secret',
+        'Auth-Key-Name': 'creds',
+      },
+    };
+    expect(redactProfileDocument(doc).ephemeralSettings).toStrictEqual({
+      'Auth-Key': '[redacted]',
+      'X-API-Key': '[redacted]',
+      'Auth-Key-Name': 'creds',
+    });
+    expect(
+      redactSecrets(`Auth-Key: mixed-auth-secret
+X-API-Key: mixed-api-secret`),
+    ).toBe(
+      `Auth-Key: [redacted]
+X-API-Key: [redacted]`,
+    );
+  });
+
+  it('preserves the original document shape and kind', () => {
+    const doc = standardDocument();
+    const redacted = redactProfileDocument(doc);
+    expect(redacted.type).toBe('standard');
+    expect(redacted.provider).toBe('openai');
+    expect(redacted.model).toBe('gpt-4o');
+    expect(redacted.modelParams['temperature']).toBe(0.2);
+  });
+
+  it('redacts a load balancer document without disturbing its members', () => {
+    const doc = loadBalancerDocument();
+    const redacted = redactProfileDocument(doc);
+    expect(redacted.type).toBe('loadbalancer');
+    expect(redacted.ephemeralSettings['auth-key']).toBe('[redacted]');
+    if (!isLoadBalancerProfileDocument(redacted)) {
+      throw new Error('expected a load balancer document');
+    }
+    expect(redacted.profiles).toStrictEqual(['alpha', 'beta', 'gamma']);
+  });
+
+  it('redacts every credential-bearing value key on the document', () => {
+    const doc: ProfileDocument = {
+      version: 1,
+      type: 'standard',
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {
+        'api-key': 'sk-1',
+        apikey: 'k2',
+        authorization: 'Bearer t3',
+        'x-api-key': 'sk-4',
+        'auth-token': 't5',
+        'auth-key-name': 'creds',
+      },
+    };
+    const redacted = redactProfileDocument(doc);
+    expect(redacted.ephemeralSettings['api-key']).toBe('[redacted]');
+    expect(redacted.ephemeralSettings['apikey']).toBe('[redacted]');
+    expect(redacted.ephemeralSettings['authorization']).toBe('[redacted]');
+    expect(redacted.ephemeralSettings['x-api-key']).toBe('[redacted]');
+    expect(redacted.ephemeralSettings['auth-token']).toBe('[redacted]');
+    expect(redacted.ephemeralSettings['auth-key-name']).toBe('creds');
+    expect(JSON.stringify(redacted)).not.toContain('sk-1');
+    expect(JSON.stringify(redacted)).not.toContain('Bearer t3');
+  });
+
+  it('carries only key names, never secret values, into a diff against a secret-bearing document', () => {
+    const doc: ProfileDocument = {
+      version: 1,
+      type: 'standard',
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {
+        'api-key': 'sk-1',
+        'x-api-key': 'sk-2',
+        'auth-key': 'sk-3',
+      },
+    };
+    const redacted = redactProfileDocument(doc);
+    const diff = diffProfileDocuments(doc, redacted);
+    for (const key of [
+      'ephemeralSettings.api-key',
+      'ephemeralSettings.x-api-key',
+      'ephemeralSettings.auth-key',
+    ]) {
+      expect(diff.changedKeys).toContain(key);
+    }
+    const serialized = JSON.stringify(diff);
+    expect(serialized).not.toContain('sk-1');
+    expect(serialized).not.toContain('sk-2');
+    expect(serialized).not.toContain('sk-3');
+    const snapshot = buildRedactedSnapshot({
+      revision: 1,
+      identity: identity(),
+      document: redacted,
+    });
+    expect(JSON.stringify(snapshot)).not.toContain('sk-1');
+  });
+});
+
+describe('buildRedactedSnapshot', () => {
+  it('builds a standard snapshot without memberCount', () => {
+    const state = {
+      revision: 4,
+      identity: identity(),
+      document: standardDocument(),
+    };
+    const snapshot = buildRedactedSnapshot(state);
+    expect(snapshot.revision).toBe(4);
+    expect(snapshot.identity.kind).toBe('saved');
+    expect(snapshot.provider).toBe('openai');
+    expect(snapshot.model).toBe('gpt-4o');
+    expect(snapshot.isLoadBalancer).toBe(false);
+    expect(snapshot.memberCount).toBeUndefined();
+  });
+
+  it('counts members for a load balancer snapshot', () => {
+    const state = {
+      revision: 5,
+      identity: identity(),
+      document: loadBalancerDocument(),
+    };
+    const snapshot = buildRedactedSnapshot(state);
+    expect(snapshot.isLoadBalancer).toBe(true);
+    expect(snapshot.memberCount).toBe(3);
+  });
+});
+
+describe('diffProfileDocuments', () => {
+  it('reports added, removed, and changed top-level keys', () => {
+    const before: ProfileDocument = {
+      version: 1,
+      type: 'standard',
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {},
+      auth: { type: 'apikey' },
+    };
+    const after: ProfileDocument = {
+      version: 1,
+      provider: 'anthropic',
+      model: 'claude-3-7-sonnet',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+    const diff = diffProfileDocuments(before, after);
+    expect(diff.removes).toContain('auth');
+    expect(diff.adds).not.toContain('provider');
+    expect(diff.changedKeys).toContain('provider');
+    expect(diff.changedKeys).toContain('model');
+  });
+
+  it('reports added and removed settings with their surface prefix', () => {
+    const before: ProfileDocument = {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: { 'auth-key-name': 'creds', 'base-url': 'u' },
+    };
+    const after: ProfileDocument = {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: { 'auth-key-name': 'creds-rotated', temperature: 0.7 },
+    };
+    const diff = diffProfileDocuments(before, after);
+    expect(diff.removes).toContain('ephemeralSettings.base-url');
+    expect(diff.adds).toContain('ephemeralSettings.temperature');
+    expect(diff.changedKeys).toContain('ephemeralSettings.auth-key-name');
+  });
+
+  it('reports changed model params without values', () => {
+    const before: ProfileDocument = {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: { temperature: 0.2 },
+      ephemeralSettings: {},
+    };
+    const after: ProfileDocument = {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: { temperature: 0.8, maxTokens: 4096 },
+      ephemeralSettings: { temperature: 2 },
+    };
+    const diff = diffProfileDocuments(before, after);
+    expect(diff.changedKeys).toContain('modelParams.temperature');
+    expect(diff.adds).toContain('modelParams.maxTokens');
+    expect(diff.changedKeys).not.toContain('modelParams.maxTokens');
+  });
+
+  it('reports identical documents as an empty diff on every surface', () => {
+    const before = standardDocument();
+    const after = standardDocument();
+    const diff = diffProfileDocuments(before, after);
+    expect(diff.changedKeys).toStrictEqual([]);
+    expect(diff.adds).toStrictEqual([]);
+    expect(diff.removes).toStrictEqual([]);
+  });
+
+  it('reports a shared key as changed only when its value differs', () => {
+    const before = standardDocument();
+    const after: ProfileDocument = {
+      ...standardDocument(),
+      model: 'gpt-4o-mini',
+    };
+    const diff = diffProfileDocuments(before, after);
+    expect(diff.changedKeys).toStrictEqual(['model']);
+    expect(diff.adds).toStrictEqual([]);
+    expect(diff.removes).toStrictEqual([]);
+  });
+
+  it('compares nested setting values structurally', () => {
+    const before: ProfileDocument = {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: { options: { depth: 2, modes: ['fast', 'deep'] } },
+      ephemeralSettings: { 'auth-key-name': 'creds' },
+    };
+    const sameNested: ProfileDocument = {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: { options: { modes: ['fast', 'deep'], depth: 2 } },
+      ephemeralSettings: { 'auth-key-name': 'creds' },
+    };
+    const unchanged = diffProfileDocuments(before, sameNested);
+    expect(unchanged.changedKeys).toStrictEqual([]);
+
+    const divergentNested: ProfileDocument = {
+      ...sameNested,
+      modelParams: { options: { modes: ['fast', 'deeper'], depth: 2 } },
+    };
+    const changed = diffProfileDocuments(before, divergentNested);
+    expect(changed.changedKeys).toStrictEqual([
+      'modelParams',
+      'modelParams.options',
+    ]);
+  });
+
+  it('reports a nested auth object as changed only when it differs', () => {
+    const before: ProfileDocument = {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {},
+      auth: { type: 'oauth', buckets: ['b1', 'b2'] },
+    };
+    const same: ProfileDocument = {
+      ...before,
+      auth: { type: 'oauth', buckets: ['b1', 'b2'] },
+    };
+    expect(diffProfileDocuments(before, same).changedKeys).toStrictEqual([]);
+
+    const different: ProfileDocument = {
+      ...before,
+      auth: { type: 'oauth', buckets: ['b1'] },
+    };
+    const diff = diffProfileDocuments(before, different);
+    expect(diff.changedKeys).toStrictEqual(['auth']);
+  });
+});

--- a/packages/core/src/profiles/contracts/profileViews.test.ts
+++ b/packages/core/src/profiles/contracts/profileViews.test.ts
@@ -73,6 +73,19 @@ describe('SECRET_SETTING_KEYS', () => {
 });
 
 describe('redactSecrets', () => {
+  it.each([...SECRET_SETTING_KEYS])(
+    'fully masks escaped JSON credentials for %s',
+    (key) => {
+      const message = JSON.stringify({
+        [key]: String.raw`prefix"credential-tail\secret-tail`,
+        model: 'gpt-4o',
+      });
+      expect(redactSecrets(message)).toStrictEqual(
+        `{"${key}": "[redacted]","model":"gpt-4o"}`,
+      );
+    },
+  );
+
   it('masks a key-value fragment', () => {
     expect(redactSecrets('build failed with auth-key: sk-123 in env')).toBe(
       'build failed with auth-key: [redacted]',

--- a/packages/core/src/profiles/contracts/profileViews.ts
+++ b/packages/core/src/profiles/contracts/profileViews.ts
@@ -45,7 +45,7 @@ export function redactSecrets(message: string): string {
   for (const key of SECRET_SETTING_KEYS) {
     const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     redacted = redacted.replace(
-      new RegExp(`("${escaped}")\\s*:\\s*"[^"]*"`, 'gi'),
+      new RegExp(`("${escaped}")\\s*:\\s*"(?:\\\\.|[^"\\\\])*"`, 'gi'),
       '$1: "[redacted]"',
     );
     redacted = redacted.replace(
@@ -100,6 +100,92 @@ export interface RedactedProfileSnapshot {
   providerOrLbSummary?: string | null;
   health?: ProfileHealth;
   roleRuntimeCount?: number;
+}
+
+function isNamedSource(value: unknown): boolean {
+  if (!isPlainRecord(value) || typeof value['name'] !== 'string') {
+    return false;
+  }
+  const source = value['source'];
+  if (!isPlainRecord(source)) {
+    return false;
+  }
+  if (source['kind'] === 'hash') {
+    return typeof source['hash'] === 'string';
+  }
+  return (
+    source['kind'] === 'stat' &&
+    typeof source['mtimeMs'] === 'number' &&
+    typeof source['size'] === 'number'
+  );
+}
+
+function isWorkingProfileIdentity(
+  value: unknown,
+): value is WorkingProfileIdentity {
+  if (!isPlainRecord(value)) {
+    return false;
+  }
+  if (value['kind'] === 'saved') {
+    return isNamedSource(value);
+  }
+  return (
+    value['kind'] === 'draft' &&
+    (value['derivedFrom'] === undefined || isNamedSource(value['derivedFrom']))
+  );
+}
+
+function isProfileHealth(value: unknown): value is ProfileHealth {
+  if (!isPlainRecord(value)) {
+    return false;
+  }
+  const status = value['status'];
+  if (status !== 'ok' && status !== 'degraded' && status !== 'failed') {
+    return false;
+  }
+  return (
+    Array.isArray(value['degradedAspects']) &&
+    value['degradedAspects'].every(
+      (aspect: unknown) => typeof aspect === 'string',
+    )
+  );
+}
+
+export function isRedactedProfileSnapshot(
+  value: unknown,
+): value is RedactedProfileSnapshot {
+  if (!isPlainRecord(value)) {
+    return false;
+  }
+  if (
+    !isWorkingProfileIdentity(value['identity']) ||
+    typeof value['isLoadBalancer'] !== 'boolean'
+  ) {
+    return false;
+  }
+  if (
+    typeof value['revision'] !== 'number' ||
+    typeof value['provider'] !== 'string' ||
+    typeof value['model'] !== 'string'
+  ) {
+    return false;
+  }
+  if (
+    !['memberCount', 'roleRuntimeCount'].every(
+      (key) => value[key] === undefined || typeof value[key] === 'number',
+    )
+  ) {
+    return false;
+  }
+  return (
+    ['identityKind', 'providerOrLbSummary'].every(
+      (key) =>
+        value[key] === undefined ||
+        value[key] === null ||
+        typeof value[key] === 'string',
+    ) &&
+    (value['health'] === undefined || isProfileHealth(value['health']))
+  );
 }
 
 /**

--- a/packages/core/src/profiles/contracts/profileViews.ts
+++ b/packages/core/src/profiles/contracts/profileViews.ts
@@ -1,0 +1,242 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ProfileDocument } from './profileDocument.js';
+import type { WorkingProfileIdentity } from './profileState.js';
+
+/**
+ * Ephemeral setting keys that hold raw secret material and must be masked before a
+ * document leaves the process.
+ *
+ * Only value-bearing credential keys are listed. Reference keys stay readable on
+ * purpose: `auth-key-name` names a stored credential and `auth-keyfile` points at
+ * a key file on disk, so neither carries the secret itself. Other v1 ephemeral
+ * keys hold references or tuning values (base-url, temperature, context-limit, ...)
+ * rather than raw secrets.
+ */
+export const SECRET_SETTING_KEYS: readonly string[] = [
+  // Raw provider credential material carried on the document itself.
+  'auth-key',
+  // Provider API key value (dashed spelling used in ephemeral settings).
+  'api-key',
+  // Provider API key value (solid alias used by settings/providers).
+  'apikey',
+  // Raw Authorization header value (bearer/basic schemes).
+  'authorization',
+  // Gateway header credential value (e.g. Anthropic-style headers).
+  'x-api-key',
+  // Bearer/session token value.
+  'auth-token',
+];
+
+/**
+ * Mask secret values embedded in free-form text.
+ *
+ * A value is masked when it appears as a `key: value` fragment or as a quoted
+ * JSON member (`"key": "value"`) for any {@link SECRET_SETTING_KEYS} key. Values
+ * are replaced with `[redacted]`; key names stay so the message remains
+ * diagnosable. Reference keys (auth-key-name, auth-keyfile) are never masked.
+ */
+export function redactSecrets(message: string): string {
+  let redacted = message;
+  for (const key of SECRET_SETTING_KEYS) {
+    const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    redacted = redacted.replace(
+      new RegExp(`("${escaped}")\\s*:\\s*"[^"]*"`, 'gi'),
+      '$1: "[redacted]"',
+    );
+    redacted = redacted.replace(
+      new RegExp(`(${escaped}\\s*:\\s*)[^\\n]*`, 'gi'),
+      '$1[redacted]',
+    );
+  }
+  return redacted;
+}
+
+/**
+ * Deep copy of a profile document with every secret setting value replaced by
+ * `[redacted]`.
+ *
+ * The input is never mutated; the returned document preserves the original kind and shape.
+ */
+export function redactProfileDocument(
+  document: ProfileDocument,
+): ProfileDocument {
+  const cloned = structuredClone(document);
+  const settings = Object.fromEntries(
+    Object.entries(cloned.ephemeralSettings).map(([key, value]) => [
+      key,
+      SECRET_SETTING_KEYS.includes(key.toLowerCase()) ? '[redacted]' : value,
+    ]),
+  );
+  return {
+    ...cloned,
+    ephemeralSettings: settings,
+  };
+}
+
+/**
+ * Redacted snapshot of the active profile workspace, safe to emit in results.
+ *
+ * The base surface (identity, revision, provider, model, isLoadBalancer, memberCount)
+ * is what the repository/save path emits via {@link buildRedactedSnapshot}. The live
+ * runtime path adds the optional summary fields: `identityKind` and
+ * `providerOrLbSummary` redact the working identity into log-safe strings (null when
+ * the workspace is unconfigured), and `health` reports the observed runtime health of
+ * a bound runtime. They are optional because a snapshot without a live runtime does
+ * not carry them.
+ */
+export interface RedactedProfileSnapshot {
+  identity: WorkingProfileIdentity;
+  revision: number;
+  provider: string;
+  model: string;
+  isLoadBalancer: boolean;
+  memberCount?: number;
+  identityKind?: string | null;
+  providerOrLbSummary?: string | null;
+  health?: ProfileHealth;
+  roleRuntimeCount?: number;
+}
+
+/**
+ * Build a redacted snapshot from configured workspace state.
+ */
+export function buildRedactedSnapshot(state: {
+  revision: number;
+  identity: WorkingProfileIdentity;
+  document: ProfileDocument;
+}): RedactedProfileSnapshot {
+  const base = {
+    identity: state.identity,
+    revision: state.revision,
+    provider: state.document.provider,
+    model: state.document.model,
+  };
+  if (state.document.type === 'loadbalancer') {
+    return {
+      ...base,
+      isLoadBalancer: true,
+      memberCount: state.document.profiles.length,
+    };
+  }
+  return { ...base, isLoadBalancer: false };
+}
+
+/**
+ * Redacted diff between two profile documents: changed, added, and removed key names
+ * across the top-level surface plus `ephemeralSettings` and `modelParams`
+ * surfaces. Only key names appear, never values.
+ */
+export interface RedactedProfileDiff {
+  changedKeys: readonly string[];
+  adds: readonly string[];
+  removes: readonly string[];
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Structural equality of two setting values: primitives compare by identity,
+ * arrays element-wise, and plain records by having the same key set with equal
+ * values per key. Mirrors JSON comparison semantics, so no value ever has to
+ * leave the process to decide whether a document changed.
+ */
+function valuesEqual(before: unknown, after: unknown): boolean {
+  if (before === after) {
+    return true;
+  }
+  if (Array.isArray(before) || Array.isArray(after)) {
+    return (
+      Array.isArray(before) &&
+      Array.isArray(after) &&
+      before.length === after.length &&
+      before.every((entry, index) => valuesEqual(entry, after[index]))
+    );
+  }
+  if (isPlainRecord(before) && isPlainRecord(after)) {
+    const beforeKeys = Object.keys(before);
+    const afterKeys = Object.keys(after);
+    if (beforeKeys.length !== afterKeys.length) {
+      return false;
+    }
+    return beforeKeys.every(
+      (key) => key in after && valuesEqual(before[key], after[key]),
+    );
+  }
+  return false;
+}
+
+function diffKeyRecords(
+  before: Readonly<Record<string, unknown>>,
+  after: Readonly<Record<string, unknown>>,
+  changedKeys: string[],
+  adds: string[],
+  removes: string[],
+  prefix?: string,
+): void {
+  const afterSet = new Set(Object.keys(after));
+  const label = (key: string): string =>
+    prefix === undefined ? key : `${prefix}.${key}`;
+  for (const key of Object.keys(before)) {
+    if (afterSet.has(key)) {
+      if (!valuesEqual(before[key], after[key])) {
+        changedKeys.push(label(key));
+      }
+    } else {
+      removes.push(label(key));
+    }
+  }
+  for (const key of afterSet) {
+    if (!(key in before)) {
+      adds.push(label(key));
+    }
+  }
+}
+
+/**
+ * Diff two profile documents by key name across every compared surface: the top-level
+ * surface plus `ephemeralSettings` and `modelParams` sub-keys. A key present in both
+ * documents is reported as changed only when its values differ structurally; a key
+ * present on one side only is an add or a remove. The diff carries key names only,
+ * never values.
+ */
+export function diffProfileDocuments(
+  before: ProfileDocument,
+  after: ProfileDocument,
+): RedactedProfileDiff {
+  const changedKeys: string[] = [];
+  const adds: string[] = [];
+  const removes: string[] = [];
+  diffKeyRecords({ ...before }, { ...after }, changedKeys, adds, removes);
+  diffKeyRecords(
+    before.ephemeralSettings,
+    after.ephemeralSettings,
+    changedKeys,
+    adds,
+    removes,
+    'ephemeralSettings',
+  );
+  diffKeyRecords(
+    before.modelParams,
+    after.modelParams,
+    changedKeys,
+    adds,
+    removes,
+    'modelParams',
+  );
+  return { changedKeys, adds, removes };
+}
+
+/**
+ * Observed health of the active profile workspace.
+ */
+export type ProfileHealth = {
+  status: 'ok' | 'degraded' | 'failed';
+  degradedAspects: readonly string[];
+};

--- a/packages/core/src/profiles/contracts/routingContexts.test.ts
+++ b/packages/core/src/profiles/contracts/routingContexts.test.ts
@@ -1,0 +1,129 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  createTurnContext,
+  createProviderCallContext,
+  createToolInvocationContext,
+  type ToolPolicySnapshot,
+} from './routingContexts.js';
+
+const policy: ToolPolicySnapshot = {
+  allowedTools: ['read', 'write'],
+  disabledTools: ['dangerous-tool'],
+  shellMode: 'allowlist',
+  approvalCeiling: 'standard',
+};
+
+describe('createTurnContext', () => {
+  it('round-trips its fields', () => {
+    const target = { agentId: 'agent-1', parentAgentId: 'root' };
+    const turn = createTurnContext(target, 5, 1234);
+    expect(turn.target.agentId).toBe('agent-1');
+    expect(turn.target.parentAgentId).toBe('root');
+    expect(turn.profileRevision).toBe(5);
+    expect(turn.startedAt).toBe(1234);
+  });
+
+  it('preserves an absent parentAgentId', () => {
+    const turn = createTurnContext({ agentId: 'agent-1' }, 0, 0);
+    expect(turn.target.parentAgentId).toBeUndefined();
+  });
+
+  it('returns a deeply frozen object', () => {
+    const turn = createTurnContext(
+      { agentId: 'agent-1', parentAgentId: 'root' },
+      5,
+      1234,
+    );
+    expect(Object.isFrozen(turn)).toBe(true);
+    expect(Object.isFrozen(turn.target)).toBe(true);
+    expect(() => {
+      turn.target.agentId = 'changed';
+    }).toThrow(TypeError);
+  });
+});
+
+describe('createProviderCallContext', () => {
+  it('round-trips its fields', () => {
+    const turn = createTurnContext({ agentId: 'agent-1' }, 5, 1234);
+    const call = createProviderCallContext(turn, 'openai', 'gpt-4o', policy);
+    expect(call.turn === turn).toBe(true);
+    expect(call.providerName).toBe('openai');
+    expect(call.model).toBe('gpt-4o');
+    expect(call.capturedPolicy.allowedTools).toStrictEqual(['read', 'write']);
+    expect(call.capturedPolicy.disabledTools).toStrictEqual(['dangerous-tool']);
+    expect(call.capturedPolicy.shellMode).toBe('allowlist');
+    expect(call.capturedPolicy.approvalCeiling).toBe('standard');
+  });
+
+  it('returns a deeply frozen object', () => {
+    const turn = createTurnContext(
+      { agentId: 'agent-1', parentAgentId: 'root' },
+      5,
+      1234,
+    );
+    const call = createProviderCallContext(turn, 'openai', 'gpt-4o', policy);
+    expect(Object.isFrozen(call)).toBe(true);
+    expect(Object.isFrozen(call.turn)).toBe(true);
+    expect(Object.isFrozen(call.turn.target)).toBe(true);
+    expect(Object.isFrozen(call.capturedPolicy)).toBe(true);
+    expect(Object.isFrozen(call.capturedPolicy.allowedTools)).toBe(true);
+    expect(() => {
+      call.providerName = 'anthropic';
+    }).toThrow(TypeError);
+    expect(() => {
+      (call.capturedPolicy.allowedTools as string[]).push('edit');
+    }).toThrow(TypeError);
+  });
+});
+
+describe('createToolInvocationContext', () => {
+  it('round-trips its fields', () => {
+    const turn = createTurnContext({ agentId: 'agent-1' }, 5, 1234);
+    const invocation = createToolInvocationContext(
+      turn,
+      'tool-9',
+      policy,
+      true,
+    );
+    expect(invocation.turn === turn).toBe(true);
+    expect(invocation.toolId).toBe('tool-9');
+    expect(invocation.capturedPolicy).toStrictEqual(policy);
+    expect(invocation.background).toBe(true);
+  });
+
+  it('returns a deeply frozen object', () => {
+    const turn = createTurnContext(
+      { agentId: 'agent-1', parentAgentId: 'root' },
+      5,
+      1234,
+    );
+    const invocation = createToolInvocationContext(
+      turn,
+      'tool-9',
+      policy,
+      true,
+    );
+    expect(Object.isFrozen(invocation)).toBe(true);
+    expect(Object.isFrozen(invocation.capturedPolicy)).toBe(true);
+    expect(Object.isFrozen(invocation.capturedPolicy.allowedTools)).toBe(true);
+    expect(() => {
+      invocation.toolId = 'tool-10';
+    }).toThrow(TypeError);
+    expect(() => {
+      (invocation.capturedPolicy.disabledTools as string[]).push('x');
+    }).toThrow(TypeError);
+  });
+});
+
+describe('captured policy is immutable across the shared snapshot input', () => {
+  it('freezes the caller-provided policy object in place', () => {
+    const mutablePolicy: ToolPolicySnapshot = policy;
+    expect(Object.isFrozen(mutablePolicy)).toBe(true);
+  });
+});

--- a/packages/core/src/profiles/contracts/routingContexts.test.ts
+++ b/packages/core/src/profiles/contracts/routingContexts.test.ts
@@ -23,15 +23,24 @@ describe('createTurnContext', () => {
   it('round-trips its fields', () => {
     const target = { agentId: 'agent-1', parentAgentId: 'root' };
     const turn = createTurnContext(target, 5, 1234);
-    expect(turn.target.agentId).toBe('agent-1');
-    expect(turn.target.parentAgentId).toBe('root');
-    expect(turn.profileRevision).toBe(5);
-    expect(turn.startedAt).toBe(1234);
+    expect(turn).toStrictEqual({ target, profileRevision: 5, startedAt: 1234 });
   });
 
   it('preserves an absent parentAgentId', () => {
     const turn = createTurnContext({ agentId: 'agent-1' }, 0, 0);
-    expect(turn.target.parentAgentId).toBeUndefined();
+    expect(turn.target.parentAgentId).toStrictEqual(undefined);
+  });
+
+  it('captures an independent target without freezing the input', () => {
+    const target = { agentId: 'agent-1', parentAgentId: 'root' };
+    const turn = createTurnContext(target, 5, 1234);
+    expect(Object.isFrozen(target)).toStrictEqual(false);
+    target.agentId = 'changed';
+    target.parentAgentId = 'changed-root';
+    expect(turn.target).toStrictEqual({
+      agentId: 'agent-1',
+      parentAgentId: 'root',
+    });
   });
 
   it('returns a deeply frozen object', () => {
@@ -40,11 +49,8 @@ describe('createTurnContext', () => {
       5,
       1234,
     );
-    expect(Object.isFrozen(turn)).toBe(true);
-    expect(Object.isFrozen(turn.target)).toBe(true);
-    expect(() => {
-      turn.target.agentId = 'changed';
-    }).toThrow(TypeError);
+    expect(Object.isFrozen(turn)).toStrictEqual(true);
+    expect(Reflect.set(turn.target, 'agentId', 'changed')).toStrictEqual(false);
   });
 });
 
@@ -52,13 +58,12 @@ describe('createProviderCallContext', () => {
   it('round-trips its fields', () => {
     const turn = createTurnContext({ agentId: 'agent-1' }, 5, 1234);
     const call = createProviderCallContext(turn, 'openai', 'gpt-4o', policy);
-    expect(call.turn === turn).toBe(true);
-    expect(call.providerName).toBe('openai');
-    expect(call.model).toBe('gpt-4o');
-    expect(call.capturedPolicy.allowedTools).toStrictEqual(['read', 'write']);
-    expect(call.capturedPolicy.disabledTools).toStrictEqual(['dangerous-tool']);
-    expect(call.capturedPolicy.shellMode).toBe('allowlist');
-    expect(call.capturedPolicy.approvalCeiling).toBe('standard');
+    expect(call).toStrictEqual({
+      turn,
+      providerName: 'openai',
+      model: 'gpt-4o',
+      capturedPolicy: policy,
+    });
   });
 
   it('returns a deeply frozen object', () => {
@@ -68,17 +73,14 @@ describe('createProviderCallContext', () => {
       1234,
     );
     const call = createProviderCallContext(turn, 'openai', 'gpt-4o', policy);
-    expect(Object.isFrozen(call)).toBe(true);
-    expect(Object.isFrozen(call.turn)).toBe(true);
-    expect(Object.isFrozen(call.turn.target)).toBe(true);
-    expect(Object.isFrozen(call.capturedPolicy)).toBe(true);
-    expect(Object.isFrozen(call.capturedPolicy.allowedTools)).toBe(true);
-    expect(() => {
-      call.providerName = 'anthropic';
-    }).toThrow(TypeError);
-    expect(() => {
-      (call.capturedPolicy.allowedTools as string[]).push('edit');
-    }).toThrow(TypeError);
+    expect(Object.isFrozen(call)).toStrictEqual(true);
+    expect(Object.isFrozen(call.turn)).toStrictEqual(true);
+    expect(Object.isFrozen(call.turn.target)).toStrictEqual(true);
+    expect(Object.isFrozen(call.capturedPolicy)).toStrictEqual(true);
+    expect(Reflect.set(call, 'providerName', 'anthropic')).toStrictEqual(false);
+    expect(
+      Reflect.set(call.capturedPolicy.allowedTools, '0', 'edit'),
+    ).toStrictEqual(false);
   });
 });
 
@@ -91,10 +93,12 @@ describe('createToolInvocationContext', () => {
       policy,
       true,
     );
-    expect(invocation.turn === turn).toBe(true);
-    expect(invocation.toolId).toBe('tool-9');
-    expect(invocation.capturedPolicy).toStrictEqual(policy);
-    expect(invocation.background).toBe(true);
+    expect(invocation).toStrictEqual({
+      turn,
+      toolId: 'tool-9',
+      capturedPolicy: policy,
+      background: true,
+    });
   });
 
   it('returns a deeply frozen object', () => {
@@ -109,21 +113,60 @@ describe('createToolInvocationContext', () => {
       policy,
       true,
     );
-    expect(Object.isFrozen(invocation)).toBe(true);
-    expect(Object.isFrozen(invocation.capturedPolicy)).toBe(true);
-    expect(Object.isFrozen(invocation.capturedPolicy.allowedTools)).toBe(true);
-    expect(() => {
-      invocation.toolId = 'tool-10';
-    }).toThrow(TypeError);
-    expect(() => {
-      (invocation.capturedPolicy.disabledTools as string[]).push('x');
-    }).toThrow(TypeError);
+    expect(Object.isFrozen(invocation)).toStrictEqual(true);
+    expect(Object.isFrozen(invocation.capturedPolicy)).toStrictEqual(true);
+    expect(Reflect.set(invocation, 'toolId', 'tool-10')).toStrictEqual(false);
+    expect(
+      Reflect.set(invocation.capturedPolicy.disabledTools, '0', 'x'),
+    ).toStrictEqual(false);
   });
 });
 
-describe('captured policy is immutable across the shared snapshot input', () => {
-  it('freezes the caller-provided policy object in place', () => {
-    const mutablePolicy: ToolPolicySnapshot = policy;
-    expect(Object.isFrozen(mutablePolicy)).toBe(true);
-  });
+describe('routing snapshots own caller-provided data', () => {
+  it.each(['provider', 'tool'])(
+    'isolates mutable turn and policy inputs for %s contexts',
+    (kind) => {
+      const turn = {
+        target: { agentId: 'agent-1', parentAgentId: 'root' },
+        profileRevision: 5,
+        startedAt: 1234,
+      };
+      const allowedTools = ['read', 'write'];
+      const disabledTools = ['dangerous-tool'];
+      const capturedPolicy: ToolPolicySnapshot = {
+        ...policy,
+        allowedTools,
+        disabledTools,
+      };
+      const context =
+        kind === 'provider'
+          ? createProviderCallContext(turn, 'openai', 'gpt-4o', capturedPolicy)
+          : createToolInvocationContext(turn, 'tool-9', capturedPolicy, false);
+
+      expect(
+        [turn, turn.target, capturedPolicy, allowedTools, disabledTools].map(
+          Object.isFrozen,
+        ),
+      ).toStrictEqual([false, false, false, false, false]);
+      turn.target.agentId = 'changed';
+      turn.target.parentAgentId = 'changed-root';
+      turn.profileRevision = 6;
+      turn.startedAt = 5678;
+      allowedTools.push('edit');
+      disabledTools.push('shell');
+      expect(context.turn).toStrictEqual({
+        target: { agentId: 'agent-1', parentAgentId: 'root' },
+        profileRevision: 5,
+        startedAt: 1234,
+      });
+      expect(context.capturedPolicy).toStrictEqual(policy);
+      expect(Object.isFrozen(context.turn.target)).toStrictEqual(true);
+      expect(
+        Object.isFrozen(context.capturedPolicy.allowedTools),
+      ).toStrictEqual(true);
+      expect(
+        Object.isFrozen(context.capturedPolicy.disabledTools),
+      ).toStrictEqual(true);
+    },
+  );
 });

--- a/packages/core/src/profiles/contracts/routingContexts.ts
+++ b/packages/core/src/profiles/contracts/routingContexts.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Immutable routing records that carry runtime identity explicitly through
+ * Agent/Turn/ProviderCall/ToolInvocation instead of ambient globals.
+ *
+ * Each factory returns a deep-frozen record: nothing that captured a context can mutate
+ * it, so in-flight work keeps its policy snapshot even when the profile transitions to a
+ * new revision mid-turn.
+ */
+
+/**
+ * Policy surface captured at a routing decision point.
+ */
+export type ToolPolicySnapshot = {
+  allowedTools: readonly string[];
+  disabledTools: readonly string[];
+  shellMode: 'allowlist' | 'all' | 'none';
+  approvalCeiling: 'yolo' | 'standard' | 'strict';
+};
+
+/**
+ * Identity of the agent a turn is routed to.
+ */
+export type AgentRoutingTarget = {
+  agentId: string;
+  parentAgentId?: string;
+};
+
+/**
+ * Identity of a single agent turn.
+ */
+export type TurnContext = {
+  target: AgentRoutingTarget;
+  profileRevision: number;
+  startedAt: number;
+};
+
+/**
+ * Routing identity for a single provider call within a turn.
+ */
+export type ProviderCallContext = {
+  turn: TurnContext;
+  providerName: string;
+  model: string;
+  capturedPolicy: ToolPolicySnapshot;
+};
+
+/**
+ * Routing identity for a single tool invocation within a turn.
+ */
+export type ToolInvocationContext = {
+  turn: TurnContext;
+  toolId: string;
+  capturedPolicy: ToolPolicySnapshot;
+  background: boolean;
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Recursively freeze a value: every nested plain object and array becomes frozen.
+ */
+export function deepFreeze<T>(value: T): T {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      deepFreeze(item);
+    }
+  } else if (isObject(value)) {
+    for (const key of Object.getOwnPropertyNames(value)) {
+      deepFreeze(value[key]);
+    }
+  }
+  return Object.freeze(value);
+}
+
+/**
+ * Build a deep-frozen turn context.
+ */
+export function createTurnContext(
+  target: AgentRoutingTarget,
+  profileRevision: number,
+  startedAt: number,
+): TurnContext {
+  return deepFreeze({ target, profileRevision, startedAt });
+}
+
+/**
+ * Build a deep-frozen provider call context.
+ */
+export function createProviderCallContext(
+  turn: TurnContext,
+  providerName: string,
+  model: string,
+  capturedPolicy: ToolPolicySnapshot,
+): ProviderCallContext {
+  return deepFreeze({ turn, providerName, model, capturedPolicy });
+}
+
+/**
+ * Build a deep-frozen tool invocation context.
+ */
+export function createToolInvocationContext(
+  turn: TurnContext,
+  toolId: string,
+  capturedPolicy: ToolPolicySnapshot,
+  background: boolean,
+): ToolInvocationContext {
+  return deepFreeze({ turn, toolId, capturedPolicy, background });
+}

--- a/packages/core/src/profiles/contracts/routingContexts.ts
+++ b/packages/core/src/profiles/contracts/routingContexts.ts
@@ -17,47 +17,47 @@
  * Policy surface captured at a routing decision point.
  */
 export type ToolPolicySnapshot = {
-  allowedTools: readonly string[];
-  disabledTools: readonly string[];
-  shellMode: 'allowlist' | 'all' | 'none';
-  approvalCeiling: 'yolo' | 'standard' | 'strict';
+  readonly allowedTools: readonly string[];
+  readonly disabledTools: readonly string[];
+  readonly shellMode: 'allowlist' | 'all' | 'none';
+  readonly approvalCeiling: 'yolo' | 'standard' | 'strict';
 };
 
 /**
  * Identity of the agent a turn is routed to.
  */
 export type AgentRoutingTarget = {
-  agentId: string;
-  parentAgentId?: string;
+  readonly agentId: string;
+  readonly parentAgentId?: string;
 };
 
 /**
  * Identity of a single agent turn.
  */
 export type TurnContext = {
-  target: AgentRoutingTarget;
-  profileRevision: number;
-  startedAt: number;
+  readonly target: AgentRoutingTarget;
+  readonly profileRevision: number;
+  readonly startedAt: number;
 };
 
 /**
  * Routing identity for a single provider call within a turn.
  */
 export type ProviderCallContext = {
-  turn: TurnContext;
-  providerName: string;
-  model: string;
-  capturedPolicy: ToolPolicySnapshot;
+  readonly turn: TurnContext;
+  readonly providerName: string;
+  readonly model: string;
+  readonly capturedPolicy: ToolPolicySnapshot;
 };
 
 /**
  * Routing identity for a single tool invocation within a turn.
  */
 export type ToolInvocationContext = {
-  turn: TurnContext;
-  toolId: string;
-  capturedPolicy: ToolPolicySnapshot;
-  background: boolean;
+  readonly turn: TurnContext;
+  readonly toolId: string;
+  readonly capturedPolicy: ToolPolicySnapshot;
+  readonly background: boolean;
 };
 
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -88,7 +88,7 @@ export function createTurnContext(
   profileRevision: number,
   startedAt: number,
 ): TurnContext {
-  return deepFreeze({ target, profileRevision, startedAt });
+  return deepFreeze(structuredClone({ target, profileRevision, startedAt }));
 }
 
 /**
@@ -100,7 +100,9 @@ export function createProviderCallContext(
   model: string,
   capturedPolicy: ToolPolicySnapshot,
 ): ProviderCallContext {
-  return deepFreeze({ turn, providerName, model, capturedPolicy });
+  return deepFreeze(
+    structuredClone({ turn, providerName, model, capturedPolicy }),
+  );
 }
 
 /**
@@ -112,5 +114,7 @@ export function createToolInvocationContext(
   capturedPolicy: ToolPolicySnapshot,
   background: boolean,
 ): ToolInvocationContext {
-  return deepFreeze({ turn, toolId, capturedPolicy, background });
+  return deepFreeze(
+    structuredClone({ turn, toolId, capturedPolicy, background }),
+  );
 }

--- a/packages/core/src/profiles/index.ts
+++ b/packages/core/src/profiles/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Profile workspace public surface.
+ *
+ * The profiles tree is split into four layers that core owns:
+ *  - contracts: structural profile documents, commands, events, views, contexts
+ *  - ports: dependency boundaries (repositories, credential resolvers, catalogs)
+ *  - reduction: pure command reducers
+ *  - resolution: intent-to-reference resolution (credential bindings, member auth)
+ */
+
+export * from './contracts/index.js';
+export * from './ports/index.js';
+export * from './reduction/index.js';
+export * from './resolution/index.js';

--- a/packages/core/src/profiles/ports/credentialResolverPort.ts
+++ b/packages/core/src/profiles/ports/credentialResolverPort.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Reference to a credential, never the secret itself.
+ *
+ * Bindings hold references only: key names, keyfile paths, or OAuth provider and
+ * bucket ids. Resolvers turn a binding into a short-lived secret at use time so key
+ * rotation is picked up on the next resolve; resolved tokens are never cached in profile
+ * state.
+ */
+export type CredentialBinding =
+  | { kind: 'key-name'; keyName: string }
+  | { kind: 'keyfile'; path: string }
+  | { kind: 'oauth'; provider: string; buckets: readonly string[] }
+  | { kind: 'provider-default'; provider: string };
+
+/**
+ * Outcome of resolving a {@link CredentialBinding}.
+ */
+export type CredentialSecret =
+  | { kind: 'resolved'; token: string }
+  | { kind: 'unavailable'; reason: string };
+
+/**
+ * Resolves credential references into use-time secrets.
+ *
+ * Implementations own the actual secret store (settings keychain, auth buckets). The
+ * resolver surface is deliberately an interface: the profiles tree names what it needs and
+ * never holds secret material.
+ */
+export interface CredentialResolverPort {
+  resolve(binding: CredentialBinding): Promise<CredentialSecret>;
+}

--- a/packages/core/src/profiles/ports/index.ts
+++ b/packages/core/src/profiles/ports/index.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Profile port exports.
+ *
+ * Ports are the boundaries the profiles tree depends on. They name what core needs
+ * (repositories, credential resolvers, model catalogs, trust ceilings, runtime
+ * factories, scheduler boundaries) without importing settings or providers, so implementations
+ * can live outside core and still meet these shapes.
+ */
+
+export type { ProfileRepositoryPort } from './profileRepositoryPort.js';
+export { ProfileRepositoryConflictError } from './profileRepositoryPort.js';
+export type {
+  CredentialBinding,
+  CredentialSecret,
+  CredentialResolverPort,
+} from './credentialResolverPort.js';
+export type { ProviderModelCatalogPort } from './providerCatalogPort.js';
+export type { TrustToolEnvironmentPort } from './trustEnvironmentPort.js';
+export type {
+  EffectiveToolPolicy,
+  ResolvedProfileSpec,
+  ProfileRuntimeBinding,
+  ProfileRuntimeFactoryPort,
+} from './profileRuntimeFactoryPort.js';
+export type {
+  SafeBoundaryOutcome,
+  SchedulerBoundaryPort,
+} from './schedulerBoundaryPort.js';

--- a/packages/core/src/profiles/ports/profileRepositoryPort.ts
+++ b/packages/core/src/profiles/ports/profileRepositoryPort.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ProfileDocument, SourceFingerprint } from '../contracts/index.js';
+
+/**
+ * Thrown by {@link ProfileRepositoryPort.save} when the persisted fingerprint does not
+ * match the caller's `expected` fingerprint.
+ *
+ * The mismatch means the underlying file changed outside the repository's knowledge since it
+ * was loaded or last saved. The caller decides how to surface the conflict; no stack or
+ * message scrubbing is done here because the record may already be redacted before this
+ * error is constructed.
+ */
+export class ProfileRepositoryConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ProfileRepositoryConflictError';
+  }
+}
+
+/**
+ * Persistence boundary for profile documents.
+ *
+ * Ports are the outer boundary of the profiles tree: implementations live outside core
+ * (settings-owned or CLI adapter) and meet this shape without importing it. This
+ * interface owns read/write of the raw document plus its source fingerprint.
+ */
+export interface ProfileRepositoryPort {
+  /**
+   * Load a profile by name.
+   *
+   * @returns the parsed document plus the fingerprint of the file it came from.
+   * @throws when the named profile does not exist or cannot be parsed.
+   */
+  load(
+    name: string,
+  ): Promise<{ document: ProfileDocument; fingerprint: SourceFingerprint }>;
+
+  /**
+   * Persist a document under `name`.
+   *
+   * Pass `expected` to optimistically-conflict: when the fingerprint that is currently
+   * persisted does not match (because of external modification), this throws
+   * {@link ProfileRepositoryConflictError}. Pass `mustCreate` to refuse an existing
+   * destination atomically with the same error instead of overwriting it.
+   *
+   * @returns the fingerprint of the file as written.
+   */
+  save(
+    name: string,
+    document: ProfileDocument,
+    expected?: SourceFingerprint,
+    opts?: { mustCreate?: boolean },
+  ): Promise<SourceFingerprint>;
+
+  /**
+   * List every saved profile name.
+   */
+  list(): Promise<ReadonlyArray<{ name: string }>>;
+
+  /**
+   * Delete a saved profile.
+   */
+  delete(name: string): Promise<void>;
+
+  /**
+   * Return the current fingerprint of the persisted file, or `null` for a
+   * missing/deleted file.
+   */
+  stat(name: string): Promise<SourceFingerprint | null>;
+}

--- a/packages/core/src/profiles/ports/profileRuntimeFactoryPort.ts
+++ b/packages/core/src/profiles/ports/profileRuntimeFactoryPort.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ProfileDocument } from '../contracts/index.js';
+import type { CredentialBinding } from './credentialResolverPort.js';
+
+/**
+ * Policy surface an effective profile is built with. These are the already-narrowed
+ * values after profile policy was applied under the environment ceilings.
+ */
+export type EffectiveToolPolicy = {
+  allowedTools: readonly string[];
+  disabledTools: readonly string[];
+  shellMode: 'allowlist' | 'all' | 'none';
+  approvalCeiling: 'yolo' | 'standard' | 'strict';
+};
+
+/**
+ * Fully resolved inputs a runtime binding is built from.
+ */
+export type ResolvedProfileSpec = {
+  document: ProfileDocument;
+  credentialBindings: readonly CredentialBinding[];
+  policy: EffectiveToolPolicy;
+  /**
+   * Resolved member documents for a load-balancer spec, keyed by member name.
+   * Carries the captures resolution already loaded so construction forks the
+   * same immutable member sources instead of rereading the repository; absent
+   * for standard documents.
+   */
+  memberDocuments?: Readonly<Record<string, ProfileDocument>>;
+};
+
+/**
+ * A live runtime built from a {@link ResolvedProfileSpec}.
+ *
+ * Disposing the binding releases its runtime resources and load-balancer operational
+ * state. AsyncDisposable ownership scope is what cleans a candidate binding's resources on
+ * build failure or cancellation.
+ */
+export interface ProfileRuntimeBinding extends AsyncDisposable {
+  readonly bindingId: string;
+  /**
+   * Structural equality key for runtime-reuse decisions. Equal configFingerprint
+   * means the existing binding can be reused, preserving load-balancer operational
+   * state instead of rebuilding it.
+   */
+  readonly configFingerprint: string;
+}
+
+/**
+ * Builds runtimes out of resolved profile specs.
+ *
+ * `prior` is the binding currently live for the workspace, when one exists. The
+ * factory owns the reuse decision: it computes the resolved spec's config fingerprint,
+ * and when the prior binding's fingerprint matches the effectively unchanged spec it
+ * returns the prior binding instead of constructing a duplicate. Controllers therefore
+ * never build-then-dispose on the reuse path.
+ */
+export interface ProfileRuntimeFactoryPort {
+  build(
+    spec: ResolvedProfileSpec,
+    prior?: ProfileRuntimeBinding,
+  ): Promise<ProfileRuntimeBinding>;
+}

--- a/packages/core/src/profiles/ports/providerCatalogPort.ts
+++ b/packages/core/src/profiles/ports/providerCatalogPort.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { StandardProfileDocument } from '../contracts/profileDocument.js';
+
+/**
+ * Metadata lookup for provider model catalogs.
+ *
+ * Query boundary for model availability and provider templates. `unknown` means the
+ * catalog metadata is unavailable, which drives unverified (not invalid) command
+ * results: the caller proceeds without a validity claim rather than treating the
+ * model as unsupported.
+ */
+export interface ProviderModelCatalogPort {
+  getDefaultModel(provider: string): Promise<string | undefined>;
+  listModels(provider: string): Promise<readonly string[]>;
+  /**
+   * Validate a model — and any model parameters the candidate carries — against the
+   * catalog's known capability constraints. Parameters the catalog cannot recognize
+   * for a model whose schema it knows produce `invalid` with a reason; a model the
+   * catalog does not know stays `unknown` regardless of parameters.
+   */
+  validateModelSupport(
+    provider: string,
+    model: string,
+    params?: Readonly<Record<string, unknown>>,
+  ): Promise<
+    | { status: 'valid' }
+    | { status: 'invalid'; reason: string }
+    | { status: 'unknown' }
+  >;
+  /**
+   * The restricted blank template the catalog materializes for `provider`, when it
+   * has one; `undefined` when the catalog carries no template for the provider.
+   */
+  getProviderTemplate(
+    provider: string,
+  ): Promise<StandardProfileDocument | undefined>;
+}

--- a/packages/core/src/profiles/ports/schedulerBoundaryPort.ts
+++ b/packages/core/src/profiles/ports/schedulerBoundaryPort.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Outcome of a held safe boundary.
+ *
+ * `committed` carries the value `fn` produced inside the held window; `cancelled`
+ * means the window could not be held (the abort signal fired or the safe point never
+ * arrived) and `fn` never ran. Once `fn` starts, its value must be returned even if
+ * cancellation occurs during execution; `fn` owns checking cancellation before swap.
+ */
+export type SafeBoundaryOutcome<T> =
+  | { status: 'committed'; value: T }
+  | { status: 'cancelled' };
+
+/**
+ * Holds a span in which no work is mid-flight for the calling agent, across the whole
+ * execution of `fn`.
+ *
+ * `safe` here means no model, tool, or continuation work is in-flight for the calling
+ * agent. A parent turn awaiting a subagent still blocks itself: the parent is itself
+ * in-flight until the subagent returns. The implementation MUST hold that safe window
+ * across `fn`'s entire execution — no new work may start between the window opening
+ * and `fn` completing — so a commit that rechecks and swaps inside `fn` can never race
+ * work that starts after the window opens. Resolves `{ status: 'committed', value }`
+ * with `fn`'s value when the window was held, or `{ status: 'cancelled' }` when the
+ * abort signal fires first or the window cannot be held; `fn` is not invoked on
+ * cancellation.
+ *
+ * The coordinator-backed implementation lands with the #2640 cutover.
+ */
+export interface SchedulerBoundaryPort {
+  withSafeBoundary<T>(
+    fn: (signal?: AbortSignal) => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<SafeBoundaryOutcome<T>>;
+}

--- a/packages/core/src/profiles/ports/trustEnvironmentPort.ts
+++ b/packages/core/src/profiles/ports/trustEnvironmentPort.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Environment/trust ceilings for the current process.
+ *
+ * These ceilings are the upper bound granted by the environment (startup flags, OS-level
+ * policy, trust prompts). Profile policy can only narrow them; nothing in the profiles
+ * tree raises a ceiling above what the environment allows.
+ */
+export interface TrustToolEnvironmentPort {
+  getToolCeiling(): {
+    allowedTools: readonly string[];
+    disabledTools: readonly string[];
+  };
+  isToolAvailable(toolId: string): boolean;
+  getShellCeiling(): 'allowlist' | 'all' | 'none';
+  getApprovalCeiling(): 'yolo' | 'standard' | 'strict';
+}

--- a/packages/core/src/profiles/profiles-boundary.test.ts
+++ b/packages/core/src/profiles/profiles-boundary.test.ts
@@ -97,7 +97,8 @@ function collectTsFiles(dir: string): string[] {
  */
 function extractImportSpecifiers(content: string): string[] {
   const specifiers: string[] = [];
-  const statements = /\b(?:from|import)\s+['"]([^'"]+)['"]/g;
+  const statements =
+    /\b(?:(?:from|import)\s+|import\s*\(\s*|import\s+(?:type\s+)?[$\w]+\s*=\s*require\s*\(\s*)['"]([^'"]+)['"]/g;
   for (const match of content.matchAll(statements)) {
     specifiers.push(match[1]);
   }
@@ -134,6 +135,19 @@ function isNodeSpecifier(specifier: string): boolean {
 
 describe('Import boundary scanner', () => {
   for (const forbidden of FORBIDDEN_IMPORT_PACKAGES) {
+    it(`flags dynamic imports and import-equals from ${forbidden}`, () => {
+      const source = `const module = import(
+  '${forbidden}'
+);
+import Provider = require ( "${forbidden}" );
+import type Settings = require('${forbidden}');`;
+      expect(extractImportSpecifiers(source)).toStrictEqual([
+        forbidden,
+        forbidden,
+        forbidden,
+      ]);
+    });
+
     it(`flags multiline imports from ${forbidden}`, () => {
       const source = `import {
   ForbiddenSymbol,

--- a/packages/core/src/profiles/profiles-boundary.test.ts
+++ b/packages/core/src/profiles/profiles-boundary.test.ts
@@ -1,0 +1,242 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Profiles package boundary behavioral tests.
+ *
+ * These tests prove the profiles tree (contracts + ports) stays inside core: no import
+ * reaches the settings or providers packages, no relative import escapes the profiles
+ * directory, and the barrels do not leak implementation-owner symbols. The settings and
+ * providers packages own the real config, secret, and catalog machinery; the profiles tree
+ * names only structural mirrors and reference-only port shapes.
+ *
+ * The credential types (CredentialBinding, CredentialResolverPort, CredentialSecret) are
+ * allowed in the barrels: they are references, not secrets. CredentialBinding holds key
+ * names, paths, and bucket ids; the resolver produces a short-lived secret at use time.
+ *
+ * @plan:PLAN-20260808-ISSUE2643
+ */
+
+import { describe, it, expect } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// This test file lives in packages/core/src/profiles/
+// Resolve paths relative to this file's location
+const THIS_DIR = __dirname; // packages/core/src/profiles
+const PROFILES_DIR = THIS_DIR;
+const CORE_SRC_DIR = path.join(THIS_DIR, '..'); // packages/core/src
+const PACKAGES_CORE_DIR = path.join(CORE_SRC_DIR, '..'); // packages/core
+
+const FORBIDDEN_IMPORT_PACKAGES = [
+  '@vybestack/llxprt-code-settings',
+  '@vybestack/llxprt-code-providers',
+];
+
+const FORBIDDEN_SUBSTRINGS = [
+  'Config',
+  'SettingsService',
+  'ProviderManager',
+  'RuntimeServices',
+  'ServiceBag',
+  'registryId',
+];
+
+/**
+ * Identifier that legitimately contains a forbidden substring and is exempt from the
+ * barrel scan: `ProfileAuthConfig` is a structural contract union ({ type: 'oauth'
+ * } | { type: 'apikey' }) — its name embeds `Config` but it is the
+ * implementation-neutral mirror, not the settings-owned Config symbol. The other five
+ * forbidden substrings must never appear.
+ */
+const ALLOWED_SUBSTRING_CONTAINERS = ['ProfileAuthConfig'];
+
+/**
+ * Return the first forbidden substring present in the content after exempted containers are
+ * removed, or null when none remain.
+ */
+function findForbiddenSubstring(content: string): string | null {
+  let remaining = content;
+  for (const allowed of ALLOWED_SUBSTRING_CONTAINERS) {
+    remaining = remaining.split(allowed).join('');
+  }
+  for (const forbidden of FORBIDDEN_SUBSTRINGS) {
+    if (remaining.includes(forbidden)) {
+      return forbidden;
+    }
+  }
+  return null;
+}
+
+/**
+ * Recursively collect every .ts file under a directory, depth-first.
+ */
+function collectTsFiles(dir: string): string[] {
+  const result: string[] = [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      result.push(...collectTsFiles(fullPath));
+    } else if (entry.name.endsWith('.ts')) {
+      result.push(fullPath);
+    }
+  }
+  return result;
+}
+
+/**
+ * Collect the import specifiers from a TypeScript source file.
+ *
+ * Handles single- and multi-line import/export-from statements across the whole source.
+ * Only the specifier string matters for the escape checks; the imported
+ * names are irrelevant to a package/directory boundary.
+ */
+function extractImportSpecifiers(content: string): string[] {
+  const specifiers: string[] = [];
+  const statements = /\b(?:from|import)\s+['"]([^'"]+)['"]/g;
+  for (const match of content.matchAll(statements)) {
+    specifiers.push(match[1]);
+  }
+  return specifiers;
+}
+
+/**
+ * Normalize a relative specifier against its file's directory and answer whether the
+ * resolved target stays inside the profiles tree.
+ */
+function resolvesWithinProfiles(specifier: string, fileDir: string): boolean {
+  if (specifier.startsWith('./') || specifier.startsWith('../')) {
+    const absolute = path.resolve(fileDir, specifier);
+    const relative = path.relative(PROFILES_DIR, absolute);
+    return !relative.startsWith('..') && !path.isAbsolute(relative);
+  }
+  return false;
+}
+
+/**
+ * Answer whether a specifier resolves to an absolute path outside the profiles tree
+ * (an import escape) versus a package or node: module.
+ */
+function isEscapingRelative(specifier: string, fileDir: string): boolean {
+  if (!specifier.startsWith('./') && !specifier.startsWith('../')) {
+    return false;
+  }
+  return !resolvesWithinProfiles(specifier, fileDir);
+}
+
+function isNodeSpecifier(specifier: string): boolean {
+  return specifier.startsWith('node:');
+}
+
+describe('Import boundary scanner', () => {
+  for (const forbidden of FORBIDDEN_IMPORT_PACKAGES) {
+    it(`flags multiline imports from ${forbidden}`, () => {
+      const source = `import {
+  ForbiddenSymbol,
+  AnotherSymbol,
+} from '${forbidden}';`;
+      const violations = extractImportSpecifiers(source).filter((specifier) =>
+        FORBIDDEN_IMPORT_PACKAGES.includes(specifier),
+      );
+      expect(violations).toStrictEqual([forbidden]);
+    });
+  }
+
+  it('extracts multiline re-exports and side-effect imports', () => {
+    expect(
+      extractImportSpecifiers(`export type {
+  Thing,
+} from '../outside.js';
+import './local.js';`),
+    ).toStrictEqual(['../outside.js', './local.js']);
+  });
+});
+
+describe('Profiles tree must not import settings or providers packages', () => {
+  const profileFiles = collectTsFiles(PROFILES_DIR).filter(
+    (filePath) => !filePath.endsWith('.test.ts'),
+  );
+
+  it('has non-test files to scan', () => {
+    expect(profileFiles.length).toBeGreaterThan(0);
+  });
+
+  for (const filePath of profileFiles) {
+    const relativePath = path.relative(CORE_SRC_DIR, filePath);
+    it(`${relativePath}: no settings/provider package imports`, () => {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      for (const specifier of extractImportSpecifiers(content)) {
+        for (const forbidden of FORBIDDEN_IMPORT_PACKAGES) {
+          expect(specifier).not.toContain(forbidden);
+        }
+      }
+    });
+
+    it(`${relativePath}: no relative import escapes the profiles tree`, () => {
+      const fileDir = path.dirname(filePath);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      for (const specifier of extractImportSpecifiers(content)) {
+        expect(isEscapingRelative(specifier, fileDir)).toBe(false);
+      }
+    });
+  }
+});
+
+describe('Profiles tree imports stay within profiles or node:', () => {
+  const profileFiles = collectTsFiles(PROFILES_DIR).filter(
+    (filePath) => !filePath.endsWith('.test.ts'),
+  );
+
+  for (const filePath of profileFiles) {
+    const relativePath = path.relative(CORE_SRC_DIR, filePath);
+    it(`${relativePath}: every import stays inside profiles or is node:`, () => {
+      const fileDir = path.dirname(filePath);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      for (const specifier of extractImportSpecifiers(content)) {
+        const ok =
+          isNodeSpecifier(specifier) ||
+          resolvesWithinProfiles(specifier, fileDir);
+        expect(ok).toBe(true);
+      }
+    });
+  }
+});
+
+describe('Profiles barrels do not leak implementation-owner symbols', () => {
+  const barrelPaths = [
+    path.join(PROFILES_DIR, 'index.ts'),
+    path.join(PROFILES_DIR, 'contracts', 'index.ts'),
+    path.join(PROFILES_DIR, 'ports', 'index.ts'),
+  ];
+
+  it('reads the three barrels', () => {
+    for (const barrelPath of barrelPaths) {
+      expect(fs.existsSync(barrelPath)).toBe(true);
+    }
+  });
+
+  for (const barrelPath of barrelPaths) {
+    const relativePath = path.relative(PROFILES_DIR, barrelPath);
+    it(`${relativePath}: no forbidden implementation symbols`, () => {
+      const content = fs.readFileSync(barrelPath, 'utf-8');
+      const forbidden = findForbiddenSubstring(content);
+      expect(forbidden).toBeNull();
+    });
+  }
+});
+
+describe('Core package manifest has no providers dependency', () => {
+  it('core package.json dependency list excludes providers', () => {
+    const corePackageJsonPath = path.join(PACKAGES_CORE_DIR, 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(corePackageJsonPath, 'utf-8')) as {
+      dependencies: Record<string, string>;
+    };
+    expect(
+      pkg.dependencies['@vybestack/llxprt-code-providers'],
+    ).toBeUndefined();
+  });
+});

--- a/packages/core/src/profiles/reduction/index.ts
+++ b/packages/core/src/profiles/reduction/index.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Profile reduction exports.
+ *
+ * Each command has a pure reducer plus any internal builder a sibling reuses
+ * (buildLoadCandidate for startup, buildProviderCandidate for provider reset and
+ * startup), so a caller can delegate without duplicating revision logic.
+ */
+
+export type { ConfiguredProfile } from './reduceModelCommand.js';
+export { reduceProfileCommand } from './reduceProfileCommand.js';
+export { reduceModelCommand } from './reduceModelCommand.js';
+export { reduceProviderCommand } from './reduceProviderCommand.js';
+export { buildProviderCandidate } from './reduceProviderCommand.js';
+export { reduceLoadCommand } from './reduceLoadCommand.js';
+export { buildLoadCandidate } from './reduceLoadCommand.js';
+export type { LoadCandidate } from './reduceLoadCommand.js';
+export { reduceSetupCommand } from './reduceSetupCommand.js';
+export { reduceSetCommand } from './reduceSetCommand.js';
+export { reduceSaveCommand } from './reduceSaveCommand.js';
+export { reduceStartupCommand } from './reduceStartupCommand.js';
+export type { ProfileReductionOutcome } from './reductionOutcome.js';
+export { toDraftIdentity } from './reductionOutcome.js';
+export type { ProfileReductionEnvironment } from './reductionEnvironment.js';
+export { emptyReductionEnvironment } from './reductionEnvironment.js';

--- a/packages/core/src/profiles/reduction/reduceLoadCommand.test.ts
+++ b/packages/core/src/profiles/reduction/reduceLoadCommand.test.ts
@@ -1,0 +1,253 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { reduceLoadCommand, buildLoadCandidate } from './reduceLoadCommand.js';
+import { emptyReductionEnvironment } from './reductionEnvironment.js';
+import type { ProfileReductionEnvironment } from './reductionEnvironment.js';
+import type {
+  CapturedStandardSource,
+  SourceFingerprint,
+} from '../contracts/profileState.js';
+import type { LoadBalancerProfileDocument } from '../contracts/profileDocument.js';
+import type { ConfiguredProfile } from './reduceModelCommand.js';
+
+const stat: SourceFingerprint = {
+  kind: 'stat',
+  mtimeMs: 1_700_000_000_000,
+  size: 1024,
+};
+
+const savedState = (revision: number): ConfiguredProfile => ({
+  status: 'configured',
+  revision,
+  identity: { kind: 'saved', name: 'work', source: { ...stat } },
+  document: {
+    version: 1,
+    type: 'standard',
+    provider: 'openai',
+    model: 'gpt-4o',
+    modelParams: {},
+    ephemeralSettings: {},
+  },
+});
+
+const draftState = (revision: number): ConfiguredProfile => ({
+  status: 'configured',
+  revision,
+  identity: { kind: 'draft' },
+  document: {
+    version: 1,
+    provider: 'openai',
+    model: 'gpt-4o',
+    modelParams: {},
+    ephemeralSettings: {},
+  },
+});
+
+const lbDoc: LoadBalancerProfileDocument = {
+  version: 1,
+  type: 'loadbalancer',
+  policy: 'roundrobin' as const,
+  profiles: ['alpha'],
+  provider: 'openai',
+  model: 'gpt-4o',
+  modelParams: { temperature: 0.2 },
+  ephemeralSettings: { 'base-url': 'https://api.example.com' },
+};
+
+const memberCapture = (): CapturedStandardSource => ({
+  revision: 3,
+  provider: 'openai',
+  sourceDocument: {
+    version: 1,
+    provider: 'openai',
+    model: 'gpt-4o',
+    modelParams: { temperature: 0.2 },
+    ephemeralSettings: { 'base-url': 'https://api.example.com' },
+  },
+  models: ['gpt-4o', 'gpt-4o-mini'],
+});
+
+describe('reduceLoadCommand', () => {
+  it('rejects an empty load balancer even with a capture named undefined', () => {
+    expect(
+      reduceLoadCommand(
+        savedState(3),
+        { kind: 'load', name: 'empty', expectedRevision: 3 },
+        {
+          ...emptyReductionEnvironment(),
+          repository: {
+            empty: { document: { ...lbDoc, profiles: [] }, fingerprint: stat },
+          },
+          memberCaptures: { undefined: memberCapture() },
+        },
+      ),
+    ).toStrictEqual({
+      kind: 'invalid',
+      errors: ['load balancer has no members'],
+      revision: 3,
+    });
+  });
+
+  it('is invalid for an unknown profile', () => {
+    const outcome = reduceLoadCommand(
+      savedState(3),
+      { kind: 'load', name: 'missing', expectedRevision: 3 },
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'invalid',
+      errors: ['unknown profile'],
+      revision: 3,
+    });
+  });
+
+  it('asks confirmation for a draft without discardUnsaved', () => {
+    const env: ProfileReductionEnvironment = {
+      ...emptyReductionEnvironment(),
+      repository: {
+        prod: {
+          document: lbDoc,
+          fingerprint: { kind: 'stat', mtimeMs: 1_700_000_000_000, size: 512 },
+        },
+      },
+    };
+    const outcome = reduceLoadCommand(
+      draftState(2),
+      { kind: 'load', name: 'prod', expectedRevision: 2 },
+      env,
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'confirmation-required',
+      pending: {
+        token: 'discard:load:prod',
+        commandKind: 'load',
+        description:
+          'Loading profile prod will discard unsaved changes to the working profile',
+      },
+      revision: 2,
+    });
+  });
+
+  it('loads without confirmation on a configured draft with discardUnsaved', () => {
+    const env: ProfileReductionEnvironment = {
+      ...emptyReductionEnvironment(),
+      repository: {
+        prod: {
+          document: {
+            version: 1,
+            type: 'standard',
+            provider: 'anthropic',
+            model: 'claude-3-7-sonnet',
+            modelParams: {},
+            ephemeralSettings: {},
+          },
+          fingerprint: { kind: 'hash', hash: 'abc123' },
+        },
+      },
+    };
+    const outcome = reduceLoadCommand(
+      draftState(2),
+      { kind: 'load', name: 'prod', discardUnsaved: true, expectedRevision: 2 },
+      env,
+    );
+    expect(outcome.kind).toBe('candidate');
+  });
+
+  it('loads without confirmation on a configured saved identity', () => {
+    const env: ProfileReductionEnvironment = {
+      ...emptyReductionEnvironment(),
+      repository: {
+        prod: {
+          document: {
+            version: 1,
+            provider: 'anthropic',
+            model: 'claude-3-7-sonnet',
+            modelParams: {},
+            ephemeralSettings: {},
+          },
+          fingerprint: { kind: 'hash', hash: 'abc123' },
+        },
+      },
+    };
+    const outcome = reduceLoadCommand(
+      savedState(1),
+      { kind: 'load', name: 'prod', expectedRevision: 1 },
+      env,
+    );
+    expect(outcome.kind).toBe('candidate');
+  });
+
+  it('builds a candidate with saved identity and activeMember from first member when captured', () => {
+    const env: ProfileReductionEnvironment = {
+      ...emptyReductionEnvironment(),
+      repository: {
+        prod: {
+          document: lbDoc,
+          fingerprint: { kind: 'hash', hash: 'abc123' },
+        },
+      },
+      memberCaptures: { alpha: memberCapture() },
+    };
+    const outcome = buildLoadCandidate(draftState(2), 'prod', env);
+    expect(outcome).toStrictEqual({
+      kind: 'candidate',
+      document: lbDoc,
+      identity: {
+        kind: 'saved',
+        name: 'prod',
+        source: { kind: 'hash', hash: 'abc123' },
+      },
+      activeMember: memberCapture(),
+      baseRevision: 2,
+      nextRevision: 3,
+    });
+  });
+});
+
+describe('load environment map safety', () => {
+  it.each(['__proto__', 'toString'])('rejects inherited profile %s', (name) => {
+    expect(
+      reduceLoadCommand(
+        savedState(3),
+        { kind: 'load', name, expectedRevision: 3 },
+        emptyReductionEnvironment(),
+      ),
+    ).toStrictEqual({
+      kind: 'invalid',
+      errors: ['unknown profile'],
+      revision: 3,
+    });
+    expect(
+      buildLoadCandidate(savedState(3), name, emptyReductionEnvironment()),
+    ).toStrictEqual({
+      kind: 'invalid',
+      errors: ['unknown profile'],
+      revision: 3,
+    });
+  });
+
+  it('does not capture an inherited first member', () => {
+    const document: LoadBalancerProfileDocument = {
+      ...lbDoc,
+      profiles: ['toString'],
+    };
+    expect(
+      buildLoadCandidate(savedState(3), 'prod', {
+        ...emptyReductionEnvironment(),
+        repository: { prod: { document, fingerprint: stat } },
+      }),
+    ).toStrictEqual({
+      kind: 'candidate',
+      document,
+      identity: { kind: 'saved', name: 'prod', source: stat },
+      activeMember: undefined,
+      baseRevision: 3,
+      nextRevision: 4,
+    });
+  });
+});

--- a/packages/core/src/profiles/reduction/reduceLoadCommand.ts
+++ b/packages/core/src/profiles/reduction/reduceLoadCommand.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ProfileCommand } from '../contracts/profileCommands.js';
+import type { ProfileDocument } from '../contracts/profileDocument.js';
+import type {
+  CapturedStandardSource,
+  ProfileState,
+  WorkingProfileIdentity,
+} from '../contracts/profileState.js';
+import type { ConfiguredProfile } from './reduceModelCommand.js';
+import type { ProfileReductionEnvironment } from './reductionEnvironment.js';
+import type { ProfileReductionOutcome } from './reductionOutcome.js';
+
+type LoadCommand = Extract<ProfileCommand, { kind: 'load' }>;
+
+export type LoadCandidate = Extract<
+  ProfileReductionOutcome,
+  { kind: 'candidate' }
+>;
+
+/**
+ * Reduce a `/profile load` command for a configured profile.
+ *
+ * Loading replaces the whole workspace, so an unsaved draft is a destructive
+ * operation. On a configured state whose identity is a draft, and without an explicit
+ * discard intent, the outcome is confirmation-required carrying a typed pending
+ * token; only a matching `confirm-discard` command, or `discardUnsaved`, lets the
+ * load proceed.
+ */
+export function reduceLoadCommand(
+  state: ConfiguredProfile,
+  command: LoadCommand,
+  env: ProfileReductionEnvironment,
+): ProfileReductionOutcome {
+  if (!Object.prototype.hasOwnProperty.call(env.repository, command.name)) {
+    return {
+      kind: 'invalid',
+      errors: ['unknown profile'],
+      revision: state.revision,
+    };
+  }
+  const discardUnsaved = command.discardUnsaved === true;
+  if (state.identity.kind === 'draft' && discardUnsaved === false) {
+    return {
+      kind: 'confirmation-required',
+      pending: {
+        token: `discard:load:${command.name}`,
+        commandKind: 'load',
+        description: `Loading profile ${command.name} will discard unsaved changes to the working profile`,
+      },
+      revision: state.revision,
+    };
+  }
+  return buildLoadCandidate(state, command.name, env);
+}
+
+/**
+ * Build a load candidate for `name` from the environment and state.
+ *
+ * The candidate's document is the repository entry verbatim, its identity is saved
+ * against the repository fingerprint, and the revision range is base at the current
+ * state revision plus one. On an unconfigured state the base revision is zero. A
+ * load-balancer document carries the captured source of its first member as
+ * activeMember only when that member appears in `memberCaptures`; a standard
+ * document carries no member.
+ */
+export function buildLoadCandidate(
+  state: ProfileState,
+  name: string,
+  env: ProfileReductionEnvironment,
+): ProfileReductionOutcome {
+  const baseRevision = state.status === 'configured' ? state.revision : 0;
+  if (!Object.prototype.hasOwnProperty.call(env.repository, name)) {
+    return {
+      kind: 'invalid',
+      errors: ['unknown profile'],
+      revision: baseRevision,
+    };
+  }
+  const repositoryEntry = env.repository[name];
+  if (
+    repositoryEntry.document.type === 'loadbalancer' &&
+    repositoryEntry.document.profiles.length === 0
+  ) {
+    return {
+      kind: 'invalid',
+      errors: ['load balancer has no members'],
+      revision: baseRevision,
+    };
+  }
+  const identity: WorkingProfileIdentity = {
+    kind: 'saved',
+    name,
+    source: repositoryEntry.fingerprint,
+  };
+  const activeMember = loadActiveMember(repositoryEntry.document, env);
+  return {
+    kind: 'candidate',
+    document: repositoryEntry.document,
+    identity,
+    activeMember,
+    baseRevision,
+    nextRevision: baseRevision + 1,
+  };
+}
+
+function loadActiveMember(
+  document: ProfileDocument,
+  env: ProfileReductionEnvironment,
+): CapturedStandardSource | undefined {
+  if (document.type !== 'loadbalancer') {
+    return undefined;
+  }
+  const first = document.profiles[0];
+  return Object.prototype.hasOwnProperty.call(env.memberCaptures, first)
+    ? env.memberCaptures[first]
+    : undefined;
+}

--- a/packages/core/src/profiles/reduction/reduceModelCommand.test.ts
+++ b/packages/core/src/profiles/reduction/reduceModelCommand.test.ts
@@ -1,0 +1,299 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { reduceModelCommand } from './reduceModelCommand.js';
+import { emptyReductionEnvironment } from './reductionEnvironment.js';
+import type { ProfileReductionEnvironment } from './reductionEnvironment.js';
+import type { ConfiguredProfile } from './reduceModelCommand.js';
+import type { ProfileCommand } from '../contracts/profileCommands.js';
+import type {
+  CapturedStandardSource,
+  WorkingProfileIdentity,
+} from '../contracts/profileState.js';
+import {
+  isStandardProfileDocument,
+  type ProfileDocument,
+  type ProfileAuthConfig,
+  type StandardProfileDocument,
+} from '../contracts/profileDocument.js';
+
+const revision = 7;
+
+const modelParams = { temperature: 0.7 };
+const ephemeralSettings = { 'auth-key': 'sk-abc' };
+const auth: ProfileAuthConfig = { type: 'oauth', buckets: ['bucket-a'] };
+
+const standardDoc = (): StandardProfileDocument => ({
+  version: 1,
+  type: 'standard',
+  provider: 'anthropic',
+  model: 'claude-3-7-sonnet',
+  modelParams,
+  ephemeralSettings,
+  auth,
+});
+
+const identity = (): Extract<WorkingProfileIdentity, { kind: 'saved' }> => ({
+  kind: 'saved',
+  name: 'work',
+  source: { kind: 'stat', mtimeMs: 1_700_000_000_000, size: 1024 },
+});
+
+const standardState = (): ConfiguredProfile => ({
+  status: 'configured',
+  revision,
+  identity: identity(),
+  document: standardDoc(),
+});
+
+const memberCapture = (
+  provider: string,
+  models: readonly string[],
+): CapturedStandardSource => ({
+  revision: 7,
+  provider,
+  sourceDocument: {
+    version: 1,
+    provider,
+    model: models[0] || 'm1',
+    modelParams: {},
+    ephemeralSettings: {},
+  },
+  models,
+});
+
+const lbDoc = (): ProfileDocument => ({
+  version: 1,
+  type: 'loadbalancer',
+  policy: 'roundrobin',
+  profiles: ['alpha', 'beta'],
+  provider: 'openai',
+  model: 'gpt-4o',
+  modelParams: {},
+  ephemeralSettings: {},
+});
+
+const lbState = (): ConfiguredProfile => ({
+  status: 'configured',
+  revision,
+  identity: identity(),
+  document: lbDoc(),
+  activeMember: memberCapture('openai', ['gpt-4o', 'gpt-4o-mini']),
+});
+
+const modelCommand = (
+  overrides: { model?: string; member?: string } = {},
+): Extract<ProfileCommand, { kind: 'model' }> => ({
+  kind: 'model',
+  model: overrides.model ?? 'claude-3-7-sonnet',
+  expectedRevision: revision,
+  ...(overrides.member === undefined ? {} : { member: overrides.member }),
+});
+
+describe('reduceModelCommand standard document', () => {
+  it('is a no-op when the model is unchanged', () => {
+    const outcome = reduceModelCommand(
+      standardState(),
+      modelCommand({ model: 'claude-3-7-sonnet' }),
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'no-op',
+      reason: 'model unchanged',
+      revision,
+    });
+  });
+
+  it('produces a candidate clone with the new model, draft identity, and no active member', () => {
+    const outcome = reduceModelCommand(
+      standardState(),
+      modelCommand({ model: 'claude-3-5-haiku' }),
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'candidate',
+      document: { ...standardDoc(), model: 'claude-3-5-haiku' },
+      identity: {
+        kind: 'draft',
+        derivedFrom: { name: 'work', source: identity().source },
+      },
+      baseRevision: revision,
+      nextRevision: revision + 1,
+    });
+  });
+
+  it('copies pinned modelParams, ephemeralSettings, and auth by reference', () => {
+    const outcome = reduceModelCommand(
+      standardState(),
+      modelCommand({ model: 'claude-3-5-haiku' }),
+      emptyReductionEnvironment(),
+    );
+    expect(outcome.kind).toBe('candidate');
+    if (outcome.kind !== 'candidate') {
+      return;
+    }
+    if (!isStandardProfileDocument(outcome.document)) {
+      throw new Error('expected a standard document');
+    }
+    expect(outcome.document.modelParams).toBe(modelParams);
+    expect(outcome.document.ephemeralSettings).toBe(ephemeralSettings);
+    expect(outcome.document.auth).toBe(auth);
+  });
+
+  it('never reads a provider template', () => {
+    const divergentEnv: ProfileReductionEnvironment = {
+      ...emptyReductionEnvironment(),
+      providerTemplates: {
+        anthropic: {
+          version: 1,
+          provider: 'anthropic',
+          model: 'would-be-used-if-read',
+          modelParams: { temperature: 9.9 },
+          ephemeralSettings: { 'auth-key': 'from-template' },
+        },
+      },
+    };
+    const outcome = reduceModelCommand(
+      standardState(),
+      modelCommand({ model: 'claude-3-5-haiku' }),
+      divergentEnv,
+    );
+    expect(outcome.kind).toBe('candidate');
+    if (outcome.kind !== 'candidate') {
+      return;
+    }
+    if (!isStandardProfileDocument(outcome.document)) {
+      throw new Error('expected a standard document');
+    }
+    expect(outcome.document.modelParams).toBe(modelParams);
+    expect(outcome.document.ephemeralSettings).toBe(ephemeralSettings);
+    expect(outcome.document.auth).toBe(auth);
+  });
+});
+
+describe('reduceModelCommand load balancer document', () => {
+  it('rejects a captured member belonging to a different load balancer', () => {
+    expect(
+      reduceModelCommand(
+        lbState(),
+        modelCommand({ model: 'gpt-4o-mini', member: 'other-lb-member' }),
+        {
+          ...emptyReductionEnvironment(),
+          memberCaptures: {
+            'other-lb-member': memberCapture('openai', ['gpt-4o-mini']),
+          },
+        },
+      ),
+    ).toStrictEqual({ kind: 'invalid', errors: ['unknown member'], revision });
+  });
+
+  it('reports an unavailable member model menu as unverified', () => {
+    const outcome = reduceModelCommand(
+      { ...lbState(), activeMember: memberCapture('openai', []) },
+      modelCommand({ model: 'gpt-4o-mini' }),
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'unverified',
+      constraints: ['model menu unavailable for provider openai'],
+      revision,
+    });
+  });
+
+  it('forks the active member source into a standard candidate with the patched model', () => {
+    const source = memberCapture('openai', [
+      'gpt-4o',
+      'gpt-4o-mini',
+    ]).sourceDocument;
+    const outcome = reduceModelCommand(
+      lbState(),
+      modelCommand({ model: 'gpt-4o-mini' }),
+      emptyReductionEnvironment(),
+    );
+    expect(outcome.kind).toBe('candidate');
+    if (outcome.kind !== 'candidate') {
+      return;
+    }
+    expect(outcome.document).toStrictEqual({
+      ...source,
+      model: 'gpt-4o-mini',
+    });
+    expect(outcome.document).not.toHaveProperty('type');
+    expect(outcome.identity).toStrictEqual({
+      kind: 'draft',
+      derivedFrom: { name: 'work', source: identity().source },
+    });
+    expect(outcome.activeMember).toBeUndefined();
+    expect(outcome.baseRevision).toBe(revision);
+    expect(outcome.nextRevision).toBe(revision + 1);
+  });
+
+  it('uses command.member over the active member when offered', () => {
+    const member = memberCapture('openai', ['gpt-4o', 'gpt-4o-mini']);
+    const env = {
+      ...emptyReductionEnvironment(),
+      memberCaptures: { alpha: member },
+    };
+    const outcome = reduceModelCommand(
+      lbState(),
+      modelCommand({ model: 'gpt-4o-mini', member: 'alpha' }),
+      env,
+    );
+    expect(outcome.kind).toBe('candidate');
+    if (outcome.kind !== 'candidate') {
+      return;
+    }
+    expect(outcome.document).toStrictEqual({
+      ...member.sourceDocument,
+      model: 'gpt-4o-mini',
+    });
+  });
+
+  it.each(['missing', '__proto__', 'toString'])(
+    'is invalid when member %s is not an own capture',
+    (member) => {
+      const outcome = reduceModelCommand(
+        lbState(),
+        modelCommand({ model: 'gpt-4o-mini', member }),
+        emptyReductionEnvironment(),
+      );
+      expect(outcome).toStrictEqual({
+        kind: 'invalid',
+        errors: ['unknown member'],
+        revision,
+      });
+    },
+  );
+
+  it('is invalid when neither an active member nor command.member is available', () => {
+    const stateWithoutMember: ConfiguredProfile = {
+      status: 'configured',
+      revision,
+      identity: identity(),
+      document: lbDoc(),
+    };
+    const outcome = reduceModelCommand(
+      stateWithoutMember,
+      modelCommand({}),
+      emptyReductionEnvironment(),
+    );
+    expect(outcome.kind).toBe('invalid');
+  });
+
+  it('is invalid when the model is not in the member menu', () => {
+    const outcome = reduceModelCommand(
+      lbState(),
+      modelCommand({ model: 'claude-3-7-sonnet' }),
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'invalid',
+      errors: ['model not offered by member provider'],
+      revision,
+    });
+  });
+});

--- a/packages/core/src/profiles/reduction/reduceModelCommand.ts
+++ b/packages/core/src/profiles/reduction/reduceModelCommand.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ProfileCommand } from '../contracts/profileCommands.js';
+import type { ProfileDocument } from '../contracts/profileDocument.js';
+import type { ProfileState } from '../contracts/profileState.js';
+import type { ProfileReductionEnvironment } from './reductionEnvironment.js';
+import {
+  toDraftIdentity,
+  type ProfileReductionOutcome,
+} from './reductionOutcome.js';
+
+/**
+ * Configured profile state: a workspace with an active document and a revision.
+ */
+export type ConfiguredProfile = Extract<ProfileState, { status: 'configured' }>;
+
+type ModelCommand = Extract<ProfileCommand, { kind: 'model' }>;
+
+/**
+ * Pure reduction of a `/model` command for a configured profile.
+ *
+ * For a standard active document the result is a structural clone patched with the new model:
+ * a no-op when the model is unchanged, otherwise a candidate derived as a draft. For a load
+ * balancer the model must name a member whose captured source offers it; the candidate is a
+ * standard fork of that member's immutable source document, which drops the load-balancer
+ * wrapper. A provider template is never reread here: explicitly pinned values survive into the
+ * clone and omitted values resolve later under the new model's defaults.
+ */
+export function reduceModelCommand(
+  state: ConfiguredProfile,
+  command: ModelCommand,
+  env: ProfileReductionEnvironment,
+): ProfileReductionOutcome {
+  const revision = state.revision;
+  if (state.document.type === 'loadbalancer') {
+    if (
+      command.member !== undefined &&
+      !state.document.profiles.includes(command.member)
+    ) {
+      return { kind: 'invalid', errors: ['unknown member'], revision };
+    }
+    return reduceLoadBalancerModelCommand(state, command, env, revision);
+  }
+  return reduceStandardModelCommand(state, command, revision);
+}
+
+function reduceStandardModelCommand(
+  state: ConfiguredProfile,
+  command: ModelCommand,
+  revision: number,
+): ProfileReductionOutcome {
+  if (command.model === state.document.model) {
+    return { kind: 'no-op', reason: 'model unchanged', revision };
+  }
+  const document: ProfileDocument = {
+    ...state.document,
+    model: command.model,
+  };
+  return {
+    kind: 'candidate',
+    document,
+    identity: toDraftIdentity(state.identity),
+    baseRevision: revision,
+    nextRevision: revision + 1,
+  };
+}
+
+function reduceLoadBalancerModelCommand(
+  state: ConfiguredProfile,
+  command: ModelCommand,
+  env: ProfileReductionEnvironment,
+  revision: number,
+): ProfileReductionOutcome {
+  const explicitMember =
+    command.member !== undefined &&
+    Object.prototype.hasOwnProperty.call(env.memberCaptures, command.member)
+      ? env.memberCaptures[command.member]
+      : undefined;
+  const captured =
+    command.member === undefined ? state.activeMember : explicitMember;
+  if (captured === undefined) {
+    return {
+      kind: 'invalid',
+      errors: ['load-balancer model change requires an explicit member'],
+      revision,
+    };
+  }
+  if (captured.models.length === 0) {
+    return {
+      kind: 'unverified',
+      constraints: [`model menu unavailable for provider ${captured.provider}`],
+      revision,
+    };
+  }
+  if (!captured.models.includes(command.model)) {
+    return {
+      kind: 'invalid',
+      errors: ['model not offered by member provider'],
+      revision,
+    };
+  }
+  const document: ProfileDocument = {
+    ...captured.sourceDocument,
+    model: command.model,
+  };
+  return {
+    kind: 'candidate',
+    document,
+    identity: toDraftIdentity(state.identity),
+    baseRevision: revision,
+    nextRevision: revision + 1,
+  };
+}

--- a/packages/core/src/profiles/reduction/reduceProfileCommand.test.ts
+++ b/packages/core/src/profiles/reduction/reduceProfileCommand.test.ts
@@ -1,0 +1,202 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { reduceProfileCommand } from './reduceProfileCommand.js';
+import { emptyReductionEnvironment } from './reductionEnvironment.js';
+import type { ProfileState } from '../contracts/profileState.js';
+import type { ProfileCommand } from '../contracts/profileCommands.js';
+
+const configured = (revision: number): ProfileState => ({
+  status: 'configured',
+  revision,
+  identity: {
+    kind: 'saved',
+    name: 'work',
+    source: { kind: 'stat', mtimeMs: 1_700_000_000_000, size: 1024 },
+  },
+  document: {
+    version: 1,
+    type: 'standard',
+    provider: 'openai',
+    model: 'gpt-4o',
+    modelParams: {},
+    ephemeralSettings: {},
+  },
+});
+
+describe('reduceProfileCommand revision gate', () => {
+  it('returns stale when expectedRevision mismatches on configured state', () => {
+    const outcome = reduceProfileCommand(
+      configured(4),
+      { kind: 'model', model: 'gpt-4o', expectedRevision: 3 },
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'stale',
+      expectedRevision: 3,
+      currentRevision: 4,
+    });
+  });
+
+  it('accepts a matching expectedRevision', () => {
+    const outcome = reduceProfileCommand(
+      configured(4),
+      { kind: 'model', model: 'gpt-4o', expectedRevision: 4 },
+      emptyReductionEnvironment(),
+    );
+    expect(outcome.kind).toBe('no-op');
+  });
+});
+
+describe('reduceProfileCommand on unconfigured state', () => {
+  it('returns stale when expectedRevision is nonzero', () => {
+    const outcome = reduceProfileCommand(
+      { status: 'unconfigured' },
+      { kind: 'startup', expectedRevision: 1 },
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'stale',
+      expectedRevision: 1,
+      currentRevision: 0,
+    });
+  });
+
+  it('rejects a non-setup/startup command', () => {
+    const outcome = reduceProfileCommand(
+      { status: 'unconfigured' },
+      { kind: 'model', model: 'gpt-4o', expectedRevision: 0 },
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'invalid',
+      errors: ['command requires a configured profile'],
+      revision: 0,
+    });
+  });
+
+  it('starts a blank draft from an unconfigured workspace with setup', () => {
+    const outcome = reduceProfileCommand(
+      { status: 'unconfigured' },
+      { kind: 'setup', expectedRevision: 0 },
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'candidate',
+      document: {
+        version: 1,
+        type: 'standard',
+        provider: '',
+        model: '',
+        modelParams: {},
+        ephemeralSettings: {},
+      },
+      identity: { kind: 'draft' },
+      baseRevision: 0,
+      nextRevision: 1,
+    });
+  });
+
+  it('rejects a blank unconfigured startup with the one-of error', () => {
+    const outcome = reduceProfileCommand(
+      { status: 'unconfigured' },
+      { kind: 'startup', expectedRevision: 0 },
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'invalid',
+      errors: ['startup requires a profile, provider, or model'],
+      revision: 0,
+    });
+  });
+});
+
+describe('reduceProfileCommand confirm-discard', () => {
+  it.each(['x', 'setup', 'provider', 'startup-provider:x'])(
+    'namespaces replacement tokens for profile %s',
+    (name) => {
+      const saved = configured(3);
+      if (
+        saved.status !== 'configured' ||
+        saved.document.type === 'loadbalancer'
+      ) {
+        throw new Error('expected configured standard fixture');
+      }
+      const state: ProfileState = { ...saved, identity: { kind: 'draft' } };
+      const env = {
+        ...emptyReductionEnvironment(),
+        repository: {
+          [name]: {
+            document: saved.document,
+            fingerprint: { kind: 'hash', hash: 'source' },
+          },
+        },
+        providerTemplates: { [name]: saved.document },
+      } satisfies ReturnType<typeof emptyReductionEnvironment>;
+      const commands: ProfileCommand[] = [
+        { kind: 'load', name, expectedRevision: 3 },
+        { kind: 'startup', profileName: name, expectedRevision: 3 },
+        { kind: 'startup', provider: name, expectedRevision: 3 },
+        { kind: 'setup', expectedRevision: 3 },
+        { kind: 'provider', provider: name, expectedRevision: 3 },
+      ];
+      const tokens = commands.map((command) => {
+        const outcome = reduceProfileCommand(state, command, env);
+        if (outcome.kind !== 'confirmation-required') {
+          throw new Error(`expected confirmation, got ${outcome.kind}`);
+        }
+        return outcome.pending.token;
+      });
+      expect(tokens).toStrictEqual([
+        `discard:load:${name}`,
+        `discard:startup:${name}`,
+        `discard:startup-provider:${name}`,
+        'discard:setup',
+        'discard:provider',
+      ]);
+      expect(new Set(tokens).size).toStrictEqual(commands.length);
+    },
+  );
+
+  it('authorizes a discard when the token is non-empty', () => {
+    const outcome = reduceProfileCommand(
+      configured(3),
+      {
+        kind: 'confirm-discard',
+        pending: {
+          token: 'tok-abc',
+          commandKind: 'load',
+          description: 'discard unsaved changes',
+        },
+        expectedRevision: 3,
+      },
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({ kind: 'discard-authorized', revision: 3 });
+  });
+
+  it('rejects a discard with an empty token', () => {
+    const outcome = reduceProfileCommand(
+      configured(3),
+      {
+        kind: 'confirm-discard',
+        pending: {
+          token: '',
+          commandKind: 'load',
+          description: 'discard unsaved changes',
+        },
+        expectedRevision: 3,
+      },
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'invalid',
+      errors: ['pending confirmation token must be non-empty'],
+      revision: 3,
+    });
+  });
+});

--- a/packages/core/src/profiles/reduction/reduceProfileCommand.ts
+++ b/packages/core/src/profiles/reduction/reduceProfileCommand.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ProfileCommand } from '../contracts/profileCommands.js';
+import type { ProfileState } from '../contracts/profileState.js';
+import type { ProfileReductionEnvironment } from './reductionEnvironment.js';
+import type { ProfileReductionOutcome } from './reductionOutcome.js';
+import { reduceModelCommand } from './reduceModelCommand.js';
+import { reduceProviderCommand } from './reduceProviderCommand.js';
+import { reduceLoadCommand } from './reduceLoadCommand.js';
+import { reduceSetupCommand } from './reduceSetupCommand.js';
+import { reduceSetCommand } from './reduceSetCommand.js';
+import { reduceSaveCommand } from './reduceSaveCommand.js';
+import { reduceStartupCommand } from './reduceStartupCommand.js';
+
+type ConfiguredState = Extract<ProfileState, { status: 'configured' }>;
+type ConfirmDiscardCommand = Extract<
+  ProfileCommand,
+  { kind: 'confirm-discard' }
+>;
+
+/**
+ * Pure literal reduction of a profile command against the current workspace state.
+ *
+ * Every branch is pure: it reads only `state`, `command`, and `env`, and returns
+ * an outcome with no I/O. The revision gate runs first so a command aimed at a stale
+ * workspace is rejected before any kind-specific work. `setup` and `startup` are
+ * valid from the unconfigured workspace; every other kind needs a configured one.
+ */
+export function reduceProfileCommand(
+  state: ProfileState,
+  command: ProfileCommand,
+  env: ProfileReductionEnvironment,
+): ProfileReductionOutcome {
+  if (state.status === 'configured') {
+    if (command.expectedRevision !== state.revision) {
+      return {
+        kind: 'stale',
+        expectedRevision: command.expectedRevision,
+        currentRevision: state.revision,
+      };
+    }
+    return reduceConfiguredCommand(state, command, env);
+  }
+  return reduceUnconfiguredCommand(command, env);
+}
+
+function reduceUnconfiguredCommand(
+  command: ProfileCommand,
+  env: ProfileReductionEnvironment,
+): ProfileReductionOutcome {
+  if (command.expectedRevision !== 0) {
+    return {
+      kind: 'stale',
+      expectedRevision: command.expectedRevision,
+      currentRevision: 0,
+    };
+  }
+  if (command.kind === 'setup') {
+    return reduceSetupCommand({ status: 'unconfigured' }, command, env);
+  }
+  if (command.kind === 'startup') {
+    return reduceStartupCommand({ status: 'unconfigured' }, command, env);
+  }
+  return {
+    kind: 'invalid',
+    errors: ['command requires a configured profile'],
+    revision: 0,
+  };
+}
+
+function reduceConfiguredCommand(
+  state: ConfiguredState,
+  command: ProfileCommand,
+  env: ProfileReductionEnvironment,
+): ProfileReductionOutcome {
+  switch (command.kind) {
+    case 'model':
+      return reduceModelCommand(state, command, env);
+    case 'provider':
+      return reduceProviderCommand(state, command, env);
+    case 'load':
+      return reduceLoadCommand(state, command, env);
+    case 'setup':
+      return reduceSetupCommand(state, command, env);
+    case 'set':
+      return reduceSetCommand(state, command, env);
+    case 'save':
+      return reduceSaveCommand(state, command, env);
+    case 'startup':
+      return reduceStartupCommand(state, command, env);
+    case 'confirm-discard':
+      return reduceConfirmDiscard(state, command);
+    default: {
+      const unhandled: never = command;
+      throw new Error(
+        `Unhandled profile command kind: ${String(unhandled)} (reduction)`,
+      );
+    }
+  }
+}
+
+function reduceConfirmDiscard(
+  state: ConfiguredState,
+  command: ConfirmDiscardCommand,
+): ProfileReductionOutcome {
+  if (command.pending.token.length === 0) {
+    return {
+      kind: 'invalid',
+      errors: ['pending confirmation token must be non-empty'],
+      revision: state.revision,
+    };
+  }
+  return { kind: 'discard-authorized', revision: state.revision };
+}

--- a/packages/core/src/profiles/reduction/reduceProviderCommand.test.ts
+++ b/packages/core/src/profiles/reduction/reduceProviderCommand.test.ts
@@ -1,0 +1,175 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { reduceProviderCommand } from './reduceProviderCommand.js';
+import { emptyReductionEnvironment } from './reductionEnvironment.js';
+import type { ProfileReductionEnvironment } from './reductionEnvironment.js';
+import type { ConfiguredProfile } from './reduceModelCommand.js';
+import type { WorkingProfileIdentity } from '../contracts/profileState.js';
+
+const revision = 5;
+
+const identity = (): WorkingProfileIdentity => ({
+  kind: 'saved',
+  name: 'work',
+  source: { kind: 'stat', mtimeMs: 1_700_000_000_000, size: 1024 },
+});
+
+const anthropicTemplate = {
+  version: 1,
+  type: 'standard',
+  provider: 'anthropic',
+  model: 'claude-3-7-sonnet',
+  modelParams: {},
+  ephemeralSettings: { 'auth-key-name': 'creds' },
+} as const;
+
+const openaiState = (): ConfiguredProfile => ({
+  status: 'configured',
+  revision,
+  identity: identity(),
+  document: {
+    version: 1,
+    type: 'standard',
+    provider: 'openai',
+    model: 'gpt-4o',
+    modelParams: { temperature: 0.9 },
+    ephemeralSettings: { 'auth-key': 'sk-current' },
+    auth: { type: 'apikey' },
+  },
+});
+
+const envWith = (
+  overrides: Partial<ProfileReductionEnvironment> = {},
+): ProfileReductionEnvironment => ({
+  ...emptyReductionEnvironment(),
+  ...overrides,
+});
+
+describe('reduceProviderCommand', () => {
+  it.each([undefined, false])(
+    'protects a draft with discardUnsaved=%s',
+    (discardUnsaved) => {
+      expect(
+        reduceProviderCommand(
+          { ...openaiState(), identity: { kind: 'draft' } },
+          {
+            kind: 'provider',
+            provider: 'anthropic',
+            discardUnsaved,
+            expectedRevision: revision,
+          },
+          envWith({ providerTemplates: { anthropic: anthropicTemplate } }),
+        ),
+      ).toStrictEqual({
+        kind: 'confirmation-required',
+        pending: {
+          token: 'discard:provider',
+          commandKind: 'provider',
+          description:
+            'Changing provider will discard unsaved changes to the working profile',
+        },
+        revision,
+      });
+    },
+  );
+
+  it('replaces a draft when discardUnsaved is true', () => {
+    expect(
+      reduceProviderCommand(
+        { ...openaiState(), identity: { kind: 'draft' } },
+        {
+          kind: 'provider',
+          provider: 'anthropic',
+          discardUnsaved: true,
+          expectedRevision: revision,
+        },
+        envWith({ providerTemplates: { anthropic: anthropicTemplate } }),
+      ),
+    ).toStrictEqual({
+      kind: 'candidate',
+      document: anthropicTemplate,
+      identity: { kind: 'draft' },
+      baseRevision: revision,
+      nextRevision: revision + 1,
+    });
+  });
+
+  it('produces a candidate equal to the template with a bare draft identity', () => {
+    const anthropicState = {
+      ...openaiState(),
+      document: { ...anthropicTemplate },
+    };
+    const outcome = reduceProviderCommand(
+      openaiState(),
+      { kind: 'provider', provider: 'anthropic', expectedRevision: revision },
+      envWith({ providerTemplates: { anthropic: anthropicState.document } }),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'candidate',
+      document: { ...anthropicTemplate },
+      identity: { kind: 'draft' },
+      baseRevision: revision,
+      nextRevision: revision + 1,
+    });
+  });
+
+  it('resets to the template even when the provider is unchanged', () => {
+    const openaiTemplate = {
+      version: 1,
+      type: 'standard',
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {},
+    } as const;
+    const outcome = reduceProviderCommand(
+      openaiState(),
+      { kind: 'provider', provider: 'openai', expectedRevision: revision },
+      envWith({ providerTemplates: { openai: { ...openaiTemplate } } }),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'candidate',
+      document: { ...openaiTemplate },
+      identity: { kind: 'draft' },
+      baseRevision: revision,
+      nextRevision: revision + 1,
+    });
+  });
+
+  it('is invalid for an unknown provider', () => {
+    const outcome = reduceProviderCommand(
+      openaiState(),
+      { kind: 'provider', provider: 'nonexistent', expectedRevision: revision },
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'invalid',
+      errors: ['unknown provider template'],
+      revision,
+    });
+  });
+});
+
+describe('provider environment map safety', () => {
+  it.each(['__proto__', 'toString'])(
+    'rejects inherited provider template %s',
+    (provider) => {
+      expect(
+        reduceProviderCommand(
+          openaiState(),
+          { kind: 'provider', provider, expectedRevision: revision },
+          emptyReductionEnvironment(),
+        ),
+      ).toStrictEqual({
+        kind: 'invalid',
+        errors: ['unknown provider template'],
+        revision,
+      });
+    },
+  );
+});

--- a/packages/core/src/profiles/reduction/reduceProviderCommand.ts
+++ b/packages/core/src/profiles/reduction/reduceProviderCommand.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ProfileCommand } from '../contracts/profileCommands.js';
+import type { ProfileDocument } from '../contracts/profileDocument.js';
+import type { ProfileReductionEnvironment } from './reductionEnvironment.js';
+import type { ProfileReductionOutcome } from './reductionOutcome.js';
+import type { ConfiguredProfile } from './reduceModelCommand.js';
+
+type ProviderCommand = Extract<ProfileCommand, { kind: 'provider' }>;
+
+/**
+ * Build a provider candidate from the environment alone.
+ *
+ * The candidate is the provider template exactly as materialized by the caller, copying
+ * nothing from the current document: a blank reset. The base revision comes from the
+ * optional state, otherwise zero; startup uses this directly, and a configured
+ * `/provider` command passes its own state for the revision range.
+ */
+export function buildProviderCandidate(
+  provider: string,
+  env: ProfileReductionEnvironment,
+  state?: ConfiguredProfile,
+): ProfileReductionOutcome {
+  if (!Object.prototype.hasOwnProperty.call(env.providerTemplates, provider)) {
+    return {
+      kind: 'invalid',
+      errors: ['unknown provider template'],
+      revision: state === undefined ? 0 : state.revision,
+    };
+  }
+  const document: ProfileDocument = env.providerTemplates[provider];
+  const baseRevision = state === undefined ? 0 : state.revision;
+  return {
+    kind: 'candidate',
+    document,
+    identity: { kind: 'draft' },
+    baseRevision,
+    nextRevision: baseRevision + 1,
+  };
+}
+
+/**
+ * Pure reduction of a `/provider` command for a configured profile.
+ */
+export function reduceProviderCommand(
+  state: ConfiguredProfile,
+  command: ProviderCommand,
+  env: ProfileReductionEnvironment,
+): ProfileReductionOutcome {
+  if (state.identity.kind === 'draft' && command.discardUnsaved !== true) {
+    return {
+      kind: 'confirmation-required',
+      pending: {
+        token: 'discard:provider',
+        commandKind: 'provider',
+        description:
+          'Changing provider will discard unsaved changes to the working profile',
+      },
+      revision: state.revision,
+    };
+  }
+  return buildProviderCandidate(command.provider, env, state);
+}

--- a/packages/core/src/profiles/reduction/reduceSaveCommand.test.ts
+++ b/packages/core/src/profiles/reduction/reduceSaveCommand.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { reduceSaveCommand } from './reduceSaveCommand.js';
+import { emptyReductionEnvironment } from './reductionEnvironment.js';
+import type { ConfiguredProfile } from './reduceModelCommand.js';
+
+const draftState = (): ConfiguredProfile => ({
+  status: 'configured',
+  revision: 5,
+  identity: { kind: 'draft' },
+  document: {
+    version: 1,
+    provider: 'openai',
+    model: 'gpt-4o',
+    modelParams: {},
+    ephemeralSettings: {},
+  },
+});
+
+const savedState = (): ConfiguredProfile => ({
+  status: 'configured',
+  revision: 5,
+  identity: {
+    kind: 'saved',
+    name: 'work',
+    source: { kind: 'hash', hash: 'abc123' },
+  },
+  document: {
+    version: 1,
+    provider: 'openai',
+    model: 'gpt-4o',
+    modelParams: {},
+    ephemeralSettings: {},
+  },
+});
+
+describe('reduceSaveCommand', () => {
+  it('is invalid when an unsaved draft has no name and none given', () => {
+    const outcome = reduceSaveCommand(
+      draftState(),
+      { kind: 'save', expectedRevision: 5 },
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'invalid',
+      errors: ['save requires a name for an unsaved draft'],
+      revision: 5,
+    });
+  });
+
+  it('is a no-op when a saved identity matches the requested name', () => {
+    const outcome = reduceSaveCommand(
+      savedState(),
+      { kind: 'save', expectedRevision: 5 },
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'no-op',
+      reason: 'working profile already saved and unchanged',
+      revision: 5,
+    });
+  });
+
+  it('carries the working document and unchanged revision in a save outcome', () => {
+    const outcome = reduceSaveCommand(
+      draftState(),
+      { kind: 'save', name: 'prod', expectedRevision: 5 },
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'save',
+      name: 'prod',
+      document: draftState().document,
+      revision: 5,
+    });
+  });
+
+  it('uses the saved name when no name is given', () => {
+    const outcome = reduceSaveCommand(
+      savedState(),
+      { kind: 'save', name: 'alt', expectedRevision: 5 },
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'save',
+      name: 'alt',
+      document: savedState().document,
+      revision: 5,
+    });
+  });
+
+  it('is a save with an explicit new name for a draft', () => {
+    const outcome = reduceSaveCommand(
+      draftState(),
+      { kind: 'save', name: 'alt', expectedRevision: 5 },
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'save',
+      name: 'alt',
+      document: draftState().document,
+      revision: 5,
+    });
+  });
+});

--- a/packages/core/src/profiles/reduction/reduceSaveCommand.ts
+++ b/packages/core/src/profiles/reduction/reduceSaveCommand.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ProfileCommand } from '../contracts/profileCommands.js';
+import type { ProfileReductionEnvironment } from './reductionEnvironment.js';
+import type { ProfileReductionOutcome } from './reductionOutcome.js';
+import type { ConfiguredProfile } from './reduceModelCommand.js';
+
+type SaveCommand = Extract<ProfileCommand, { kind: 'save' }>;
+
+/**
+ * Reduce a `/profile save` command for a configured profile.
+ *
+ * Saving names the working document. A command name wins when offered; otherwise an
+ * already-saved identity supplies its name, and a draft that was never saved has no
+ * name to fall back on. A save that would write the current name back over its own
+ * unchanged working document is a no-op. A real save is a `save` outcome that
+ * carries the working document and the unchanged revision; the controller persists
+ * it through the repository port.
+ *
+ * The no-op requires the current name to match too: a named draft, or a draft
+ * that renames to its source, is the same identity and needs no repository write.
+ */
+function invalid(
+  state: ConfiguredProfile,
+  error: string,
+): ProfileReductionOutcome {
+  return { kind: 'invalid', errors: [error], revision: state.revision };
+}
+
+export function reduceSaveCommand(
+  state: ConfiguredProfile,
+  command: SaveCommand,
+  env: ProfileReductionEnvironment,
+): ProfileReductionOutcome {
+  void env;
+  const name: string | undefined =
+    command.name ??
+    (state.identity.kind === 'saved' ? state.identity.name : undefined);
+  if (name === undefined) {
+    return invalid(state, 'save requires a name for an unsaved draft');
+  }
+  if (state.identity.kind === 'saved' && name === state.identity.name) {
+    return {
+      kind: 'no-op',
+      reason: 'working profile already saved and unchanged',
+      revision: state.revision,
+    };
+  }
+  return {
+    kind: 'save',
+    name,
+    document: state.document,
+    revision: state.revision,
+  };
+}

--- a/packages/core/src/profiles/reduction/reduceSetCommand.test.ts
+++ b/packages/core/src/profiles/reduction/reduceSetCommand.test.ts
@@ -1,0 +1,257 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { reduceSetCommand } from './reduceSetCommand.js';
+import { emptyReductionEnvironment } from './reductionEnvironment.js';
+import type { ProfileCommand } from '../contracts/profileCommands.js';
+import type { CapturedStandardSource } from '../contracts/profileState.js';
+import type { ConfiguredProfile } from './reduceModelCommand.js';
+
+const setCommand = (
+  patch: Record<string, unknown>,
+): Extract<ProfileCommand, { kind: 'set' }> => ({
+  kind: 'set',
+  patch,
+  expectedRevision: 2,
+});
+
+const auth = (): CapturedStandardSource => ({
+  revision: 1,
+  provider: 'openai',
+  sourceDocument: {
+    version: 1,
+    provider: 'openai',
+    model: 'gpt-4o',
+    modelParams: { temperature: 0.2 },
+    ephemeralSettings: { 'base-url': 'https://api.example.com' },
+  },
+  models: ['gpt-4o'],
+});
+
+const state = (): ConfiguredProfile => ({
+  status: 'configured',
+  revision: 2,
+  identity: { kind: 'draft' },
+  document: {
+    version: 1,
+    type: 'standard',
+    provider: 'openai',
+    model: 'gpt-4o',
+    modelParams: { temperature: 0.2 },
+    ephemeralSettings: {
+      temperature: 0.2,
+      'base-url': 'https://api.example.com',
+    },
+  },
+});
+
+const lbState = (): ConfiguredProfile => ({
+  status: 'configured',
+  revision: 2,
+  identity: { kind: 'draft' },
+  activeMember: auth(),
+  document: {
+    version: 1,
+    type: 'loadbalancer',
+    policy: 'roundrobin',
+    profiles: ['alpha'],
+    provider: '',
+    model: '',
+    modelParams: {},
+    ephemeralSettings: { temperature: 0.7 },
+  },
+});
+
+describe('reduceSetCommand', () => {
+  it('rejects every application-owned key with settings guidance', () => {
+    const env = {
+      ...emptyReductionEnvironment(),
+      isApplicationOwnedKey: (key: string) => key === 'temperature',
+    };
+    const outcome = reduceSetCommand(
+      state(),
+      setCommand({ temperature: 0.9, 'base-url': 'u' }),
+      env,
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'invalid',
+      errors: [
+        'key temperature is application-owned; configure it via /settings',
+      ],
+      revision: 2,
+    });
+  });
+
+  it('reports every owned key when several are owned', () => {
+    const env = {
+      ...emptyReductionEnvironment(),
+      isApplicationOwnedKey: (key: string) =>
+        key === 'temperature' || key === 'context-length',
+    };
+    const outcome = reduceSetCommand(
+      state(),
+      setCommand({ temperature: 1.0, 'context-length': 5 }),
+      env,
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'invalid',
+      errors: [
+        'key context-length is application-owned; configure it via /settings',
+        'key temperature is application-owned; configure it via /settings',
+      ],
+      revision: 2,
+    });
+  });
+
+  it('sets a key and derives a draft identity', () => {
+    const outcome = reduceSetCommand(
+      state(),
+      setCommand({ 'base-url': 'https://new.example.com' }),
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'candidate',
+      document: {
+        version: 1,
+        type: 'standard',
+        provider: 'openai',
+        model: 'gpt-4o',
+        modelParams: { temperature: 0.2 },
+        ephemeralSettings: {
+          temperature: 0.2,
+          'base-url': 'https://new.example.com',
+        },
+      },
+      identity: { kind: 'draft' },
+      baseRevision: 2,
+      nextRevision: 3,
+    });
+  });
+
+  it('deletes a key when value is null', () => {
+    const outcome = reduceSetCommand(
+      state(),
+      setCommand({ temperature: null }),
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'candidate',
+      document: {
+        version: 1,
+        type: 'standard',
+        provider: 'openai',
+        model: 'gpt-4o',
+        modelParams: { temperature: 0.2 },
+        ephemeralSettings: { 'base-url': 'https://api.example.com' },
+      },
+      identity: { kind: 'draft' },
+      baseRevision: 2,
+      nextRevision: 3,
+    });
+  });
+
+  it('is a no-op when the patch changes nothing', () => {
+    const outcome = reduceSetCommand(
+      state(),
+      setCommand({ temperature: 0.2 }),
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'no-op',
+      reason: 'patch changes nothing',
+      revision: 2,
+    });
+  });
+
+  it('preserves the active member on a load balancer', () => {
+    const outcome = reduceSetCommand(
+      lbState(),
+      setCommand({ shellMode: 'strict' }),
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'candidate',
+      document: {
+        version: 1,
+        type: 'loadbalancer',
+        policy: 'roundrobin',
+        profiles: ['alpha'],
+        provider: '',
+        model: '',
+        modelParams: {},
+        ephemeralSettings: { temperature: 0.7, shellMode: 'strict' },
+      },
+      identity: { kind: 'draft' },
+      activeMember: auth(),
+      baseRevision: 2,
+      nextRevision: 3,
+    });
+  });
+
+  it('carries no active member on a standard document', () => {
+    const outcome = reduceSetCommand(
+      state(),
+      setCommand({ 'base-url': 'x' }),
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'candidate',
+      document: {
+        version: 1,
+        type: 'standard',
+        provider: 'openai',
+        model: 'gpt-4o',
+        modelParams: { temperature: 0.2 },
+        ephemeralSettings: {
+          'base-url': 'x',
+          temperature: 0.2,
+        },
+      },
+      identity: { kind: 'draft' },
+      baseRevision: 2,
+      nextRevision: 3,
+    });
+  });
+});
+
+describe('set unsafe keys', () => {
+  it.each(['__proto__', 'constructor', 'prototype'])(
+    'rejects %s without changing settings or their prototype',
+    (key) => {
+      const original = state();
+      const env = emptyReductionEnvironment();
+      for (const value of ['x', { polluted: true }]) {
+        expect(
+          reduceSetCommand(original, setCommand({ [key]: value }), env),
+        ).toStrictEqual({
+          kind: 'invalid',
+          errors: [`unsafe setting key ${key}`],
+          revision: 2,
+        });
+      }
+      const valid = reduceSetCommand(
+        original,
+        setCommand({ temperature: 0.9 }),
+        env,
+      );
+      if (valid.kind !== 'candidate') {
+        throw new Error('expected a valid settings candidate');
+      }
+      expect(valid.document.ephemeralSettings).toStrictEqual({
+        temperature: 0.9,
+        'base-url': 'https://api.example.com',
+      });
+      expect(
+        Object.getPrototypeOf(valid.document.ephemeralSettings),
+      ).toStrictEqual(Object.prototype);
+      expect(original).toStrictEqual(state());
+      expect(
+        Object.getPrototypeOf(original.document.ephemeralSettings),
+      ).toStrictEqual(Object.prototype);
+    },
+  );
+});

--- a/packages/core/src/profiles/reduction/reduceSetCommand.ts
+++ b/packages/core/src/profiles/reduction/reduceSetCommand.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ProfileCommand } from '../contracts/profileCommands.js';
+import type { ProfileDocument } from '../contracts/profileDocument.js';
+import type { ProfileReductionOutcome } from './reductionOutcome.js';
+import { toDraftIdentity } from './reductionOutcome.js';
+import type { ProfileReductionEnvironment } from './reductionEnvironment.js';
+import type { ConfiguredProfile } from './reduceModelCommand.js';
+
+type SetCommand = Extract<ProfileCommand, { kind: 'set' }>;
+
+/**
+ * Reduce a profile `/set` command for a configured profile.
+ *
+ * The patch applies only to `ephemeralSettings`. Every key the caller flags as
+ * application-owned is invalid up front with `/settings` guidance; a patch that
+ * changes no key is a no-op. Otherwise the candidate is the cloned document with the
+ * patched settings, a draft identity derived from the current one, and the current
+ * active member preserved for a load balancer.
+ */
+export function reduceSetCommand(
+  state: ConfiguredProfile,
+  command: SetCommand,
+  env: ProfileReductionEnvironment,
+): ProfileReductionOutcome {
+  const ownedKeys: string[] = [];
+  for (const key of Object.keys(command.patch)) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      return {
+        kind: 'invalid',
+        errors: [`unsafe setting key ${key}`],
+        revision: state.revision,
+      };
+    }
+    if (env.isApplicationOwnedKey(key)) {
+      ownedKeys.push(key);
+    }
+  }
+  if (ownedKeys.length > 0) {
+    ownedKeys.sort();
+    return {
+      kind: 'invalid',
+      errors: ownedKeys.map(
+        (owned) =>
+          `key ${owned} is application-owned; configure it via /settings`,
+      ),
+      revision: state.revision,
+    };
+  }
+  const patchedSettings: Record<string, unknown> = {
+    ...state.document.ephemeralSettings,
+  };
+  for (const [key, value] of Object.entries(command.patch)) {
+    if (value === null) {
+      delete patchedSettings[key];
+    } else {
+      patchedSettings[key] = value;
+    }
+  }
+  const identical =
+    Object.keys(patchedSettings).length ===
+      Object.keys(state.document.ephemeralSettings).length &&
+    Object.entries(patchedSettings).every(
+      ([key, value]) => state.document.ephemeralSettings[key] === value,
+    );
+  if (identical) {
+    return {
+      kind: 'no-op',
+      reason: 'patch changes nothing',
+      revision: state.revision,
+    };
+  }
+  const document: ProfileDocument = {
+    ...state.document,
+    ephemeralSettings: patchedSettings,
+  };
+  const activeMember =
+    state.document.type === 'loadbalancer' ? state.activeMember : undefined;
+  const identity = toDraftIdentity(state.identity);
+  const candidate: ProfileReductionOutcome = {
+    kind: 'candidate',
+    document,
+    identity,
+    ...(activeMember === undefined ? {} : { activeMember }),
+    baseRevision: state.revision,
+    nextRevision: state.revision + 1,
+  };
+  return candidate;
+}

--- a/packages/core/src/profiles/reduction/reduceSetupCommand.test.ts
+++ b/packages/core/src/profiles/reduction/reduceSetupCommand.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { reduceSetupCommand } from './reduceSetupCommand.js';
+import { emptyReductionEnvironment } from './reductionEnvironment.js';
+import type { ProfileReductionEnvironment } from './reductionEnvironment.js';
+import type { ProfileState } from '../contracts/profileState.js';
+
+const configured = (): ProfileState => ({
+  status: 'configured',
+  revision: 4,
+  identity: {
+    kind: 'saved',
+    name: 'work',
+    source: { kind: 'stat', mtimeMs: 1_700_000_000_000, size: 1024 },
+  },
+  document: {
+    version: 1,
+    type: 'standard',
+    provider: 'openai',
+    model: 'gpt-4o',
+    modelParams: { temperature: 0.2 },
+    ephemeralSettings: { 'base-url': 'https://api.example.com' },
+  },
+});
+
+const envWith = (): ProfileReductionEnvironment => emptyReductionEnvironment();
+
+describe('reduceSetupCommand', () => {
+  it('builds the exact blank draft from an unconfigured state', () => {
+    const outcome = reduceSetupCommand(
+      { status: 'unconfigured' },
+      { kind: 'setup', expectedRevision: 0 },
+      envWith(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'candidate',
+      document: {
+        version: 1,
+        type: 'standard',
+        provider: '',
+        model: '',
+        modelParams: {},
+        ephemeralSettings: {},
+      },
+      identity: { kind: 'draft' },
+      baseRevision: 0,
+      nextRevision: 1,
+    });
+  });
+
+  it('starts a blank draft from a configured state at its revision', () => {
+    const outcome = reduceSetupCommand(
+      configured(),
+      { kind: 'setup', expectedRevision: 4 },
+      envWith(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'candidate',
+      document: {
+        version: 1,
+        type: 'standard',
+        provider: '',
+        model: '',
+        modelParams: {},
+        ephemeralSettings: {},
+      },
+      identity: { kind: 'draft' },
+      baseRevision: 4,
+      nextRevision: 5,
+    });
+  });
+
+  it('carries no active member', () => {
+    const state: ProfileState = {
+      status: 'configured',
+      revision: 1,
+      identity: { kind: 'draft' },
+      document: {
+        version: 1,
+        provider: 'openai',
+        model: 'gpt-4o',
+        modelParams: {},
+        ephemeralSettings: {},
+      },
+    };
+    const outcome = reduceSetupCommand(
+      state,
+      { kind: 'setup', discardUnsaved: true, expectedRevision: 1 },
+      envWith(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'candidate',
+      document: {
+        version: 1,
+        type: 'standard',
+        provider: '',
+        model: '',
+        modelParams: {},
+        ephemeralSettings: {},
+      },
+      identity: { kind: 'draft' },
+      baseRevision: 1,
+      nextRevision: 2,
+    });
+  });
+});
+
+describe('setup draft replacement', () => {
+  it.each([undefined, false])(
+    'requires confirmation with discardUnsaved=%s',
+    (discardUnsaved) => {
+      const saved = configured();
+      if (saved.status !== 'configured') {
+        throw new Error('expected a configured fixture');
+      }
+      expect(
+        reduceSetupCommand(
+          { ...saved, identity: { kind: 'draft' } },
+          { kind: 'setup', discardUnsaved, expectedRevision: 4 },
+          envWith(),
+        ),
+      ).toStrictEqual({
+        kind: 'confirmation-required',
+        pending: {
+          token: 'discard:setup',
+          commandKind: 'setup',
+          description:
+            'Setup will discard unsaved changes to the working profile',
+        },
+        revision: 4,
+      });
+    },
+  );
+});

--- a/packages/core/src/profiles/reduction/reduceSetupCommand.ts
+++ b/packages/core/src/profiles/reduction/reduceSetupCommand.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ProfileCommand } from '../contracts/profileCommands.js';
+import type { ProfileDocument } from '../contracts/profileDocument.js';
+import type { ProfileState } from '../contracts/profileState.js';
+import type { ProfileReductionEnvironment } from './reductionEnvironment.js';
+import type { ProfileReductionOutcome } from './reductionOutcome.js';
+
+type SetupCommand = Extract<ProfileCommand, { kind: 'setup' }>;
+
+/**
+ * Reduce a `/setup` command.
+ *
+ * Setup always starts a blank wizard draft: an empty standard document with no
+ * provider, model, parameters, settings, or member. It is valid both from the
+ * unconfigured state (base revision zero) and from a configured state (base revision
+ * at the current revision).
+ */
+export function reduceSetupCommand(
+  state: ProfileState,
+  command: SetupCommand,
+  env: ProfileReductionEnvironment,
+): ProfileReductionOutcome {
+  void env;
+  if (
+    state.status === 'configured' &&
+    state.identity.kind === 'draft' &&
+    command.discardUnsaved !== true
+  ) {
+    return {
+      kind: 'confirmation-required',
+      pending: {
+        token: 'discard:setup',
+        commandKind: 'setup',
+        description:
+          'Setup will discard unsaved changes to the working profile',
+      },
+      revision: state.revision,
+    };
+  }
+  const blank: ProfileDocument = {
+    version: 1,
+    type: 'standard',
+    provider: '',
+    model: '',
+    modelParams: {},
+    ephemeralSettings: {},
+  };
+  const baseRevision = state.status === 'configured' ? state.revision : 0;
+  return {
+    kind: 'candidate',
+    document: blank,
+    identity: { kind: 'draft' },
+    baseRevision,
+    nextRevision: baseRevision + 1,
+  };
+}

--- a/packages/core/src/profiles/reduction/reduceStartupCommand.test.ts
+++ b/packages/core/src/profiles/reduction/reduceStartupCommand.test.ts
@@ -1,0 +1,787 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { reduceStartupCommand } from './reduceStartupCommand.js';
+import { emptyReductionEnvironment } from './reductionEnvironment.js';
+import type { ProfileReductionEnvironment } from './reductionEnvironment.js';
+import type {
+  CapturedStandardSource,
+  ProfileState,
+} from '../contracts/profileState.js';
+import type { ProfileCommand } from '../contracts/profileCommands.js';
+
+const profileState = (): ProfileState => ({
+  status: 'configured',
+  revision: 2,
+  identity: { kind: 'draft' },
+  document: {
+    version: 1,
+    provider: 'openai',
+    model: 'gpt-4o',
+    modelParams: { temperature: 0.2 },
+    ephemeralSettings: { 'base-url': 'https://api.example.com' },
+  },
+});
+
+const startup = (
+  overrides: Partial<Extract<ProfileCommand, { kind: 'startup' }>> = {},
+): Extract<ProfileCommand, { kind: 'startup' }> => ({
+  kind: 'startup',
+  ...overrides,
+  expectedRevision: overrides.expectedRevision ?? 0,
+});
+
+const envStandard = {
+  ...emptyReductionEnvironment(),
+  repository: {
+    prod: {
+      document: {
+        version: 1,
+        type: 'standard',
+        provider: 'anthropic',
+        model: 'claude-3-7-sonnet',
+        modelParams: {},
+        ephemeralSettings: {},
+      },
+      fingerprint: { kind: 'hash', hash: 'abc123' },
+    },
+  },
+} satisfies ProfileReductionEnvironment;
+
+const alpha: CapturedStandardSource = {
+  revision: 3,
+  provider: 'openai',
+  sourceDocument: {
+    version: 1,
+    provider: 'openai',
+    model: 'gpt-4o',
+    modelParams: { temperature: 0.2 },
+    ephemeralSettings: { 'base-url': 'https://api.example.com' },
+  },
+  models: ['gpt-4o', 'gpt-4o-mini'],
+};
+
+const lbEnv: ProfileReductionEnvironment = {
+  ...emptyReductionEnvironment(),
+  repository: {
+    lb: {
+      document: {
+        version: 1,
+        type: 'loadbalancer',
+        policy: 'roundrobin',
+        profiles: ['alpha'],
+        provider: '',
+        model: '',
+        modelParams: {},
+        ephemeralSettings: {},
+      },
+      fingerprint: { kind: 'hash', hash: 'lb123' },
+    },
+  },
+  memberCaptures: { alpha },
+};
+
+describe('reduceStartupCommand validation', () => {
+  it('is invalid with none of profile, provider, or model', () => {
+    const outcome = reduceStartupCommand(
+      { status: 'unconfigured' },
+      startup({}),
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'invalid',
+      errors: ['startup requires a profile, provider, or model'],
+      revision: 0,
+    });
+  });
+
+  it('is invalid with both provider and profile', () => {
+    const outcome = reduceStartupCommand(
+      { status: 'unconfigured' },
+      startup({ profileName: 'prod', provider: 'anthropic' }),
+      envStandard,
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'invalid',
+      errors: ['startup cannot specify both provider and profile'],
+      revision: 0,
+    });
+  });
+
+  it('is invalid with a model needing a profile or provider', () => {
+    const outcome = reduceStartupCommand(
+      { status: 'unconfigured' },
+      startup({ model: 'claude-3-7-sonnet' }),
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'invalid',
+      errors: ['startup model requires a profile or provider'],
+      revision: 0,
+    });
+  });
+
+  it('is invalid with a load-balancer profile and model without a member', () => {
+    const outcome = reduceStartupCommand(
+      { status: 'unconfigured' },
+      startup({ profileName: 'lb', model: 'gpt-4o' }),
+      lbEnv,
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'invalid',
+      errors: [
+        'startup with a load-balancer profile and model requires an explicit member',
+      ],
+      revision: 0,
+    });
+  });
+
+  it('is invalid with a load-balancer profile, model, but an unknown member', () => {
+    const outcome = reduceStartupCommand(
+      { status: 'unconfigured' },
+      startup({ profileName: 'lb', model: 'gpt-4o', member: 'beta' }),
+      lbEnv,
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'invalid',
+      errors: ['unknown member'],
+      revision: 0,
+    });
+  });
+
+  it('is invalid when the model is missing from the member menu', () => {
+    const outcome = reduceStartupCommand(
+      { status: 'unconfigured' },
+      startup({ profileName: 'lb', model: 'not-in-menu', member: 'alpha' }),
+      lbEnv,
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'invalid',
+      errors: ['model must be in the member menu'],
+      revision: 0,
+    });
+  });
+
+  it('forks an explicit captured member into a standard candidate with the model', () => {
+    const outcome = reduceStartupCommand(
+      { status: 'unconfigured' },
+      startup({ profileName: 'lb', model: 'gpt-4o', member: 'alpha' }),
+      lbEnv,
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'candidate',
+      document: {
+        version: 1,
+        provider: 'openai',
+        model: 'gpt-4o',
+        modelParams: { temperature: 0.2 },
+        ephemeralSettings: { 'base-url': 'https://api.example.com' },
+      },
+      identity: { kind: 'draft' },
+      baseRevision: 0,
+      nextRevision: 1,
+    });
+  });
+
+  it('starts a standard profile loading a repository document', () => {
+    const outcome = reduceStartupCommand(
+      { status: 'unconfigured' },
+      startup({ profileName: 'prod' }),
+      envStandard,
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'candidate',
+      document: {
+        version: 1,
+        type: 'standard',
+        provider: 'anthropic',
+        model: 'claude-3-7-sonnet',
+        modelParams: {},
+        ephemeralSettings: {},
+      },
+      identity: {
+        kind: 'saved',
+        name: 'prod',
+        source: { kind: 'hash', hash: 'abc123' },
+      },
+      baseRevision: 0,
+      nextRevision: 1,
+    });
+  });
+
+  it('starts a configured state and loads with confirmation on a draft', () => {
+    const outcome = reduceStartupCommand(
+      profileState(),
+      startup({ profileName: 'prod' }),
+      envStandard,
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'confirmation-required',
+      pending: {
+        token: 'discard:startup:prod',
+        commandKind: 'startup',
+        description:
+          'Loading profile prod will discard unsaved changes to the working profile',
+      },
+      revision: 2,
+    });
+  });
+
+  it('applies a model on a loaded standard document', () => {
+    const state: ProfileState = {
+      status: 'configured',
+      revision: 1,
+      identity: {
+        kind: 'saved',
+        name: 'prod',
+        source: { kind: 'hash', hash: 'abc123' },
+      },
+      document: {
+        version: 1,
+        provider: 'openai',
+        model: 'gpt-4o',
+        modelParams: { temperature: 0.2 },
+        ephemeralSettings: { 'base-url': 'https://api.example.com' },
+      },
+    };
+    const outcome = reduceStartupCommand(
+      state,
+      startup({
+        profileName: 'prod',
+        model: 'claude-3-5-haiku',
+        expectedRevision: 1,
+      }),
+      envStandard,
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'candidate',
+      document: {
+        ...envStandard.repository.prod.document,
+        model: 'claude-3-5-haiku',
+      },
+      identity: {
+        kind: 'draft',
+        derivedFrom: {
+          name: 'prod',
+          source: envStandard.repository.prod.fingerprint,
+        },
+      },
+      baseRevision: 1,
+      nextRevision: 2,
+    });
+  });
+
+  it('starts by provider name as a provider reset', () => {
+    const env: ProfileReductionEnvironment = {
+      ...emptyReductionEnvironment(),
+      providerTemplates: {
+        anthropic: {
+          version: 1,
+          type: 'standard',
+          provider: 'anthropic',
+          model: 'claude-3-7-sonnet',
+          modelParams: {},
+          ephemeralSettings: {},
+        },
+      },
+    };
+    const outcome = reduceStartupCommand(
+      { status: 'unconfigured' },
+      startup({ provider: 'anthropic' }),
+      env,
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'candidate',
+      document: {
+        version: 1,
+        type: 'standard',
+        provider: 'anthropic',
+        model: 'claude-3-7-sonnet',
+        modelParams: {},
+        ephemeralSettings: {},
+      },
+      identity: { kind: 'draft' },
+      baseRevision: 0,
+      nextRevision: 1,
+    });
+  });
+
+  it('applies an explicit model on top of the provider template', () => {
+    const env: ProfileReductionEnvironment = {
+      ...emptyReductionEnvironment(),
+      providerTemplates: {
+        anthropic: {
+          version: 1,
+          type: 'standard',
+          provider: 'anthropic',
+          model: 'claude-3-7-sonnet',
+          modelParams: { temperature: 0.4 },
+          ephemeralSettings: { 'auth-key-name': 'creds' },
+        },
+      },
+      providerModelMenus: {
+        anthropic: ['claude-3-7-sonnet', 'claude-3-5-haiku'],
+      },
+    };
+    const outcome = reduceStartupCommand(
+      { status: 'unconfigured' },
+      startup({ provider: 'anthropic', model: 'claude-3-5-haiku' }),
+      env,
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'candidate',
+      document: {
+        version: 1,
+        type: 'standard',
+        provider: 'anthropic',
+        model: 'claude-3-5-haiku',
+        modelParams: { temperature: 0.4 },
+        ephemeralSettings: { 'auth-key-name': 'creds' },
+      },
+      identity: { kind: 'draft' },
+      baseRevision: 0,
+      nextRevision: 1,
+    });
+  });
+
+  it('is invalid when a composed model is outside the provider menu', () => {
+    const env: ProfileReductionEnvironment = {
+      ...emptyReductionEnvironment(),
+      providerTemplates: {
+        anthropic: {
+          version: 1,
+          type: 'standard',
+          provider: 'anthropic',
+          model: 'claude-3-7-sonnet',
+          modelParams: {},
+          ephemeralSettings: {},
+        },
+      },
+      providerModelMenus: {
+        anthropic: ['claude-3-7-sonnet', 'claude-3-5-haiku'],
+      },
+    };
+    const outcome = reduceStartupCommand(
+      { status: 'unconfigured' },
+      startup({ provider: 'anthropic', model: 'gpt-4o' }),
+      env,
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'invalid',
+      errors: ['model must be in the provider menu'],
+      revision: 0,
+    });
+  });
+
+  it('keeps a composed model unverified when no provider menu is captured', () => {
+    const env: ProfileReductionEnvironment = {
+      ...emptyReductionEnvironment(),
+      providerTemplates: {
+        anthropic: {
+          version: 1,
+          type: 'standard',
+          provider: 'anthropic',
+          model: 'claude-3-7-sonnet',
+          modelParams: {},
+          ephemeralSettings: {},
+        },
+      },
+    };
+    const outcome = reduceStartupCommand(
+      { status: 'unconfigured' },
+      startup({ provider: 'anthropic', model: 'gpt-4o' }),
+      env,
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'candidate',
+      document: {
+        version: 1,
+        type: 'standard',
+        provider: 'anthropic',
+        model: 'gpt-4o',
+        modelParams: {},
+        ephemeralSettings: {},
+      },
+      identity: { kind: 'draft' },
+      baseRevision: 0,
+      nextRevision: 1,
+    });
+  });
+
+  it('is invalid for a named profile the repository does not have', () => {
+    const outcome = reduceStartupCommand(
+      { status: 'unconfigured' },
+      startup({ profileName: 'missing' }),
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'invalid',
+      errors: ['unknown profile missing'],
+      revision: 0,
+    });
+  });
+
+  it('is invalid for a missing profile even with a model', () => {
+    const outcome = reduceStartupCommand(
+      { status: 'unconfigured' },
+      startup({ profileName: 'missing', model: 'gpt-4o' }),
+      emptyReductionEnvironment(),
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'invalid',
+      errors: ['unknown profile missing'],
+      revision: 0,
+    });
+  });
+
+  it('advances the revision from a configured state on a provider startup', () => {
+    const env: ProfileReductionEnvironment = {
+      ...emptyReductionEnvironment(),
+      providerTemplates: {
+        anthropic: {
+          version: 1,
+          type: 'standard',
+          provider: 'anthropic',
+          model: 'claude-3-7-sonnet',
+          modelParams: {},
+          ephemeralSettings: {},
+        },
+      },
+    };
+    const state: ProfileState = {
+      status: 'configured',
+      revision: 7,
+      identity: {
+        kind: 'saved',
+        name: 'work',
+        source: { kind: 'hash', hash: 'abc123' },
+      },
+      document: {
+        version: 1,
+        provider: 'openai',
+        model: 'gpt-4o',
+        modelParams: {},
+        ephemeralSettings: {},
+      },
+    };
+    const outcome = reduceStartupCommand(
+      state,
+      startup({ provider: 'anthropic', expectedRevision: 7 }),
+      env,
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'candidate',
+      document: {
+        version: 1,
+        type: 'standard',
+        provider: 'anthropic',
+        model: 'claude-3-7-sonnet',
+        modelParams: {},
+        ephemeralSettings: {},
+      },
+      identity: { kind: 'draft' },
+      baseRevision: 7,
+      nextRevision: 8,
+    });
+  });
+});
+
+describe('startup replacement safety', () => {
+  it.each([undefined, false])(
+    'protects drafts on provider startup with discardUnsaved=%s',
+    (discardUnsaved) => {
+      expect(
+        reduceStartupCommand(
+          profileState(),
+          startup({
+            provider: 'anthropic',
+            discardUnsaved,
+            expectedRevision: 2,
+          }),
+          {
+            ...envStandard,
+            providerTemplates: {
+              anthropic: envStandard.repository.prod.document,
+            },
+          },
+        ),
+      ).toStrictEqual({
+        kind: 'confirmation-required',
+        pending: {
+          token: 'discard:startup-provider:anthropic',
+          commandKind: 'startup',
+          description:
+            'Starting provider anthropic will discard unsaved changes to the working profile',
+        },
+        revision: 2,
+      });
+    },
+  );
+
+  it('allows an explicitly confirmed provider startup over a draft', () => {
+    expect(
+      reduceStartupCommand(
+        profileState(),
+        startup({
+          provider: 'anthropic',
+          discardUnsaved: true,
+          expectedRevision: 2,
+        }),
+        {
+          ...envStandard,
+          providerTemplates: {
+            anthropic: envStandard.repository.prod.document,
+          },
+        },
+      ),
+    ).toStrictEqual({
+      kind: 'candidate',
+      document: envStandard.repository.prod.document,
+      identity: { kind: 'draft' },
+      baseRevision: 2,
+      nextRevision: 3,
+    });
+  });
+
+  it('keeps the loaded saved identity when the requested model is unchanged', () => {
+    expect(
+      reduceStartupCommand(
+        { status: 'unconfigured' },
+        startup({ profileName: 'prod', model: 'claude-3-7-sonnet' }),
+        envStandard,
+      ),
+    ).toStrictEqual({
+      kind: 'candidate',
+      document: envStandard.repository.prod.document,
+      identity: {
+        kind: 'saved',
+        name: 'prod',
+        source: envStandard.repository.prod.fingerprint,
+      },
+      activeMember: undefined,
+      baseRevision: 0,
+      nextRevision: 1,
+    });
+  });
+
+  it('reports a member catalog outage as unverified', () => {
+    expect(
+      reduceStartupCommand(
+        { status: 'unconfigured' },
+        startup({ profileName: 'lb', model: 'gpt-4o-mini', member: 'alpha' }),
+        { ...lbEnv, memberCaptures: { alpha: { ...alpha, models: [] } } },
+      ),
+    ).toStrictEqual({
+      kind: 'unverified',
+      constraints: ['model menu unavailable for provider openai'],
+      revision: 0,
+    });
+  });
+
+  it.each(['__proto__', 'toString'])(
+    'rejects inherited repository entry %s',
+    (profileName) => {
+      expect(
+        reduceStartupCommand(
+          { status: 'unconfigured' },
+          startup({ profileName }),
+          emptyReductionEnvironment(),
+        ),
+      ).toStrictEqual({
+        kind: 'invalid',
+        errors: [`unknown profile ${profileName}`],
+        revision: 0,
+      });
+    },
+  );
+
+  it('rejects an inherited member capture even when listed in the target', () => {
+    const env: ProfileReductionEnvironment = {
+      ...lbEnv,
+      repository: {
+        lb: {
+          ...lbEnv.repository.lb,
+          document: {
+            ...lbEnv.repository.lb.document,
+            type: 'loadbalancer',
+            policy: 'roundrobin',
+            profiles: ['toString'],
+          },
+        },
+      },
+    };
+    expect(
+      reduceStartupCommand(
+        { status: 'unconfigured' },
+        startup({ profileName: 'lb', model: 'gpt-4o', member: 'toString' }),
+        env,
+      ),
+    ).toStrictEqual({
+      kind: 'invalid',
+      errors: ['unknown member'],
+      revision: 0,
+    });
+  });
+
+  it.each([undefined, false])(
+    'requires confirmation before applying a model with discardUnsaved=%s',
+    (discardUnsaved) => {
+      expect(
+        reduceStartupCommand(
+          profileState(),
+          startup({
+            profileName: 'prod',
+            model: 'claude-3-5-haiku',
+            discardUnsaved,
+            expectedRevision: 2,
+          }),
+          envStandard,
+        ),
+      ).toStrictEqual({
+        kind: 'confirmation-required',
+        pending: {
+          token: 'discard:startup:prod',
+          commandKind: 'startup',
+          description:
+            'Loading profile prod will discard unsaved changes to the working profile',
+        },
+        revision: 2,
+      });
+    },
+  );
+
+  it.each([undefined, 'claude-3-5-haiku'])(
+    'loads over a draft with explicit discard and model=%s',
+    (model) => {
+      const outcome = reduceStartupCommand(
+        profileState(),
+        startup({
+          profileName: 'prod',
+          model,
+          discardUnsaved: true,
+          expectedRevision: 2,
+        }),
+        envStandard,
+      );
+      expect(outcome).toStrictEqual({
+        kind: 'candidate',
+        document: {
+          ...envStandard.repository.prod.document,
+          model: model ?? 'claude-3-7-sonnet',
+        },
+        identity:
+          model === undefined
+            ? {
+                kind: 'saved',
+                name: 'prod',
+                source: { kind: 'hash', hash: 'abc123' },
+              }
+            : {
+                kind: 'draft',
+                derivedFrom: {
+                  name: 'prod',
+                  source: { kind: 'hash', hash: 'abc123' },
+                },
+              },
+        baseRevision: 2,
+        nextRevision: 3,
+      });
+    },
+  );
+
+  it.each(['alpha', 'beta'])(
+    'checks member %s against the target load balancer',
+    (member) => {
+      const beta: CapturedStandardSource = {
+        ...alpha,
+        sourceDocument: {
+          ...alpha.sourceDocument,
+          ephemeralSettings: { 'base-url': 'https://beta.example.com' },
+        },
+      };
+      const state: ProfileState = {
+        status: 'configured',
+        revision: 2,
+        identity: {
+          kind: 'saved',
+          name: 'lbA',
+          source: { kind: 'hash', hash: 'lbA' },
+        },
+        document: lbEnv.repository.lb.document,
+        activeMember: alpha,
+      };
+      const env: ProfileReductionEnvironment = {
+        ...lbEnv,
+        repository: {
+          lbB: {
+            document: {
+              ...lbEnv.repository.lb.document,
+              type: 'loadbalancer',
+              policy: 'roundrobin',
+              profiles: ['beta'],
+            },
+            fingerprint: { kind: 'hash', hash: 'lbB' },
+          },
+        },
+        memberCaptures: { alpha, beta },
+      };
+      const outcome = reduceStartupCommand(
+        state,
+        startup({
+          profileName: 'lbB',
+          model: 'gpt-4o-mini',
+          member,
+          expectedRevision: 2,
+        }),
+        env,
+      );
+      expect(outcome).toStrictEqual(
+        member === 'alpha'
+          ? { kind: 'invalid', errors: ['unknown member'], revision: 2 }
+          : {
+              kind: 'candidate',
+              document: { ...beta.sourceDocument, model: 'gpt-4o-mini' },
+              identity: { kind: 'draft' },
+              baseRevision: 2,
+              nextRevision: 3,
+            },
+      );
+    },
+  );
+
+  it('does not use an inherited provider model menu', () => {
+    const outcome = reduceStartupCommand(
+      { status: 'unconfigured' },
+      startup({ provider: 'custom', model: 'custom-model' }),
+      {
+        ...emptyReductionEnvironment(),
+        providerTemplates: {
+          custom: {
+            version: 1,
+            provider: 'toString',
+            model: 'default',
+            modelParams: {},
+            ephemeralSettings: {},
+          },
+        },
+      },
+    );
+    expect(outcome).toStrictEqual({
+      kind: 'candidate',
+      document: {
+        version: 1,
+        provider: 'toString',
+        model: 'custom-model',
+        modelParams: {},
+        ephemeralSettings: {},
+      },
+      identity: { kind: 'draft' },
+      baseRevision: 0,
+      nextRevision: 1,
+    });
+  });
+});

--- a/packages/core/src/profiles/reduction/reduceStartupCommand.ts
+++ b/packages/core/src/profiles/reduction/reduceStartupCommand.ts
@@ -1,0 +1,248 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ProfileCommand } from '../contracts/profileCommands.js';
+import type { ProfileDocument } from '../contracts/profileDocument.js';
+import type { ProfileState } from '../contracts/profileState.js';
+import type { ProfileReductionOutcome } from './reductionOutcome.js';
+import { toDraftIdentity } from './reductionOutcome.js';
+import type { ProfileReductionEnvironment } from './reductionEnvironment.js';
+import { buildLoadCandidate, type LoadCandidate } from './reduceLoadCommand.js';
+import { buildProviderCandidate } from './reduceProviderCommand.js';
+
+type StartupCommand = Extract<ProfileCommand, { kind: 'startup' }>;
+
+/**
+ * Reduce a `startup` command.
+ *
+ * Startup names a profile, a provider, or a model. A blank startup is invalid,
+ * provider-with-profile is invalid, and a model alone is invalid. A named profile
+ * loads through the repository; a name the repository does not have is invalid. The
+ * draft-confirmation rules apply on a configured workspace, and an unconfigured
+ * workspace has nothing to discard. A load-balancer profile with a model forks an
+ * explicit captured member offering the model. A provider-by-name startup is the
+ * blank provider reset, built from the current state so a configured workspace keeps
+ * its revision sequence; a model composed with a provider is applied to the provider
+ * template and checked against that provider's captured model menu when the
+ * environment carries one, and stays unverified when it does not. A model on a
+ * loaded standard document patches only the model.
+ */
+export function reduceStartupCommand(
+  state: ProfileState,
+  command: StartupCommand,
+  env: ProfileReductionEnvironment,
+): ProfileReductionOutcome {
+  if (
+    command.profileName === undefined &&
+    command.provider === undefined &&
+    command.model === undefined
+  ) {
+    return invalid(state, 'startup requires a profile, provider, or model');
+  }
+  if (command.provider !== undefined && command.profileName !== undefined) {
+    return invalid(state, 'startup cannot specify both provider and profile');
+  }
+  if (
+    command.model !== undefined &&
+    command.provider === undefined &&
+    command.profileName === undefined
+  ) {
+    return invalid(state, 'startup model requires a profile or provider');
+  }
+  if (command.provider !== undefined) {
+    if (
+      state.status === 'configured' &&
+      state.identity.kind === 'draft' &&
+      command.discardUnsaved !== true
+    ) {
+      return {
+        kind: 'confirmation-required',
+        pending: {
+          token: `discard:startup-provider:${command.provider}`,
+          commandKind: 'startup',
+          description: `Starting provider ${command.provider} will discard unsaved changes to the working profile`,
+        },
+        revision: state.revision,
+      };
+    }
+    return reduceStartupProvider(state, command.provider, command.model, env);
+  }
+  const name = command.profileName;
+  if (name === undefined) {
+    return invalid(state, 'startup requires a profile, provider, or model');
+  }
+  return reduceStartupProfile(state, name, command, env);
+}
+
+function invalid(state: ProfileState, error: string): ProfileReductionOutcome {
+  const revision = state.status === 'configured' ? state.revision : 0;
+  return { kind: 'invalid', errors: [error], revision };
+}
+
+/**
+ * Reduce a provider-name startup, optionally composed with a model.
+ *
+ * The provider template candidate is built first — with the current state, so a
+ * configured workspace advances `revision -> revision + 1` instead of resetting —
+ * and an explicit model is then applied to that template. When the environment
+ * carries a captured menu for the provider, a model outside it is invalid; without
+ * a menu the composite candidate is returned and model support stays unverified for
+ * candidate resolution to settle.
+ */
+function reduceStartupProvider(
+  state: ProfileState,
+  provider: string,
+  model: string | undefined,
+  env: ProfileReductionEnvironment,
+): ProfileReductionOutcome {
+  const candidate = buildProviderCandidate(
+    provider,
+    env,
+    state.status === 'configured' ? state : undefined,
+  );
+  if (candidate.kind !== 'candidate' || model === undefined) {
+    return candidate;
+  }
+  const menuProvider = candidate.document.provider;
+  if (
+    Object.prototype.hasOwnProperty.call(env.providerModelMenus, menuProvider)
+  ) {
+    const menu = env.providerModelMenus[menuProvider];
+    if (menu.includes(model) === false) {
+      return {
+        kind: 'invalid',
+        errors: ['model must be in the provider menu'],
+        revision: candidate.baseRevision,
+      };
+    }
+  }
+  const document: ProfileDocument = { ...candidate.document, model };
+  return {
+    kind: 'candidate',
+    document,
+    identity: { kind: 'draft' },
+    baseRevision: candidate.baseRevision,
+    nextRevision: candidate.nextRevision,
+  };
+}
+
+function reduceStartupProfile(
+  state: ProfileState,
+  profileName: string,
+  command: StartupCommand,
+  env: ProfileReductionEnvironment,
+): ProfileReductionOutcome {
+  if (!Object.prototype.hasOwnProperty.call(env.repository, profileName)) {
+    return invalid(state, `unknown profile ${profileName}`);
+  }
+  if (
+    state.status === 'configured' &&
+    state.identity.kind === 'draft' &&
+    command.discardUnsaved !== true
+  ) {
+    return {
+      kind: 'confirmation-required',
+      pending: {
+        token: `discard:startup:${profileName}`,
+        commandKind: 'startup',
+        description: `Loading profile ${profileName} will discard unsaved changes to the working profile`,
+      },
+      revision: state.revision,
+    };
+  }
+  const loaded = buildLoadCandidate(state, profileName, env);
+  if (loaded.kind !== 'candidate') {
+    return loaded;
+  }
+  if (command.model !== undefined) {
+    if (loaded.document.type === 'loadbalancer') {
+      return forkLoadBalancerModel(
+        loaded,
+        loaded.document.profiles,
+        command.model,
+        command.member,
+        env,
+      );
+    }
+    return standardForkWithModel(loaded, command.model);
+  }
+  return {
+    kind: 'candidate',
+    document: loaded.document,
+    identity: loaded.identity,
+    ...(loaded.activeMember === undefined
+      ? {}
+      : { activeMember: loaded.activeMember }),
+    baseRevision: loaded.baseRevision,
+    nextRevision: loaded.nextRevision,
+  };
+}
+
+function standardForkWithModel(
+  loaded: LoadCandidate,
+  model: string,
+): ProfileReductionOutcome {
+  if (model === loaded.document.model) {
+    return loaded;
+  }
+  const document: ProfileDocument = { ...loaded.document, model };
+  return {
+    kind: 'candidate',
+    document,
+    identity: toDraftIdentity(loaded.identity),
+    baseRevision: loaded.baseRevision,
+    nextRevision: loaded.nextRevision,
+  };
+}
+function forkLoadBalancerModel(
+  loaded: LoadCandidate,
+  profiles: readonly string[],
+  model: string,
+  member: string | undefined,
+  env: ProfileReductionEnvironment,
+): ProfileReductionOutcome {
+  if (member === undefined) {
+    return {
+      kind: 'invalid',
+      errors: [
+        'startup with a load-balancer profile and model requires an explicit member',
+      ],
+      revision: loaded.baseRevision,
+    };
+  }
+  if (
+    !profiles.includes(member) ||
+    !Object.prototype.hasOwnProperty.call(env.memberCaptures, member)
+  ) {
+    return {
+      kind: 'invalid',
+      errors: ['unknown member'],
+      revision: loaded.baseRevision,
+    };
+  }
+  const captured = env.memberCaptures[member];
+  if (captured.models.length === 0) {
+    return {
+      kind: 'unverified',
+      constraints: [`model menu unavailable for provider ${captured.provider}`],
+      revision: loaded.baseRevision,
+    };
+  }
+  if (captured.models.includes(model) === false) {
+    return {
+      kind: 'invalid',
+      errors: ['model must be in the member menu'],
+      revision: loaded.baseRevision,
+    };
+  }
+  return {
+    kind: 'candidate',
+    document: { ...captured.sourceDocument, model },
+    identity: { kind: 'draft' },
+    baseRevision: loaded.baseRevision,
+    nextRevision: loaded.nextRevision,
+  };
+}

--- a/packages/core/src/profiles/reduction/reductionEnvironment.ts
+++ b/packages/core/src/profiles/reduction/reductionEnvironment.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  ProfileDocument,
+  StandardProfileDocument,
+} from '../contracts/profileDocument.js';
+import type {
+  CapturedStandardSource,
+  SourceFingerprint,
+} from '../contracts/profileState.js';
+
+/**
+ * Pre-fetched plain data and pure predicates the literal reducer runs against.
+ *
+ * The environment carries ONLY plain data (materialized provider templates,
+ * repository documents, member captures) and pure predicates
+ * (isApplicationOwnedKey). All async port access — loading template and repository
+ * documents, resolving credentials — happens in the caller before reduction runs, so
+ * reduceProfileCommand stays pure: same state, command, and environment always
+ * produce the same outcome with no I/O and no side effects.
+ */
+export interface ProfileReductionEnvironment {
+  providerTemplates: Readonly<Record<string, StandardProfileDocument>>;
+  /**
+   * Model menus captured from the provider catalog before reduction runs, keyed by
+   * provider. An absent entry means the catalog offered no menu for that provider,
+   * so a model chosen for it stays unverified until candidate resolution runs.
+   */
+  providerModelMenus: Readonly<Record<string, readonly string[]>>;
+  repository: Readonly<
+    Record<
+      string,
+      { document: ProfileDocument; fingerprint: SourceFingerprint }
+    >
+  >;
+  isApplicationOwnedKey: (key: string) => boolean;
+  memberCaptures: Readonly<Record<string, CapturedStandardSource>>;
+}
+
+/**
+ * Empty reduction environment: empty maps and a classifier that never treats any key as
+ * application-owned. Useful as a baseline in tests and for reducers that read none
+ * of the environment surfaces.
+ */
+export function emptyReductionEnvironment(): ProfileReductionEnvironment {
+  return {
+    providerTemplates: {},
+    providerModelMenus: {},
+    repository: {},
+    isApplicationOwnedKey: () => false,
+    memberCaptures: {},
+  };
+}

--- a/packages/core/src/profiles/reduction/reductionOutcome.test.ts
+++ b/packages/core/src/profiles/reduction/reductionOutcome.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { toDraftIdentity } from './reductionOutcome.js';
+import type { WorkingProfileIdentity } from '../contracts/profileState.js';
+
+const stat = { kind: 'stat', mtimeMs: 1_700_000_000_000, size: 1024 } as const;
+
+const saved = (): WorkingProfileIdentity => ({
+  kind: 'saved',
+  name: 'work',
+  source: { ...stat },
+});
+
+describe('toDraftIdentity', () => {
+  it('converts a saved identity to a draft with derivedFrom', () => {
+    const result = toDraftIdentity(saved());
+    expect(result).toStrictEqual({
+      kind: 'draft',
+      derivedFrom: {
+        name: 'work',
+        source: { kind: 'stat', mtimeMs: 1_700_000_000_000, size: 1024 },
+      },
+    });
+  });
+
+  it('keeps a draft with derivedFrom unchanged', () => {
+    const draft: WorkingProfileIdentity = {
+      kind: 'draft',
+      derivedFrom: { name: 'work', source: { ...stat } },
+    };
+    expect(toDraftIdentity(draft)).toBe(draft);
+  });
+
+  it('keeps a bare draft bare', () => {
+    const draft: WorkingProfileIdentity = { kind: 'draft' };
+    expect(toDraftIdentity(draft)).toBe(draft);
+  });
+});

--- a/packages/core/src/profiles/reduction/reductionOutcome.ts
+++ b/packages/core/src/profiles/reduction/reductionOutcome.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ProfileDocument } from '../contracts/profileDocument.js';
+import type { PendingConfirmation } from '../contracts/profileCommands.js';
+import type {
+  CapturedStandardSource,
+  WorkingProfileIdentity,
+} from '../contracts/profileState.js';
+
+/**
+ * Result of a pure literal reduction step.
+ *
+ * A `candidate` carries the proposed document plus the identity, active member, and
+ * revision range the candidate would commit at. `no-op` and `invalid` carry the
+ * current revision so callers can map fully to ProfileCommandResult without extra
+ * state. `confirmation-required` pauses a destructive command behind a typed
+ * confirmation token. `stale` reports an expected/current revision mismatch.
+ * `discard-authorized` signals that a previously-confirmed unsaved draft may be
+ * overwritten.
+ */
+export type ProfileReductionOutcome =
+  | {
+      kind: 'candidate';
+      document: ProfileDocument;
+      identity: WorkingProfileIdentity;
+      activeMember?: CapturedStandardSource;
+      baseRevision: number;
+      nextRevision: number;
+    }
+  | {
+      kind: 'save';
+      name: string;
+      document: ProfileDocument;
+      revision: number;
+    }
+  | { kind: 'no-op'; reason: string; revision: number }
+  | { kind: 'invalid'; errors: string[]; revision: number }
+  | { kind: 'unverified'; constraints: string[]; revision: number }
+  | {
+      kind: 'confirmation-required';
+      pending: PendingConfirmation;
+      revision: number;
+    }
+  | { kind: 'stale'; expectedRevision: number; currentRevision: number }
+  | { kind: 'discard-authorized'; revision: number };
+
+/**
+ * Convert a saved identity to a draft derived from it.
+ *
+ * A saved `{ name, source }` identity becomes `{ kind: 'draft', derivedFrom: { name,
+ * source } }`, recording that the workspace was detached from its source file. An
+ * already-draft identity is returned unchanged with the same derivedFrom, so the
+ * conversion is idempotent and never overwrites an existing derivation chain.
+ */
+export function toDraftIdentity(
+  identity: WorkingProfileIdentity,
+): WorkingProfileIdentity {
+  if (identity.kind === 'draft') {
+    return identity;
+  }
+  return {
+    kind: 'draft',
+    derivedFrom: { name: identity.name, source: identity.source },
+  };
+}

--- a/packages/core/src/profiles/resolution.test.ts
+++ b/packages/core/src/profiles/resolution.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  deriveCredentialBindings,
+  deriveMemberAuthBinding,
+  memberCredentialBindings,
+  intersectPolicy,
+} from './resolution/index.js';
+import type {
+  LoadBalancerProfileDocument,
+  StandardProfileDocument,
+} from './contracts/profileDocument.js';
+
+describe('resolution module coverage exports', () => {
+  it('derives oauth credentials from a member', () => {
+    const doc: StandardProfileDocument = {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: {},
+      auth: { type: 'oauth' as const, buckets: ['b1'] },
+    };
+    expect(deriveCredentialBindings(doc).bindings).toStrictEqual([
+      { kind: 'oauth', provider: 'openai', buckets: ['b1'] },
+    ]);
+  });
+
+  it('derives member auth binding', () => {
+    const member: StandardProfileDocument = {
+      version: 1,
+      provider: 'anthropic',
+      model: 'claude',
+      modelParams: {},
+      ephemeralSettings: { 'auth-key-name': 'A' },
+    };
+    expect(deriveMemberAuthBinding(member).binding).toStrictEqual({
+      kind: 'key-name',
+      keyName: 'A',
+    });
+  });
+
+  it('resolves members with attribution', () => {
+    const lb: LoadBalancerProfileDocument = {
+      version: 1,
+      type: 'loadbalancer',
+      policy: 'roundrobin',
+      profiles: ['miss'],
+      provider: '',
+      model: '',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+    const members: Partial<Record<string, StandardProfileDocument>> = {};
+    const out = memberCredentialBindings(lb, members);
+    expect(out.warnings).toStrictEqual(['member miss document unavailable']);
+  });
+
+  it('intersects profile policies', () => {
+    const policy = intersectPolicy({ allowedTools: ['x'] }, {}, {});
+    expect(policy.policy.allowedTools).toStrictEqual(['x']);
+  });
+});

--- a/packages/core/src/profiles/resolution/credentialBindings.test.ts
+++ b/packages/core/src/profiles/resolution/credentialBindings.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import type { StandardProfileDocument } from '../contracts/profileDocument.js';
+import { deriveCredentialBindings } from './credentialBindings.js';
+
+const base = (): StandardProfileDocument => ({
+  version: 1,
+  provider: 'openai',
+  model: 'gpt-4o',
+  modelParams: {},
+  ephemeralSettings: {},
+});
+
+describe('deriveCredentialBindings precedence', () => {
+  it('prefers an OAuth auth config', () => {
+    const outcome = deriveCredentialBindings({
+      ...base(),
+      auth: { type: 'oauth', buckets: ['bucket-a', 'bucket-b'] },
+    });
+    expect(outcome).toStrictEqual({
+      bindings: [
+        {
+          kind: 'oauth',
+          provider: 'openai',
+          buckets: ['bucket-a', 'bucket-b'],
+        },
+      ],
+      warnings: [],
+    });
+  });
+
+  it('uses OAuth with empty buckets when none are given', () => {
+    const outcome = deriveCredentialBindings({
+      ...base(),
+      auth: { type: 'oauth' },
+    });
+    expect(outcome).toStrictEqual({
+      bindings: [{ kind: 'oauth', provider: 'openai', buckets: [] }],
+      warnings: [],
+    });
+  });
+
+  it('uses an auth-key-name setting next', () => {
+    const outcome = deriveCredentialBindings({
+      ...base(),
+      ephemeralSettings: { 'auth-key-name': 'LLM_API_KEY' },
+    });
+    expect(outcome).toStrictEqual({
+      bindings: [{ kind: 'key-name', keyName: 'LLM_API_KEY' }],
+      warnings: [],
+    });
+  });
+
+  it('uses an auth-keyfile setting over an inline auth-key', () => {
+    const outcome = deriveCredentialBindings({
+      ...base(),
+      ephemeralSettings: {
+        'auth-keyfile': '~/.keys/openai.pem',
+        'auth-key': 'sk-secret-abc',
+      },
+    });
+    expect(outcome).toStrictEqual({
+      bindings: [{ kind: 'keyfile', path: '~/.keys/openai.pem' }],
+      warnings: [],
+    });
+  });
+
+  it('prefers auth-key-name over auth-keyfile and inline auth-key', () => {
+    const outcome = deriveCredentialBindings({
+      ...base(),
+      ephemeralSettings: {
+        'auth-key-name': 'OPENAI_KEY',
+        'auth-keyfile': '~/.keys/openai.pem',
+        'auth-key': 'sk-secret-abc',
+      },
+    });
+    expect(outcome).toStrictEqual({
+      bindings: [{ kind: 'key-name', keyName: 'OPENAI_KEY' }],
+      warnings: [],
+    });
+  });
+
+  it('warns on an inline auth-key without a key-name or keyfile', () => {
+    const outcome = deriveCredentialBindings({
+      ...base(),
+      ephemeralSettings: { 'auth-key': 'sk-secret-abc' },
+    });
+    expect(outcome).toStrictEqual({
+      bindings: [],
+      warnings: ['inline auth-key present; prefer auth-key-name for rotation'],
+    });
+  });
+
+  it('falls back to a provider-default binding when there is a provider', () => {
+    const outcome = deriveCredentialBindings({
+      ...base(),
+      provider: 'anthropic',
+    });
+    expect(outcome).toStrictEqual({
+      bindings: [{ kind: 'provider-default', provider: 'anthropic' }],
+      warnings: [],
+    });
+  });
+
+  it('returns an empty result for an empty provider', () => {
+    const outcome = deriveCredentialBindings({
+      ...base(),
+      provider: '',
+    });
+    expect(outcome).toStrictEqual({
+      bindings: [],
+      warnings: [],
+    });
+  });
+
+  it('never copies secret material into bindings', () => {
+    const outcome = deriveCredentialBindings({
+      ...base(),
+      ephemeralSettings: { 'auth-key': 'sk-super-secret-value' },
+    });
+    const serialized = JSON.stringify(outcome.bindings);
+    expect(serialized).not.toContain('sk-super-secret-value');
+    expect(outcome.bindings).toHaveLength(0);
+  });
+});

--- a/packages/core/src/profiles/resolution/credentialBindings.ts
+++ b/packages/core/src/profiles/resolution/credentialBindings.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CredentialBinding } from '../ports/credentialResolverPort.js';
+import type { StandardProfileDocument } from '../contracts/profileDocument.js';
+
+export type CredentialBindingOutcome = {
+  bindings: readonly CredentialBinding[];
+  warnings: readonly string[];
+};
+
+/**
+ * Derive credential bindings from a standard profile document.
+ *
+ * The first explicit intent wins: OAuth auth config, an auth-key-name setting, an
+ * auth-keyfile path, or a present auth-key. An inline auth-key is only a warning
+ * because the key itself is secret material and is never copied into a binding. Without
+ * explicit intent the provider itself is the binding; an empty provider means no binding
+ * at all. Bindings carry references only, never secrets.
+ */
+export function deriveCredentialBindings(
+  document: StandardProfileDocument,
+): CredentialBindingOutcome {
+  if (document.auth?.type === 'oauth') {
+    return {
+      bindings: [
+        {
+          kind: 'oauth',
+          provider: document.provider,
+          buckets: document.auth.buckets ?? [],
+        },
+      ],
+      warnings: [],
+    };
+  }
+  const keyName = document.ephemeralSettings['auth-key-name'];
+  if (typeof keyName === 'string') {
+    return {
+      bindings: [{ kind: 'key-name', keyName }],
+      warnings: [],
+    };
+  }
+  const keyfile = document.ephemeralSettings['auth-keyfile'];
+  if (typeof keyfile === 'string') {
+    return {
+      bindings: [{ kind: 'keyfile', path: keyfile }],
+      warnings: [],
+    };
+  }
+  if (document.ephemeralSettings['auth-key'] !== undefined) {
+    return {
+      bindings: [],
+      warnings: ['inline auth-key present; prefer auth-key-name for rotation'],
+    };
+  }
+  if (document.provider !== '') {
+    return {
+      bindings: [{ kind: 'provider-default', provider: document.provider }],
+      warnings: [],
+    };
+  }
+  return { bindings: [], warnings: [] };
+}

--- a/packages/core/src/profiles/resolution/index.ts
+++ b/packages/core/src/profiles/resolution/index.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Profile resolution exports.
+ *
+ * Resolution turns profile intent into executable references: credential
+ * bindings derived from standard documents, load-balancer member bindings, and
+ * the effective tool policy under the environment and session ceilings.
+ * Bindings carry references only, never secret material.
+ */
+
+export {
+  deriveCredentialBindings,
+  type CredentialBindingOutcome,
+} from './credentialBindings.js';
+export {
+  deriveMemberAuthBinding,
+  memberCredentialBindings,
+  type MemberAuthOutcome,
+  type MemberCredentialOutcome,
+} from './memberAuthResolution.js';
+export {
+  intersectPolicy,
+  type ProfilePolicyIntent,
+  type PolicyCeiling,
+  type PolicyExplanation,
+  type PolicyIntersectionOutcome,
+} from './policyIntersection.js';
+export {
+  resolveProfileCandidate,
+  type ProfileCandidateResolutionInput,
+  type ResolveProfileCandidateDeps,
+  type ProfileCandidateResolution,
+} from './resolveProfileCandidate.js';

--- a/packages/core/src/profiles/resolution/memberAuthResolution.test.ts
+++ b/packages/core/src/profiles/resolution/memberAuthResolution.test.ts
@@ -1,0 +1,186 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import type {
+  LoadBalancerProfileDocument,
+  StandardProfileDocument,
+} from '../contracts/profileDocument.js';
+import {
+  deriveMemberAuthBinding,
+  memberCredentialBindings,
+} from './memberAuthResolution.js';
+
+const member = (
+  overrides: Partial<StandardProfileDocument> = {},
+): StandardProfileDocument => ({
+  version: 1,
+  provider: 'openai',
+  model: 'gpt-4o',
+  modelParams: {},
+  ephemeralSettings: {},
+  ...overrides,
+});
+
+const lb = (profiles: readonly string[]): LoadBalancerProfileDocument => ({
+  version: 1,
+  type: 'loadbalancer',
+  policy: 'roundrobin',
+  profiles,
+  provider: '',
+  model: '',
+  modelParams: {},
+  ephemeralSettings: {},
+});
+
+describe('deriveMemberAuthBinding', () => {
+  it('prefers a member OAuth auth config', () => {
+    const outcome = deriveMemberAuthBinding(
+      member({ auth: { type: 'oauth', buckets: ['member-bucket'] } }),
+    );
+    expect(outcome).toStrictEqual({
+      binding: {
+        kind: 'oauth',
+        provider: 'openai',
+        buckets: ['member-bucket'],
+      },
+      warnings: [],
+    });
+  });
+
+  it('keeps the member OAuth buckets distinct that differ from the parent', () => {
+    const outcome = deriveMemberAuthBinding(
+      member({
+        provider: 'anthropic',
+        auth: { type: 'oauth', buckets: ['anthropic-prod'] },
+      }),
+    );
+    expect(outcome).toStrictEqual({
+      binding: {
+        kind: 'oauth',
+        provider: 'anthropic',
+        buckets: ['anthropic-prod'],
+      },
+      warnings: [],
+    });
+  });
+
+  it('uses a member key-name without the parent key-file', () => {
+    const outcome = deriveMemberAuthBinding(
+      member({ ephemeralSettings: { 'auth-key-name': 'MEMBER_KEY' } }),
+    );
+    expect(outcome).toStrictEqual({
+      binding: { kind: 'key-name', keyName: 'MEMBER_KEY' },
+      warnings: [],
+    });
+  });
+
+  it('warns on a member inline auth-key', () => {
+    const outcome = deriveMemberAuthBinding(
+      member({ ephemeralSettings: { 'auth-key': 'member-secret' } }),
+    );
+    expect(outcome).toStrictEqual({
+      binding: undefined,
+      warnings: ['inline auth-key present; prefer auth-key-name for rotation'],
+    });
+  });
+
+  it('falls back to the member provider without explicit intent', () => {
+    const outcome = deriveMemberAuthBinding(member({ provider: 'openai' }));
+    expect(outcome).toStrictEqual({
+      binding: { kind: 'provider-default', provider: 'openai' },
+      warnings: [],
+    });
+  });
+
+  it('scopes binding to the own member provider when only its auth-key-name matters', () => {
+    const outcome = deriveMemberAuthBinding(
+      member({
+        provider: 'anthropic',
+        ephemeralSettings: { 'auth-key-name': 'PARENT_OWNED' },
+      }),
+    );
+    expect(outcome).toStrictEqual({
+      binding: { kind: 'key-name', keyName: 'PARENT_OWNED' },
+      warnings: [],
+    });
+  });
+});
+
+describe('memberCredentialBindings', () => {
+  it('resolves members in lb.profiles order', () => {
+    const members = {
+      alpha: member({
+        provider: 'openai',
+        auth: { type: 'oauth', buckets: ['alpha-bucket'] },
+      }),
+      beta: member({ provider: 'anthropic' }),
+    };
+    const outcome = memberCredentialBindings(lb(['alpha', 'beta']), members);
+    expect(outcome.bindings).toStrictEqual([
+      { kind: 'oauth', provider: 'openai', buckets: ['alpha-bucket'] },
+      { kind: 'provider-default', provider: 'anthropic' },
+    ]);
+    expect(outcome.perMember).toStrictEqual([
+      {
+        member: 'alpha',
+        binding: {
+          kind: 'oauth',
+          provider: 'openai',
+          buckets: ['alpha-bucket'],
+        },
+      },
+      {
+        member: 'beta',
+        binding: { kind: 'provider-default', provider: 'anthropic' },
+      },
+    ]);
+    expect(outcome.warnings).toStrictEqual([]);
+  });
+
+  it('keeps a member OAuth binding distinct from a parent OAuth config', () => {
+    const members = {
+      parent: member({
+        provider: 'openai',
+        ephemeralSettings: { 'auth-key-name': 'PARENT_KEY' },
+      }),
+    };
+    const outcome = memberCredentialBindings(lb(['parent']), members);
+    expect(outcome.bindings).toStrictEqual([
+      { kind: 'key-name', keyName: 'PARENT_KEY' },
+    ]);
+  });
+
+  it('emits a warning and no binding for a missing member', () => {
+    const outcome = memberCredentialBindings(lb(['alpha']), {});
+    expect(outcome.bindings).toStrictEqual([]);
+    expect(outcome.perMember).toStrictEqual([
+      { member: 'alpha', binding: undefined },
+    ]);
+    expect(outcome.warnings).toStrictEqual([
+      'member alpha document unavailable',
+    ]);
+  });
+
+  it('preserves per-member order when a middle member is missing', () => {
+    const outcome = memberCredentialBindings(lb(['alpha', 'missing', 'beta']), {
+      beta: member({ provider: 'anthropic' }),
+      alpha: member({ provider: 'openai' }),
+    });
+    expect(outcome.perMember.map((entry) => entry.member)).toStrictEqual([
+      'alpha',
+      'missing',
+      'beta',
+    ]);
+    expect(outcome.warnings).toStrictEqual([
+      'member missing document unavailable',
+    ]);
+    expect(outcome.bindings).toStrictEqual([
+      { kind: 'provider-default', provider: 'openai' },
+      { kind: 'provider-default', provider: 'anthropic' },
+    ]);
+  });
+});

--- a/packages/core/src/profiles/resolution/memberAuthResolution.test.ts
+++ b/packages/core/src/profiles/resolution/memberAuthResolution.test.ts
@@ -111,6 +111,17 @@ describe('deriveMemberAuthBinding', () => {
 });
 
 describe('memberCredentialBindings', () => {
+  it.each(['__proto__', 'constructor', 'toString'])(
+    'does not bind inherited member %s',
+    (name) => {
+      expect(memberCredentialBindings(lb([name]), {})).toStrictEqual({
+        bindings: [],
+        perMember: [{ member: name, binding: undefined }],
+        warnings: [`member ${name} document unavailable`],
+      });
+    },
+  );
+
   it('resolves members in lb.profiles order', () => {
     const members = {
       alpha: member({

--- a/packages/core/src/profiles/resolution/memberAuthResolution.ts
+++ b/packages/core/src/profiles/resolution/memberAuthResolution.ts
@@ -89,7 +89,9 @@ export function memberCredentialBindings(
   }> = [];
   const warnings: string[] = [];
   for (const name of lb.profiles) {
-    const member = members[name];
+    const member = Object.prototype.hasOwnProperty.call(members, name)
+      ? members[name]
+      : undefined;
     if (member === undefined) {
       perMember.push({ member: name, binding: undefined });
       warnings.push(`member ${name} document unavailable`);

--- a/packages/core/src/profiles/resolution/memberAuthResolution.ts
+++ b/packages/core/src/profiles/resolution/memberAuthResolution.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CredentialBinding } from '../ports/credentialResolverPort.js';
+import type {
+  LoadBalancerProfileDocument,
+  StandardProfileDocument,
+} from '../contracts/profileDocument.js';
+
+export type MemberAuthOutcome = {
+  binding: CredentialBinding | undefined;
+  warnings: readonly string[];
+};
+
+export type MemberCredentialOutcome = {
+  bindings: readonly CredentialBinding[];
+  perMember: ReadonlyArray<{
+    member: string;
+    binding: CredentialBinding | undefined;
+  }>;
+  warnings: readonly string[];
+};
+
+/**
+ * Derive a single member's credential binding.
+ *
+ * Precedence mirrors the standalone document derivation, scoped to the member. A member
+ * with no explicit intent falls back to its own provider. Each member resolves its OWN
+ * auth identity and never inherits any parent credential intent.
+ */
+export function deriveMemberAuthBinding(
+  member: StandardProfileDocument,
+): MemberAuthOutcome {
+  if (member.auth?.type === 'oauth') {
+    return {
+      binding: {
+        kind: 'oauth',
+        provider: member.provider,
+        buckets: member.auth.buckets ?? [],
+      },
+      warnings: [],
+    };
+  }
+  const keyName = member.ephemeralSettings['auth-key-name'];
+  if (typeof keyName === 'string') {
+    return {
+      binding: { kind: 'key-name', keyName },
+      warnings: [],
+    };
+  }
+  const keyfile = member.ephemeralSettings['auth-keyfile'];
+  if (typeof keyfile === 'string') {
+    return {
+      binding: { kind: 'keyfile', path: keyfile },
+      warnings: [],
+    };
+  }
+  if (member.ephemeralSettings['auth-key'] !== undefined) {
+    return {
+      binding: undefined,
+      warnings: ['inline auth-key present; prefer auth-key-name for rotation'],
+    };
+  }
+  return {
+    binding: { kind: 'provider-default', provider: member.provider },
+    warnings: [],
+  };
+}
+
+/**
+ * Resolve every load-balancer member in `lb.profiles` order.
+ *
+ * Members are resolved in the load balancer's declared order with per-member
+ * attribution: a member's binding always comes from the member's own document. A
+ * member missing from the map produces a warning and no binding instead of erroring, so a
+ * partially captured member set still resolves what it has.
+ */
+export function memberCredentialBindings(
+  lb: LoadBalancerProfileDocument,
+  members: Partial<Record<string, StandardProfileDocument>>,
+): MemberCredentialOutcome {
+  const bindings: CredentialBinding[] = [];
+  const perMember: Array<{
+    member: string;
+    binding: CredentialBinding | undefined;
+  }> = [];
+  const warnings: string[] = [];
+  for (const name of lb.profiles) {
+    const member = members[name];
+    if (member === undefined) {
+      perMember.push({ member: name, binding: undefined });
+      warnings.push(`member ${name} document unavailable`);
+      continue;
+    }
+    const outcome = deriveMemberAuthBinding(member);
+    perMember.push({ member: name, binding: outcome.binding });
+    if (outcome.binding !== undefined) {
+      bindings.push(outcome.binding);
+    }
+    warnings.push(...outcome.warnings);
+  }
+  return { bindings, perMember, warnings };
+}

--- a/packages/core/src/profiles/resolution/policyIntersection.test.ts
+++ b/packages/core/src/profiles/resolution/policyIntersection.test.ts
@@ -1,0 +1,163 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { intersectPolicy } from './policyIntersection.js';
+import type { PolicyCeiling } from './policyIntersection.js';
+
+function checkBasics(
+  intent: Parameters<typeof intersectPolicy>[0],
+  environment: PolicyCeiling,
+  session: PolicyCeiling,
+) {
+  const outcome = intersectPolicy(intent, environment, session);
+  expect(outcome.errors).toStrictEqual([]);
+  expect(outcome.warnings).toStrictEqual([]);
+  expect(outcome.explanations).toStrictEqual([]);
+  return outcome;
+}
+
+describe('intersectPolicy', () => {
+  it('seeds disabled tools from the intent, not from the allowed list', () => {
+    const outcome = checkBasics(
+      { allowedTools: ['read', 'write', 'exec'], disabledTools: ['exec'] },
+      {},
+      {},
+    );
+    expect(outcome.policy.disabledTools).toStrictEqual(['exec']);
+    expect(outcome.policy.allowedTools).toStrictEqual(['read', 'write']);
+  });
+
+  it('rolls back an unavailable tool and emits the removal warning', () => {
+    const outcome = intersectPolicy(
+      { allowedTools: ['read', 'magic'] },
+      {},
+      {},
+      undefined,
+      (id) => id !== 'magic',
+    );
+    expect(outcome.policy.allowedTools).toStrictEqual(['read']);
+    expect(outcome.warnings).toStrictEqual([
+      'tool magic requested but unavailable; removed from effective policy',
+    ]);
+    expect(outcome.errors).toStrictEqual([]);
+    expect(outcome.explanations).toStrictEqual([]);
+  });
+
+  it('uses the isToolAvailable predicate to remove a ceiling-covered unavailable tool', () => {
+    const unavailable = intersectPolicy(
+      { allowedTools: ['db'], requiredTools: ['db'] },
+      { allowedTools: ['db'] },
+      {},
+      undefined,
+      () => false,
+    );
+    expect(unavailable.policy.allowedTools).toStrictEqual([]);
+    expect(unavailable.errors).toStrictEqual([
+      'required tool db is not effectively allowed',
+    ]);
+    expect(unavailable.explanations).toStrictEqual([]);
+  });
+
+  it('unions disabled tools across the intent and all layers', () => {
+    const outcome = intersectPolicy(
+      { disabledTools: ['a'] },
+      { disabledTools: ['b'] },
+      { disabledTools: ['c'] },
+    );
+    expect(outcome.policy.disabledTools).toStrictEqual(['a', 'b', 'c']);
+    expect(outcome.policy.allowedTools).toStrictEqual([]);
+  });
+
+  it('removes a tool disabled by a ceiling layer from the effective set', () => {
+    const outcome = checkBasics(
+      { allowedTools: ['read', 'write'] },
+      {},
+      { disabledTools: ['write'] },
+    );
+    expect(outcome.policy.allowedTools).toStrictEqual(['read']);
+    expect(outcome.policy.disabledTools).toStrictEqual(['write']);
+  });
+
+  it('does not treat an omitted allowlist as an empty restriction', () => {
+    const outcome = checkBasics(
+      { allowedTools: ['read'] },
+      { disabledTools: ['unrelated'] },
+      {},
+    );
+    expect(outcome.policy.allowedTools).toStrictEqual(['read']);
+  });
+
+  it('narrows an absent-intent shell mode to the narrowest layer', () => {
+    const outcome = intersectPolicy(
+      {},
+      { shellMode: 'allowlist' as const },
+      { shellMode: 'none' as const },
+    );
+    expect(outcome.policy.shellMode).toBe('none');
+    expect(outcome.explanations).toContainEqual({
+      aspect: 'shell mode',
+      requested: 'all',
+      effective: 'none',
+      note: 'no intent; environment ceiling applies',
+    });
+  });
+
+  it('errors when a required tool is disabled by a ceiling layer', () => {
+    const outcome = intersectPolicy(
+      { allowedTools: ['read'], requiredTools: ['read'] },
+      {},
+      { disabledTools: ['read'] },
+    );
+    expect(outcome.errors).toStrictEqual([
+      'required tool read is disabled by policy',
+    ]);
+    expect(outcome.policy.allowedTools).toStrictEqual([]);
+  });
+
+  it('errors when a required tool is disabled by the intent', () => {
+    const outcome = intersectPolicy(
+      {
+        allowedTools: ['write'],
+        requiredTools: ['write'],
+        disabledTools: ['write'],
+      },
+      {},
+      {},
+    );
+    expect(outcome.errors).toStrictEqual([
+      'required tool write is disabled by policy',
+    ]);
+  });
+
+  it('picks the narrowest shell mode across intent and layers', () => {
+    const outcome = intersectPolicy(
+      { shellMode: 'all' as const },
+      { shellMode: 'none' as const },
+      {},
+    );
+    expect(outcome.policy.shellMode).toBe('none');
+    expect(outcome.explanations).toContainEqual({
+      aspect: 'shell mode',
+      requested: 'all',
+      effective: 'none',
+    });
+  });
+
+  it('keeps an absent ceiling unrestricted for shell mode', () => {
+    const outcome = checkBasics({}, {}, {});
+    expect(outcome.policy.shellMode).toBe('all');
+  });
+
+  it('applies the strictest approval ceiling', () => {
+    const outcome = intersectPolicy(
+      {},
+      { approvalCeiling: 'yolo' as const },
+      { approvalCeiling: 'strict' as const },
+    );
+    expect(outcome.policy.shellMode).toBe('all');
+  });
+});

--- a/packages/core/src/profiles/resolution/policyIntersection.ts
+++ b/packages/core/src/profiles/resolution/policyIntersection.ts
@@ -1,0 +1,345 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { EffectiveToolPolicy } from '../ports/profileRuntimeFactoryPort.js';
+
+export type ProfilePolicyIntent = {
+  allowedTools?: readonly string[];
+  disabledTools?: readonly string[];
+  requiredTools?: readonly string[];
+  shellMode?: 'allowlist' | 'all' | 'none';
+  approvalCeiling?: 'yolo' | 'standard' | 'strict';
+};
+
+export type PolicyCeiling = {
+  allowedTools?: readonly string[];
+  disabledTools?: readonly string[];
+  shellMode?: 'allowlist' | 'all' | 'none';
+  approvalCeiling?: 'yolo' | 'standard' | 'strict';
+};
+
+export type PolicyExplanation = {
+  aspect: string;
+  requested: string;
+  effective: string;
+  note?: string;
+};
+
+export type PolicyIntersectionOutcome = {
+  policy: EffectiveToolPolicy;
+  explanations: readonly PolicyExplanation[];
+  errors: readonly string[];
+  warnings: readonly string[];
+};
+
+/**
+ * Intersection of an intent with the `EffectiveToolPolicy` built to run it.
+ *
+ * Tools must be allowed by the intent AND every ceiling layer that explicitly defines
+ * an allowlist; a layer without one is unrestricted. Disabled tools are the union of
+ * the intent's and every present layer's disabled tools, and they are subtracted from
+ * the effective allowed set before availability is considered. Intent-allowed tools
+ * that remain but are unavailable are removed with a warning. Required tools that are
+ * disabled or that the final effective set dropped produce an error. Shell mode
+ * narrows to the most restrictive of the present layers; approval ceiling is the
+ * strictest. Every narrowing is explained. Nothing here reads or emits secrets.
+ */
+export function intersectPolicy(
+  intent: ProfilePolicyIntent,
+  environment: PolicyCeiling,
+  session: PolicyCeiling,
+  role?: PolicyCeiling,
+  isToolAvailable?: (id: string) => boolean,
+): PolicyIntersectionOutcome {
+  const ceilings: ReadonlyArray<PolicyCeiling | undefined> = [
+    environment,
+    session,
+    role,
+  ];
+  const presentLayers = ceilings.filter(
+    (layer): layer is PolicyCeiling => layer !== undefined,
+  );
+  const intended = intent.allowedTools ?? [];
+  // A layer without an explicit allowlist is unrestricted: only layers that define
+  // allowedTools take part in the intersection. With no restricting layer the intent
+  // passes through, because `every` over an empty layer list holds.
+  const presentAllowed: ReadonlyArray<readonly string[]> = presentLayers
+    .map((layer) => layer.allowedTools)
+    .filter((allowed): allowed is readonly string[] => allowed !== undefined);
+  const explanations: PolicyExplanation[] = [];
+  const warnings: string[] = [];
+  const errors: string[] = [];
+  const disabledTools = mergeUnique(
+    intent.disabledTools ?? [],
+    ...presentLayers.map((layer) => layer.disabledTools ?? []),
+  );
+  const disabledSet = new Set(disabledTools);
+  const allowedTools = intersectAllowedTools(intended, presentAllowed).filter(
+    (id) => !disabledSet.has(id),
+  );
+  const unavailableTools =
+    isToolAvailable === undefined
+      ? []
+      : allowedTools.filter((id) => !isToolAvailable(id));
+  const unavailableSet = new Set(unavailableTools);
+  for (const id of allowedTools) {
+    if (unavailableSet.has(id)) {
+      warnings.push(
+        `tool ${id} requested but unavailable; removed from effective policy`,
+      );
+    }
+  }
+  const effectiveAllowedTools = allowedTools.filter(
+    (id) => !unavailableSet.has(id),
+  );
+
+  const shellMode = narrowShellMode(
+    'shell mode',
+    intent.shellMode,
+    presentLayers,
+  );
+  if (shellMode.explanation !== undefined) {
+    explanations.push(shellMode.explanation);
+  }
+  const approval = strictApprovalCeiling(
+    'approval ceiling',
+    intent.approvalCeiling,
+    presentLayers,
+  );
+  if (approval.explanation !== undefined) {
+    explanations.push(approval.explanation);
+  }
+
+  errors.push(
+    ...requiredToolErrors(
+      intent.requiredTools ?? [],
+      disabledSet,
+      effectiveAllowedTools,
+    ),
+  );
+
+  return {
+    policy: {
+      allowedTools: effectiveAllowedTools,
+      disabledTools,
+      shellMode: shellMode.result,
+      approvalCeiling: approval.result,
+    },
+    explanations,
+    errors,
+    warnings,
+  };
+}
+
+/**
+ * Merges a set of lists into one array with no duplicates, preserving order.
+ */
+function mergeUnique(
+  into: readonly string[],
+  ...rest: ReadonlyArray<readonly string[]>
+): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const list of [into, ...rest]) {
+    for (const item of list) {
+      if (seen.has(item)) {
+        continue;
+      }
+      seen.add(item);
+      result.push(item);
+    }
+  }
+  return result;
+}
+
+/**
+ * Errors for every required tool that policy excludes: first a tool disabled by the
+ * intent or any layer, then a tool the effective allowed set dropped.
+ */
+function requiredToolErrors(
+  required: readonly string[],
+  disabledSet: ReadonlySet<string>,
+  effectiveAllowedTools: readonly string[],
+): string[] {
+  const errors: string[] = [];
+  for (const id of required) {
+    const error = requiredToolError(id, disabledSet, effectiveAllowedTools);
+    if (error !== undefined) {
+      errors.push(error);
+    }
+  }
+  return errors;
+}
+
+function requiredToolError(
+  id: string,
+  disabledSet: ReadonlySet<string>,
+  effectiveAllowedTools: readonly string[],
+): string | undefined {
+  if (disabledSet.has(id)) {
+    return `required tool ${id} is disabled by policy`;
+  }
+  if (effectiveAllowedTools.includes(id)) {
+    return undefined;
+  }
+  return `required tool ${id} is not effectively allowed`;
+}
+
+function intersectAllowedTools(
+  intended: readonly string[],
+  layers: ReadonlyArray<readonly string[]>,
+): string[] {
+  return intended.filter((id) => layers.every((layer) => layer.includes(id)));
+}
+
+function narrowShellMode(
+  aspect: string,
+  intended: 'allowlist' | 'all' | 'none' | undefined,
+  layers: readonly PolicyCeiling[],
+): { result: 'allowlist' | 'all' | 'none'; explanation?: PolicyExplanation } {
+  if (intended === undefined) {
+    const applied: Array<'allowlist' | 'all' | 'none'> = [];
+    for (const layer of layers) {
+      if (layer.shellMode !== undefined) {
+        applied.push(layer.shellMode);
+      }
+    }
+    const result = applied.length === 0 ? 'all' : narrowestShell(applied);
+    if (result !== 'all') {
+      return {
+        result,
+        explanation: {
+          aspect,
+          requested: 'all',
+          effective: result,
+          note: 'no intent; environment ceiling applies',
+        },
+      };
+    }
+    return { result };
+  }
+  const values: Array<'allowlist' | 'all' | 'none'> = [intended];
+  for (const layer of layers) {
+    if (layer.shellMode !== undefined) {
+      values.push(layer.shellMode);
+    }
+  }
+  const result = narrowestShell(values);
+  if (result !== intended) {
+    return {
+      result,
+      explanation: { aspect, requested: intended, effective: result },
+    };
+  }
+  return { result };
+}
+
+/**
+ * Narrowest (most restrictive) shell mode across the given values: none beats
+ * allowlist beats all.
+ */
+function narrowestShell(
+  values: ReadonlyArray<'allowlist' | 'all' | 'none'>,
+): 'allowlist' | 'all' | 'none' {
+  let result: 'allowlist' | 'all' | 'none' = values[0];
+  for (const value of values) {
+    if (narrowerShell(value, result)) {
+      result = value;
+    }
+  }
+  return result;
+}
+
+function narrowerShell(
+  left: 'allowlist' | 'all' | 'none',
+  right: 'allowlist' | 'all' | 'none',
+): boolean {
+  if (left === 'none') {
+    return right !== 'none';
+  }
+  if (left === 'allowlist') {
+    return right === 'all';
+  }
+  return false;
+}
+
+function strictApprovalCeiling(
+  aspect: string,
+  intended: 'yolo' | 'standard' | 'strict' | undefined,
+  layers: readonly PolicyCeiling[],
+): { result: 'yolo' | 'standard' | 'strict'; explanation?: PolicyExplanation } {
+  if (intended === undefined) {
+    const values: Array<'yolo' | 'standard' | 'strict'> =
+      approvalValues(layers);
+    if (values.length > 0) {
+      const result = strictestOf(values);
+      return {
+        result,
+        explanation: {
+          aspect,
+          requested: 'yolo',
+          effective: result,
+          note: 'absent intent; values come from environment and session ceilings',
+        },
+      };
+    }
+    return { result: 'yolo' };
+  }
+  let result: 'yolo' | 'standard' | 'strict' = intended;
+  for (const layer of layers) {
+    const layerValue = layer.approvalCeiling;
+    if (layerValue === undefined) {
+      continue;
+    }
+    if (moreStrict(layerValue, result)) {
+      result = layerValue;
+    }
+  }
+  if (result !== intended) {
+    return {
+      result,
+      explanation: { aspect, requested: intended, effective: result },
+    };
+  }
+  return { result };
+}
+
+function approvalValues(
+  layers: readonly PolicyCeiling[],
+): Array<'yolo' | 'standard' | 'strict'> {
+  const values: Array<'yolo' | 'standard' | 'strict'> = [];
+  for (const layer of layers) {
+    if (layer.approvalCeiling !== undefined) {
+      values.push(layer.approvalCeiling);
+    }
+  }
+  return values;
+}
+
+function strictestOf(
+  values: ReadonlyArray<'yolo' | 'standard' | 'strict'>,
+): 'yolo' | 'standard' | 'strict' {
+  let result: 'yolo' | 'standard' | 'strict' = values[0];
+  for (const value of values) {
+    if (moreStrict(value, result)) {
+      result = value;
+    }
+  }
+  return result;
+}
+
+function moreStrict(
+  left: 'yolo' | 'standard' | 'strict',
+  right: 'yolo' | 'standard' | 'strict',
+): boolean {
+  if (left === 'strict') {
+    return right !== 'strict';
+  }
+  if (left === 'standard') {
+    return right === 'yolo';
+  }
+  return false;
+}

--- a/packages/core/src/profiles/resolution/resolveProfileCandidate.test.ts
+++ b/packages/core/src/profiles/resolution/resolveProfileCandidate.test.ts
@@ -1,0 +1,424 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'bun:test';
+import type { ProfileRepositoryPort } from '../ports/profileRepositoryPort.js';
+import type { ProviderModelCatalogPort } from '../ports/providerCatalogPort.js';
+import type {
+  LoadBalancerProfileDocument,
+  StandardProfileDocument,
+} from '../contracts/profileDocument.js';
+import type {
+  ProfilePolicyIntent,
+  PolicyCeiling,
+} from './policyIntersection.js';
+import { resolveProfileCandidate } from './resolveProfileCandidate.js';
+
+const standard = (
+  overrides: Partial<StandardProfileDocument> = {},
+): StandardProfileDocument => ({
+  version: 1,
+  provider: 'openai',
+  model: 'gpt-4o',
+  modelParams: {},
+  ephemeralSettings: {},
+  ...overrides,
+});
+
+const lb = (profiles: readonly string[] = []): LoadBalancerProfileDocument => ({
+  version: 1,
+  type: 'loadbalancer',
+  policy: 'roundrobin',
+  profiles,
+  provider: '',
+  model: '',
+  modelParams: {},
+  ephemeralSettings: {},
+});
+
+const catalog = (
+  validate: (
+    provider: string,
+    model: string,
+    params?: Readonly<Record<string, unknown>>,
+  ) => { status: 'valid' | 'invalid' | 'unknown'; reason?: string },
+  listModels: (provider: string) => string[],
+): ProviderModelCatalogPort => ({
+  validateModelSupport: async (provider, model, params) => {
+    const support = validate(provider, model, params);
+    if (support.status === 'invalid') {
+      return { status: 'invalid', reason: support.reason ?? '' };
+    }
+    if (support.status === 'unknown') {
+      return { status: 'unknown' };
+    }
+    return { status: 'valid' };
+  },
+  listModels: async (provider: string) => listModels(provider),
+  getDefaultModel: async () => undefined,
+  getProviderTemplate: async () => undefined,
+});
+
+const trust = {
+  getToolCeiling: () => ({
+    allowedTools: [] as readonly string[],
+    disabledTools: [] as readonly string[],
+  }),
+  isToolAvailable: () => true,
+  getShellCeiling: () => 'all' as const,
+  getApprovalCeiling: () => 'standard' as const,
+};
+
+function deps(
+  overrides: {
+    catalog?: ReturnType<typeof catalog>;
+    repository?: ProfileRepositoryPort;
+    policyIntent?: ProfilePolicyIntent;
+    role?: PolicyCeiling;
+    session?: PolicyCeiling;
+  } = {},
+) {
+  const repo = overrides.repository;
+  return {
+    catalog:
+      overrides.catalog ??
+      catalog(
+        () => ({ status: 'valid' }),
+        () => [],
+      ),
+    trust,
+    session: overrides.session ?? {},
+    role: overrides.role,
+    repository: repo,
+    policyIntent: overrides.policyIntent ?? {},
+  };
+}
+
+describe('resolveProfileCandidate standard documents', () => {
+  for (const model of ['gpt-4o', 'unknown-model']) {
+    it(`validates model parameters for ${model} without treating unknown metadata as invalid`, async () => {
+      const result = await resolveProfileCandidate(
+        {
+          document: standard({ model, modelParams: { 'bogus-param': true } }),
+          policyIntent: {},
+        },
+        deps({
+          catalog: catalog(
+            (_provider, candidateModel, params) => {
+              if (candidateModel !== 'gpt-4o') {
+                return { status: 'unknown' };
+              }
+              return params !== undefined && 'bogus-param' in params
+                ? { status: 'invalid', reason: 'unknown parameter bogus-param' }
+                : { status: 'valid' };
+            },
+            () => ['gpt-4o'],
+          ),
+        }),
+      );
+      expect(result.status).toStrictEqual(
+        model === 'gpt-4o' ? 'invalid' : 'unverified',
+      );
+      expect(result.errors).toStrictEqual(
+        model === 'gpt-4o'
+          ? [
+              'unknown parameter bogus-param',
+              'model gpt-4o is not supported by provider openai',
+            ]
+          : [],
+      );
+    });
+  }
+
+  it('resolves a valid standard document to valid with a provider-default binding', async () => {
+    const document = standard();
+    const result = await resolveProfileCandidate(
+      { document, policyIntent: {} },
+      deps(),
+    );
+    expect(result.status).toBe('valid');
+    expect(result.resolved.credentialBindings).toStrictEqual([
+      { kind: 'provider-default', provider: 'openai' },
+    ]);
+    expect(result.resolved.document).toBe(document);
+    expect(result.errors).toStrictEqual([]);
+    expect(result.memberCaptures).toBeUndefined();
+  });
+
+  it('marks an unsupported model invalid and reports the exact message', async () => {
+    const result = await resolveProfileCandidate(
+      { document: standard(), policyIntent: {} },
+      deps({
+        catalog: catalog(
+          () => ({ status: 'invalid', reason: 'model retired' }),
+          () => [],
+        ),
+      }),
+    );
+    expect(result.status).toBe('invalid');
+    expect(result.errors).toContain(
+      'model gpt-4o is not supported by provider openai',
+    );
+    expect(result.errors).toContain('model retired');
+  });
+
+  it('marks an unknown model unverified without unverified errors', async () => {
+    const result = await resolveProfileCandidate(
+      { document: standard(), policyIntent: {} },
+      deps({
+        catalog: catalog(
+          () => ({ status: 'unknown' }),
+          () => [],
+        ),
+      }),
+    );
+    expect(result.status).toBe('unverified');
+    expect(result.unverifiedConstraints).toStrictEqual([
+      'model support unknown for provider openai',
+    ]);
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it('propagates auth-key warnings from a standard document', async () => {
+    const result = await resolveProfileCandidate(
+      {
+        document: standard({ ephemeralSettings: { 'auth-key': 'sk-secret' } }),
+        policyIntent: {},
+      },
+      deps(),
+    );
+    expect(result.status).toBe('valid');
+    expect(result.warnings).toContain(
+      'inline auth-key present; prefer auth-key-name for rotation',
+    );
+  });
+
+  it('commits a blank setup draft without a runtime build', async () => {
+    const blank: StandardProfileDocument = {
+      version: 1,
+      provider: '',
+      model: '',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+    const result = await resolveProfileCandidate(
+      { document: blank, policyIntent: {} },
+      deps(),
+    );
+    expect(result.status).toBe('valid');
+    expect(result.resolved.credentialBindings).toStrictEqual([]);
+    expect(result.resolved.policy).toStrictEqual({
+      allowedTools: [],
+      disabledTools: [],
+      shellMode: 'all',
+      approvalCeiling: 'standard',
+    });
+    expect(result.errors).toStrictEqual([]);
+    expect(result.warnings).toStrictEqual([]);
+  });
+
+  it('rejects an empty provider with a non-empty model', async () => {
+    const result = await resolveProfileCandidate(
+      {
+        document: standard({ provider: '', model: 'gpt-4o' }),
+        policyIntent: {},
+      },
+      deps({
+        catalog: catalog(
+          () => ({ status: 'invalid', reason: '' }),
+          () => [],
+        ),
+      }),
+    );
+    expect(result.status).toBe('invalid');
+    expect(result.errors).toContain('provider is required');
+  });
+});
+
+describe('resolveProfileCandidate load balancer documents', () => {
+  it('resolves members with distinct per-member bindings and unmutated document', async () => {
+    const document = lb(['alpha', 'beta']);
+    const alpha = standard({
+      provider: 'openai',
+      model: 'gpt-4o',
+      modelParams: {},
+      ephemeralSettings: { 'auth-key-name': 'OPENAI_KEY' },
+    });
+    const beta = standard({
+      provider: 'anthropic',
+      model: 'claude-3',
+      modelParams: {},
+      ephemeralSettings: { 'auth-key-name': 'ANTHROPIC_KEY' },
+    });
+    const listModels = (provider: string): string[] =>
+      provider === 'openai' ? ['gpt-4o'] : ['claude-3'];
+    const repo: ProfileRepositoryPort = {
+      load: async (name: string) => {
+        if (name === 'alpha') {
+          return { document: alpha, fingerprint: { kind: 'hash', hash: 'x' } };
+        }
+        return { document: beta, fingerprint: { kind: 'hash', hash: 'y' } };
+      },
+      save: async () => ({ kind: 'hash', hash: 'z' }),
+      list: async () => [{ name: 'alpha' }, { name: 'beta' }],
+      delete: async () => {},
+      stat: async () => ({ kind: 'hash', hash: 'z' }),
+    };
+    const result = await resolveProfileCandidate(
+      { document, policyIntent: {} },
+      deps({
+        repository: repo,
+        catalog: catalog(() => ({ status: 'valid' }), listModels),
+      }),
+    );
+    expect(result.status).toBe('valid');
+    expect(result.errors).toStrictEqual([]);
+    const alphaCapture = result.memberCaptures?.['alpha'];
+    const betaCapture = result.memberCaptures?.['beta'];
+    expect(alphaCapture?.provider).toBe('openai');
+    expect(betaCapture?.provider).toBe('anthropic');
+    expect(alphaCapture?.models).toStrictEqual(['gpt-4o']);
+    expect(betaCapture?.models).toStrictEqual(['claude-3']);
+    expect(result.resolved.credentialBindings).toStrictEqual([
+      { kind: 'key-name', keyName: 'OPENAI_KEY' },
+      { kind: 'key-name', keyName: 'ANTHROPIC_KEY' },
+    ]);
+    expect(result.resolved.document).toBe(document);
+  });
+
+  it('rejects a load balancer with a missing member', async () => {
+    const repo: ProfileRepositoryPort = {
+      load: async () => {
+        throw new Error('not found');
+      },
+      save: async () => ({ kind: 'hash', hash: 'z' }),
+      list: async () => [],
+      delete: async () => {},
+      stat: async () => null,
+    };
+    const result = await resolveProfileCandidate(
+      { document: lb(['ghost']), policyIntent: {} },
+      deps({ repository: repo }),
+    );
+    expect(result.status).toBe('invalid');
+    expect(result.errors).toContain('member ghost could not be loaded');
+  });
+
+  it('rejects a load-balancer member that is itself a load balancer', async () => {
+    const nested = lb(['deep']);
+    const repo: ProfileRepositoryPort = {
+      load: async () => ({
+        document: nested,
+        fingerprint: { kind: 'hash', hash: 'w' },
+      }),
+      save: async () => ({ kind: 'hash', hash: 'z' }),
+      list: async () => [],
+      delete: async () => {},
+      stat: async () => null,
+    };
+    const result = await resolveProfileCandidate(
+      { document: lb(['nested']), policyIntent: {} },
+      deps({ repository: repo }),
+    );
+    expect(result.status).toBe('invalid');
+    expect(result.errors).toContain('member nested must be a standard profile');
+  });
+
+  it('hard-fails when members cannot be loaded without a repository', async () => {
+    const result = await resolveProfileCandidate(
+      { document: lb(['alpha']), policyIntent: {} },
+      deps({ repository: undefined }),
+    );
+    expect(result.status).toBe('invalid');
+    expect(result.errors).toContain('member alpha could not be loaded');
+  });
+
+  it('marks an unsupported member model invalid', async () => {
+    const alpha = standard();
+    const repo: ProfileRepositoryPort = {
+      load: async () => ({
+        document: alpha,
+        fingerprint: { kind: 'hash', hash: 'x' },
+      }),
+      save: async () => ({ kind: 'hash', hash: 'z' }),
+      list: async () => [],
+      delete: async () => {},
+      stat: async () => null,
+    };
+    const result = await resolveProfileCandidate(
+      { document: lb(['alpha']), policyIntent: {} },
+      deps({
+        repository: repo,
+        catalog: catalog(
+          () => ({ status: 'invalid', reason: '' }),
+          () => [],
+        ),
+      }),
+    );
+    expect(result.status).toBe('invalid');
+    expect(result.errors).toContain(
+      'model gpt-4o is not supported by provider openai',
+    );
+  });
+
+  it('treats an unknown member model as unverified but not invalid', async () => {
+    const alpha = standard();
+    const repo: ProfileRepositoryPort = {
+      load: async () => ({
+        document: alpha,
+        fingerprint: { kind: 'hash', hash: 'x' },
+      }),
+      save: async () => ({ kind: 'hash', hash: 'z' }),
+      list: async () => [],
+      delete: async () => {},
+      stat: async () => null,
+    };
+    const result = await resolveProfileCandidate(
+      { document: lb(['alpha']), policyIntent: {} },
+      deps({
+        repository: repo,
+        catalog: catalog(
+          (p) => ({ status: p === 'openai' ? 'unknown' : 'valid' }),
+          () => {
+            throw new Error('menu down');
+          },
+        ),
+      }),
+    );
+    expect(result.status).toBe('unverified');
+    expect(result.unverifiedConstraints).toContain(
+      'model support unknown for provider openai',
+    );
+  });
+
+  it('rejects a policy required tool that the trust disallows', async () => {
+    const document = standard();
+    const strictTrust = {
+      ...trust,
+      isToolAvailable: () => false,
+    };
+    const strictCatalog = catalog(
+      () => ({ status: 'valid' }),
+      () => [],
+    );
+    const result = await resolveProfileCandidate(
+      {
+        document,
+        policyIntent: { allowedTools: ['tool-a'], requiredTools: ['tool-a'] },
+      },
+      {
+        ...deps(),
+        catalog: strictCatalog,
+        trust: strictTrust,
+        session: { allowedTools: ['tool-a'] },
+      },
+    );
+    expect(result.status).toBe('invalid');
+    expect(result.errors).toContain(
+      'required tool tool-a is not effectively allowed',
+    );
+  });
+});

--- a/packages/core/src/profiles/resolution/resolveProfileCandidate.test.ts
+++ b/packages/core/src/profiles/resolution/resolveProfileCandidate.test.ts
@@ -238,7 +238,128 @@ describe('resolveProfileCandidate standard documents', () => {
   });
 });
 
+const memberRepository = (
+  document: StandardProfileDocument,
+): ProfileRepositoryPort => ({
+  load: async () => ({
+    document,
+    fingerprint: { kind: 'hash', hash: 'member' },
+  }),
+  save: async () => ({ kind: 'hash', hash: 'saved' }),
+  list: async () => [],
+  delete: async () => {},
+  stat: async () => null,
+});
+
 describe('resolveProfileCandidate load balancer documents', () => {
+  it.each([
+    { provider: '', model: 'gpt-4o' },
+    { provider: 'openai', model: '' },
+    { provider: '', model: '' },
+  ])(
+    'rejects unconfigured member %j despite a validating catalog',
+    async (fields) => {
+      const result = await resolveProfileCandidate(
+        { document: lb(['blank']), policyIntent: {} },
+        deps({ repository: memberRepository(standard(fields)) }),
+      );
+      expect(result.status).toStrictEqual('invalid');
+      expect(result.errors).toStrictEqual([
+        'member blank must configure a provider and model',
+      ]);
+      expect(result.resolved.credentialBindings).toStrictEqual([]);
+      expect(Object.keys(result.memberCaptures ?? {})).toStrictEqual([]);
+    },
+  );
+
+  it('rejects a load balancer without members', async () => {
+    const result = await resolveProfileCandidate(
+      { document: lb([]), policyIntent: {} },
+      deps(),
+    );
+    expect(result.status).toStrictEqual('invalid');
+    expect(result.errors).toStrictEqual([
+      'load balancer must include at least one member',
+    ]);
+    expect(result.resolved.credentialBindings).toStrictEqual([]);
+  });
+
+  it.each(['__proto__', 'constructor', 'toString'])(
+    'resolves own member %s without prototype pollution',
+    async (name) => {
+      const member = standard();
+      const result = await resolveProfileCandidate(
+        { document: lb([name]), policyIntent: {} },
+        deps({ repository: memberRepository(member) }),
+      );
+      expect(result.status).toStrictEqual('valid');
+      expect(result.errors).toStrictEqual([]);
+      expect(Object.keys(result.resolved.memberDocuments ?? {})).toStrictEqual([
+        name,
+      ]);
+      expect(Object.keys(result.memberCaptures ?? {})).toStrictEqual([name]);
+      expect(result.resolved.memberDocuments?.[name]).toStrictEqual(member);
+      expect(result.memberCaptures?.[name]).toStrictEqual({
+        revision: 0,
+        provider: 'openai',
+        sourceDocument: member,
+        models: [],
+      });
+      expect(result.resolved.credentialBindings).toStrictEqual([
+        { kind: 'provider-default', provider: 'openai' },
+      ]);
+      expect(
+        Object.getPrototypeOf(result.resolved.memberDocuments),
+      ).toStrictEqual(null);
+      expect(Object.getPrototypeOf(result.memberCaptures)).toStrictEqual(null);
+    },
+  );
+
+  it.each(['__proto__', 'constructor', 'toString'])(
+    'rejects unavailable member %s without reading inherited properties',
+    async (name) => {
+      const result = await resolveProfileCandidate(
+        { document: lb([name]), policyIntent: {} },
+        deps(),
+      );
+      expect(result.status).toStrictEqual('invalid');
+      expect(result.errors).toStrictEqual([
+        `member ${name} could not be loaded`,
+      ]);
+      expect(result.resolved.credentialBindings).toStrictEqual([]);
+    },
+  );
+
+  it.each(['standard', 'loadbalancer'])(
+    'reports rejected model support as unverified for %s',
+    async (kind) => {
+      const rejectingCatalog: ProviderModelCatalogPort = {
+        ...catalog(
+          () => ({ status: 'valid' }),
+          () => [],
+        ),
+        validateModelSupport: async () => {
+          throw new Error('catalog offline');
+        },
+      };
+      const result = await resolveProfileCandidate(
+        {
+          document: kind === 'standard' ? standard() : lb(['alpha']),
+          policyIntent: {},
+        },
+        deps({
+          catalog: rejectingCatalog,
+          repository: memberRepository(standard()),
+        }),
+      );
+      expect(result.status).toStrictEqual('unverified');
+      expect(result.errors).toStrictEqual([]);
+      expect(result.unverifiedConstraints).toStrictEqual([
+        'model support unavailable for provider openai',
+      ]);
+    },
+  );
+
   it('resolves members with distinct per-member bindings and unmutated document', async () => {
     const document = lb(['alpha', 'beta']);
     const alpha = standard({

--- a/packages/core/src/profiles/resolution/resolveProfileCandidate.ts
+++ b/packages/core/src/profiles/resolution/resolveProfileCandidate.ts
@@ -1,0 +1,438 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ProfileDocument } from '../contracts/profileDocument.js';
+import {
+  isLoadBalancerProfileDocument,
+  isStandardProfileDocument,
+} from '../contracts/profileDocument.js';
+import type {
+  LoadBalancerProfileDocument,
+  StandardProfileDocument,
+} from '../contracts/profileDocument.js';
+import type { CapturedStandardSource } from '../contracts/profileState.js';
+import type { CredentialBinding } from '../ports/credentialResolverPort.js';
+import type { ProfileRepositoryPort } from '../ports/profileRepositoryPort.js';
+import type { ProviderModelCatalogPort } from '../ports/providerCatalogPort.js';
+import type { ResolvedProfileSpec } from '../ports/profileRuntimeFactoryPort.js';
+import type { TrustToolEnvironmentPort } from '../ports/trustEnvironmentPort.js';
+import { deriveCredentialBindings } from './credentialBindings.js';
+import { memberCredentialBindings } from './memberAuthResolution.js';
+import {
+  intersectPolicy,
+  type PolicyCeiling,
+  type PolicyExplanation,
+  type ProfilePolicyIntent,
+} from './policyIntersection.js';
+
+/**
+ * Input to candidate resolution: the document under consideration plus the policy intent
+ * its effective profile is desired with.
+ */
+export interface ProfileCandidateResolutionInput {
+  document: ProfileDocument;
+  policyIntent: ProfilePolicyIntent;
+}
+
+/**
+ * Ports and ceilings candidate resolution needs. The catalog validates model support
+ * (including the candidate's model parameters) and lists per-provider model menus;
+ * trust supplies the environment ceilings and the availability predicate; session
+ * (and optionally role) narrow policy further. The repository is only consulted for
+ * load-balancer members. Provider templates are never consulted here: template
+ * availability does not change candidate validity.
+ */
+export interface ResolveProfileCandidateDeps {
+  catalog: ProviderModelCatalogPort;
+  trust: TrustToolEnvironmentPort;
+  session: PolicyCeiling;
+  role?: PolicyCeiling;
+  repository?: ProfileRepositoryPort;
+}
+
+/**
+ * Result of resolving a profile candidate.
+ *
+ * `status` precedence is invalid > unverified > valid. Drafts that never enter a
+ * runtime still get a full resolver record; unverified constraints are surfaced so the
+ * caller can defer a build instead of silently treating an unverifiable candidate as
+ * valid.
+ */
+export type ProfileCandidateResolution = {
+  status: 'valid' | 'invalid' | 'unverified';
+  resolved: ResolvedProfileSpec;
+  memberCaptures?: Readonly<Record<string, CapturedStandardSource>>;
+  errors: readonly string[];
+  warnings: readonly string[];
+  unverifiedConstraints: readonly string[];
+  requestedVsEffective: readonly PolicyExplanation[];
+};
+
+/**
+ * Build the environment policy ceiling from the trust port.
+ */
+function trustPolicyCeiling(trust: TrustToolEnvironmentPort): PolicyCeiling {
+  return {
+    allowedTools: trust.getToolCeiling().allowedTools,
+    disabledTools: trust.getToolCeiling().disabledTools,
+    shellMode: trust.getShellCeiling(),
+    approvalCeiling: trust.getApprovalCeiling(),
+  };
+}
+
+async function loadRawProfile(
+  name: string,
+  repository: ProfileRepositoryPort | undefined,
+  errors: string[],
+): Promise<ProfileDocument | null> {
+  if (repository === undefined) {
+    errors.push(`member ${name} could not be loaded`);
+    return null;
+  }
+  let document: ProfileDocument;
+  try {
+    const entry = await repository.load(name);
+    document = entry.document;
+  } catch {
+    errors.push(`member ${name} could not be loaded`);
+    return null;
+  }
+  return document;
+}
+
+function enforceLoaded(
+  document: ProfileDocument | null,
+  name: string,
+  errors: string[],
+): StandardProfileDocument | null {
+  if (document === null) {
+    return null;
+  }
+  if (isStandardProfileDocument(document)) {
+    return document;
+  }
+  errors.push(`member ${name} must be a standard profile`);
+  return null;
+}
+
+async function rawMember(
+  name: string,
+  repository: ProfileRepositoryPort | undefined,
+  errors: string[],
+): Promise<StandardProfileDocument | null> {
+  const raw = await loadRawProfile(name, repository, errors);
+  return enforceLoaded(raw, name, errors);
+}
+
+async function resolveMembers(
+  document: LoadBalancerProfileDocument,
+  deps: ResolveProfileCandidateDeps,
+  errors: string[],
+): Promise<Readonly<Record<string, StandardProfileDocument>>> {
+  const members: Record<string, StandardProfileDocument> = {};
+  for (const name of document.profiles) {
+    const loaded = await rawMember(name, deps.repository, errors);
+    if (loaded !== null) {
+      members[name] = loaded;
+    }
+  }
+  return members;
+}
+
+async function modelMenu(
+  provider: string,
+  catalog: ProviderModelCatalogPort,
+  menus: Map<string, readonly string[]>,
+  unverified: string[],
+): Promise<readonly string[]> {
+  const cached = menus.get(provider);
+  if (cached !== undefined) {
+    return cached;
+  }
+  try {
+    const models = await catalog.listModels(provider);
+    menus.set(provider, models);
+    return models;
+  } catch {
+    unverified.push(`model menu unavailable for provider ${provider}`);
+    return [];
+  }
+}
+
+async function captureMembers(
+  document: LoadBalancerProfileDocument,
+  members: Readonly<Record<string, StandardProfileDocument>>,
+  catalog: ProviderModelCatalogPort,
+  unverified: string[],
+): Promise<Readonly<Record<string, CapturedStandardSource>>> {
+  const captures: Record<string, CapturedStandardSource> = {};
+  const menus = new Map<string, readonly string[]>();
+  const memberEntries = Object.entries(members);
+  for (const entry of memberEntries) {
+    const models = await modelMenu(
+      entry[1].provider,
+      catalog,
+      menus,
+      unverified,
+    );
+    captures[entry[0]] = {
+      revision: 0,
+      provider: entry[1].provider,
+      sourceDocument: entry[1],
+      models,
+    };
+  }
+  return captures;
+}
+
+function flagModelSupport(
+  support: { status: 'valid' | 'invalid' | 'unknown'; reason?: string },
+  model: string,
+  provider: string,
+  errors: string[],
+  unverified: string[],
+): void {
+  if (support.status === 'invalid') {
+    if (support.reason !== undefined && support.reason.length > 0) {
+      errors.push(support.reason);
+    }
+    errors.push(`model ${model} is not supported by provider ${provider}`);
+  }
+  if (support.status === 'unknown') {
+    unverified.push(`model support unknown for provider ${provider}`);
+  }
+}
+
+async function flagMemberModels(
+  document: LoadBalancerProfileDocument,
+  members: Readonly<Record<string, StandardProfileDocument>>,
+  catalog: ProviderModelCatalogPort,
+  errors: string[],
+  unverified: string[],
+): Promise<void> {
+  const memberEntries = Object.entries(members);
+  for (const entry of memberEntries) {
+    const support = await catalog.validateModelSupport(
+      entry[1].provider,
+      entry[1].model,
+      entry[1].modelParams,
+    );
+    flagModelSupport(
+      support,
+      entry[1].model,
+      entry[1].provider,
+      errors,
+      unverified,
+    );
+  }
+}
+
+/**
+ * Candidate resolution over a load-balancer document: the document is the
+ * load-balancer member the existing {@link isLoadBalancerProfileDocument} predicate
+ * narrowed before this input was built.
+ */
+type LoadBalancerResolutionInput = ProfileCandidateResolutionInput & {
+  document: LoadBalancerProfileDocument;
+};
+
+/**
+ * Candidate resolution over a standard document: the complement of the load-balancer
+ * predicate narrowing on the complete {@link ProfileDocument} union.
+ */
+type StandardResolutionInput = ProfileCandidateResolutionInput & {
+  document: StandardProfileDocument;
+};
+
+function applyPolicy(
+  intent: ProfilePolicyIntent,
+  deps: ResolveProfileCandidateDeps,
+  errors: string[],
+  warnings: string[],
+  requestedVsEffective: PolicyExplanation[],
+): ReturnType<typeof intersectPolicy> {
+  const outcome = intersectPolicy(
+    intent,
+    trustPolicyCeiling(deps.trust),
+    deps.session,
+    deps.role,
+    (toolId) => deps.trust.isToolAvailable(toolId),
+  );
+  errors.push(...outcome.errors);
+  warnings.push(...outcome.warnings);
+  requestedVsEffective.push(...outcome.explanations);
+  return outcome;
+}
+
+async function resolveLoadBalancerSpec(
+  input: LoadBalancerResolutionInput,
+  deps: ResolveProfileCandidateDeps,
+): Promise<ProfileCandidateResolution> {
+  const loadable = input.document;
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const unverified: string[] = [];
+  const requestedVsEffective: PolicyExplanation[] = [];
+  const members = await resolveMembers(loadable, deps, errors);
+  const bindingsOutcome = memberCredentialBindings(loadable, members);
+  warnings.push(...bindingsOutcome.warnings);
+  const captures = await captureMembers(
+    loadable,
+    members,
+    deps.catalog,
+    unverified,
+  );
+  await flagMemberModels(loadable, members, deps.catalog, errors, unverified);
+  const policyOutcome = applyPolicy(
+    input.policyIntent,
+    deps,
+    errors,
+    warnings,
+    requestedVsEffective,
+  );
+  return {
+    status: resultStatus(errors, unverified),
+    resolved: {
+      document: input.document,
+      credentialBindings: bindingsOutcome.bindings,
+      policy: policyOutcome.policy,
+      memberDocuments: members,
+    },
+    memberCaptures: captures,
+    errors,
+    warnings,
+    unverifiedConstraints: unverified,
+    requestedVsEffective,
+  };
+}
+
+function applyPolicyForStandard(
+  intent: ProfilePolicyIntent,
+  deps: ResolveProfileCandidateDeps,
+  errors: string[],
+  warnings: string[],
+  requestedVsEffective: PolicyExplanation[],
+): ReturnType<typeof intersectPolicy> {
+  return applyPolicy(intent, deps, errors, warnings, requestedVsEffective);
+}
+
+async function resolveStandardDocument(
+  input: StandardResolutionInput,
+  deps: ResolveProfileCandidateDeps,
+): Promise<ProfileCandidateResolution> {
+  const standardDocument = input.document;
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const unverified: string[] = [];
+  const requestedVsEffective: PolicyExplanation[] = [];
+  let bindings: readonly CredentialBinding[] = [];
+  const blankDraft =
+    standardDocument.provider === '' && standardDocument.model === '';
+  const policyOutcome = applyPolicyForStandard(
+    input.policyIntent,
+    deps,
+    errors,
+    warnings,
+    requestedVsEffective,
+  );
+  if (blankDraft) {
+    bindings = [];
+    return {
+      status: errors.length > 0 ? 'invalid' : 'valid',
+      resolved: {
+        document: standardDocument,
+        credentialBindings: bindings,
+        policy: policyOutcome.policy,
+      },
+      errors,
+      warnings,
+      unverifiedConstraints: unverified,
+      requestedVsEffective,
+    };
+  }
+  if (standardDocument.provider === '') {
+    errors.push('provider is required');
+    return {
+      status: 'invalid',
+      resolved: {
+        document: standardDocument,
+        credentialBindings: bindings,
+        policy: policyOutcome.policy,
+      },
+      errors,
+      warnings,
+      unverifiedConstraints: unverified,
+      requestedVsEffective,
+    };
+  }
+  const bindingsOutcome = deriveCredentialBindings(standardDocument);
+  warnings.push(...bindingsOutcome.warnings);
+  bindings = bindingsOutcome.bindings;
+  const support = await deps.catalog.validateModelSupport(
+    standardDocument.provider,
+    standardDocument.model,
+    standardDocument.modelParams,
+  );
+  flagModelSupport(
+    support,
+    standardDocument.model,
+    standardDocument.provider,
+    errors,
+    unverified,
+  );
+  return {
+    status: resultStatus(errors, unverified),
+    resolved: {
+      document: standardDocument,
+      credentialBindings: bindings,
+      policy: policyOutcome.policy,
+    },
+    errors,
+    warnings,
+    unverifiedConstraints: unverified,
+    requestedVsEffective,
+  };
+}
+
+/**
+ * Resolve a profile candidate into a buildable spec.
+ *
+ * A blank setup draft (empty provider and model) is a valid draft the controller
+ * may commit without a runtime build. Standard documents validate model support through the
+ * catalog and derive their credential bindings from their own document. Load-balancer
+ * documents load each member through the repository, capture each member's model menu, and
+ * carry per-member credential bindings; the loaded member documents also travel on the
+ * resolved spec as `memberDocuments` so construction never rereads them. The returned
+ * document is always the original input, never a copy or mutation.
+ */
+export async function resolveProfileCandidate(
+  input: ProfileCandidateResolutionInput,
+  deps: ResolveProfileCandidateDeps,
+): Promise<ProfileCandidateResolution> {
+  if (isLoadBalancerProfileDocument(input.document)) {
+    return resolveLoadBalancerSpec(
+      { document: input.document, policyIntent: input.policyIntent },
+      deps,
+    );
+  }
+  return resolveStandardDocument(
+    { document: input.document, policyIntent: input.policyIntent },
+    deps,
+  );
+}
+
+function resultStatus(
+  errors: readonly string[],
+  unverified: readonly string[],
+): 'valid' | 'invalid' | 'unverified' {
+  if (errors.length > 0) {
+    return 'invalid';
+  }
+  if (unverified.length > 0) {
+    return 'unverified';
+  }
+  return 'valid';
+}

--- a/packages/core/src/profiles/resolution/resolveProfileCandidate.ts
+++ b/packages/core/src/profiles/resolution/resolveProfileCandidate.ts
@@ -112,6 +112,10 @@ function enforceLoaded(
     return null;
   }
   if (isStandardProfileDocument(document)) {
+    if (document.provider === '' || document.model === '') {
+      errors.push(`member ${name} must configure a provider and model`);
+      return null;
+    }
     return document;
   }
   errors.push(`member ${name} must be a standard profile`);
@@ -132,7 +136,7 @@ async function resolveMembers(
   deps: ResolveProfileCandidateDeps,
   errors: string[],
 ): Promise<Readonly<Record<string, StandardProfileDocument>>> {
-  const members: Record<string, StandardProfileDocument> = {};
+  const members: Record<string, StandardProfileDocument> = Object.create(null);
   for (const name of document.profiles) {
     const loaded = await rawMember(name, deps.repository, errors);
     if (loaded !== null) {
@@ -168,7 +172,7 @@ async function captureMembers(
   catalog: ProviderModelCatalogPort,
   unverified: string[],
 ): Promise<Readonly<Record<string, CapturedStandardSource>>> {
-  const captures: Record<string, CapturedStandardSource> = {};
+  const captures: Record<string, CapturedStandardSource> = Object.create(null);
   const menus = new Map<string, readonly string[]>();
   const memberEntries = Object.entries(members);
   for (const entry of memberEntries) {
@@ -206,6 +210,36 @@ function flagModelSupport(
   }
 }
 
+async function flagDocumentModel(
+  document: StandardProfileDocument,
+  catalog: ProviderModelCatalogPort,
+  errors: string[],
+  unverified: string[],
+): Promise<void> {
+  let support: Awaited<
+    ReturnType<ProviderModelCatalogPort['validateModelSupport']>
+  >;
+  try {
+    support = await catalog.validateModelSupport(
+      document.provider,
+      document.model,
+      document.modelParams,
+    );
+  } catch {
+    unverified.push(
+      `model support unavailable for provider ${document.provider}`,
+    );
+    return;
+  }
+  flagModelSupport(
+    support,
+    document.model,
+    document.provider,
+    errors,
+    unverified,
+  );
+}
+
 async function flagMemberModels(
   document: LoadBalancerProfileDocument,
   members: Readonly<Record<string, StandardProfileDocument>>,
@@ -215,18 +249,7 @@ async function flagMemberModels(
 ): Promise<void> {
   const memberEntries = Object.entries(members);
   for (const entry of memberEntries) {
-    const support = await catalog.validateModelSupport(
-      entry[1].provider,
-      entry[1].model,
-      entry[1].modelParams,
-    );
-    flagModelSupport(
-      support,
-      entry[1].model,
-      entry[1].provider,
-      errors,
-      unverified,
-    );
+    await flagDocumentModel(entry[1], catalog, errors, unverified);
   }
 }
 
@@ -276,6 +299,9 @@ async function resolveLoadBalancerSpec(
   const warnings: string[] = [];
   const unverified: string[] = [];
   const requestedVsEffective: PolicyExplanation[] = [];
+  if (loadable.profiles.length === 0) {
+    errors.push('load balancer must include at least one member');
+  }
   const members = await resolveMembers(loadable, deps, errors);
   const bindingsOutcome = memberCredentialBindings(loadable, members);
   warnings.push(...bindingsOutcome.warnings);
@@ -371,18 +397,7 @@ async function resolveStandardDocument(
   const bindingsOutcome = deriveCredentialBindings(standardDocument);
   warnings.push(...bindingsOutcome.warnings);
   bindings = bindingsOutcome.bindings;
-  const support = await deps.catalog.validateModelSupport(
-    standardDocument.provider,
-    standardDocument.model,
-    standardDocument.modelParams,
-  );
-  flagModelSupport(
-    support,
-    standardDocument.model,
-    standardDocument.provider,
-    errors,
-    unverified,
-  );
+  await flagDocumentModel(standardDocument, deps.catalog, errors, unverified);
   return {
     status: resultStatus(errors, unverified),
     resolved: {

--- a/packages/providers/src/BaseProvider.ts
+++ b/packages/providers/src/BaseProvider.ts
@@ -853,6 +853,9 @@ export abstract class BaseProvider implements IProvider {
           providedOptions.resolved?.baseURL ?? resolvedBaseURL,
         ),
         ...(runtimeId === undefined ? {} : { runtimeId }),
+        ...(typeof providedOptions.metadata?.profileId === 'string'
+          ? { profileId: providedOptions.metadata.profileId }
+          : {}),
       });
       resolvedAuth = authResult.token ?? '';
       if (authResult.token === null) {

--- a/packages/providers/src/BaseProvider.ts
+++ b/packages/providers/src/BaseProvider.ts
@@ -847,14 +847,16 @@ export abstract class BaseProvider implements IProvider {
       providedOptions.invocation?.runtimeId ??
       peekActiveProviderRuntimeContext()?.runtimeId;
     if (resolveAuthentication) {
+      const { authIntent, profileId } = providedOptions.metadata ?? {};
       const authResult = await this.authResolver.resolveAuthenticationResult({
         settingsService: settings,
         includeOAuth: this.isOAuthEligible(
           providedOptions.resolved?.baseURL ?? resolvedBaseURL,
         ),
         ...(runtimeId === undefined ? {} : { runtimeId }),
-        ...(typeof providedOptions.metadata?.profileId === 'string'
-          ? { profileId: providedOptions.metadata.profileId }
+        ...(typeof profileId === 'string' ? { profileId } : {}),
+        ...(authIntent === 'oauth' || authIntent === 'apikey'
+          ? { authIntent }
           : {}),
       });
       resolvedAuth = authResult.token ?? '';

--- a/packages/providers/src/LoadBalancingProvider.ts
+++ b/packages/providers/src/LoadBalancingProvider.ts
@@ -34,6 +34,7 @@ import { extractFailoverSettings as extractFailoverSettingsFromEphemeral } from 
 import { isTimeoutError } from './loadBalancing/streamTimeout.js';
 import { buildExtendedStats } from './loadBalancing/statsBuilder.js';
 import { buildRoundRobinResolvedOptions as buildRoundRobinResolvedOptionsExternal } from './loadBalancing/resolvedOptionsBuilder.js';
+import { resolveMemberAuthentication } from './loadBalancing/memberAuthentication.js';
 import { cloneContentsForCompression } from './loadBalancing/contentClone.js';
 import {
   getRequestSignal,
@@ -211,10 +212,14 @@ export class LoadBalancingProvider implements IProvider {
    */
   private async estimateForSubProfile(
     subProfile: ResolvedSubProfile | LoadBalancerSubProfile,
-    resolvedOptions: GenerateChatOptions,
+    options: GenerateChatOptions,
     delegateProvider: IProvider,
   ): Promise<EstimationResult> {
     const model = resolveSubProfileModel(subProfile);
+    const resolvedOptions = this.buildDelegateResolvedOptions(
+      await resolveMemberAuthentication(subProfile, this.logger),
+      options,
+    );
     const result = await estimatePreparedPrompt(
       subProfile,
       resolvedOptions,
@@ -263,7 +268,7 @@ export class LoadBalancingProvider implements IProvider {
     const compressedOptions = { ...options, contents: compressed };
     const compressedResult = await this.estimateForSubProfile(
       subProfile,
-      this.buildDelegateResolvedOptions(subProfile, compressedOptions),
+      compressedOptions,
       delegateProvider,
     );
     if (compressedResult.tokens <= contextLimit) {
@@ -319,13 +324,9 @@ export class LoadBalancingProvider implements IProvider {
       subProfile.providerName,
       resolveSubProfileModel(subProfile),
     );
-    const resolvedOptions = this.buildDelegateResolvedOptions(
-      subProfile,
-      targetOptions,
-    );
     const result = await this.estimateForSubProfile(
       subProfile,
-      resolvedOptions,
+      targetOptions,
       delegateProvider,
     );
     if (contextLimit === undefined || result.tokens <= contextLimit) {
@@ -403,7 +404,7 @@ export class LoadBalancingProvider implements IProvider {
     );
 
     const resolvedOptions = this.buildRoundRobinResolvedOptions(
-      subProfile,
+      await resolveMemberAuthentication(subProfile, this.logger),
       preparedTarget.options,
     );
     requireTransportAttempt(resolvedOptions);

--- a/packages/providers/src/LoadBalancingProvider.ts
+++ b/packages/providers/src/LoadBalancingProvider.ts
@@ -98,6 +98,7 @@ export type { TokenAccountingDiagnostics } from './loadBalancing/tokenAccounting
 export { isLoadBalancerProfileFormat } from './loadBalancing/loadBalancerProfileFormat.js';
 
 interface PreparedLoadBalancerTarget {
+  readonly authenticatedSubProfile: ResolvedSubProfile | LoadBalancerSubProfile;
   readonly options: GenerateChatOptions;
   readonly delegateProvider: IProvider;
 }
@@ -217,7 +218,9 @@ export class LoadBalancingProvider implements IProvider {
   ): Promise<EstimationResult> {
     const model = resolveSubProfileModel(subProfile);
     const resolvedOptions = this.buildDelegateResolvedOptions(
-      await resolveMemberAuthentication(subProfile, this.logger),
+      this.config.strategy === 'failover'
+        ? await resolveMemberAuthentication(subProfile, this.logger)
+        : subProfile,
       options,
     );
     const result = await estimatePreparedPrompt(
@@ -305,6 +308,10 @@ export class LoadBalancingProvider implements IProvider {
     options: GenerateChatOptions,
     subProfile: ResolvedSubProfile | LoadBalancerSubProfile,
   ): Promise<PreparedLoadBalancerTarget> {
+    const authenticatedSubProfile =
+      this.config.strategy === 'failover'
+        ? subProfile
+        : await resolveMemberAuthentication(subProfile, this.logger);
     const sharedLimit = this.getEffectiveContextLimit();
     const contextLimit = getTargetContextLimit(subProfile, sharedLimit);
     const delegateProvider = this.providerManager.getProviderByName(
@@ -325,7 +332,7 @@ export class LoadBalancingProvider implements IProvider {
       resolveSubProfileModel(subProfile),
     );
     const result = await this.estimateForSubProfile(
-      subProfile,
+      authenticatedSubProfile,
       targetOptions,
       delegateProvider,
     );
@@ -333,17 +340,18 @@ export class LoadBalancingProvider implements IProvider {
       return {
         options: optionsWithPromptProjection(targetOptions, result),
         delegateProvider,
+        authenticatedSubProfile,
       };
     }
     const compressed = await this.compressForContextLimit(
       targetOptions,
-      subProfile,
+      authenticatedSubProfile,
       result,
       contextLimit,
       delegateProvider,
     );
     if (compressed !== undefined) {
-      return { options: compressed, delegateProvider };
+      return { options: compressed, delegateProvider, authenticatedSubProfile };
     }
 
     throw new LoadBalancerContextLimitError({
@@ -404,7 +412,7 @@ export class LoadBalancingProvider implements IProvider {
     );
 
     const resolvedOptions = this.buildRoundRobinResolvedOptions(
-      await resolveMemberAuthentication(subProfile, this.logger),
+      preparedTarget.authenticatedSubProfile,
       preparedTarget.options,
     );
     requireTransportAttempt(resolvedOptions);

--- a/packages/providers/src/__tests__/extracted-helpers.behavior.test.ts
+++ b/packages/providers/src/__tests__/extracted-helpers.behavior.test.ts
@@ -693,13 +693,51 @@ describe('extracted provider helper behavior', () => {
       modelParams: { temperature: 0.2, max_tokens: 1024, maxTokens: 2048 },
     });
     expect(resolved.invocation?.runtimeId).toBe('lb-runtime');
-    expect(resolved.invocation?.ephemerals).toMatchObject({
-      streaming: true,
-      extra: 'value',
-      temperature: 0.2,
-      max_tokens: 1024,
-      maxTokens: 2048,
+  });
+
+  it('carries the member profileId on delegate metadata alongside loadBalancerDelegate (#2643)', () => {
+    const settingsService = new SettingsService();
+    const config = { getConversationLoggingEnabled: () => false } as Config;
+    const options: GenerateChatOptions = {
+      contents: [],
+      settings: settingsService,
+      runtime: {
+        settingsService,
+        config,
+        runtimeId: 'lb-runtime',
+        metadata: { parent: true },
+      },
+      metadata: { request: true },
+      resolved: { authToken: 'parent-token' },
+    };
+
+    const resolved = buildRoundRobinResolvedOptions(
+      {
+        name: 'team-member',
+        providerName: 'openai',
+        model: 'gpt-4o',
+        authToken: 'member-oauth-token',
+        ephemeralSettings: {},
+        modelParams: {},
+      },
+      options,
+      {
+        lbProfileEphemeralSettings: undefined,
+        lbProfileModelParams: undefined,
+        logger: debugLoggerStub(),
+        providerName: 'load-balancer',
+        getEffectiveContextLimit: () => undefined,
+      },
+    );
+
+    expect(resolved.metadata).toMatchObject({
+      loadBalancerDelegate: true,
+      profileId: 'team-member',
     });
+    expect(
+      (resolved.resolved as { profileId?: string }).profileId,
+    ).toBeUndefined();
+    expect(resolved.resolved?.authToken).toBe('member-oauth-token');
   });
 });
 

--- a/packages/providers/src/auth/__tests__/lb-member-auth-identity.behavioral.spec.ts
+++ b/packages/providers/src/auth/__tests__/lb-member-auth-identity.behavioral.spec.ts
@@ -1,0 +1,369 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Behavioral proof for issue #2643 acceptance criterion: two OAuth members of
+ * one load balancer using different accounts of the same provider each
+ * authenticate as their own account (no cross-substitution, no shared default).
+ *
+ * The chain under test is the real one a delegate call drives:
+ *   buildResolvedSubProfileOptions → metadata.profileId = member name
+ *   → resolveProfileBuckets(provider, { profileId }) → member-scoped buckets.
+ *
+ * Real ProfileManager and real profile files under the isolated storage root set up
+ * by the bun test harness preload (scripts/tests/storage-isolation-guard.ts).
+ * No mocks of the code under test.
+ */
+
+import { describe, it, expect, afterEach } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+
+import {
+  ProfileManager,
+  SettingsService,
+  type StandardProfile,
+  type LoadBalancerProfile,
+} from '@vybestack/llxprt-code-settings';
+import { resolveProfileBuckets } from '../token-profile-resolver.js';
+import { buildRoundRobinResolvedOptions } from '../../loadBalancing/resolvedOptionsBuilder.js';
+import type { ResolvedSubProfile } from '../../LoadBalancingProvider.js';
+import type { GenerateChatOptions } from '../../IProvider.js';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import { clearActiveProviderRuntimeContext } from '@vybestack/llxprt-code-core/runtime/providerRuntimeContext.js';
+import {
+  BaseProvider,
+  type NormalizedGenerateChatOptions,
+} from '../../BaseProvider.js';
+import { OAuthManager } from '../oauth-manager.js';
+import { OAuthBucketManager } from '../OAuthBucketManager.js';
+import {
+  MemoryTokenStore,
+  makeToken,
+  createTestProvider,
+} from './behavioral/test-utils.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import {
+  AuthPrecedenceResolver,
+  flushRuntimeAuthScope,
+  runtimeScopedStates,
+  type OAuthTokenRequestMetadata,
+} from '@vybestack/llxprt-code-auth';
+
+class RecordingOAuthManager extends OAuthManager {
+  readonly requests: Array<OAuthTokenRequestMetadata | undefined> = [];
+
+  override async getToken(
+    provider: string,
+    metadata?: OAuthTokenRequestMetadata,
+  ): Promise<string | null> {
+    this.requests.push(metadata);
+    return super.getToken(provider, metadata);
+  }
+}
+
+class AuthProbeProvider extends BaseProvider {
+  protected supportsOAuth(): boolean {
+    return true;
+  }
+  async getModels(): Promise<never[]> {
+    return [];
+  }
+  getDefaultModel(): string {
+    return 'm1';
+  }
+  protected async *generateChatCompletionWithOptions(
+    options: NormalizedGenerateChatOptions,
+  ): AsyncIterableIterator<IContent> {
+    const token = options.resolved.authToken;
+    if (typeof token !== 'string')
+      throw new Error('Expected resolved OAuth token');
+    yield { speaker: 'ai', blocks: [{ type: 'text', text: token }] };
+  }
+}
+
+const PROVIDER = 'llbx-oauth-test';
+const uniqueSuffix = `${Date.now()}-${randomUUID()}`;
+const memberAName = `lb-member-a-${uniqueSuffix}`;
+const memberBName = `lb-member-b-${uniqueSuffix}`;
+const lbParentName = `lb-parent-${uniqueSuffix}`;
+
+const noopLogger = new DebugLogger('llxprt:test:lb-member-auth');
+
+describe('load balancer member OAuth identity (#2643)', () => {
+  let manager: ProfileManager | undefined;
+
+  async function createFixtureProfiles(): Promise<ProfileManager> {
+    if (process.env.LLXPRT_TEST_STORAGE_ISOLATED !== '1') {
+      throw new Error(
+        'lb-member-auth-identity tests require isolated storage (preload guard)',
+      );
+    }
+
+    const fixtureManager = new ProfileManager();
+
+    const memberA: StandardProfile = {
+      version: 1,
+      provider: PROVIDER,
+      model: 'm1',
+      modelParams: {},
+      ephemeralSettings: {},
+      auth: { type: 'oauth', buckets: ['acct-alpha'] },
+    };
+    const memberB: StandardProfile = {
+      version: 1,
+      provider: PROVIDER,
+      model: 'm1',
+      modelParams: {},
+      ephemeralSettings: {},
+      auth: { type: 'oauth', buckets: ['acct-beta'] },
+    };
+    const lbParent: LoadBalancerProfile = {
+      version: 1,
+      type: 'loadbalancer',
+      policy: 'roundrobin',
+      profiles: [memberAName, memberBName],
+      provider: '',
+      model: '',
+      modelParams: {},
+      ephemeralSettings: {},
+    };
+
+    await fixtureManager.saveProfile(memberAName, memberA);
+    await fixtureManager.saveProfile(memberBName, memberB);
+    await fixtureManager.saveProfile(lbParentName, lbParent);
+
+    return fixtureManager;
+  }
+
+  async function cleanupProfiles(): Promise<void> {
+    if (!manager) {
+      return;
+    }
+    // The load balancer references its members, so delete the parent first.
+    await manager.deleteProfile(lbParentName).catch((error) => {
+      if (!(error instanceof Error) || !error.message.includes('not found')) {
+        throw error;
+      }
+    });
+    await manager.deleteProfile(memberAName).catch((error) => {
+      if (!(error instanceof Error) || !error.message.includes('not found')) {
+        throw error;
+      }
+    });
+    await manager.deleteProfile(memberBName).catch((error) => {
+      if (!(error instanceof Error) || !error.message.includes('not found')) {
+        throw error;
+      }
+    });
+  }
+
+  afterEach(async () => {
+    await cleanupProfiles();
+    manager = undefined;
+  });
+
+  it('member-scoped bucket resolution returns each member its own account', async () => {
+    manager = await createFixtureProfiles();
+
+    const bucketsA = await resolveProfileBuckets(PROVIDER, {
+      profileId: memberAName,
+    });
+    const bucketsB = await resolveProfileBuckets(PROVIDER, {
+      profileId: memberBName,
+    });
+
+    expect(bucketsA).toStrictEqual(['acct-alpha']);
+    expect(bucketsB).toStrictEqual(['acct-beta']);
+  });
+
+  it('ambient lookup cannot identify member buckets (old failure mode)', async () => {
+    manager = await createFixtureProfiles();
+
+    // No metadata: oauthRuntimeBridge has no current profile in tests, so the
+    // bucket resolution has no member to scope to and returns no buckets. The LB
+    // parent has provider '' so it can never match the requested provider either.
+    const buckets = await resolveProfileBuckets(PROVIDER);
+    expect(buckets).toStrictEqual([]);
+  });
+
+  it('two members never cross-substitute buckets', async () => {
+    manager = await createFixtureProfiles();
+
+    const [bucketsA, bucketsB] = await Promise.all([
+      resolveProfileBuckets(PROVIDER, { profileId: memberAName }),
+      resolveProfileBuckets(PROVIDER, { profileId: memberBName }),
+    ]);
+
+    expect(bucketsA).toStrictEqual(['acct-alpha']);
+    expect(bucketsB).toStrictEqual(['acct-beta']);
+  });
+
+  it('BaseProvider resolves each delegate through its own OAuth profile and session bucket', async () => {
+    manager = await createFixtureProfiles();
+    const store = new MemoryTokenStore();
+    await store.saveToken(PROVIDER, makeToken('alpha-token'), 'acct-alpha');
+    await store.saveToken(PROVIDER, makeToken('beta-token'), 'acct-beta');
+    await store.saveToken(PROVIDER, makeToken('ambient-token'));
+    const oauth = new RecordingOAuthManager(store);
+    oauth.registerProvider(createTestProvider(PROVIDER));
+    await oauth.toggleOAuthEnabled(PROVIDER);
+    const buckets = new OAuthBucketManager(store);
+    const settings = new SettingsService();
+    settings.setCurrentProfileName(lbParentName);
+    const config = createRuntimeConfigStub(settings);
+    const runtime = {
+      settingsService: settings,
+      config,
+      runtimeId: lbParentName,
+    };
+    const delegate = new AuthProbeProvider(
+      {
+        name: PROVIDER,
+        supportsOAuth: true,
+        isOAuthEnabled: true,
+        oauthProvider: PROVIDER,
+        oauthManager: oauth,
+      },
+      undefined,
+      config,
+      settings,
+    );
+    const observed: IContent[] = [];
+    try {
+      for (const name of [memberAName, memberBName, memberAName]) {
+        const options = buildRoundRobinResolvedOptions(
+          {
+            name,
+            providerName: PROVIDER,
+            model: 'm1',
+            ephemeralSettings: {},
+            modelParams: {},
+            auth: { type: 'oauth' },
+          },
+          { contents: [], settings, config, runtime },
+          {
+            lbProfileEphemeralSettings: undefined,
+            lbProfileModelParams: undefined,
+            logger: noopLogger,
+            providerName: 'load-balancer',
+            getEffectiveContextLimit: () => undefined,
+          },
+        );
+        for await (const chunk of delegate.generateChatCompletion(options))
+          observed.push(chunk);
+      }
+      expect(observed).toStrictEqual([
+        { speaker: 'ai', blocks: [{ type: 'text', text: 'alpha-token' }] },
+        { speaker: 'ai', blocks: [{ type: 'text', text: 'beta-token' }] },
+        { speaker: 'ai', blocks: [{ type: 'text', text: 'alpha-token' }] },
+      ]);
+      expect(oauth.requests.map((request) => request?.profileId)).toStrictEqual(
+        [memberAName, memberBName, memberAName],
+      );
+      expect(
+        oauth.requests.map((request) =>
+          buckets.getSessionBucketScopeKey(PROVIDER, request),
+        ),
+      ).toStrictEqual([
+        `${PROVIDER}::${memberAName}`,
+        `${PROVIDER}::${memberBName}`,
+        `${PROVIDER}::${memberAName}`,
+      ]);
+      expect(
+        oauth.getSessionBucket(PROVIDER, { profileId: memberAName }),
+      ).toStrictEqual('acct-alpha');
+      expect(
+        oauth.getSessionBucket(PROVIDER, { profileId: memberBName }),
+      ).toStrictEqual('acct-beta');
+    } finally {
+      flushRuntimeAuthScope(lbParentName);
+      clearActiveProviderRuntimeContext();
+    }
+  });
+
+  it('scopes runtime token caches by explicit member and retains ambient fallback', async () => {
+    expect(runtimeScopedStates.has(lbParentName)).toStrictEqual(false);
+    manager = await createFixtureProfiles();
+    const store = new MemoryTokenStore();
+    await store.saveToken(PROVIDER, makeToken('alpha-token'), 'acct-alpha');
+    await store.saveToken(PROVIDER, makeToken('beta-token'), 'acct-beta');
+    const oauth = new RecordingOAuthManager(store);
+    oauth.registerProvider(createTestProvider(PROVIDER));
+    await oauth.toggleOAuthEnabled(PROVIDER);
+    const settings = new SettingsService();
+    settings.setCurrentProfileName(memberAName);
+    const runtime = { settingsService: settings, runtimeId: lbParentName };
+    const resolver = new AuthPrecedenceResolver(
+      {
+        providerId: PROVIDER,
+        oauthProvider: PROVIDER,
+        isOAuthEnabled: true,
+        supportsOAuth: true,
+      },
+      {
+        settingsService: settings,
+        oauthManager: oauth,
+        getActiveRuntimeContext: () => runtime,
+      },
+    );
+    try {
+      const tokens: Array<string | null> = [];
+      for (const profileId of [
+        memberAName,
+        memberBName,
+        undefined,
+        memberBName,
+      ]) {
+        const result = await resolver.resolveAuthenticationResult({
+          includeOAuth: true,
+          profileId,
+        });
+        tokens.push(result.token);
+      }
+      expect(tokens).toStrictEqual([
+        'alpha-token',
+        'beta-token',
+        'alpha-token',
+        'beta-token',
+      ]);
+      expect(oauth.requests.map((request) => request?.profileId)).toStrictEqual(
+        [memberAName, memberBName],
+      );
+      expect([
+        ...(runtimeScopedStates.get(lbParentName)?.entries.keys() ?? []),
+      ]).toStrictEqual([
+        `${lbParentName}::${PROVIDER}::${memberAName}`,
+        `${lbParentName}::${PROVIDER}::${memberBName}`,
+      ]);
+    } finally {
+      flushRuntimeAuthScope(lbParentName);
+    }
+  });
+
+  it('delegate options carry the member identity', async () => {
+    const subProfile: ResolvedSubProfile = {
+      name: memberAName,
+      providerName: PROVIDER,
+      model: 'm1',
+      ephemeralSettings: {},
+      modelParams: {},
+    };
+
+    const options: GenerateChatOptions = {
+      contents: [],
+      metadata: {},
+    };
+
+    const result = buildRoundRobinResolvedOptions(subProfile, options, {
+      lbProfileEphemeralSettings: undefined,
+      lbProfileModelParams: undefined,
+      logger: noopLogger,
+      providerName: 'llb',
+      getEffectiveContextLimit: () => undefined,
+    });
+
+    expect(result.metadata?.profileId).toBe(memberAName);
+  });
+});

--- a/packages/providers/src/auth/__tests__/lb-member-auth-identity.behavioral.spec.ts
+++ b/packages/providers/src/auth/__tests__/lb-member-auth-identity.behavioral.spec.ts
@@ -212,6 +212,8 @@ describe('load balancer member OAuth identity (#2643)', () => {
     const buckets = new OAuthBucketManager(store);
     const settings = new SettingsService();
     settings.setCurrentProfileName(lbParentName);
+    settings.set('authOnly', false);
+    settings.setProviderSetting(PROVIDER, 'auth-key', 'ambient-provider-key');
     const config = createRuntimeConfigStub(settings);
     const runtime = {
       settingsService: settings,

--- a/packages/providers/src/loadBalancing/backendAttemptExecutor.ts
+++ b/packages/providers/src/loadBalancing/backendAttemptExecutor.ts
@@ -34,6 +34,7 @@ import {
 } from '../retryRequestContext.js';
 import { createHash } from 'node:crypto';
 import type { CircuitBreakerManager } from './circuitBreakerManager.js';
+import { resolveMemberAuthentication } from './memberAuthentication.js';
 
 export interface BackendAttemptDeps {
   readonly logger: DebugLogger;
@@ -75,18 +76,23 @@ export interface BackendAttemptParams {
  * Returns the resolved options and delegate provider so the caller can
  * start the lifecycle and invoke the delegate immediately after.
  */
-function resolveBackendDelegate(
-  subProfile: ResolvedSubProfile | LoadBalancerSubProfile,
+async function resolveBackendDelegate(
+  configuredSubProfile: ResolvedSubProfile | LoadBalancerSubProfile,
   options: GenerateChatOptions,
   delegateProvider: IProvider,
   deps: BackendAttemptDeps,
-): {
+): Promise<{
   resolvedOptions: GenerateChatOptions;
   delegateProvider: IProvider;
-} {
+  subProfile: ResolvedSubProfile | LoadBalancerSubProfile;
+}> {
+  const subProfile = await resolveMemberAuthentication(
+    configuredSubProfile,
+    deps.logger,
+  );
   const resolvedOptions = deps.buildResolvedOptions(subProfile, options);
   requireTransportAttempt(resolvedOptions);
-  return { resolvedOptions, delegateProvider };
+  return { resolvedOptions, delegateProvider, subProfile };
 }
 
 /**
@@ -171,7 +177,7 @@ export async function* executeBackendAttempt(
   let attemptCtx: BackendAttemptContext | null = null;
   let terminalEmitted = false;
 
-  const prepared = resolveBackendDelegate(
+  const prepared = await resolveBackendDelegate(
     subProfile,
     options,
     delegateProvider,
@@ -186,7 +192,7 @@ export async function* executeBackendAttempt(
       prepared.delegateProvider,
       prepared.resolvedOptions,
       settings,
-      subProfile,
+      prepared.subProfile,
       deps,
     );
     for await (const chunk of cleanupDelegateAttempt(

--- a/packages/providers/src/loadBalancing/loadBalancerTypes.ts
+++ b/packages/providers/src/loadBalancing/loadBalancerTypes.ts
@@ -61,14 +61,26 @@ export interface ExtendedLoadBalancerStats extends LoadBalancerStats {
   currentTPM: Record<string, number>;
 }
 
+/**
+ * Records a load-balancer member's declared auth intent at registration time,
+ * without secret material. Request-time identity scoping uses the delegate's
+ * metadata.profileId, not this field.
+ */
+export interface ProfileAuthIntent {
+  type: 'oauth' | 'apikey';
+  buckets?: readonly string[];
+}
+
 export interface ResolvedSubProfile {
   name: string;
   providerName: string;
   model: string;
   baseURL?: string;
   authToken?: string;
+  authKeyName?: string;
   authKeyfile?: string;
   contextWindow?: number;
+  auth?: ProfileAuthIntent;
   ephemeralSettings: Record<string, unknown>;
   modelParams: Record<string, unknown>;
 }
@@ -138,7 +150,7 @@ function hasResolvedSettings(profile: unknown): profile is ResolvedSubProfile {
   );
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+export function isRecord(value: unknown): value is Record<string, unknown> {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     return false;
   }

--- a/packages/providers/src/loadBalancing/memberAuthentication.projection.test.ts
+++ b/packages/providers/src/loadBalancing/memberAuthentication.projection.test.ts
@@ -22,6 +22,7 @@ const storedKeys = new Map<string, string>();
 
 function createProjectionFixture(
   strategy: LoadBalancingProviderConfig['strategy'],
+  rotateDuringProjection = false,
 ): {
   lb: LoadBalancingProvider;
   member: ResolvedSubProfile;
@@ -49,18 +50,47 @@ function createProjectionFixture(
     getDefaultModel: () => 'test-model',
     projectPromptEnvelope: async (options) => {
       projections.push(options);
-      return undefined;
+      if (!rotateDuringProjection) return undefined;
+      storedKeys.set('member-key', 'rotated-after-projection');
+      return {
+        model: 'test-model',
+        protocol: 'openai-responses',
+        method: 'responses/v1',
+        projectionRevision: 3,
+        unsupportedMedia: [],
+        transportToken: { credential: options.resolved?.authToken },
+        finalizedProjection: Object.freeze({
+          kind: 'llxprt-provider-prompt-v3',
+          protocol: 'openai-responses',
+          promptText: 'test prompt',
+        }),
+        legacyEstimate: async () => 1,
+      };
     },
-    async *generateChatCompletion(): AsyncGenerator<IContent> {
+    async *generateChatCompletion(options): AsyncGenerator<IContent> {
+      if (Array.isArray(options)) throw new Error('expected delegate options');
+      if (rotateDuringProjection) {
+        expect(options.promptEnvelopeTransportToken).toStrictEqual({
+          credential: options.resolved?.authToken,
+        });
+        expect(options.resolved?.authToken).not.toStrictEqual(
+          storedKeys.get('member-key'),
+        );
+      }
       yield { speaker: 'ai', blocks: [{ type: 'text', text: 'done' }] };
     },
   };
   manager.registerProvider(delegate);
   manager.setTokenizerFactory({
     getTokenizer: () => undefined,
-    estimatePrompt: async () => {
-      throw new Error('An unavailable projection uses the fallback estimator');
-    },
+    estimatePrompt: async (request) => ({
+      count: await request.legacyEstimate(),
+      method: 'calibrated',
+      family: 'legacy-unregistered',
+      estimatorVersion: 'test-v1',
+      assetRevision: 'none',
+      projectionRevision: request.projectionRevision,
+    }),
   });
   const member: ResolvedSubProfile = {
     name: 'key-member',
@@ -162,7 +192,23 @@ describe('load balancer projection credentials', () => {
     },
   );
 
-  it('resolves the current member key again for the compressed projection', async () => {
+  it('carries the projection credential through round-robin transport despite rotation', async () => {
+    const { lb, options, projections } = createProjectionFixture(
+      'round-robin',
+      true,
+    );
+    try {
+      storedKeys.set('member-key', 'projection-credential');
+      expect(await consume(lb, options)).toStrictEqual([
+        { speaker: 'ai', blocks: [{ type: 'text', text: 'done' }] },
+      ]);
+      expect(projections.length).toStrictEqual(1);
+    } finally {
+      storedKeys.clear();
+    }
+  });
+
+  it('retains the attempt credential for the compressed projection', async () => {
     const { lb, member, options, projections } =
       createProjectionFixture('round-robin');
     try {
@@ -188,7 +234,7 @@ describe('load balancer projection credentials', () => {
         })),
       ).toStrictEqual([
         { token: 'before-compression', profileId: 'key-member' },
-        { token: 'after-compression', profileId: 'key-member' },
+        { token: 'before-compression', profileId: 'key-member' },
       ]);
       expect(member.authToken).toStrictEqual(undefined);
     } finally {

--- a/packages/providers/src/loadBalancing/memberAuthentication.projection.test.ts
+++ b/packages/providers/src/loadBalancing/memberAuthentication.projection.test.ts
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'bun:test';
+import { SettingsService } from '@vybestack/llxprt-code-settings';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import type { GenerateChatOptions, IProvider } from '../IProvider.js';
+import { LoadBalancingProvider } from '../LoadBalancingProvider.js';
+import { ProviderManager } from '../ProviderManager.js';
+import type {
+  LoadBalancingProviderConfig,
+  ResolvedSubProfile,
+} from './loadBalancerTypes.js';
+
+import { createProviderKeyStorage } from '../runtime/runtimeSettings.js';
+
+const storedKeys = new Map<string, string>();
+
+function createProjectionFixture(
+  strategy: LoadBalancingProviderConfig['strategy'],
+): {
+  lb: LoadBalancingProvider;
+  member: ResolvedSubProfile;
+  options: GenerateChatOptions;
+  projections: GenerateChatOptions[];
+} {
+  const settings = new SettingsService();
+  settings.setCurrentProfileName('ambient-profile');
+  settings.setProviderSetting('projection-probe', 'auth-key', 'ambient-key');
+  const config = createRuntimeConfigStub(settings);
+  const runtime = {
+    settingsService: settings,
+    config,
+    runtimeId: 'projection-test',
+  };
+  const manager = new ProviderManager({
+    settingsService: settings,
+    config,
+    runtime,
+  });
+  const projections: GenerateChatOptions[] = [];
+  const delegate: IProvider = {
+    name: 'projection-probe',
+    getModels: async () => [],
+    getDefaultModel: () => 'test-model',
+    projectPromptEnvelope: async (options) => {
+      projections.push(options);
+      return undefined;
+    },
+    async *generateChatCompletion(): AsyncGenerator<IContent> {
+      yield { speaker: 'ai', blocks: [{ type: 'text', text: 'done' }] };
+    },
+  };
+  manager.registerProvider(delegate);
+  manager.setTokenizerFactory({
+    getTokenizer: () => undefined,
+    estimatePrompt: async () => {
+      throw new Error('An unavailable projection uses the fallback estimator');
+    },
+  });
+  const member: ResolvedSubProfile = {
+    name: 'key-member',
+    providerName: delegate.name,
+    model: 'test-model',
+    baseURL: 'https://projection-probe.example.test',
+    authKeyName: 'member-key',
+    auth: { type: 'apikey' },
+    ephemeralSettings: {},
+    modelParams: {},
+  };
+  const lb = new LoadBalancingProvider(
+    {
+      profileName: 'lb-projection',
+      strategy,
+      contextLimit: 100,
+      subProfiles: [member, { ...member, name: 'second-member' }],
+    },
+    manager,
+  );
+  return {
+    lb,
+    member,
+    projections,
+    options: {
+      contents: [],
+      settings,
+      config,
+      runtime,
+      metadata: { profileId: 'ambient-profile' },
+      resolved: { authToken: 'parent-key' },
+    },
+  };
+}
+
+async function consume(
+  lb: LoadBalancingProvider,
+  options: GenerateChatOptions,
+): Promise<IContent[]> {
+  const chunks: IContent[] = [];
+  for await (const chunk of lb.generateChatCompletion(options))
+    chunks.push(chunk);
+  return chunks;
+}
+
+describe('load balancer projection credentials', () => {
+  let restoreStorage: (() => void) | undefined;
+
+  beforeEach(() => {
+    if (process.env.LLXPRT_TEST_STORAGE_ISOLATED !== '1') {
+      throw new Error('Projection credential tests require isolated storage');
+    }
+    const getKey = vi.spyOn(createProviderKeyStorage(), 'getKey');
+    restoreStorage = () => getKey.mockRestore();
+    getKey.mockImplementation(async (name) => storedKeys.get(name) ?? null);
+  });
+
+  afterEach(() => {
+    restoreStorage?.();
+    restoreStorage = undefined;
+  });
+
+  const strategies: Array<LoadBalancingProviderConfig['strategy']> = [
+    'round-robin',
+    'failover',
+  ];
+
+  it.each(strategies)(
+    '%s projects with the member key and reads rotation on the next projection',
+    async (strategy) => {
+      const { lb, member, options, projections } =
+        createProjectionFixture(strategy);
+      try {
+        storedKeys.set('member-key', '  first-key  ');
+        await consume(lb, options);
+        storedKeys.set('member-key', '  rotated-key  ');
+        await consume(lb, options);
+
+        expect(
+          projections.map((projection) => ({
+            token: projection.resolved?.authToken,
+            profileId: projection.metadata?.profileId,
+            delegate: projection.metadata?.loadBalancerDelegate,
+          })),
+        ).toStrictEqual([
+          { token: 'first-key', profileId: 'key-member', delegate: true },
+          {
+            token: 'rotated-key',
+            profileId:
+              strategy === 'round-robin' ? 'second-member' : 'key-member',
+            delegate: true,
+          },
+        ]);
+        expect(member.authToken).toStrictEqual(undefined);
+        expect(options.resolved?.authToken).toStrictEqual('parent-key');
+      } finally {
+        storedKeys.clear();
+      }
+    },
+  );
+
+  it('resolves the current member key again for the compressed projection', async () => {
+    const { lb, member, options, projections } =
+      createProjectionFixture('round-robin');
+    try {
+      storedKeys.set('member-key', 'before-compression');
+      lb.setCompressionCallback(async () => {
+        storedKeys.set('member-key', 'after-compression');
+        return [];
+      });
+      await consume(lb, {
+        ...options,
+        contents: [
+          {
+            speaker: 'human',
+            blocks: [{ type: 'text', text: 'long prompt '.repeat(1000) }],
+          },
+        ],
+      });
+
+      expect(
+        projections.map((projection) => ({
+          token: projection.resolved?.authToken,
+          profileId: projection.metadata?.profileId,
+        })),
+      ).toStrictEqual([
+        { token: 'before-compression', profileId: 'key-member' },
+        { token: 'after-compression', profileId: 'key-member' },
+      ]);
+      expect(member.authToken).toStrictEqual(undefined);
+    } finally {
+      storedKeys.clear();
+    }
+  });
+});

--- a/packages/providers/src/loadBalancing/memberAuthentication.ts
+++ b/packages/providers/src/loadBalancing/memberAuthentication.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import { createProviderKeyStorage } from '../runtime/runtimeSettings.js';
+import {
+  isResolvedSubProfile,
+  type LoadBalancerSubProfile,
+  type ResolvedSubProfile,
+} from './loadBalancerTypes.js';
+
+interface AuthLogger {
+  debug(messageFactory: () => string): void;
+  warn(messageFactory: () => string): void;
+}
+
+export async function readMemberKeyfile(
+  profileName: string,
+  authKeyfile: string | undefined,
+  logger: AuthLogger,
+): Promise<string | undefined> {
+  if (authKeyfile === undefined) return undefined;
+  try {
+    const keyfilePath = authKeyfile.startsWith('~')
+      ? path.join(homedir(), authKeyfile.slice(1))
+      : authKeyfile;
+    const token = (await readFile(keyfilePath, 'utf-8')).trim();
+    logger.debug(
+      () => `Resolved authToken from keyfile for sub-profile ${profileName}`,
+    );
+    return token;
+  } catch (error) {
+    logger.warn(
+      () =>
+        `Failed to read auth-keyfile for sub-profile ${profileName}: ${error}`,
+    );
+    return undefined;
+  }
+}
+
+export async function resolveMemberAuthentication(
+  subProfile: ResolvedSubProfile | LoadBalancerSubProfile,
+  logger: AuthLogger,
+): Promise<ResolvedSubProfile | LoadBalancerSubProfile> {
+  if (!isResolvedSubProfile(subProfile) || subProfile.auth?.type === 'oauth') {
+    return subProfile;
+  }
+  const { authKeyName, name } = subProfile;
+  if (authKeyName === undefined) {
+    if (
+      subProfile.authToken !== undefined ||
+      subProfile.authKeyfile === undefined
+    ) {
+      return subProfile;
+    }
+    return {
+      ...subProfile,
+      authToken: await readMemberKeyfile(name, subProfile.authKeyfile, logger),
+    };
+  }
+  try {
+    const resolvedKey = await createProviderKeyStorage().getKey(authKeyName);
+    if (typeof resolvedKey === 'string' && resolvedKey.trim() !== '') {
+      logger.debug(
+        () => `Resolved auth-key-name '${authKeyName}' for sub-profile ${name}`,
+      );
+      return { ...subProfile, authToken: resolvedKey.trim() };
+    }
+    logger.warn(
+      () =>
+        `Key '${authKeyName}' not found in secure storage for sub-profile ${name}; falling back.`,
+    );
+  } catch (error) {
+    logger.warn(
+      () =>
+        `Failed to resolve auth-key-name '${authKeyName}' for sub-profile ${name}: ${error}`,
+    );
+  }
+  return {
+    ...subProfile,
+    authToken: await readMemberKeyfile(name, subProfile.authKeyfile, logger),
+  };
+}

--- a/packages/providers/src/loadBalancing/resolvedOptionsBuilder.ts
+++ b/packages/providers/src/loadBalancing/resolvedOptionsBuilder.ts
@@ -69,7 +69,14 @@ function buildDelegateResolvedOptions(
   ctx: OptionsBuildContext,
 ): GenerateChatOptions {
   if (isResolvedSubProfile(subProfile)) {
-    return buildResolvedSubProfileOptions(subProfile, options, ctx);
+    const memberOptions =
+      subProfile.auth === undefined
+        ? options
+        : {
+            ...options,
+            metadata: { ...options.metadata, authIntent: subProfile.auth.type },
+          };
+    return buildResolvedSubProfileOptions(subProfile, memberOptions, ctx);
   }
 
   // LoadBalancerSubProfile (legacy path)

--- a/packages/providers/src/loadBalancing/resolvedOptionsBuilder.ts
+++ b/packages/providers/src/loadBalancing/resolvedOptionsBuilder.ts
@@ -117,19 +117,15 @@ function buildResolvedSubProfileOptions(
   if (contextLimit !== undefined) {
     mergedEphemeralSettings['context-limit'] = contextLimit;
   }
-
   const mergedModelParams = {
     ...subProfile.modelParams,
     ...ctx.lbProfileModelParams,
   };
-  // Session-scoped keys from the immutable upstream invocation snapshot must
-  // overlay member/LB profile ephemerals LAST so an explicit session override
-  // (e.g. `/dumpcontext on`) is never clobbered by a delegate profile value.
-  const upstreamSessionEphemerals = extractUpstreamSessionEphemerals(options);
+
   const mergedInvocationEphemerals = {
     ...mergedEphemeralSettings,
     ...mergedModelParams,
-    ...upstreamSessionEphemerals,
+    ...extractUpstreamSessionEphemerals(options),
   };
 
   const temperature = readNumericSetting(
@@ -169,6 +165,7 @@ function buildResolvedSubProfileOptions(
     metadata: {
       ...options.metadata,
       loadBalancerDelegate: true,
+      profileId: subProfile.name,
       ephemeralSettings: mergedEphemeralSettings,
       modelParams: mergedModelParams,
     },

--- a/packages/providers/src/runtime/__tests__/profileApplication.lb.authkey.test.ts
+++ b/packages/providers/src/runtime/__tests__/profileApplication.lb.authkey.test.ts
@@ -6,6 +6,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test';
 import type { Profile } from '@vybestack/llxprt-code-settings';
 import * as fs from 'node:fs/promises';
+import { DebugLogger } from '@vybestack/llxprt-code-core/debug/DebugLogger.js';
+import type { GenerateChatOptions } from '../../IProvider.js';
+import {
+  isResolvedSubProfile,
+  type ResolvedSubProfile,
+} from '../../loadBalancing/loadBalancerTypes.js';
+import { resolveMemberAuthentication } from '../../loadBalancing/memberAuthentication.js';
+import { buildRoundRobinResolvedOptions } from '../../loadBalancing/resolvedOptionsBuilder.js';
+import { createProviderKeyStorage } from '../../auth/proxy/credential-store-factory.js';
 import {
   switchActiveProviderMock,
   setActiveModelMock,
@@ -19,7 +28,6 @@ import {
   getActiveProviderOrThrowMock,
   isCliStatelessProviderModeEnabledMock,
   isCliRuntimeStatelessReadyMock,
-  createProviderKeyStorageMock,
   keyStorageStub,
   profileManagerStub,
   wrapRegisterProviderToCaptureLB,
@@ -38,7 +46,7 @@ void vi.mock('../runtimeSettings.js', () => ({
   clearActiveModelParam: clearActiveModelParamMock,
   getActiveModelParams: getActiveModelParamsMock,
   setEphemeralSetting: setEphemeralSettingMock,
-  createProviderKeyStorage: createProviderKeyStorageMock,
+  createProviderKeyStorage,
   getCliRuntimeServices: getCliRuntimeServicesMock,
   getActiveProviderOrThrow: getActiveProviderOrThrowMock,
   isCliStatelessProviderModeEnabled: isCliStatelessProviderModeEnabledMock,
@@ -46,6 +54,34 @@ void vi.mock('../runtimeSettings.js', () => ({
 }));
 
 const { applyProfileWithGuards } = await import('../profileApplication.js');
+
+function getResolvedMember(
+  lbProvider: Parameters<typeof getLbSubProfiles>[0],
+  name: string,
+): ResolvedSubProfile {
+  const member = getLbSubProfiles(lbProvider).find((sp) => sp.name === name);
+  if (!isResolvedSubProfile(member)) {
+    throw new Error(`Expected registered member ${name}`);
+  }
+  return member;
+}
+
+async function buildMemberOptions(
+  member: ResolvedSubProfile,
+): Promise<GenerateChatOptions> {
+  const logger = new DebugLogger('llxprt:test:lb-auth-key');
+  return buildRoundRobinResolvedOptions(
+    await resolveMemberAuthentication(member, logger),
+    { contents: [] },
+    {
+      lbProfileEphemeralSettings: undefined,
+      lbProfileModelParams: undefined,
+      logger,
+      providerName: 'load-balancer',
+      getEffectiveContextLimit: () => undefined,
+    },
+  );
+}
 
 async function resolveNamedApiKey(name: string): Promise<string | null> {
   if (name === 'chutes') return 'resolved-chutes-api-key';
@@ -79,15 +115,25 @@ async function loadNamedAuthProfile(profileName: string): Promise<Profile> {
 }
 
 describe('auth-key-name resolution in sub-profiles (issue #1970)', () => {
+  let restoreStorage: (() => void) | undefined;
+
   beforeEach(() => {
     resetLbProfileApplicationStubs();
+    if (process.env.LLXPRT_TEST_STORAGE_ISOLATED !== '1') {
+      throw new Error('LB auth-key tests require isolated storage');
+    }
+    const getKey = vi.spyOn(createProviderKeyStorage(), 'getKey');
+    restoreStorage = () => getKey.mockRestore();
+    getKey.mockImplementation(keyStorageStub.getKey);
   });
 
   afterEach(() => {
+    restoreStorage?.();
+    restoreStorage = undefined;
     vi.clearAllMocks();
   });
 
-  it('resolves auth-key-name from secure storage into sub-profile authToken', async () => {
+  it('resolves each member named key into delegate options only at use time', async () => {
     keyStorageStub.getKey.mockImplementation(resolveNamedApiKey);
 
     const lbProfile = makeLbProfile(['zai', 'ollamaglm51']);
@@ -103,15 +149,87 @@ describe('auth-key-name resolution in sub-profiles (issue #1970)', () => {
 
     const lbProvider = getLBProvider();
     expect(lbProvider).not.toBeNull();
-    expect(createProviderKeyStorageMock).toHaveBeenCalled();
-    expect(keyStorageStub.getKey).toHaveBeenCalledWith('chutes');
-    expect(keyStorageStub.getKey).toHaveBeenCalledWith('openrouter');
+    const zaiSub = getResolvedMember(lbProvider, 'zai');
+    const ollamaSub = getResolvedMember(lbProvider, 'ollamaglm51');
+    expect(zaiSub.authKeyName).toBe('chutes');
+    expect(ollamaSub.authKeyName).toBe('openrouter');
+    expect(zaiSub.authToken).toBeUndefined();
+    expect(ollamaSub.authToken).toBeUndefined();
+    expect(keyStorageStub.getKey).not.toHaveBeenCalled();
 
-    const subProfiles = getLbSubProfiles(lbProvider);
-    const zaiSub = subProfiles.find((sp) => sp.name === 'zai');
-    const ollamaSub = subProfiles.find((sp) => sp.name === 'ollamaglm51');
-    expect(zaiSub?.authToken).toBe('resolved-chutes-api-key');
-    expect(ollamaSub?.authToken).toBe('resolved-openrouter-api-key');
+    const zaiOptions = await buildMemberOptions(zaiSub);
+    expect(zaiOptions.metadata?.profileId).toBe('zai');
+    expect(zaiOptions.resolved?.authToken).toBe('resolved-chutes-api-key');
+    expect(keyStorageStub.getKey).toHaveBeenCalledWith('chutes');
+    expect(keyStorageStub.getKey).not.toHaveBeenCalledWith('openrouter');
+
+    const ollamaOptions = await buildMemberOptions(ollamaSub);
+    expect(ollamaOptions.metadata?.profileId).toBe('ollamaglm51');
+    expect(ollamaOptions.resolved?.authToken).toBe(
+      'resolved-openrouter-api-key',
+    );
+    expect(keyStorageStub.getKey).toHaveBeenCalledWith('openrouter');
+    expect(zaiSub.authToken).toBeUndefined();
+    expect(ollamaSub.authToken).toBeUndefined();
+  });
+
+  it('reads a rotated named key on the next options build without caching plaintext', async () => {
+    keyStorageStub.getKey.mockResolvedValue('  key-A  ');
+    profileManagerStub.loadProfile = vi.fn(loadNamedAuthProfile);
+    const { getLBProvider } = wrapRegisterProviderToCaptureLB();
+
+    await applyProfileWithGuards(makeLbProfile(['zai']), {
+      profileName: 'glm',
+    });
+
+    const member = getResolvedMember(getLBProvider(), 'zai');
+    expect(member.authKeyName).toBe('chutes');
+    expect(member.authToken).toBeUndefined();
+    expect(keyStorageStub.getKey).not.toHaveBeenCalled();
+
+    const firstOptions = await buildMemberOptions(member);
+    expect(firstOptions.resolved?.authToken).toBe('key-A');
+    expect(member.authToken).toBeUndefined();
+
+    keyStorageStub.getKey.mockResolvedValue('  key-B  ');
+    const secondOptions = await buildMemberOptions(member);
+    expect(secondOptions.resolved?.authToken).toBe('key-B');
+    expect(firstOptions.resolved?.authToken).toBe('key-A');
+    expect(member.authToken).toBeUndefined();
+    expect(keyStorageStub.getKey).toHaveBeenCalledTimes(2);
+    expect(keyStorageStub.getKey).toHaveBeenCalledWith('chutes');
+  });
+
+  it('reads keyfile rotation between attempts without storing plaintext on the member', async () => {
+    const { tempDir, keyfilePath } =
+      await createTempKeyfile('  first-file-key  ');
+    try {
+      profileManagerStub.loadProfile = vi.fn(
+        async (): Promise<Profile> => ({
+          version: 1,
+          provider: 'gemini',
+          model: 'gemini-flash',
+          modelParams: {},
+          ephemeralSettings: { 'auth-keyfile': keyfilePath },
+        }),
+      );
+      const { getLBProvider } = wrapRegisterProviderToCaptureLB();
+      await applyProfileWithGuards(makeLbProfile(['keyfile-member']), {
+        profileName: 'file-lb',
+      });
+      const member = getResolvedMember(getLBProvider(), 'keyfile-member');
+      expect(member.authToken).toStrictEqual(undefined);
+      const first = await buildMemberOptions(member);
+      await fs.writeFile(keyfilePath, '  second-file-key  ');
+      const second = await buildMemberOptions(member);
+      expect([
+        first.resolved?.authToken,
+        second.resolved?.authToken,
+      ]).toStrictEqual(['first-file-key', 'second-file-key']);
+      expect(member.authToken).toStrictEqual(undefined);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('prefers explicit auth-key over auth-key-name', async () => {
@@ -141,12 +259,17 @@ describe('auth-key-name resolution in sub-profiles (issue #1970)', () => {
 
     const lbProvider = getLBProvider();
     expect(lbProvider).not.toBeNull();
-    const subProfiles = getLbSubProfiles(lbProvider);
+    const member = getResolvedMember(lbProvider, 'explicitKey');
     expect(keyStorageStub.getKey).not.toHaveBeenCalled();
-    expect(subProfiles[0]?.authToken).toBe('explicit-direct-key');
+    expect(member.authToken).toBe('explicit-direct-key');
+    expect(member.authKeyName).toBeUndefined();
+
+    const options = await buildMemberOptions(member);
+    expect(options.resolved?.authToken).toBe('explicit-direct-key');
+    expect(keyStorageStub.getKey).not.toHaveBeenCalled();
   });
 
-  it('warns and continues when auth-key-name references a missing key', async () => {
+  it('continues without a token when the named key is missing at use time', async () => {
     keyStorageStub.getKey.mockResolvedValue(null);
 
     const lbProfile = makeLbProfile(['missingKeyProfile']);
@@ -172,11 +295,18 @@ describe('auth-key-name resolution in sub-profiles (issue #1970)', () => {
 
     const lbProvider = getLBProvider();
     expect(lbProvider).not.toBeNull();
-    const subProfiles = getLbSubProfiles(lbProvider);
-    expect(subProfiles[0]?.authToken).toBeUndefined();
+    const member = getResolvedMember(lbProvider, 'missingKeyProfile');
+    expect(member.authKeyName).toBe('nonexistent-key');
+    expect(member.authToken).toBeUndefined();
+    expect(keyStorageStub.getKey).not.toHaveBeenCalled();
+
+    const options = await buildMemberOptions(member);
+    expect(options.metadata?.profileId).toBe('missingKeyProfile');
+    expect(options.resolved?.authToken).toBeUndefined();
+    expect(keyStorageStub.getKey).toHaveBeenCalledWith('nonexistent-key');
   });
 
-  it('resolves auth-key-name and falls back to auth-keyfile when named key missing', async () => {
+  it('falls back to the member keyfile at use time when the named key is missing', async () => {
     keyStorageStub.getKey.mockResolvedValue(null);
     const { tempDir, keyfilePath } = await createTempKeyfile(
       'resolved-from-keyfile\n',
@@ -207,8 +337,20 @@ describe('auth-key-name resolution in sub-profiles (issue #1970)', () => {
 
       const lbProvider = getLBProvider();
       expect(lbProvider).not.toBeNull();
-      const subProfiles = getLbSubProfiles(lbProvider);
-      expect(subProfiles[0]?.authToken).toBe('resolved-from-keyfile');
+      const member = getResolvedMember(lbProvider, 'fallbackProfile');
+      expect(member.authKeyName).toBe('missing-key');
+      expect(member.authKeyfile).toBe(keyfilePath);
+      expect(member.authToken).toBeUndefined();
+      expect(keyStorageStub.getKey).not.toHaveBeenCalled();
+
+      await fs.writeFile(keyfilePath, '  resolved-from-keyfile-at-use-time  ');
+      const options = await buildMemberOptions(member);
+      expect(options.metadata?.profileId).toBe('fallbackProfile');
+      expect(options.resolved?.authToken).toBe(
+        'resolved-from-keyfile-at-use-time',
+      );
+      expect(keyStorageStub.getKey).toHaveBeenCalledWith('missing-key');
+      expect(member.authToken).toBeUndefined();
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }

--- a/packages/providers/src/runtime/profile-application/loadBalancerProfile.memberAuth.test.ts
+++ b/packages/providers/src/runtime/profile-application/loadBalancerProfile.memberAuth.test.ts
@@ -4,26 +4,60 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  afterAll,
+  vi,
+} from 'bun:test';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import {
   ProfileManager,
-  SettingsService,
   type AuthConfig,
 } from '@vybestack/llxprt-code-settings';
-import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
 import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
 import { LoadBalancingProvider } from '../../LoadBalancingProvider.js';
-import { ProviderManager } from '../../ProviderManager.js';
 import type { GenerateChatOptions, IProvider } from '../../IProvider.js';
-import { createProviderKeyStorage } from '../runtimeSettings.js';
+import { createProviderKeyStorage } from '../../auth/proxy/credential-store-factory.js';
 import { resolveLoadBalancerSubProfile } from './loadBalancerProfile.js';
 import { resolveMemberAuthentication } from '../../loadBalancing/memberAuthentication.js';
 
+const realProviderManagerModule = {
+  ...(await import('../../ProviderManager.js')),
+};
+void vi.mock('../../ProviderManager.js', () => ({
+  ProviderManager: class {
+    private readonly providers = new Map<string, IProvider>();
+
+    registerProvider(provider: IProvider): void {
+      this.providers.set(provider.name, provider);
+    }
+
+    getProviderByName(name: string): IProvider | undefined {
+      return this.providers.get(name);
+    }
+
+    getTokenizerFactory(): undefined {
+      return undefined;
+    }
+  },
+}));
+const { ProviderManager: StubProviderManager } = await import(
+  '../../ProviderManager.js'
+);
+
 describe('resolveLoadBalancerSubProfile — member auth handling', () => {
   const tempDirs: string[] = [];
+  let restoreStorage: (() => void) | undefined;
+
+  afterAll(() => {
+    void vi.mock('../../ProviderManager.js', () => realProviderManagerModule);
+  });
 
   async function makeTempDir(): Promise<string> {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'llxprt-lb-auth-'));
@@ -57,9 +91,35 @@ describe('resolveLoadBalancerSubProfile — member auth handling', () => {
         'loadBalancerProfile.memberAuth tests require isolated storage (preload guard)',
       );
     }
+    const keys = new Map<string, string | Error>([
+      ['invalid key name!', new Error('Invalid key name')],
+    ]);
+    const storage = createProviderKeyStorage();
+    const getKey = vi
+      .spyOn(storage, 'getKey')
+      .mockImplementation(async (name) => {
+        const value = keys.get(name);
+        if (value instanceof Error) throw value;
+        return value ?? null;
+      });
+    const saveKey = vi
+      .spyOn(storage, 'saveKey')
+      .mockImplementation(async (name, value) => {
+        keys.set(name, value);
+      });
+    const deleteKey = vi
+      .spyOn(storage, 'deleteKey')
+      .mockImplementation(async (name) => keys.delete(name));
+    restoreStorage = () => {
+      getKey.mockRestore();
+      saveKey.mockRestore();
+      deleteKey.mockRestore();
+    };
   });
 
   afterEach(async () => {
+    restoreStorage?.();
+    restoreStorage = undefined;
     await Promise.all(
       tempDirs.map((dir) =>
         fs.rm(dir, { recursive: true, force: true }).catch(() => {}),
@@ -174,18 +234,7 @@ describe('resolveLoadBalancerSubProfile — member auth handling', () => {
           'member-keyname',
           deps(pm),
         );
-        const settings = new SettingsService();
-        const config = createRuntimeConfigStub(settings);
-        const runtime = {
-          settingsService: settings,
-          config,
-          runtimeId: keyName,
-        };
-        const providerManager = new ProviderManager({
-          settingsService: settings,
-          config,
-          runtime,
-        });
+        const providerManager = new StubProviderManager();
         const delegate: IProvider = {
           name: 'key-probe',
           getModels: async () => [],
@@ -216,9 +265,6 @@ describe('resolveLoadBalancerSubProfile — member auth handling', () => {
           await fs.writeFile(keyfile, value);
           for await (const chunk of lb.generateChatCompletion({
             contents: [],
-            settings,
-            config,
-            runtime,
           })) {
             observed.push(chunk);
           }

--- a/packages/providers/src/runtime/profile-application/loadBalancerProfile.memberAuth.test.ts
+++ b/packages/providers/src/runtime/profile-application/loadBalancerProfile.memberAuth.test.ts
@@ -1,0 +1,395 @@
+/**
+ * @license
+ * Copyright 2026 Vybestack LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import {
+  ProfileManager,
+  SettingsService,
+  type AuthConfig,
+} from '@vybestack/llxprt-code-settings';
+import { createRuntimeConfigStub } from '@vybestack/llxprt-code-core/test-utils/runtime.js';
+import type { IContent } from '@vybestack/llxprt-code-core/services/history/IContent.js';
+import { LoadBalancingProvider } from '../../LoadBalancingProvider.js';
+import { ProviderManager } from '../../ProviderManager.js';
+import type { GenerateChatOptions, IProvider } from '../../IProvider.js';
+import { createProviderKeyStorage } from '../runtimeSettings.js';
+import { resolveLoadBalancerSubProfile } from './loadBalancerProfile.js';
+import { resolveMemberAuthentication } from '../../loadBalancing/memberAuthentication.js';
+
+describe('resolveLoadBalancerSubProfile — member auth handling', () => {
+  const tempDirs: string[] = [];
+
+  async function makeTempDir(): Promise<string> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'llxprt-lb-auth-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  function silentLogger(): {
+    debug: (messageFactory: () => string) => void;
+    warn: (messageFactory: () => string) => void;
+  } {
+    return {
+      debug: () => {},
+      warn: () => {},
+    };
+  }
+
+  function deps(
+    profileManagerInstance: ProfileManager,
+  ): Parameters<typeof resolveLoadBalancerSubProfile>[1] {
+    return {
+      lbName: 'lb-main',
+      profileManagerInstance,
+      lbLogger: silentLogger(),
+    };
+  }
+
+  beforeEach(() => {
+    if (process.env.LLXPRT_TEST_STORAGE_ISOLATED !== '1') {
+      throw new Error(
+        'loadBalancerProfile.memberAuth tests require isolated storage (preload guard)',
+      );
+    }
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) =>
+        fs.rm(dir, { recursive: true, force: true }).catch(() => {}),
+      ),
+    );
+    tempDirs.length = 0;
+  });
+  it('copies an OAuth auth intent and resolves NO plaintext authToken', async () => {
+    const tempDir = await makeTempDir();
+    const pm = new ProfileManager(path.join(tempDir, 'profiles'));
+    await pm.saveProfile('member-oauth', {
+      version: 1,
+      type: 'standard',
+      provider: 'anthropic',
+      model: 'claude-sonnet',
+      modelParams: {},
+      ephemeralSettings: {},
+      auth: { type: 'oauth', buckets: ['acct-a'] },
+    });
+
+    const resolved = await resolveLoadBalancerSubProfile(
+      'member-oauth',
+      deps(pm),
+    );
+
+    expect(resolved.auth).toStrictEqual({ type: 'oauth', buckets: ['acct-a'] });
+    expect(resolved.authToken).toBeUndefined();
+  });
+
+  it.each(['auth-key', 'auth-key-name'])(
+    'ignores stray %s when the member explicitly selects OAuth',
+    async (key) => {
+      const tempDir = await makeTempDir();
+      const pm = new ProfileManager(path.join(tempDir, 'profiles'));
+      await pm.saveProfile('member-oauth', {
+        version: 1,
+        provider: 'anthropic',
+        model: 'claude-sonnet',
+        modelParams: {},
+        ephemeralSettings: { [key]: 'stray-credential' },
+        auth: { type: 'oauth', buckets: ['acct-a'] },
+      });
+      const storage = createProviderKeyStorage();
+      await storage.saveKey('stray-credential', 'stray-secret');
+      try {
+        const resolved = await resolveLoadBalancerSubProfile(
+          'member-oauth',
+          deps(pm),
+        );
+        expect(resolved.authToken).toStrictEqual(undefined);
+        expect(resolved.authKeyName).toStrictEqual(undefined);
+        expect(resolved.auth).toStrictEqual({
+          type: 'oauth',
+          buckets: ['acct-a'],
+        });
+      } finally {
+        await storage.deleteKey('stray-credential');
+      }
+    },
+  );
+
+  it('retains an API-key name without reading secret material at registration', async () => {
+    const tempDir = await makeTempDir();
+    const pm = new ProfileManager(path.join(tempDir, 'profiles'));
+    await pm.saveProfile('member-keyname', {
+      version: 1,
+      provider: 'openai',
+      model: 'gpt-4',
+      modelParams: {},
+      ephemeralSettings: { 'auth-key-name': 'not-yet-stored' },
+      auth: { type: 'apikey' },
+    });
+    const resolved = await resolveLoadBalancerSubProfile(
+      'member-keyname',
+      deps(pm),
+    );
+    expect(resolved.authKeyName).toStrictEqual('not-yet-stored');
+    expect(resolved.authToken).toStrictEqual(undefined);
+    expect(resolved.auth).toStrictEqual({ type: 'apikey' });
+  });
+
+  const strategies: Array<'round-robin' | 'failover'> = [
+    'round-robin',
+    'failover',
+  ];
+  const rotationCases = strategies.flatMap((strategy) =>
+    ['auth-key-name', 'auth-keyfile'].map((source) => ({ strategy, source })),
+  );
+  it.each(rotationCases)(
+    '$strategy resolves and trims $source on every delegate attempt',
+    async ({ strategy, source }) => {
+      const tempDir = await makeTempDir();
+      const pm = new ProfileManager(path.join(tempDir, 'profiles'));
+      const keyName = `lb-rotation-${path.basename(tempDir)}`;
+      const keyfile = path.join(tempDir, 'rotating.key');
+      await fs.writeFile(keyfile, '  first-key  ');
+      await pm.saveProfile('member-keyname', {
+        version: 1,
+        provider: 'key-probe',
+        model: 'test-model',
+        modelParams: {},
+        ephemeralSettings: {
+          [source]: source === 'auth-keyfile' ? keyfile : keyName,
+          'base-url': 'https://key-probe.example.test',
+        },
+        auth: { type: 'apikey' },
+      });
+      const storage = createProviderKeyStorage();
+      await storage.saveKey(keyName, '  first-key  ');
+      try {
+        const resolved = await resolveLoadBalancerSubProfile(
+          'member-keyname',
+          deps(pm),
+        );
+        const settings = new SettingsService();
+        const config = createRuntimeConfigStub(settings);
+        const runtime = {
+          settingsService: settings,
+          config,
+          runtimeId: keyName,
+        };
+        const providerManager = new ProviderManager({
+          settingsService: settings,
+          config,
+          runtime,
+        });
+        const delegate: IProvider = {
+          name: 'key-probe',
+          getModels: async () => [],
+          getDefaultModel: () => 'test-model',
+          async *generateChatCompletion(
+            options: GenerateChatOptions | IContent[],
+          ): AsyncGenerator<IContent> {
+            if (Array.isArray(options))
+              throw new Error('Expected delegate options');
+            const token = options.resolved?.authToken;
+            if (typeof token !== 'string')
+              throw new Error('Expected resolved key');
+            yield { speaker: 'ai', blocks: [{ type: 'text', text: token }] };
+          },
+        };
+        providerManager.registerProvider(delegate);
+        const lb = new LoadBalancingProvider(
+          {
+            profileName: 'lb-main',
+            strategy,
+            subProfiles: [resolved, { ...resolved, name: 'second-member' }],
+          },
+          providerManager,
+        );
+        const observed: IContent[] = [];
+        for (const value of ['  first-key  ', '  rotated-key  ']) {
+          await storage.saveKey(keyName, value);
+          await fs.writeFile(keyfile, value);
+          for await (const chunk of lb.generateChatCompletion({
+            contents: [],
+            settings,
+            config,
+            runtime,
+          })) {
+            observed.push(chunk);
+          }
+        }
+        expect(observed).toStrictEqual([
+          { speaker: 'ai', blocks: [{ type: 'text', text: 'first-key' }] },
+          { speaker: 'ai', blocks: [{ type: 'text', text: 'rotated-key' }] },
+        ]);
+        expect(resolved.authToken).toStrictEqual(undefined);
+      } finally {
+        await storage.deleteKey(keyName);
+      }
+    },
+  );
+
+  it.each(['missing-key', 'invalid key name!'])(
+    'falls back to the member keyfile when the named key is unavailable (%s)',
+    async (authKeyName) => {
+      const tempDir = await makeTempDir();
+      const authKeyfile = path.join(tempDir, 'fallback.key');
+      await fs.writeFile(authKeyfile, '  fallback-token  ');
+      const member = {
+        name: 'member',
+        providerName: 'openai',
+        model: 'm1',
+        authKeyName,
+        authKeyfile,
+        ephemeralSettings: {},
+        modelParams: {},
+      };
+      const resolved = await resolveMemberAuthentication(
+        member,
+        silentLogger(),
+      );
+      expect(resolved.authToken).toStrictEqual('fallback-token');
+      const missing = await resolveMemberAuthentication(
+        { ...member, authKeyfile: undefined },
+        silentLogger(),
+      );
+      expect(missing.authToken).toStrictEqual(undefined);
+    },
+  );
+
+  it('rejects non-plain auth records during registration', async () => {
+    const auth = { type: 'oauth', buckets: ['account'] } satisfies AuthConfig;
+    Object.setPrototypeOf(auth, { inherited: true });
+    const member = await resolveLoadBalancerSubProfile('non-plain-auth', {
+      lbName: 'lb-main',
+      lbLogger: silentLogger(),
+      profileManagerInstance: {
+        loadProfile: async () => ({
+          version: 1,
+          provider: 'openai',
+          model: 'm1',
+          modelParams: {},
+          ephemeralSettings: {},
+          auth,
+        }),
+      },
+    });
+    expect(member.auth).toStrictEqual(undefined);
+  });
+
+  it('retains inline key precedence over a named key', async () => {
+    const resolved = await resolveLoadBalancerSubProfile('inline-member', {
+      lbName: 'lb-main',
+      lbLogger: silentLogger(),
+      profileManagerInstance: {
+        loadProfile: async () => ({
+          version: 1,
+          provider: 'openai',
+          model: 'm1',
+          modelParams: {},
+          ephemeralSettings: {
+            'auth-key': 'inline-key',
+            'auth-key-name': 'unused-name',
+          },
+        }),
+      },
+    });
+    expect(resolved.authToken).toStrictEqual('inline-key');
+    expect(resolved.authKeyName).toStrictEqual(undefined);
+  });
+
+  it('ignores a stray auth-keyfile when the member explicitly selects OAuth', async () => {
+    const tempDir = await makeTempDir();
+    const authKeyfile = path.join(tempDir, 'oauth.key');
+    await fs.writeFile(authKeyfile, '  file-token  ');
+    const resolved = await resolveLoadBalancerSubProfile(
+      'oauth-keyfile-member',
+      {
+        lbName: 'lb-main',
+        lbLogger: silentLogger(),
+        profileManagerInstance: {
+          loadProfile: async () => ({
+            version: 1,
+            provider: 'openai',
+            model: 'm1',
+            modelParams: {},
+            auth: { type: 'oauth', buckets: ['account'] },
+            ephemeralSettings: {
+              'auth-key': 'stray-key',
+              'auth-keyfile': authKeyfile,
+            },
+          }),
+        },
+      },
+    );
+    expect(resolved.authToken).toStrictEqual(undefined);
+    expect(
+      (await resolveMemberAuthentication(resolved, silentLogger())).authToken,
+    ).toStrictEqual(undefined);
+    expect(resolved.auth).toStrictEqual({
+      type: 'oauth',
+      buckets: ['account'],
+    });
+  });
+
+  it('retains keyfile intent at registration and reads rotated content at use time', async () => {
+    const tempDir = await makeTempDir();
+    const pm = new ProfileManager(path.join(tempDir, 'profiles'));
+    const keyfilePath = path.join(tempDir, 'member.key');
+    await fs.writeFile(keyfilePath, ' file-token ', 'utf8');
+    await pm.saveProfile('member-keyfile', {
+      version: 1,
+      type: 'standard',
+      provider: 'openai',
+      model: 'gpt-4',
+      modelParams: {},
+      ephemeralSettings: { 'auth-keyfile': keyfilePath },
+    });
+
+    const resolved = await resolveLoadBalancerSubProfile(
+      'member-keyfile',
+      deps(pm),
+    );
+
+    expect(resolved.authToken).toStrictEqual(undefined);
+    expect(resolved.authKeyfile).toStrictEqual(keyfilePath);
+    const first = await resolveMemberAuthentication(resolved, silentLogger());
+    await fs.writeFile(keyfilePath, '  rotated-token  ', 'utf8');
+    const second = await resolveMemberAuthentication(resolved, silentLogger());
+    expect([first.authToken, second.authToken]).toStrictEqual([
+      'file-token',
+      'rotated-token',
+    ]);
+    expect(resolved.authToken).toStrictEqual(undefined);
+    await fs.unlink(keyfilePath);
+    expect(
+      (await resolveMemberAuthentication(resolved, silentLogger())).authToken,
+    ).toStrictEqual(undefined);
+  });
+
+  it('leaves authToken and auth intent undefined when the member has no auth', async () => {
+    const tempDir = await makeTempDir();
+    const pm = new ProfileManager(path.join(tempDir, 'profiles'));
+    await pm.saveProfile('member-plain', {
+      version: 1,
+      type: 'standard',
+      provider: 'openai',
+      model: 'gpt-4',
+      modelParams: {},
+      ephemeralSettings: {},
+    });
+
+    const resolved = await resolveLoadBalancerSubProfile(
+      'member-plain',
+      deps(pm),
+    );
+
+    expect(resolved.authToken).toBeUndefined();
+    expect(resolved.auth).toBeUndefined();
+  });
+});

--- a/packages/providers/src/runtime/profile-application/loadBalancerProfile.ts
+++ b/packages/providers/src/runtime/profile-application/loadBalancerProfile.ts
@@ -9,16 +9,17 @@ import {
   type ResolvedSubProfile,
 } from '../../LoadBalancingProvider.js';
 import {
+  isRecord,
+  type ProfileAuthIntent,
+} from '../../loadBalancing/loadBalancerTypes.js';
+import {
   type LoadBalancerProfile,
   type Profile,
 } from '@vybestack/llxprt-code-settings';
 import { ProfileManager } from '@vybestack/llxprt-code-settings';
 import { isLoadBalancerProfile } from '@vybestack/llxprt-code-settings/profiles/types.js';
-import * as fs from 'node:fs/promises';
-import { homedir } from 'node:os';
-import path from 'node:path';
 import type { getCliRuntimeServices } from '../runtimeSettings.js';
-import { createProviderKeyStorage } from '../runtimeSettings.js';
+
 import {
   getProfileEphemeralSettings,
   getProfileModel,
@@ -72,64 +73,6 @@ function ensureSubProfileIsNotLoadBalancer(
     throw new Error(
       `Load balancer profile "${lbName}" cannot reference another loadbalancer profile "${profileName}"`,
     );
-  }
-}
-
-async function resolveSubProfileAuthToken(
-  profileName: string,
-  subProfileEphemeralSettings: Record<string, unknown>,
-  authKeyfile: string | undefined,
-  deps: LoadBalancerResolutionDeps,
-): Promise<string | undefined> {
-  const authToken = getStringValue(subProfileEphemeralSettings, 'auth-key');
-  if (authToken !== undefined) {
-    return authToken;
-  }
-
-  const authKeyName = getStringValue(
-    subProfileEphemeralSettings,
-    'auth-key-name',
-  );
-  if (authKeyName !== undefined) {
-    try {
-      const resolvedKey = await createProviderKeyStorage().getKey(authKeyName);
-      if (resolvedKey && resolvedKey.trim() !== '') {
-        deps.lbLogger.debug(
-          () =>
-            `Resolved auth-key-name '${authKeyName}' for sub-profile ${profileName}`,
-        );
-        return resolvedKey.trim();
-      }
-      deps.lbLogger.warn(
-        () =>
-          `Key '${authKeyName}' not found in secure storage for sub-profile ${profileName}; falling back.`,
-      );
-    } catch (error) {
-      deps.lbLogger.warn(
-        () =>
-          `Failed to resolve auth-key-name '${authKeyName}' for sub-profile ${profileName}: ${error}`,
-      );
-    }
-  }
-
-  if (authKeyfile === undefined) {
-    return undefined;
-  }
-  try {
-    const keyfilePath = authKeyfile.startsWith('~')
-      ? path.join(homedir(), authKeyfile.slice(1))
-      : authKeyfile;
-    const keyfileToken = (await fs.readFile(keyfilePath, 'utf-8')).trim();
-    deps.lbLogger.debug(
-      () => `Resolved authToken from keyfile for sub-profile ${profileName}`,
-    );
-    return keyfileToken;
-  } catch (error) {
-    deps.lbLogger.warn(
-      () =>
-        `Failed to read auth-keyfile for sub-profile ${profileName}: ${error}`,
-    );
-    return undefined;
   }
 }
 
@@ -197,7 +140,35 @@ async function resolveSubProfileContextWindow(
   }
 }
 
-async function resolveLoadBalancerSubProfile(
+/**
+ * Extracts the member's on-disk `auth` block (issue #2643). Load-balancer
+ * members with their own OAuth buckets must keep that intent so request-time
+ * resolution uses the member identity, not one shared default. Only the intent is
+ * copied; token material continues to flow via authToken/authKeyfile.
+ */
+function resolveSubProfileAuthIntent(
+  subProfile: unknown,
+): ProfileAuthIntent | undefined {
+  if (!isRecord(subProfile)) return undefined;
+  const candidate = subProfile.auth;
+  if (!isRecord(candidate)) {
+    return undefined;
+  }
+  if (candidate.type !== 'oauth' && candidate.type !== 'apikey') {
+    return undefined;
+  }
+  if (!Array.isArray(candidate.buckets)) {
+    return { type: candidate.type };
+  }
+  return {
+    type: candidate.type,
+    buckets: candidate.buckets.filter(
+      (bucket): bucket is string => typeof bucket === 'string',
+    ),
+  };
+}
+
+export async function resolveLoadBalancerSubProfile(
   profileName: string,
   deps: LoadBalancerResolutionDeps,
 ): Promise<ResolvedSubProfile> {
@@ -208,12 +179,16 @@ async function resolveLoadBalancerSubProfile(
     subProfileEphemeralSettings,
     'auth-keyfile',
   );
-  const authToken = await resolveSubProfileAuthToken(
-    profileName,
-    subProfileEphemeralSettings,
-    authKeyfile,
-    deps,
-  );
+  const auth = resolveSubProfileAuthIntent(subProfile);
+  const inlineToken =
+    auth?.type === 'oauth'
+      ? undefined
+      : getStringValue(subProfileEphemeralSettings, 'auth-key');
+  const authKeyName =
+    auth?.type === 'oauth' || inlineToken !== undefined
+      ? undefined
+      : getStringValue(subProfileEphemeralSettings, 'auth-key-name');
+  const authToken = inlineToken;
   const providerName = getProfileProvider(subProfile);
   const model = getProfileModel(subProfile);
   const contextWindow = await resolveSubProfileContextWindow(
@@ -228,8 +203,10 @@ async function resolveLoadBalancerSubProfile(
     model,
     baseURL: getStringValue(subProfileEphemeralSettings, 'base-url'),
     authToken,
+    authKeyName,
     authKeyfile,
     contextWindow,
+    auth,
     ephemeralSettings: subProfileEphemeralSettings,
     modelParams: getProfileModelParams(subProfile),
   };

--- a/packages/settings/src/profiles/ProfileManager.ts
+++ b/packages/settings/src/profiles/ProfileManager.ts
@@ -26,7 +26,11 @@ import {
 import fs from 'fs/promises';
 import path from 'path';
 import { Storage } from '@vybestack/llxprt-code-storage';
-import { writeProfileFile, deleteProfileFile } from './profileStore.js';
+import {
+  writeProfileFile,
+  writeProfileFileIfUnchanged,
+  deleteProfileFile,
+} from './profileStore.js';
 
 interface ProfileSettingsServiceLike {
   exportForProfile?: () => Promise<{
@@ -101,6 +105,19 @@ export class ProfileManager {
       profileName,
       JSON.stringify(profile, null, 2),
       'overwrite',
+    );
+  }
+
+  async saveProfileIfUnchanged(
+    profileName: string,
+    profile: PersistableProfile,
+    expected: { mtimeMs: number; size: number },
+  ): Promise<boolean> {
+    return writeProfileFileIfUnchanged(
+      this.profilesDir,
+      profileName,
+      JSON.stringify(profile, null, 2),
+      expected,
     );
   }
 

--- a/packages/settings/src/profiles/ProfileManager.ts
+++ b/packages/settings/src/profiles/ProfileManager.ts
@@ -146,35 +146,20 @@ export class ProfileManager {
     return parsed.value;
   }
 
-  async saveLoadBalancerProfile(name: string, profile: unknown): Promise<void> {
+  async validateLoadBalancerProfile(
+    name: string,
+    profile: unknown,
+  ): Promise<LoadBalancerProfile> {
     const loadBalancerProfile = parseLoadBalancerProfile(name, profile);
+    await this.validateLoadBalancerReferences(name, loadBalancerProfile);
+    return loadBalancerProfile;
+  }
 
-    const availableProfiles = await this.listProfiles();
-
-    for (const referencedProfile of loadBalancerProfile.profiles) {
-      if (!availableProfiles.includes(referencedProfile)) {
-        throw new Error(
-          `LoadBalancer profile '${name}' references non-existent profile '${referencedProfile}'`,
-        );
-      }
-
-      const referencedProfilePath = path.join(
-        this.profilesDir,
-        `${referencedProfile}.json`,
-      );
-      const referencedContent = await fs.readFile(
-        referencedProfilePath,
-        'utf8',
-      );
-      const referencedProfileData: unknown =
-        ProfileManager.parseProfileContent(referencedContent);
-
-      if (referencedProfileIsLoadBalancer(referencedProfileData)) {
-        throw new Error(
-          `LoadBalancer profile '${name}' cannot reference another LoadBalancer profile '${referencedProfile}'`,
-        );
-      }
-    }
+  async saveLoadBalancerProfile(name: string, profile: unknown): Promise<void> {
+    const loadBalancerProfile = await this.validateLoadBalancerProfile(
+      name,
+      profile,
+    );
 
     await fs.mkdir(this.profilesDir, { recursive: true });
 
@@ -199,6 +184,11 @@ export class ProfileManager {
     const availableProfiles = await this.listProfiles();
 
     for (const referencedProfile of loadBalancerProfile.profiles) {
+      if (referencedProfile === profileName) {
+        throw new Error(
+          `LoadBalancer profile '${profileName}' cannot reference itself`,
+        );
+      }
       if (!availableProfiles.includes(referencedProfile)) {
         throw new Error(
           `LoadBalancer profile '${profileName}' references non-existent profile '${referencedProfile}'`,

--- a/packages/settings/src/profiles/profileStore.ts
+++ b/packages/settings/src/profiles/profileStore.ts
@@ -845,6 +845,31 @@ function profileFilePath(profilesDir: string, profileName: string): string {
   return resolvedFile;
 }
 
+export async function writeProfileFileIfUnchanged(
+  profilesDir: string,
+  profileName: string,
+  data: string,
+  expected: { mtimeMs: number; size: number },
+): Promise<boolean> {
+  const filePath = profileFilePath(profilesDir, profileName);
+  return withProfilesLock(profilesDir, async () => {
+    let info: fsSync.Stats;
+    try {
+      info = await fs.stat(filePath);
+    } catch (error) {
+      if (hasErrnoCode(error, 'ENOENT') || hasErrnoCode(error, 'ENOTDIR')) {
+        return false;
+      }
+      throw error;
+    }
+    if (info.mtimeMs !== expected.mtimeMs || info.size !== expected.size) {
+      return false;
+    }
+    await atomicWriteFile(filePath, data, info.mode & 0o777);
+    return true;
+  });
+}
+
 /**
  * Cohesive public API for writing a canonical profile JSON file under the
  * shared profiles lock. Preserves create-only vs overwrite behavior and

--- a/project-plans/20260908-issue2643-transactional-profile-controller/PLAN.md
+++ b/project-plans/20260908-issue2643-transactional-profile-controller/PLAN.md
@@ -1,0 +1,459 @@
+# Issue #2643 — Transactional ProfileController: literal commands, scheduler-safe commit, and runtime ownership
+
+Branch: `issue2643`
+Parent epic: #2635. Consumes #2642 (merged as PR #3312: single parser path in
+`ProfileManager`, registry `owner`/`propagation` metadata).
+
+## Objective (accepted behavior)
+
+Build the core transactional per-agent profile state machine against the
+existing v1 on-disk format:
+
+1. Core contracts and ports (`packages/core`) — implementation-neutral.
+2. Pure literal command reduction and candidate resolution (`packages/core`).
+3. Load-balancer member auth identity fix (`packages/settings` +
+   `packages/providers`, live code, real bug).
+4. `ProfileController` + `ActiveProfileRuntime` lifecycle
+   (`packages/agents`).
+
+Entry-point cutovers (CLI/Zed startup, Agent API, subagent, compression) are
+**separate subissues** (#2640, #2637). Nothing in production is re-routed
+through the new controller by this PR. The LB member auth fix is the one
+live-path behavioral change.
+
+## Non-goals (hard boundaries)
+
+- No `ProfileDocumentV2`, no qualified repository IDs, no etags, no generation
+  migration. v1 files load unchanged.
+- No removal of ambient accessors (`oauthRuntimeBridge`,
+  `getCliRuntimeServices`) — that is #2616.
+- No Config decomposition (#2615), no interactive auth UI (#2562), no retry
+  budget changes (#2532).
+- No cutover of `/model`, `/provider`, `/profile`, `/setup`, `/set` CLI
+  handlers to the new command path.
+- Core `profiles` tree must not import settings/provider implementations and
+  must not expose a generic runtime/service bag.
+
+## Acceptance criteria → tests
+
+| # | Accepted behavior | Proof |
+|---|---|---|
+| AC1 | Core contracts: configured/unconfigured `ProfileState`, tagged saved/draft identity, `ProfileCommand` union with expected revision + unsaved-discard intent, typed result union (committed/no-op/queued/confirmation-required/cancelled/busy/stale/conflict/invalid/unverified/failed), redacted snapshot/diff/error/health views, factual agent+command+revision events, narrow `AgentProfile` capability + smaller read capabilities, ports (repository, runtime factory, credential resolver, provider/model catalog+capability, trust/tool environment, scheduler boundary), immutable `TurnContext`/`ProviderCallContext`/`ToolInvocationContext` | Contract type tests + boundary guard test (no settings/provider imports in the tree; no forbidden types in public surface) |
+| AC2 | Literal reduction rules exactly as epic #2635 specifies: `/model` clones concrete standard source and patches model only (no template reread, no-op on same model); LB `/model` clones the immutable captured active member source (no cross-provider inference, removes LB state; startup LB+model requires explicit member); `/provider` blank reset from restricted template materialization copying nothing even for same provider; `/profile load` exact repository document; `/setup` blank candidate; profile `/set` clone+patch rejecting application-owned keys; startup one composite command. Pin/unset, saved/draft provenance, no-op detection, expected-revision stale rejection, unsaved-draft confirmation | Pure reducer behavioral tests per command + edge cases |
+| AC3 | Candidate resolution with injected ports: defaults without mutating document; reference graphs from captured documents; discriminated credential bindings without copied secrets; provider/model validation returning valid/invalid/unverified; active LB member capture; per-member auth identity resolution into its own binding; policy intersection (env/trust ∩ application/session ∩ role/delegation ∩ profile intent) that narrows only, with requested-vs-effective explanations without secrets; missing required tool invalidates; unavailable allowed tool warns+intersects; unknown disabled IDs portable | Resolver behavioral tests |
+| AC4 | LB member auth identity (live fix): `ResolvedSubProfile` carries member auth intent; member auth resolution reads full member auth intent (not just 3 ephemeral keys); bucket selection for a delegate call is member-scoped, not ambient; two OAuth members of one LB on different accounts of the same provider authenticate as their own accounts; member secrets resolved at use time (no plaintext caching at registration); `hasAuthConfig`/`isOAuthProfile` recognize member auth intent without breaking standard-profile behavior | Behavioral tests with real `ProfileManager` temp-dir profiles through the real LB registration + delegate options + bucket resolution paths |
+| AC5 | `ProfileController`: one per agent, no singleton; serialized commands; queued commands retain base revision, never rebase; stale expected-revision rejection; pure reduction before wait; commit only at scheduler-safe boundary; revision + source-file recheck after wait; minimal non-failing ownership swap; async-disposable candidate scope with full cleanup on failure/cancel; isolated listener errors; bounded best-effort old-runtime disposal; unchanged effective config reuses runtime (LB reapply preserves rr/cb/TPM/failover state); tool registries stable with filtered declarations + immutable policy snapshots; lazy role runtimes are children of parent revision capturing the referenced document; external edit/delete converts saved identity to draft, increments revision, preserves document/runtime, never hot-reloads; health typed separately from identity, never auto-rewrites document | Controller/runtime behavioral tests incl. cleanup races, listener failures, disposal, parent/subagent boundaries, background tools, external file changes, simultaneous agents |
+| AC6 | Full verification passes: `npm run test`, `lint`, `typecheck`, `format`, `build`, smoke profile `stepfun-37` | CI + local cycle |
+
+## Design decisions (pinned)
+
+### Directory layout
+
+```
+packages/core/src/profiles/
+  contracts/   profileState.ts, profileCommands.ts, profileResults.ts,
+               profileEvents.ts, profileViews.ts, capabilities.ts,
+               routingContexts.ts, index.ts
+  ports/       profileRepositoryPort.ts, profileRuntimeFactoryPort.ts,
+               credentialResolverPort.ts, providerCatalogPort.ts,
+               trustEnvironmentPort.ts, schedulerBoundaryPort.ts, index.ts
+  reduction/   reduceModelCommand.ts, reduceProviderCommand.ts,
+               reduceLoadCommand.ts, reduceSetCommand.ts, reduceSetupCommand.ts,
+               reduceStartupCommand.ts, commandEnvironment.ts, index.ts
+  resolution/  resolveProfileCandidate.ts, policyIntersection.ts,
+               credentialBindings.ts, memberAuthResolution.ts, index.ts
+  profiles-boundary.test.ts  (guard: no settings/provider imports in tree)
+  co-located *.test.ts per module (match core/runtime/contracts style)
+
+packages/agents/src/core/profile/
+  ProfileController.ts, ActiveProfileRuntime.ts, commandQueue.ts,
+  ownershipScope.ts, runtimeHealth.ts, sourceFingerprint.ts,
+  settingsProfileRepository.ts (adapter over ProfileManager),
+  executionCoordinatorBoundary.ts, index.ts
+  __tests__/profileController.*.test.ts (behavioral)
+```
+
+Lint budgets: 800 lines/file, 80 lines/function, complexity 25. Decompose
+accordingly (per-command reducer modules, per-concern controller modules).
+
+### Document model
+
+Core defines `ProfileDocument` as a structural mirror of v1
+(`StandardProfileDocument | LoadBalancerProfileDocument`) with readonly maps.
+Structural compatibility means settings' `Profile` passes through adapters
+without conversion. The discriminated auth intent
+(`key-name | keyfile | oauth+buckets | provider-default | inline-key`) is a
+RESOLUTION output, not an on-disk change; documents keep `auth?` +
+ephemeral keys exactly as v1.
+
+### Where owner-metadata knowledge enters core
+
+`/set` must reject application-owned keys, but core cannot import the settings
+registry. The reduction environment carries an injected pure classifier
+(`isApplicationOwnedKey(key): boolean`) supplied by the composition layer
+(agents adapter reads registry owner metadata from settings). Core stays
+implementation-neutral; the rule is still enforced at reduction time.
+
+### Result union semantics
+
+- `committed` — swap done; carries new revision + redacted snapshot.
+- `no-op` — candidate document equals current; identity/revision preserved.
+- `queued` — accepted behind an in-flight command; carries base revision.
+- `confirmation-required` — destructive op on unsaved draft without
+  `discardUnsaved`; carries a typed confirmation token; a follow-up command
+  with the confirmation (or `discardUnsaved: true`) proceeds.
+- `cancelled` — aborted while waiting (signal/boundary cancel).
+- `busy` — non-queuing entry point invoked while a command is in flight.
+- `stale` — expected revision ≠ current revision at submit or recheck.
+- `conflict` — source file fingerprint changed externally in ways that break
+  the expected source state (repository save collision).
+- `invalid` — structural/capability/reference validation failure (redacted).
+- `unverified` — candidate constructible but provider/model metadata
+  unavailable to prove constraints.
+- `failed` — construction/commit error after validation (redacted).
+
+### Controller commit sequence (per issue, verbatim)
+
+```
+submit(command)
+  → serialize (queue if in flight; retain base revision; never rebase)
+  → pure reduction + validation + revision capture   (before waiting)
+  → wait scheduler-safe boundary (parent awaiting subagent blocks itself)
+  → recheck revision and source-file state
+  → resolve credentials + build candidate runtime locally (ownership scope)
+  → minimal non-failing ownership swap
+  → emit isolated redacted events
+  → bounded best-effort disposal of old runtime (cannot roll back)
+```
+
+### Runtime reuse rule
+
+Before building, compare the candidate's resolved effective configuration
+with the current runtime's resolved configuration (structural equality of the
+resolved spec, not file identity). Equal → reuse the existing runtime binding
+object (LB rr/circuit-breaker/TPM/failover state survives). Only explicitly
+safe shared stores/transports/caches may be borrowed. Test proves operational
+counters survive an unchanged LB reapply through the real controller.
+
+### External-change detection
+
+`SourceFingerprint = { mtimeMs; size } | { hash }`. On each command recheck
+(and on explicit query), compare the saved identity's fingerprint against the
+file's current stat. Mismatch or deletion → identity becomes draft
+(`derivedFrom` preserved), revision increments, document and runtime stay
+active, nothing hot-reloads. No repository event system.
+
+### LB member auth identity (live fix) mechanics
+
+- `ResolvedSubProfile` gains `auth?: { type: 'oauth' | 'apikey'; buckets?: string[] }`.
+- `resolveLoadBalancerSubProfile` reads `subProfile.auth` (member document)
+  in addition to the three ephemeral keys.
+- OAuth members do NOT resolve an inline token at registration; their
+  identity flows to delegate calls so token resolution scopes buckets to the
+  member document (the established `profileId` metadata channel — see
+  `subagent-isolation.behavioral.spec.ts` and `token-profile-resolver.ts`
+  `resolveProfileBuckets`, which already loads a requested profile and
+  applies the provider-match guard correctly for standard member docs).
+- `hasAuthConfig`/`isOAuthProfile` remain correct for standard profiles and
+  member auth intent becomes recognizable through member-aware paths.
+- Registration-time plaintext caching for OAuth members is removed in favor
+  of use-time resolution; key rotation is picked up.
+
+## Test-first requirements
+
+TDD per dev-docs/RULES.md and the typescript-test-writing skill. Bun +
+`bun:test` only. Behavioral tests, no mock theater:
+
+- Reducer/resolver: pure functions under test are real; ports are real
+  in-memory implementations (data + simple logic), never `vi.fn()` mirrors.
+- LB auth: real `ProfileManager` over temp-dir files, real LB registration
+  path, real delegate option building, real bucket resolution; assert derived
+  behavior (which account/bucket each member's request used), not mock calls.
+- Controller: real controller + real runtime objects with observable state;
+  test infrastructure (boundary that resolves on command, repository adapter
+  over real temp files) is legitimate infrastructure, not self-mocking.
+- Shared helpers for temp dirs / fixture profiles; no copy-pasted setup.
+
+## Implementation sequencing (subagent runs)
+
+1. **Run 1** — core contracts + ports + reducer + resolver + tests (AC1–AC3).
+2. **Run 2** — LB member auth identity fix (AC4).
+3. **Run 3** — ProfileController + ActiveProfileRuntime + adapters + tests
+   (AC5).
+4. Full verification cycle, deepthinker review (cap 2 rounds), OCR (cap 2
+   rounds), PR.
+
+### Execution status (2026-09-12)
+
+- Runs 1a/1b/2/3/3c DONE (see git tree: core contracts/ports/reduction/resolution,
+  providers LB member auth fix, agents controller/runtime/adapter + behavioral
+  suites).
+- deepthinker review round 1: 23 findings (4 BLOCKER / 16 MAJOR / 2 MINOR / 1
+  NOTE). All 20 blocking+majors remediated across batches 1, 2a, 2b, 2c, 3;
+  finding 6's coordinator implementation explicitly deferred to #2640 (port
+  contract `withSafeBoundary` landed instead). Test migration:
+  profileApplication.lb.authkey.test.ts moved from registration-time named-key
+  resolution to use-time (issue superseded #1970 registration semantics).
+- Environmental flakes filed: #3638 (grep-ephemeral), #3643
+  (skillManager/extensionSkillRefresh leak ~55 ambient machine skills; both
+  reproduce on clean HEAD).
+- Verification cycle (final): build:types→typecheck→build FINAL:0; workspace
+  tests pass except the two #3643 files; format clean; stepfun-37 smoke EXIT:0
+  (haiku); audit scan delta = new tests only, categories consistent with
+  baseline.
+- OCR final review round 1 (zai-anthropic, glm-5.3, agent audience): 42 findings
+  (4 high / ~20 medium / ~18 low), all triaged valid; status "partial" (30/80
+  items failed LLM-side, 44 recovered by retries — round 2 completes coverage).
+  Remediated in four batches, all green:
+  - Batch A (core contracts/views): bare-form redaction masks to end of line;
+    case-insensitive document redaction; structuredClone deep copy; sound
+    per-kind isProfileCommand/isProfileCommandResult validators; single-source
+    kind whitelist; contextLimit validation + presence-vs-defined consistency;
+    negative tests for auth-config branches.
+  - Batch B (core reduction): Object.hasOwn-style env lookups (prototype-key
+    names → typed invalid); startup draft gate ordered before model branch;
+    setup draft gate; discardUnsaved field for startup/setup + reducer honor;
+    /set rejects __proto__/constructor/prototype keys; member validated
+    against TARGET LB; blank-startup test replaced dead duplicate; dead void
+    removed. 391 core tests.
+  - Batch C (agents): closed/cancellation guards on execute + save route
+    (no state adoption/events after abort); binding-reuse ownership transfer
+    (releaseOwnership); captureMember tolerates catalog failure (unverified,
+    not failed); adapter stat→load→stat retry-once TOCTOU fix + name
+    validation (RangeError before FS); policy required; save anchoring vs
+    external edits + mustCreate create-only save-as (port + adapter);
+    blank-draft discriminator provider===''&&model===''; test-suite cleanups
+    (dead scaffolding, failNextRead rename, shared helpers, strengthened
+    fingerprint assertions, startup/setup confirm round-trips). 483 tests.
+    Surfaced settings-parser limitation → filed #3645.
+  - Batch D (providers): OAuth members skip stray auth-keyfile too (intent
+    wins; no plaintext override of member-scoped OAuth); ResolvedSubProfile.auth
+    doc corrected (intent record vs metadata.profileId channel);
+    flushRuntimeAuthScope cleanup in behavioral spec; dead mock-restore
+    scaffolding removed; LLXPRT_TEST_STORAGE_ISOLATED guard on memberAuth
+    suite; projection-time member credential resolution (enforceTokenLimit
+    path resolves member secret + member-scoped metadata, rotation covered).
+    540 tests combined; providers tsc baseline unchanged (3306 before/after).
+- Verification cycle (post-OCR-remediation): build:types→typecheck→build
+  chain FINAL:1 where the only failures are the two #3643 environmental
+  files (0 native-runner failures); format clean; stepfun-37 smoke EXIT:0
+  (haiku).
+- OCR round 2 (findings-verification, glm-5.3): 17 findings (1 high /
+  9 medium / 7 low) — all classified as failure-to-fix completeness,
+  fix-induced regressions, or same-defect-class stragglers of round 1; none
+  widened scope. Review cap (2) reached; remediation batches E + F:
+  - E (core reduction + controller confirmation plumbing): startup-provider
+    draft gate (`discard:startup-provider:<p>`); /model member validated
+    against current document profiles; /provider draft gate + discardUnsaved
+    (command contract + validator + replay); empty-LB guard (typed invalid);
+    dead discardUnsaved parameter removed from buildLoadCandidate (+ void
+    cleanups); catalog-outage → unverified in forkLoadBalancerModel;
+    unchanged startup model preserves saved identity (no-op-style, no draft
+    downgrade); confirmation tokens namespaced by command kind +
+    controller validates pending.commandKind on replay (mismatch → invalid,
+    token not consumed); startup-with-model test now exercises the fork.
+    505 tests green across core+agents.
+  - F (agents + providers): [high] anchored overwrite TOCTOU closed via
+    ProfileManager.saveProfileIfUnchanged (fingerprint check + write under
+    the SAME profiles lock; contention test); post-write cancellation
+    reconciles persisted fingerprint before returning cancelled/failed (no
+    phantom draft promotion on next command); per-binding try/catch in
+    CandidateScope.disposeAll (sync throws isolated); adapter deep-copies
+    both directions (structuredClone); stat rethrows non-ENOENT/ENOTDIR
+    (EACCES/EMFILE propagate — fail fast); binding-reuse reordering (attach
+    before releaseOwnership, every failure point leaves exactly one owner);
+    keyfile-only LB members resolve plaintext at use time with rotation
+    tests (round-robin/failover/option-builder); strict isRecord exported
+    from loadBalancerTypes and reused. 569 tests green across all trees;
+    providers tsc baseline 3306 unchanged.
+- Final gate re-run after E+F: build:types → typecheck → build → format.
+
+<details><summary>Earlier run-by-run log (collapsed)</summary>
+
+- Run 1a DONE — contracts + ports + boundary guard (124 tests).
+- Run 1b DONE — reducer (model/provider/load/save/set/setup/startup) +
+  candidate resolver incl. policy intersection, credential bindings, member
+  auth resolution (272 cumulative core tests, eslint clean).
+- Run 2 DONE — LB member auth identity fix: `ResolvedSubProfile.auth`
+  intent, registration reads member `auth`, OAuth members skip ephemeral
+  plaintext caching, delegate `metadata.profileId` scopes
+  `resolveProfileBuckets` to the member; 4-case behavioral spec + unit
+  tests green.
+- Run 3a DONE — `profileRepositoryAdapter.ts` (ProfileManager-backed port
+  + conflict error), `activeProfileRuntime.ts` (attach/snapshot/health,
+  bounded best-effort disposal, injectable `disposeTimeoutMs`), 16 tests.
+- Run 3b DONE — controller seams `controllerTypes.ts`,
+  `controllerEnv.ts` (environment builder: provider templates via catalog,
+  repo snapshot + stat, LB member captures), `controllerSave.ts`
+  (optimistic-fingerprint save route), `controllerCommit.ts` (resolve →
+  boundary wait → revision + source recheck with external-change draft
+  promotion → build with configFingerprint reuse → minimal swap → emit),
+  `profileController.ts` (serialization/queue/busy, reduction routing,
+  confirmation-token re-drive, isolated listeners, best-effort disposal).
+  typecheck + eslint clean on all six files.
+- Run 3c DONE — 18 behavioral cases across serialization (9) + lifecycle (9)
+  files. Behavioral tests surfaced and fixed 4 real seam bugs: (1)
+  `reduceProfileCommand` missing from the reduction barrel (module-load
+  failure for package consumers), (2) commit route reading `state.revision`
+  on unconfigured state so the first commit always went `stale`, (3)
+  unknown-provider had to return `invalid` without touching the live
+  binding, (4) LB reapply rebuilt the runtime instead of reusing the
+  binding (configFingerprint reuse now skips disposal of the kept binding).
+- Verification cycle DONE (2026-09-11): adapter `EphemeralSettings` →
+  `Record<string, unknown>` bridge via `Object.fromEntries`; duplicate
+  auth-copy functions merged into one structural `copyAuthConfig`; 73
+  typecheck errors in test files fixed type-level only (narrowing
+  predicates, literal typing — zero assertion-semantics changes; final
+  counts 303 profile tests pass, both package typechecks exit 0);
+  `build:types` → `typecheck` → `build` chain FINAL:0; workspace tests
+  132/133 native files (only failure = pre-existing flaky
+  grep-ephemeral-precedence, proven on clean HEAD, filed as #3638);
+  format clean; stepfun-37 smoke passes; audit scan delta = +1 finding,
+  triaged as false positive (identity-stability `toBe` assertion is the
+  contract; two real smells were fixed).
+
+</details>
+
+## Review-finding triage policy
+
+Every finding classified Blocker-Fix / In-scope-Fix / Reject / Defer.
+Reviewer suggestions do not authorize scope expansion (no new subsystems, no
+public abstractions beyond the issue's list, no dependency changes, no
+workflow/agent-memory/quality-tool changes, no unrelated refactors).
+
+## Known follow-ups (deferred, not this PR)
+
+- Live-path LB runtime reuse on re-registration (controller path proves the
+  behavior; live `profileApplication` cutover belongs to #2640/#2637).
+- Entry-point cutovers (#2640, #2637) and legacy-path deletion (#2644).
+- Ambient accessor removal (#2616).
+
+## Controller implementation spec (dispatched to implementer)
+
+Location: `packages/agents/src/core/profile/profileController.ts` (+ helper
+modules when line budgets demand). Consumes core profiles contracts/ports/
+reduction/resolution and the existing `ActiveProfileRuntime`.
+
+### API
+
+```ts
+export interface ProfileControllerDeps {
+  agentId: string;
+  repository: ProfileRepositoryPort;
+  runtimeFactory: ProfileRuntimeFactoryPort;
+  boundary: SchedulerBoundaryPort;
+  catalog: ProviderModelCatalogPort;
+  trust: TrustEnvironmentPort;
+  session: PolicyCeiling;
+  role?: PolicyCeiling;
+  isApplicationOwnedKey: (key: string) => boolean;
+  getPolicyIntent?: (document: ProfileDocument) => ProfilePolicyIntent;
+  listeners?: ReadonlyArray<(event: ProfileEvent) => void>;
+}
+
+export class ProfileController {
+  constructor(deps: ProfileControllerDeps);
+  getState(): ProfileState;                       // current committed state
+  getRuntime(): ActiveProfileRuntime | undefined; // current runtime
+  getPendingConfirmations(): readonly string[];   // tokens awaiting confirm
+  execute(command: ProfileCommand,
+          options?: { signal?: AbortSignal; queue?: boolean }):
+      Promise<ProfileCommandResult>;
+  dispose(): Promise<void>;   // clear queue, dispose runtime best-effort
+}
+```
+
+### Semantics (exact)
+
+1. **Serialization.** One in-flight command. While in-flight:
+   `queue === false` → `{kind:'busy', activeCommandKind, revision}`;
+   default → enqueue `{command, signal}` and immediately return
+   `{kind:'queued', baseRevision}` (revision at enqueue). Dequeued commands
+   run against the *current* state; an old `expectedRevision` then produces a
+   `stale` result. Queued commands are never rebased.
+2. **Env build (async, before any waiting).** For the command kind:
+   provider/startup-with-provider → template
+   `{version:1,type:'standard',provider,model: catalog.getDefaultModel(provider) ?? '',
+     modelParams:{}, ephemeralSettings:{}}`;
+   load/startup-with-profileName → `repository.load(name)` + `repository.stat(name)`
+   into `env.repository[name]`; for any loadbalancer document in play (current
+   state or loaded) → per member: `repository.load(member)` and
+   `catalog.listModels(memberProvider)` into
+   `env.memberCaptures[member] = {revision:0, provider, sourceDocument, models}`;
+   load failures skip that capture (reducer/resolver handle missing).
+3. **Reduce.** `reduceProfileCommand(state, command, env)`; route outcomes:
+   `stale` → stale result; `invalid` → invalid result; `no-op` → emit event,
+   no-op result; `confirmation-required` → store token→original-command Map,
+   return the confirmation-required result; `discard-authorized` → look up
+   token (missing → invalid 'unknown confirmation token'), re-drive the
+   *stored* command with `discardUnsaved: true`, delete the entry, loop back
+   to env-build once (guard against re-loop); `save` →
+   `repository.save(name, document, expectedFingerprint = current identity
+   saved ? identity.source : undefined)` → success: identity becomes
+   `{kind:'saved', name, source: newFingerprint}`, **revision unchanged,
+   runtime/binding unchanged** (save never rebuilds) → committed result with
+   redacted snapshot; `ProfileRepositoryConflictError` →
+   `{kind:'conflict', cause:'source-changed', revision}`; `candidate` → step 4.
+4. **Commit pipeline.**
+   a. `resolveProfileCandidate({document, policyIntent: getPolicyIntent?.(document)
+      ?? empty}, {catalog, trust, session, role, repository})` → `invalid` →
+      invalid result; `unverified` → unverified result (no commit); valid → b.
+   b. `boundary.waitSafeBoundary(signal)` → `'cancelled'` → cancelled result.
+   c. **Recheck.** `state.revision !== command.expectedRevision` → stale.
+      Saved identity → `repository.stat(name)`: null or fingerprint mismatch →
+      EXTERNAL CHANGE: identity → draft (`derivedFrom {name, source: old}`),
+      revision+1, document/binding preserved (no hot reload), emit event,
+      stale result with `currentRevision` = new revision.
+   d. **Build locally.** Blank setup draft (provider `''` and model `''`) →
+      binding `undefined`. Else `runtimeFactory.build(...)`; throw → failed
+      result `{error: message}` (prior state active).
+   e. **Reuse.** Old binding && new binding && equal `configFingerprint` →
+      dispose the NEW binding (best-effort), keep the OLD binding object
+      (LB rr/circuit-breaker/TPM/failover state preserved).
+   f. **Swap minimal non-failing.** New `ActiveProfileRuntime` with
+      `{status:'configured', revision: nextRevision, identity, document,
+      activeMember}`; attach chosen binding; assign. Failure → dispose new
+      binding, failed result, old runtime stays active.
+   g. Dispose OLD runtime fire-and-forget with isolated catch (cannot roll
+      back). Emit committed event. Return
+      `{kind:'committed', revision: nextRevision, snapshot}`.
+5. **Events.** `emit()` wraps each listener call in try/catch; listener
+   errors never affect command results. Facts only: agentId, commandKind,
+   revision, per contracts `ProfileEvent` union.
+6. **Drain.** After each command completes, dequeue and process the next
+   queued command sequentially, then clear in-flight.
+
+### Controller test matrix (behavioral, infra fakes for ports only)
+
+In-memory repository (implements `ProfileRepositoryPort`), deferred boundary,
+counting runtime factory (distinct `configFingerprint`, dispose counters),
+catalog/trust fakes, one throwing listener. Real core reducer/resolver.
+
+1. Serialization: second execute while boundary pending → `queued` with
+   baseRevision; runs after the first completes.
+2. Queued command with stale expectedRevision after first commit → `stale`
+   (never rebased).
+3. `queue:false` while in-flight → `busy` with `activeCommandKind`.
+4. Load on unsaved draft without `discardUnsaved` → `confirmation-required`
+   + registered token.
+5. `confirm-discard` with that token re-drives and commits the load.
+6. `confirm-discard` with unknown token → `invalid`.
+7. Save fingerprint conflict → `conflict`; runtime/document unchanged.
+8. Save success → saved identity, revision unchanged, SAME binding object.
+9. `/model` same model → `no-op`, revision unchanged.
+10. `/provider` unknown → `invalid`, prior state intact.
+11. Throwing listener does not break the commit result; other listeners still
+    notified.
+12. Unverified candidate (catalog unknown) → `unverified`, no commit.
+13. Boundary cancelled → `cancelled`; candidate binding disposed; prior
+    runtime active (binding object identity preserved).
+14. External file edit before boundary release → stale result, identity draft
+    with `derivedFrom`, revision+1, document/binding preserved.
+15. Unchanged LB reapply → same binding object retained (counters continue),
+    new candidate binding disposed.
+16. Two controllers over the same repository → fully independent state,
+    bindings, health.
+17. Failed build → `failed`, prior runtime active, candidate resources
+    cleaned.
+18. In-flight captured snapshot (getRuntime state object reference) is not
+    mutated by a later commit (background work retains captured contexts).


### PR DESCRIPTION
## TLDR

Implements #2643 (epic #2635): a transactional ProfileController with scheduler-safe commit boundaries and runtime ownership, built on new implementation-neutral profile contracts/ports in core, plus the live-path fix for load-balancer member OAuth auth identity. 86 files, ~15.9k insertions, 569 new tests.

**What reviewers should look at:**
- `packages/core/src/profiles/` — contracts (document/state/command/result/event/view), ports (repository, credential resolver, catalog, trust, runtime factory, scheduler boundary), the pure literal-command reducer, and the candidate resolver with narrow-only policy intersection. Zero settings/providers imports (enforced by a boundary test).
- `packages/agents/src/core/profile/` — ProfileController (serialized commands, queued commands never rebased, kind-checked confirmation-token replays), commit route (reduce → wait for safe scheduler boundary → revision + source-fingerprint recheck → build with configFingerprint-equal binding reuse → minimal non-failing ownership swap), ActiveProfileRuntime, and the ProfileManager-backed repository adapter with lock-atomic anchored saves.
- LB member auth (providers/auth/settings): `ResolvedSubProfile.auth` intent, use-time plaintext resolution for named-key/keyfile members (rotation-safe), OAuth bucket/token-cache scoping via `metadata.profileId`, including the token-limit projection path.

## Dive Deeper

**Controller transaction semantics.** Pure reduction and validation run before any wait; commit happens only at a `SchedulerBoundaryPort` safe boundary; revision and source fingerprints are rechecked after the wait (external file edits promote saved→draft with revision bump, document/runtime preserved). Cancellation and build failure leave the prior runtime fully owning its binding; candidate scopes are `AsyncDisposable` and cleaned on every failure path. Unchanged resolved config (equal `configFingerprint`) reuses the existing binding, preserving LB round-robin/TPM operational state.

**Anchored persistence.** `ProfileManager.saveProfileIfUnchanged` performs the fingerprint check and the write under the same profiles lock, closing the stat-outside-lock TOCTOU on the overwrite path; `mustCreate` gives create-only semantics for save-as. The adapter rejects path traversal/separator/whitespace/NUL names before touching the FS, and propagates non-ENOENT stat errors instead of masking them as "missing".

**Draft-confirmation gates.** Every workspace-replacing command (`load`, `setup`, `startup`, `/provider`) gates on unsaved drafts: `confirmation-required` with a token namespaced by command kind + discriminator; `confirm-discard` replays the original command with `discardUnsaved` and rejects kind-mismatched tokens.

**Member auth identity.** OAuth members read no plaintext at registration (intent wins over stray auth-key/auth-key-name/auth-keyfile); named-key and keyfile-only members store references and resolve at attempt time, so key rotation takes effect on the next attempt. Delegate `metadata.profileId` scopes bucket resolution and the token cache per member, keeping two OAuth members of different accounts separated (behavioral spec included).

**Reviews.** Two rounds each: deepthinker (23 findings) and OCR glm-5.3 (42 + 17 findings). All remediated in batches; round-2 findings were failure-to-fix completeness and fix-induced regressions of round 1, no scope widening.

**Out of scope (explicitly deferred):** entry-point cutovers (#2640 CLI/Zed, #2637 Agent API), interactive auth (#2562), retry budgets (#2532), config decomposition (#2615), ambient accessor removal (#2616), live-path LB runtime reuse on re-registration.

## Reviewer Test Plan

```bash
bun test packages/core/src/profiles packages/agents/src/core/profile \
  packages/providers/src/loadBalancing packages/providers/src/runtime/profile-application \
  packages/providers/src/auth/__tests__/lb-member-auth-identity.behavioral.spec.ts
npx eslint packages/core/src/profiles packages/agents/src/core/profile packages/providers/src/loadBalancing
npm run typecheck -w @vybestack/llxprt-code-core -w @vybestack/llxprt-code-agents -w @vybestack/llxprt-code-providers
```

Behavioral suites to skim: `profileController.serialization.test.ts` (queued/busy/confirm/conflict/no-op), `profileController.lifecycle.test.ts` (cancel, external edit, LB reuse, dual controllers, failed build, state immutability), `lb-member-auth-identity.behavioral.spec.ts` (two OAuth members, different accounts, isolated buckets/tokens), `profileApplication.lb.authkey.test.ts` (keyfile/key rotation at use time). Plan document with full acceptance-criteria mapping: `project-plans/20260908-issue2643-transactional-profile-controller/PLAN.md`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | -   | -   | -   |
| Seatbelt | ❓  | -   | -   |

macOS (this machine): full workspace gate chain (build:types → typecheck → build → format) exit 0; 569 tests green across touched trees; `stepfun-37` smoke profile EXIT:0. Known unrelated flakes documented in #3638/#3643 (pre-existing, proven on clean main).

## Linked issues / bugs

Fixes #2643
Progress on #2635 (epic; entry-point cutovers tracked in #2640/#2637)
Related: #3645 (settings blank-profile parser gap surfaced by the persistence tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added profile workspace management for setup, loading, saving, model/provider changes, drafts, confirmations, and queued commands.
  * Added load-balancer profiles with per-member model and authentication handling.
  * Added policy enforcement, runtime health tracking, immutable snapshots, and secret redaction.
  * Added profile-scoped authentication, OAuth identity isolation, and keyfile fallback.
* **Bug Fixes**
  * Prevented credentials from being cached or cross-shared between load-balancer members.
  * Added protection against conflicting profile saves and external file changes.
* **Tests**
  * Expanded coverage for lifecycle, persistence, serialization, security, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->